### PR TITLE
Add Membership Card section with Apple/Google Wallet actions and referral sharing

### DIFF
--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -127,6 +127,31 @@
             {% endif %}
         </div>
     </div>
+
+    <!-- Membership Card -->
+    <div class="bg-white rounded-xl shadow-sm h-full">
+        <div class="p-6">
+            <h5 class="font-semibold text-lg mb-2">{% trans "Membership Card" %}</h5>
+            <p class="text-gray-500 mb-4">{% trans "Save your Crush.lu membership card to your mobile wallet and share your referral link." %}</p>
+            <div class="flex flex-col sm:flex-row gap-3 flex-wrap">
+                <a href="{% url 'crush_lu:wallet_apple_pass' %}" class="btn-crush-primary inline-flex items-center gap-2 text-sm">
+                    {% include "shared/icons/arrow-down-tray.html" with class="w-4 h-4" %}
+                    {% trans "Add to Apple Wallet" %}
+                </a>
+                <a href="{% url 'crush_lu:wallet_google_save' %}" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-gray-300 text-gray-700 hover:bg-gray-50 rounded-lg transition-colors">
+                    {% include "shared/icons/device-mobile.html" with class="w-4 h-4" %}
+                    {% trans "Save to Google Wallet" %}
+                </a>
+            </div>
+            <div class="mt-4">
+                <button type="button" id="share-referral-btn" data-referral-url="{{ referral_url }}" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-purple-300 text-purple-600 hover:bg-purple-50 rounded-lg transition-colors">
+                    {% include "shared/icons/link.html" with class="w-4 h-4" %}
+                    {% trans "Share Referral Link" %}
+                </button>
+                <p id="share-referral-status" class="text-sm text-green-600 mt-2 hidden" role="status" aria-live="polite"></p>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="grid grid-cols-1 gap-6 mb-6">
@@ -221,6 +246,85 @@
     </div>
 </div>
 {% endif %}
+
+{% trans "Crush.lu" as referral_share_title %}
+{% trans "Join me on Crush.lu" as referral_share_text %}
+{% trans "Referral link shared!" as referral_shared_message %}
+{% trans "Referral link copied to clipboard." as referral_copied_message %}
+{% trans "Unable to copy referral link." as referral_copy_failed_message %}
+{% trans "Referral link unavailable." as referral_unavailable_message %}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const shareButton = document.getElementById('share-referral-btn');
+        if (!shareButton) {
+            return;
+        }
+
+        const statusElement = document.getElementById('share-referral-status');
+        const referralUrl = shareButton.dataset.referralUrl;
+        const shareTitle = "{{ referral_share_title|escapejs }}";
+        const shareText = "{{ referral_share_text|escapejs }}";
+        const sharedMessage = "{{ referral_shared_message|escapejs }}";
+        const copiedMessage = "{{ referral_copied_message|escapejs }}";
+        const copyFailedMessage = "{{ referral_copy_failed_message|escapejs }}";
+        const unavailableMessage = "{{ referral_unavailable_message|escapejs }}";
+
+        const setStatus = (message, isError = false) => {
+            if (!statusElement) {
+                return;
+            }
+            statusElement.textContent = message;
+            statusElement.classList.remove('hidden');
+            statusElement.classList.toggle('text-green-600', !isError);
+            statusElement.classList.toggle('text-red-600', isError);
+        };
+
+        shareButton.addEventListener('click', async () => {
+            if (!referralUrl) {
+                setStatus(unavailableMessage, true);
+                return;
+            }
+
+            if (navigator.share) {
+                try {
+                    await navigator.share({
+                        title: shareTitle,
+                        text: shareText,
+                        url: referralUrl,
+                    });
+                    setStatus(sharedMessage);
+                    return;
+                } catch (error) {
+                    if (error && error.name === 'AbortError') {
+                        return;
+                    }
+                }
+            }
+
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                try {
+                    await navigator.clipboard.writeText(referralUrl);
+                    setStatus(copiedMessage);
+                    return;
+                } catch (error) {
+                    // Fall back to legacy copy below.
+                }
+            }
+
+            const tempInput = document.createElement('input');
+            tempInput.value = referralUrl;
+            document.body.appendChild(tempInput);
+            tempInput.select();
+            const copied = document.execCommand('copy');
+            document.body.removeChild(tempInput);
+            if (copied) {
+                setStatus(copiedMessage);
+            } else {
+                setStatus(copyFailedMessage, true);
+            }
+        });
+    });
+</script>
 
 <!-- Styles are in static/crush_lu/css/pages/dashboard.css -->
 {% endblock %}

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -95,6 +95,10 @@ urlpatterns = [
     # Secure media serving
     path('media/profile/<int:user_id>/<str:photo_field>/', views_media.serve_profile_photo, name='serve_profile_photo'),
 
+    # Wallet passes
+    path('wallet/apple/pass/', views.wallet_apple_pass, name='wallet_apple_pass'),
+    path('wallet/google/save/', views.wallet_google_save, name='wallet_google_save'),
+
     # Landing and public pages
     path('', views.home, name='home'),
     path('about/', views.about, name='about'),


### PR DESCRIPTION
### Motivation
- Provide users an easy way to save a Crush.lu membership card to their mobile wallet (Apple Wallet / Google Wallet) from the dashboard.  
- On iOS, open a direct pass URL that will trigger Add to Wallet behavior when a `.pkpass` is served.  
- On Android, offer a Save to Google Wallet flow by redirecting to a configured JWT Save URL.  
- Let users share their referral link from the dashboard using the Web Share API with a clipboard fallback.

### Description
- Generate a backend `referral_url` in the dashboard view and add it to the template context using `reverse` and `urlencode` in `crush_lu/views.py`.  
- Add two wallet handler views `wallet_apple_pass` and `wallet_google_save` in `crush_lu/views.py` that redirect to `APPLE_WALLET_PASS_URL` and `GOOGLE_WALLET_SAVE_URL` respectively (configured via settings).  
- Register the new routes `/wallet/apple/pass/` and `/wallet/google/save/` in `crush_lu/urls.py`.  
- Update `crush_lu/templates/crush_lu/dashboard.html` to add a „Membership Card" card with buttons for Apple Wallet and Google Wallet and a `Share Referral Link` button that uses the Web Share API and falls back to `navigator.clipboard` or legacy copy behavior.

### Testing
- No automated tests were run against these changes in this rollout.  
- The changes are limited to view logic and templates and should be covered by functional/manual QA in a staging environment to verify redirects and the Share/clipboard UX.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595cfede70833096488879d9865484)