### PR TITLE
Expose import_cost_data command under entreprinder app

### DIFF
--- a/entreprinder/management/commands/import_cost_data.py
+++ b/entreprinder/management/commands/import_cost_data.py
@@ -1,0 +1,14 @@
+"""Expose FinOps import_cost_data command via the entreprinder app.
+
+The actual implementation lives under entreprinder.finops, but that package
+isn't installed as a separate Django app. By importing and subclassing the
+FinOps command here, Django's command discovery (which looks only at
+INSTALLED_APPS) can find it in production deployments.
+"""
+
+from entreprinder.finops.management.commands.import_cost_data import Command as FinOpsImportCostDataCommand
+
+
+class Command(FinOpsImportCostDataCommand):
+    """Alias for the FinOps import_cost_data command."""
+


### PR DESCRIPTION
## Summary
- add an entreprinder management command alias that re-exports the FinOps import_cost_data command
- document why the alias is required so Django can discover the command in production

## Testing
- python manage.py help import_cost_data (fails: SECRET_KEY not set in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694423cc9e188330b4ed27787d010eab)