### PR TITLE
Use Azure blob URL for social preview image

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -114,6 +114,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.i18n',  # Ensure this line is present
                 'crush_lu.context_processors.crush_user_context',  # Crush.lu user context
+                'crush_lu.context_processors.social_preview_context',
                 'azureproject.analytics_context.analytics_ids',  # Domain-specific GA4/FB Pixel IDs
             ],
             # 'builtins': [ # Simplify builtins to only include allauth account tags
@@ -356,6 +357,11 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
 ]
 
+SOCIAL_PREVIEW_IMAGE_URL = os.getenv(
+    'SOCIAL_PREVIEW_IMAGE_URL',
+    'https://crush.lu/static/crush_lu/crush_social_preview.jpg'
+)
+
 # Azure Blob Storage Settings (Conditional for Development)
 if os.getenv('AZURE_ACCOUNT_NAME'):
     DEFAULT_FILE_STORAGE = 'storages.backends.azure_storage.AzureStorage'
@@ -363,6 +369,11 @@ if os.getenv('AZURE_ACCOUNT_NAME'):
     AZURE_ACCOUNT_KEY = os.getenv('AZURE_ACCOUNT_KEY')
     AZURE_CONTAINER_NAME = os.getenv('AZURE_CONTAINER_NAME')
     MEDIA_URL = f'https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/{AZURE_CONTAINER_NAME}/'
+    if 'SOCIAL_PREVIEW_IMAGE_URL' not in os.environ:
+        SOCIAL_PREVIEW_IMAGE_URL = (
+            f'https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/'
+            f'{AZURE_CONTAINER_NAME}/crush_social_preview.jpg'
+        )
     print("Using Azure Blob Storage for media files.")
 else:
     MEDIA_URL = '/media/'

--- a/crush_lu/context_processors.py
+++ b/crush_lu/context_processors.py
@@ -4,6 +4,7 @@ These make variables available to all templates
 """
 from django.db.models import Q
 from django.utils import timezone
+from django.conf import settings
 from .models import (
     EventConnection, CrushProfile, CrushCoach, SpecialUserExperience,
     JourneyProgress, ProfileSubmission, EventRegistration, MeetupEvent
@@ -86,3 +87,10 @@ def crush_user_context(request):
                 context['journey_progress'] = journey_progress
 
     return context
+
+
+def social_preview_context(request):
+    """Expose social preview settings for Open Graph/Twitter tags."""
+    return {
+        "social_preview_image_url": settings.SOCIAL_PREVIEW_IMAGE_URL,
+    }

--- a/crush_lu/templates/crush_lu/base.html
+++ b/crush_lu/templates/crush_lu/base.html
@@ -28,7 +28,7 @@
     <meta property="og:url" content="https://crush.lu{{ request.path }}">
     <meta property="og:title" content="{% block og_title %}Crush.lu - Meet New People in Luxembourg{% endblock %}">
     <meta property="og:description" content="{% block og_description %}Privacy-first dating platform for Luxembourg. Meet real people at organized events - no endless swiping, just authentic connections.{% endblock %}">
-    <meta property="og:image" content="{% block og_image %}https://crush.lu{% static 'crush_lu/crush_social_preview.jpg' %}{% endblock %}">
+    <meta property="og:image" content="{% block og_image %}{{ social_preview_image_url }}{% endblock %}">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:locale" content="{{ LANGUAGE_CODE|default:'en' }}_{{ LANGUAGE_CODE|default:'EN'|upper }}">
@@ -40,7 +40,7 @@
     <meta property="twitter:url" content="https://crush.lu{{ request.path }}">
     <meta property="twitter:title" content="{% block twitter_title %}Crush.lu - Meet New People in Luxembourg{% endblock %}">
     <meta property="twitter:description" content="{% block twitter_description %}Privacy-first dating platform for Luxembourg. Meet real people at organized events - no endless swiping, just authentic connections.{% endblock %}">
-    <meta property="twitter:image" content="{% block twitter_image %}https://crush.lu{% static 'crush_lu/crush_social_preview.jpg' %}{% endblock %}">
+    <meta property="twitter:image" content="{% block twitter_image %}{{ social_preview_image_url }}{% endblock %}">
 
     <!-- Additional SEO -->
     <meta name="description" content="{% block meta_description %}Privacy-first dating platform for Luxembourg. Coach-curated profiles and event-based meetups for authentic connections.{% endblock %}">


### PR DESCRIPTION
### Motivation
- Messenger was intermittently failing to show previews because static file URLs are fingerprinted and can change between deployments (hash in filename). Using a stable, deployment-scope URL avoids cache/suppression issues.
- Provide a single canonical OG/Twitter image URL that can be hosted in Azure Blob Storage (or overridden via env) so social platforms always fetch the same resource.

### Description
- Added a `SOCIAL_PREVIEW_IMAGE_URL` setting (default falls back to `/static/crush_lu/crush_social_preview.jpg`) and, when Azure storage is configured, defaults to the Azure container URL: `https://<AZURE_ACCOUNT_NAME>.blob.core.windows.net/<AZURE_CONTAINER_NAME>/crush_social_preview.jpg` (`azureproject/settings.py`).
- Added a new context processor `social_preview_context` to expose `social_preview_image_url` to templates (`crush_lu/context_processors.py`) and registered it in `TEMPLATES[...]['OPTIONS']['context_processors']`.
- Updated the base template to use the injected `{{ social_preview_image_url }}` for `og:image` and `twitter:image` (`crush_lu/templates/crush_lu/base.html`).
- Minor imports: context processor now imports `settings` to read the new config.

### Testing
- Automated tests: none run for this change.
- Manual/next steps recommended (not executed here):
  - Deploy with `AZURE_ACCOUNT_NAME`/`AZURE_CONTAINER_NAME` set and confirm `{{ social_preview_image_url }}` resolves to the blob URL.
  - Use Facebook Sharing Debugger / Messenger to re-scrape the exact URL (and try a cache-busting query param) to confirm preview updates.
  - If desired, add a smoke test that renders the `/signup/` template and asserts the `og:image` tag equals `SOCIAL_PREVIEW_IMAGE_URL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945708856408330b0df0203b0469f45)