### PR TITLE
Remove duplicate `user` kwarg from welcome email context

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -167,7 +167,6 @@ def send_welcome_email(user, request):
 
     context = get_email_context_with_unsubscribe(user, request,
         first_name=user.first_name,
-        user=user,
         profile_url=profile_url,
         how_it_works_url=how_it_works_url,
     )


### PR DESCRIPTION
### Motivation
- Fix a TypeError in the welcome email flow caused by passing `user` twice to `get_email_context_with_unsubscribe`.
- The helper already receives `user` as its first positional argument, so the extra `user=user` kwarg conflicted with the call.
- Keep the other required context values (`first_name`, `profile_url`, `how_it_works_url`) while removing the duplicate.

### Description
- Updated `send_welcome_email` in `crush_lu/email_helpers.py` to remove the `user=user` keyword argument when calling `get_email_context_with_unsubscribe`.
- Preserved passing of `first_name`, `profile_url`, and `how_it_works_url` into the email context.
- No other functional changes were made.

### Testing
- Ran `pytest crush_lu/tests/test_profiles.py::RegistrationFlowTests::test_user_can_register_and_create_profile` to exercise the signup/welcome flow but the run hung in the email transport and was interrupted.
- Because the test run was interrupted, automated confirmation of the TypeError fix via that test could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598604e42c8330bd5fb55a0c73aac8)