### PR TITLE
fix(phone-verification): CSP-safe Alpine.js expressions for phone verification

### DIFF
--- a/crush_lu/templates/crush_lu/create_profile.html
+++ b/crush_lu/templates/crush_lu/create_profile.html
@@ -180,7 +180,7 @@
                                 @click="startVerification"
                                 x-bind:disabled="cannotVerify"
                                 class="px-5 py-3 bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold rounded-lg hover:from-purple-700 hover:to-pink-600 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 flex items-center gap-2 shadow-lg hover:shadow-xl hover:scale-105 disabled:hover:scale-100"
-                                x-bind:class="cannotVerify ? '' : 'animate-pulse-subtle'">
+                                x-bind:class="verifyButtonPulseClass">
                             {% include "shared/icons/shield-check.html" with class="w-5 h-5" %}
                             <span>{% trans "Verify" %}</span>
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -190,7 +190,7 @@
                         <!-- Change phone number button removed - users must contact support to change verified phone -->
                     </div>
 
-                    <p class="text-sm mt-2" x-bind:class="notVerified ? 'text-purple-600 font-medium' : 'text-gray-500'">
+                    <p class="text-sm mt-2" x-bind:class="phoneHintClass">
                         <span x-show="notVerified" class="inline-flex items-center gap-1">
                             <svg class="w-4 h-4 animate-bounce" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"/>

--- a/static/crush_lu/js/alpine-components.js
+++ b/static/crush_lu/js/alpine-components.js
@@ -2038,6 +2038,8 @@ document.addEventListener('alpine:init', function() {
             get notVerified() { return !this.verified; },
             get cannotVerify() { return !this.canVerify; },
             get verifiedValue() { return this.verified ? 'true' : 'false'; },
+            get verifyButtonPulseClass() { return this.canVerify ? 'animate-pulse-subtle' : ''; },
+            get phoneHintClass() { return !this.verified ? 'text-purple-600 font-medium' : 'text-gray-500'; },
 
             init: function() {
                 var self = this;


### PR DESCRIPTION
## Summary
- Fix Alpine.js CSP violations in phone verification component on create profile page
- Add computed getters `verifyButtonPulseClass` and `phoneHintClass` to `phoneVerificationComponent`
- Replace inline ternary expressions with CSP-safe getter references

## Problem
The phone verification UI was throwing CSP errors in production:
```
Alpine Error: Alpine is unable to interpret the following expression using the CSP-friendly build:
"cannotVerify ? '' : 'animate-pulse-subtle'"
"notVerified ? 'text-purple-600 font-medium' : 'text-gray-500'"
```

## Solution
Added computed getters in `alpine-components.js` that return the class strings directly:
```javascript
get verifyButtonPulseClass() { return this.canVerify ? 'animate-pulse-subtle' : ''; },
get phoneHintClass() { return !this.verified ? 'text-purple-600 font-medium' : 'text-gray-500'; },
```

## Files Changed
- `static/crush_lu/js/alpine-components.js` - Added 2 computed getters
- `crush_lu/templates/crush_lu/create_profile.html` - Updated x-bind:class to use getters

## Test plan
- [ ] Verify phone verification UI renders without CSP errors
- [ ] Test verify button shows pulse animation when phone is valid
- [ ] Test hint text styling changes between verified/unverified states
- [ ] Test full phone verification flow (send code → enter OTP → verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)