### PR TITLE
Align swipe action tests with domain settings

### DIFF
--- a/entreprinder/tests.py
+++ b/entreprinder/tests.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import TestCase, Client
 from django.urls import reverse
 from django.contrib.auth.models import User
@@ -122,3 +124,63 @@ class MatchingTestCase(TestCase):
         
         Like.objects.create(liker=self.profile2, liked=self.profile1)
         self.assertEqual(Match.objects.count(), 1, "Match should be created after mutual likes")
+
+
+class SwipeActionValidationTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Align the test site with the currently active settings module (local or production).
+        from django.conf import settings
+        from azureproject import domains
+
+        preferred_host = None
+        for host, config in domains.DOMAINS.items():
+            if config.get('app') == 'entreprinder':
+                preferred_host = host
+                break
+
+        preferred_host = preferred_host or domains.PRODUCTION_DEFAULT
+
+        cls.site, _ = Site.objects.update_or_create(
+            id=getattr(settings, 'SITE_ID', 1),
+            defaults={'domain': preferred_host, 'name': preferred_host}
+        )
+        cls.test_host = preferred_host
+
+    def setUp(self):
+        self.client = Client(HTTP_HOST=self.test_host)
+        self.user = User.objects.create_user(username='swipeuser', password='12345')
+        self.target_user = User.objects.create_user(username='targetuser', password='12345')
+        self.industry = Industry.objects.create(name='Tech')
+        self.user_profile = EntrepreneurProfile.objects.create(user=self.user, industry=self.industry)
+        self.target_profile = EntrepreneurProfile.objects.create(user=self.target_user, industry=self.industry)
+        self.client.login(username='swipeuser', password='12345')
+
+    def test_invalid_json_returns_error(self):
+        response = self.client.post(
+            '/matching/swipe/action/',
+            data='not-json',
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['message'], 'Invalid JSON payload')
+
+    def test_invalid_action_returns_error(self):
+        payload = {'profile_id': self.target_profile.id, 'action': 'maybe'}
+        response = self.client.post(
+            '/matching/swipe/action/',
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['message'], 'Invalid action')
+
+    def test_missing_profile_returns_not_found(self):
+        payload = {'profile_id': 9999, 'action': 'like'}
+        response = self.client.post(
+            '/matching/swipe/action/',
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()['message'], 'Profile not found')


### PR DESCRIPTION
## Summary
- derive swipe action test host from the entreprinder domain configuration so it works with both local and production settings modules
- use the configured `SITE_ID` and preferred host when preparing the Sites entry and test client
- ensure the tests file ends with a newline

## Testing
- SECRET_KEY=testkey python manage.py test entreprinder.tests.SwipeActionValidationTestCase

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944054860108330a9ea1b71f8e2887c)