### PR TITLE
Fix account deletion cleanup and guard profile lookup; add tests

### DIFF
--- a/crush_lu/context_processors.py
+++ b/crush_lu/context_processors.py
@@ -33,8 +33,8 @@ def crush_user_context(request):
 
         # Profile submission status for visual indicators
         profile_submission = None
-        if hasattr(request.user, 'crushprofile'):
-            profile = request.user.crushprofile
+        profile = CrushProfile.objects.filter(user=request.user).first()
+        if profile:
             context['profile_completion_status'] = profile.completion_status
 
             profile_submission = ProfileSubmission.objects.filter(

--- a/crush_lu/tests/test_account_deletion.py
+++ b/crush_lu/tests/test_account_deletion.py
@@ -1,0 +1,93 @@
+"""
+Account deletion tests for Crush.lu.
+
+Run with: pytest crush_lu/tests/test_account_deletion.py -v
+"""
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory
+from django.utils import timezone
+
+
+class AccountDeletionTests(TestCase):
+    def setUp(self):
+        from django.contrib.auth import get_user_model
+        from crush_lu.models import MeetupEvent, CrushProfile
+
+        self.factory = RequestFactory()
+        self.User = get_user_model()
+
+        self.user = self.User.objects.create_user(
+            username='deleteme@example.com',
+            email='deleteme@example.com',
+            password='testpass123',
+            first_name='Delete',
+            last_name='Me'
+        )
+
+        self.other_user = self.User.objects.create_user(
+            username='other@example.com',
+            email='other@example.com',
+            password='testpass123',
+            first_name='Other',
+            last_name='User'
+        )
+
+        self.event = MeetupEvent.objects.create(
+            title='Deletion Test Event',
+            description='Event for deletion tests',
+            event_type='mixer',
+            date_time=timezone.now() - timedelta(hours=2),
+            location='Luxembourg',
+            address='123 Test Street',
+            max_participants=20,
+            registration_deadline=timezone.now() - timedelta(days=3),
+            is_published=True
+        )
+
+        for user, gender in [(self.user, 'M'), (self.other_user, 'F')]:
+            CrushProfile.objects.create(
+                user=user,
+                date_of_birth=date(1995, 5, 15),
+                gender=gender,
+                location='Luxembourg',
+                is_approved=True,
+                is_active=True
+            )
+
+    @patch('crush_lu.views.delete_user_storage', return_value=(True, 0))
+    def test_delete_user_data_removes_connections_and_messages(self, _mock_storage):
+        from crush_lu.models import EventConnection, ConnectionMessage
+        from crush_lu.views import delete_user_data
+
+        connection = EventConnection.objects.create(
+            event=self.event,
+            requester=self.user,
+            recipient=self.other_user
+        )
+        ConnectionMessage.objects.create(
+            connection=connection,
+            sender=self.user,
+            message='hello'
+        )
+
+        delete_user_data(self.user, confirmation_code='test-code')
+
+        self.assertFalse(EventConnection.objects.exists())
+        self.assertFalse(ConnectionMessage.objects.exists())
+
+    def test_crush_user_context_handles_deleted_profile(self):
+        from crush_lu.context_processors import crush_user_context
+        from crush_lu.models import CrushProfile
+
+        profile = self.user.crushprofile
+        profile.delete()
+
+        request = self.factory.get('/fake-path/')
+        request.user = self.user
+
+        context = crush_user_context(request)
+
+        self.assertNotIn('profile_completion_status', context)
+

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -328,11 +328,15 @@ def delete_user_data(user, confirmation_code):
         # Delete EventRegistrations
         EventRegistration.objects.filter(user=user).delete()
 
-        # Delete EventConnections (both as user1 and user2)
-        EventConnection.objects.filter(Q(user1=user) | Q(user2=user)).delete()
-
         # Delete ConnectionMessages
-        ConnectionMessage.objects.filter(Q(sender=user) | Q(recipient=user)).delete()
+        ConnectionMessage.objects.filter(
+            Q(sender=user)
+            | Q(connection__requester=user)
+            | Q(connection__recipient=user)
+        ).delete()
+
+        # Delete EventConnections (both as requester and recipient)
+        EventConnection.objects.filter(Q(requester=user) | Q(recipient=user)).delete()
 
         # Delete CoachSessions
         CoachSession.objects.filter(user=user).delete()
@@ -3587,4 +3591,3 @@ def pwa_debug_view(request):
     return render(request, 'crush_lu/pwa_debug.html', {
         'sw_version': 'crush-v16-icon-cache-fix',  # Keep in sync with sw-workbox.js
     })
-


### PR DESCRIPTION
### Motivation
- Ensure user data deletion removes all connection-related messages and avoids leaving orphaned `EventConnection` records.
- Prevent attribute access errors in the context processor when a user has a deleted or unsaved `CrushProfile`.
- Add automated tests that validate deletion behavior and context handling after profile deletion.

### Description
- Adjusted deletion logic in `delete_user_data` to remove `ConnectionMessage` rows linked via `connection__requester`/`connection__recipient` before deleting `EventConnection` rows.
- Replaced incorrect `EventConnection` filters that referenced `user1`/`user2` with the correct `requester`/`recipient` fields.
- Guarded profile lookup in `crush_user_context` by using `CrushProfile.objects.filter(user=request.user).first()` and checking for a profile before accessing attributes.
- Added `crush_lu/tests/test_account_deletion.py` containing tests for `delete_user_data` cleanup and for `crush_user_context` behavior when a profile is deleted.

### Testing
- Added unit tests in `crush_lu/tests/test_account_deletion.py` that cover connection/message cleanup and deleted-profile context behavior.
- The deletion test patches `delete_user_storage` and verifies that `EventConnection` and `ConnectionMessage` records are removed after `delete_user_data` runs.
- The context processor test deletes a `CrushProfile` and asserts `profile_completion_status` is not present in the returned context.
- No automated test suite was executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596d4b814c8330abcd4a2b0f07dd93)