### PR TITLE
Initialize CrushProfile language from request/session and fallback to request locale for email URLs

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -37,6 +37,10 @@ def get_user_language_url(user, url_name, request, **kwargs):
             lang = profile_lang
         elif profile_lang:
             logger.warning(f"User {user.id} has invalid language: {profile_lang}, using 'en'")
+    else:
+        request_language = getattr(request, 'LANGUAGE_CODE', None)
+        if request_language in ['en', 'de', 'fr']:
+            lang = request_language
 
     # Use override() context manager for thread-safety
     # This ensures language state is reset after the block

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -117,12 +117,22 @@ def create_crush_profile_on_login(sender, request, user, **kwargs):
         logger.debug(f"Skipping CrushProfile creation for delegation subdomain: {host}")
         return
 
+    preferred_language = 'en'
+    request_language = getattr(request, 'LANGUAGE_CODE', None)
+    if request_language in ['en', 'de', 'fr']:
+        preferred_language = request_language
+    else:
+        session_language = request.session.get('django_language')
+        if session_language in ['en', 'de', 'fr']:
+            preferred_language = session_language
+
     try:
         # Use get_or_create to avoid duplicates
         profile, created = CrushProfile.objects.get_or_create(
             user=user,
             defaults={
                 'completion_status': 'not_started',  # Mark as not started
+                'preferred_language': preferred_language,
             }
         )
 


### PR DESCRIPTION
### Motivation

- Ensure new users who sign up from non-English pages (e.g., `/fr/` or `/de/`) receive a matching `preferred_language` on their `CrushProfile` rather than the default `en`.
- Allow email URL generation to use the request-level locale when a user profile is not yet present so outbound emails use the correct language prefix.
- Keep the existing post-login sync behavior (`sync_language_preference_on_login`) for later adjustments.

### Description

- In `crush_lu/signals.py` inside `create_crush_profile_on_login` determine `preferred_language` from `request.LANGUAGE_CODE` or `request.session['django_language']` when the value is one of `['en', 'de', 'fr']`, and pass it to `CrushProfile.objects.get_or_create` via the `defaults` dict.
- In `crush_lu/email_helpers.py` update `get_user_language_url` to fall back to `request.LANGUAGE_CODE` when the `user` has no `crushprofile`, validating it against `['en', 'de', 'fr']` before use.
- Modified files: `crush_lu/signals.py` and `crush_lu/email_helpers.py`, and no changes were made to `sync_language_preference_on_login` logic.

### Testing

- No automated tests were executed as part of this change.
- Existing code paths that rely on `get_user_language_url` and profile creation will now pick up the request/session locale when appropriate.
- Manual verification is recommended in dev/staging by signing up on `/fr/` and `/de/` and inspecting the created `CrushProfile.preferred_language` and generated email URLs.
- Unit tests covering `get_user_language_url` and profile language sync should be run to confirm behavior in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598e35bb408330aa3a91f39b9d2271)