### PR TITLE
Enforce Graph API for all domains and use shared GRAPH_* credentials

### DIFF
--- a/azureproject/email_utils.py
+++ b/azureproject/email_utils.py
@@ -22,29 +22,25 @@ def _normalize_domain(domain):
 DOMAIN_EMAIL_CONFIG = {
     'crush.lu': {
         # Microsoft Graph API configuration (Graph API only - SMTP disabled by M365)
-        'USE_GRAPH_API': os.getenv('CRUSH_USE_GRAPH_API', 'True').lower() == 'true',
-        'GRAPH_TENANT_ID': os.getenv('CRUSH_GRAPH_TENANT_ID'),
-        'GRAPH_CLIENT_ID': os.getenv('CRUSH_GRAPH_CLIENT_ID'),
-        'GRAPH_CLIENT_SECRET': os.getenv('CRUSH_GRAPH_CLIENT_SECRET'),
-        'DEFAULT_FROM_EMAIL': os.getenv('CRUSH_DEFAULT_FROM_EMAIL', 'noreply@crush.lu'),
+        'USE_GRAPH_API': True,
+        'GRAPH_TENANT_ID': os.getenv('GRAPH_TENANT_ID'),
+        'GRAPH_CLIENT_ID': os.getenv('GRAPH_CLIENT_ID'),
+        'GRAPH_CLIENT_SECRET': os.getenv('GRAPH_CLIENT_SECRET'),
+        'DEFAULT_FROM_EMAIL': os.getenv('CRUSH_DEFAULT_FROM_EMAIL', 'info@crush.lu'),
     },
     'powerup.lu': {
-        'EMAIL_HOST': os.getenv('EMAIL_HOST', 'mail.power-up.lu'),
-        'EMAIL_PORT': int(os.getenv('EMAIL_PORT', '465')),
-        'EMAIL_HOST_USER': os.getenv('EMAIL_HOST_USER'),
-        'EMAIL_HOST_PASSWORD': os.getenv('EMAIL_HOST_PASSWORD'),
-        'EMAIL_USE_TLS': os.getenv('EMAIL_USE_TLS', 'False').lower() == 'true',
-        'EMAIL_USE_SSL': os.getenv('EMAIL_USE_SSL', 'True').lower() == 'true',
-        'DEFAULT_FROM_EMAIL': os.getenv('DEFAULT_FROM_EMAIL', os.getenv('EMAIL_HOST_USER')),
+        'USE_GRAPH_API': True,
+        'GRAPH_TENANT_ID': os.getenv('GRAPH_TENANT_ID'),
+        'GRAPH_CLIENT_ID': os.getenv('GRAPH_CLIENT_ID'),
+        'GRAPH_CLIENT_SECRET': os.getenv('GRAPH_CLIENT_SECRET'),
+        'DEFAULT_FROM_EMAIL': os.getenv('POWERUP_DEFAULT_FROM_EMAIL', 'info@powerup.lu'),
     },
     'vinsdelux.com': {
-        'EMAIL_HOST': os.getenv('VINSDELUX_EMAIL_HOST', os.getenv('EMAIL_HOST', 'mail.power-up.lu')),
-        'EMAIL_PORT': int(os.getenv('VINSDELUX_EMAIL_PORT', os.getenv('EMAIL_PORT', '465'))),
-        'EMAIL_HOST_USER': os.getenv('VINSDELUX_EMAIL_HOST_USER', os.getenv('EMAIL_HOST_USER')),
-        'EMAIL_HOST_PASSWORD': os.getenv('VINSDELUX_EMAIL_HOST_PASSWORD', os.getenv('EMAIL_HOST_PASSWORD')),
-        'EMAIL_USE_TLS': os.getenv('VINSDELUX_EMAIL_USE_TLS', os.getenv('EMAIL_USE_TLS', 'False')).lower() == 'true',
-        'EMAIL_USE_SSL': os.getenv('VINSDELUX_EMAIL_USE_SSL', os.getenv('EMAIL_USE_SSL', 'True')).lower() == 'true',
-        'DEFAULT_FROM_EMAIL': os.getenv('VINSDELUX_DEFAULT_FROM_EMAIL', os.getenv('DEFAULT_FROM_EMAIL', os.getenv('EMAIL_HOST_USER'))),
+        'USE_GRAPH_API': True,
+        'GRAPH_TENANT_ID': os.getenv('GRAPH_TENANT_ID'),
+        'GRAPH_CLIENT_ID': os.getenv('GRAPH_CLIENT_ID'),
+        'GRAPH_CLIENT_SECRET': os.getenv('GRAPH_CLIENT_SECRET'),
+        'DEFAULT_FROM_EMAIL': os.getenv('VINSDELUX_DEFAULT_FROM_EMAIL', 'info@vinsdelux.com'),
     },
 }
 
@@ -132,10 +128,11 @@ def send_domain_email(subject, message, recipient_list, request=None, domain=Non
                 client_secret=config['GRAPH_CLIENT_SECRET'],
                 from_email=email_from
             )
+        elif use_graph:
+            logger.error("Graph API enabled but credentials missing; refusing SMTP fallback")
+            raise ValueError("Graph API credentials are required for this domain.")
         else:
             # Use SMTP backend (for domains that don't have Graph API configured)
-            if use_graph:
-                logger.warning("Graph API enabled but credentials missing, falling back to SMTP")
 
             # Get SMTP settings with defaults to avoid KeyError
             connection = get_connection(


### PR DESCRIPTION
### Motivation

- Ensure all configured domains send mail via Microsoft Graph API and avoid accidental SMTP fallbacks.
- Allow a single M365 app/connection to be used across domains without per-domain Graph credentials.
- Make sure each domain has a real M365 mailbox as the default `FROM` address.
- Fail fast when Graph is enabled but credentials are missing to avoid silent delivery changes.

### Description

- Set `USE_GRAPH_API: True` for `crush.lu`, `powerup.lu`, and `vinsdelux.com` and remove per-domain SMTP settings.  
- Use shared environment variables `GRAPH_TENANT_ID`, `GRAPH_CLIENT_ID`, and `GRAPH_CLIENT_SECRET` for all domains (previous per-domain `*_GRAPH_*` lookups removed).  
- Add per-domain `DEFAULT_FROM_EMAIL` values (`CRUSH_DEFAULT_FROM_EMAIL`, `POWERUP_DEFAULT_FROM_EMAIL`, `VINSDELUX_DEFAULT_FROM_EMAIL`) defaulting to real mailbox addresses and still allow overrides via env vars.  
- When `USE_GRAPH_API` is true but Graph credentials are missing the code now logs an error and raises `ValueError` instead of falling back to SMTP, while `DEBUG` still uses the console backend.

### Testing

- No automated unit tests or CI were executed for this change.  
- Manual review and local linting only (no failures reported).  
- The code compiles/commits locally into the repository.  
- If you only have a single M365 connection, set the global `GRAPH_TENANT_ID`, `GRAPH_CLIENT_ID`, and `GRAPH_CLIENT_SECRET` env vars and the change will use that shared credential set for all domains.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fa5dc0b48330b3228f7b7624afab)