### PR TITLE
feat(arborist): Add new arborist.lu domain and app

### DIFF
--- a/arborist/__init__.py
+++ b/arborist/__init__.py
@@ -1,0 +1,1 @@
+# Arborist app package

--- a/arborist/admin.py
+++ b/arborist/admin.py
@@ -1,0 +1,33 @@
+from django.contrib import admin
+
+
+# ============================================================================
+# CUSTOM ADMIN SITE - Arborist Administration
+# ============================================================================
+
+
+class ArboristAdminSite(admin.AdminSite):
+    """
+    Custom admin site for Arborist informational site.
+
+    This admin panel manages the arborist.lu domain.
+    Currently a static site, but this admin provides a consistent
+    experience across all platform admin panels.
+    """
+
+    site_header = "Arborist Administration"
+    site_title = "Arborist Admin"
+    index_title = "Site Management"
+
+    def get_app_list(self, request, app_label=None):
+        """
+        Override to customize the admin index page.
+        Arborist is currently a static site with no models,
+        but this can be extended in the future.
+        """
+        app_list = super().get_app_list(request, app_label)
+        return app_list
+
+
+# Instantiate the custom admin site
+arborist_admin_site = ArboristAdminSite(name="arborist_admin")

--- a/arborist/apps.py
+++ b/arborist/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class ArboristConfig(AppConfig):
+    """Configuration for the Arborist informational site app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "arborist"
+    verbose_name = "Arborist"

--- a/arborist/migrations/__init__.py
+++ b/arborist/migrations/__init__.py
@@ -1,0 +1,1 @@
+# Arborist migrations package

--- a/arborist/models.py
+++ b/arborist/models.py
@@ -1,0 +1,6 @@
+"""
+Models for Arborist app.
+
+Currently a static informational site with no database models.
+Add models here as needed for future functionality.
+"""

--- a/arborist/templates/arborist/about.html
+++ b/arborist/templates/arborist/about.html
@@ -1,0 +1,89 @@
+{% extends "arborist/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<!-- Header -->
+<section class="bg-green-800 text-white py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto text-center">
+            <h1 class="text-4xl font-bold mb-4">
+                {% trans "About Us" %}
+            </h1>
+            <p class="text-xl">
+                {% trans "Dedicated to preserving and caring for Luxembourg's trees." %}
+            </p>
+        </div>
+    </div>
+</section>
+
+<!-- Our Story -->
+<section class="py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto">
+            <h2 class="text-3xl font-bold mb-8 text-green-800">
+                {% trans "Our Story" %}
+            </h2>
+            <div class="text-gray-700 space-y-4">
+                <p class="text-lg">
+                    {% trans "Arborist was founded with a simple mission: to provide professional, reliable tree care services to the people of Luxembourg." %}
+                </p>
+                <p class="text-lg">
+                    {% trans "Our team of certified arborists brings years of experience and a deep passion for trees. We understand that trees are valuable assets to any property, providing beauty, shade, and environmental benefits." %}
+                </p>
+                <p class="text-lg">
+                    {% trans "Whether you need routine maintenance, emergency tree removal, or expert consultation, we're here to help with professionalism and care." %}
+                </p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Values -->
+<section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto">
+            <h2 class="text-3xl font-bold mb-8 text-center text-green-800">
+                {% trans "Our Values" %}
+            </h2>
+            <div class="grid md:grid-cols-3 gap-8">
+                <div class="text-center">
+                    <div class="text-4xl mb-4">🌱</div>
+                    <h3 class="text-xl font-semibold mb-2">{% trans "Sustainability" %}</h3>
+                    <p class="text-gray-600">
+                        {% trans "We prioritize tree preservation and environmentally responsible practices." %}
+                    </p>
+                </div>
+                <div class="text-center">
+                    <div class="text-4xl mb-4">⚡</div>
+                    <h3 class="text-xl font-semibold mb-2">{% trans "Excellence" %}</h3>
+                    <p class="text-gray-600">
+                        {% trans "We maintain the highest standards of professionalism and quality." %}
+                    </p>
+                </div>
+                <div class="text-center">
+                    <div class="text-4xl mb-4">🤝</div>
+                    <h3 class="text-xl font-semibold mb-2">{% trans "Trust" %}</h3>
+                    <p class="text-gray-600">
+                        {% trans "We build lasting relationships through honesty and reliability." %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- CTA -->
+<section class="py-16 bg-green-800 text-white">
+    <div class="container mx-auto px-4 text-center">
+        <h2 class="text-3xl font-bold mb-4">
+            {% trans "Let's Work Together" %}
+        </h2>
+        <p class="text-xl mb-8">
+            {% trans "Contact us to discuss your tree care needs." %}
+        </p>
+        <a href="{% url 'arborist:contact' %}" class="btn" style="background: #fff; color: #2d5016;">
+            {% trans "Get in Touch" %}
+        </a>
+    </div>
+</section>
+{% endblock %}

--- a/arborist/templates/arborist/base.html
+++ b/arborist/templates/arborist/base.html
@@ -1,0 +1,123 @@
+{% load static %}
+{% load i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ page_title|default:"Arborist" }}{% endblock %}</title>
+
+    <!-- Theme Color -->
+    <meta name="theme-color" content="#2d5016">
+    <meta name="msapplication-TileColor" content="#2d5016">
+
+    <!-- Tailwind CSS (using shared base styles) -->
+    <style>
+        /* Base Tailwind-like styles for Arborist */
+        *, *::before, *::after { box-sizing: border-box; }
+        body { margin: 0; font-family: system-ui, -apple-system, sans-serif; line-height: 1.5; }
+        .container { max-width: 1200px; margin: 0 auto; padding: 0 1rem; }
+        .bg-green-800 { background-color: #2d5016; }
+        .bg-green-700 { background-color: #3d6b1f; }
+        .bg-green-600 { background-color: #4d8428; }
+        .bg-green-100 { background-color: #dcfce7; }
+        .bg-green-50 { background-color: #f0fdf4; }
+        .bg-white { background-color: #fff; }
+        .bg-gray-50 { background-color: #f9fafb; }
+        .bg-gray-900 { background-color: #111827; }
+        .text-white { color: #fff; }
+        .text-gray-600 { color: #4b5563; }
+        .text-gray-700 { color: #374151; }
+        .text-gray-900 { color: #111827; }
+        .text-green-800 { color: #2d5016; }
+        .text-green-600 { color: #4d8428; }
+        .font-bold { font-weight: 700; }
+        .font-semibold { font-weight: 600; }
+        .text-xl { font-size: 1.25rem; }
+        .text-2xl { font-size: 1.5rem; }
+        .text-3xl { font-size: 1.875rem; }
+        .text-4xl { font-size: 2.25rem; }
+        .text-lg { font-size: 1.125rem; }
+        .text-sm { font-size: 0.875rem; }
+        .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+        .py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+        .py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+        .py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+        .py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+        .py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+        .px-4 { padding-left: 1rem; padding-right: 1rem; }
+        .px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+        .px-8 { padding-left: 2rem; padding-right: 2rem; }
+        .mt-4 { margin-top: 1rem; }
+        .mt-8 { margin-top: 2rem; }
+        .mb-4 { margin-bottom: 1rem; }
+        .mb-8 { margin-bottom: 2rem; }
+        .mx-auto { margin-left: auto; margin-right: auto; }
+        .flex { display: flex; }
+        .grid { display: grid; }
+        .items-center { align-items: center; }
+        .justify-between { justify-content: space-between; }
+        .justify-center { justify-content: center; }
+        .gap-4 { gap: 1rem; }
+        .gap-8 { gap: 2rem; }
+        .space-x-4 > * + * { margin-left: 1rem; }
+        .space-x-8 > * + * { margin-left: 2rem; }
+        .rounded { border-radius: 0.25rem; }
+        .rounded-lg { border-radius: 0.5rem; }
+        .rounded-xl { border-radius: 0.75rem; }
+        .shadow { box-shadow: 0 1px 3px rgba(0,0,0,.1); }
+        .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,.1); }
+        .max-w-2xl { max-width: 42rem; }
+        .max-w-4xl { max-width: 56rem; }
+        .max-w-6xl { max-width: 72rem; }
+        .w-full { width: 100%; }
+        .h-16 { height: 4rem; }
+        .min-h-screen { min-height: 100vh; }
+        a { color: inherit; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        .btn { display: inline-block; padding: 0.75rem 1.5rem; border-radius: 0.5rem; font-weight: 600; text-decoration: none; transition: background-color 0.2s; }
+        .btn:hover { text-decoration: none; }
+        .btn-primary { background-color: #2d5016; color: #fff; }
+        .btn-primary:hover { background-color: #3d6b1f; }
+        .btn-secondary { background-color: #fff; color: #2d5016; border: 2px solid #2d5016; }
+        .btn-secondary:hover { background-color: #f0fdf4; }
+        .card { background: #fff; border-radius: 0.75rem; box-shadow: 0 4px 6px -1px rgba(0,0,0,.1); padding: 1.5rem; }
+        .list-none { list-style: none; padding: 0; margin: 0; }
+        @media (min-width: 768px) {
+            .md\\:flex { display: flex; }
+            .md\\:hidden { display: none; }
+            .md\\:grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
+            .md\\:grid-cols-3 { grid-template-columns: repeat(3, 1fr); }
+            .md\\:text-5xl { font-size: 3rem; }
+        }
+        .hidden { display: none; }
+    </style>
+
+    <!-- SEO Meta Tags -->
+    <meta name="description" content="{% block meta_description %}{{ meta_description|default:"Professional arborist services in Luxembourg." }}{% endblock %}">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://arborist.lu{{ request.path }}">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:title" content="{% block og_title %}{{ page_title|default:"Arborist" }}{% endblock %}">
+    <meta property="og:description" content="{{ meta_description|default:"Professional arborist services in Luxembourg." }}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://arborist.lu{{ request.path }}">
+    <meta property="og:site_name" content="Arborist">
+    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+
+    {% block extra_head %}{% endblock %}
+</head>
+<body class="bg-white text-gray-900">
+    {% include "arborist/partials/navigation.html" %}
+
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+
+    {% include "arborist/partials/footer.html" %}
+
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/arborist/templates/arborist/contact.html
+++ b/arborist/templates/arborist/contact.html
@@ -1,0 +1,110 @@
+{% extends "arborist/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<!-- Header -->
+<section class="bg-green-800 text-white py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto text-center">
+            <h1 class="text-4xl font-bold mb-4">
+                {% trans "Contact Us" %}
+            </h1>
+            <p class="text-xl">
+                {% trans "Get in touch for a free consultation and quote." %}
+            </p>
+        </div>
+    </div>
+</section>
+
+<!-- Contact Info -->
+<section class="py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto">
+            <div class="grid md:grid-cols-2 gap-8">
+                <!-- Contact Details -->
+                <div>
+                    <h2 class="text-2xl font-bold mb-6 text-green-800">
+                        {% trans "Get in Touch" %}
+                    </h2>
+                    <div class="space-y-4">
+                        <div class="flex gap-4">
+                            <div class="text-2xl">📍</div>
+                            <div>
+                                <h3 class="font-semibold">{% trans "Address" %}</h3>
+                                <p class="text-gray-600">Luxembourg</p>
+                            </div>
+                        </div>
+                        <div class="flex gap-4">
+                            <div class="text-2xl">📞</div>
+                            <div>
+                                <h3 class="font-semibold">{% trans "Phone" %}</h3>
+                                <p class="text-gray-600">+352 XXX XXX XXX</p>
+                            </div>
+                        </div>
+                        <div class="flex gap-4">
+                            <div class="text-2xl">📧</div>
+                            <div>
+                                <h3 class="font-semibold">{% trans "Email" %}</h3>
+                                <p class="text-gray-600">info@arborist.lu</p>
+                            </div>
+                        </div>
+                        <div class="flex gap-4">
+                            <div class="text-2xl">🕐</div>
+                            <div>
+                                <h3 class="font-semibold">{% trans "Hours" %}</h3>
+                                <p class="text-gray-600">{% trans "Monday - Friday: 8:00 - 18:00" %}</p>
+                                <p class="text-gray-600">{% trans "Saturday: 9:00 - 14:00" %}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Quick Info -->
+                <div class="card bg-green-50">
+                    <h2 class="text-2xl font-bold mb-6 text-green-800">
+                        {% trans "Free Consultation" %}
+                    </h2>
+                    <p class="text-gray-700 mb-6">
+                        {% trans "We offer free on-site consultations for all tree care projects. Our experts will assess your needs and provide a detailed quote with no obligation." %}
+                    </p>
+                    <div class="space-y-3">
+                        <div class="flex gap-2">
+                            <span class="text-green-600">✓</span>
+                            <span>{% trans "No obligation quote" %}</span>
+                        </div>
+                        <div class="flex gap-2">
+                            <span class="text-green-600">✓</span>
+                            <span>{% trans "Expert assessment" %}</span>
+                        </div>
+                        <div class="flex gap-2">
+                            <span class="text-green-600">✓</span>
+                            <span>{% trans "Flexible scheduling" %}</span>
+                        </div>
+                        <div class="flex gap-2">
+                            <span class="text-green-600">✓</span>
+                            <span>{% trans "Written recommendations" %}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Service Areas -->
+<section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto text-center">
+            <h2 class="text-2xl font-bold mb-6 text-green-800">
+                {% trans "Service Areas" %}
+            </h2>
+            <p class="text-gray-600 mb-4">
+                {% trans "We provide tree care services throughout Luxembourg, including:" %}
+            </p>
+            <p class="text-gray-700">
+                Luxembourg City • Esch-sur-Alzette • Differdange • Dudelange • Ettelbruck • Diekirch • Wiltz • Echternach
+            </p>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/arborist/templates/arborist/home.html
+++ b/arborist/templates/arborist/home.html
@@ -1,0 +1,114 @@
+{% extends "arborist/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<!-- Hero Section -->
+<section class="bg-green-800 text-white py-20">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto text-center">
+            <h1 class="text-4xl md:text-5xl font-bold mb-4">
+                {% trans "Professional Tree Care Services" %}
+            </h1>
+            <p class="text-xl mb-8">
+                {% trans "Expert arborist services in Luxembourg. Pruning, removal, health assessment, and consultation." %}
+            </p>
+            <div class="flex justify-center gap-4">
+                <a href="{% url 'arborist:services' %}" class="btn btn-secondary">
+                    {% trans "Our Services" %}
+                </a>
+                <a href="{% url 'arborist:contact' %}" class="btn btn-primary" style="background: #fff; color: #2d5016;">
+                    {% trans "Get a Quote" %}
+                </a>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Services Overview -->
+<section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4">
+        <h2 class="text-3xl font-bold text-center mb-8 text-green-800">
+            {% trans "What We Do" %}
+        </h2>
+        <div class="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+            <div class="card text-center">
+                <div class="text-4xl mb-4">🌳</div>
+                <h3 class="text-xl font-semibold mb-2 text-green-800">{% trans "Tree Pruning" %}</h3>
+                <p class="text-gray-600">
+                    {% trans "Professional pruning to maintain tree health, shape, and safety." %}
+                </p>
+            </div>
+            <div class="card text-center">
+                <div class="text-4xl mb-4">🪓</div>
+                <h3 class="text-xl font-semibold mb-2 text-green-800">{% trans "Tree Removal" %}</h3>
+                <p class="text-gray-600">
+                    {% trans "Safe and efficient removal of hazardous or unwanted trees." %}
+                </p>
+            </div>
+            <div class="card text-center">
+                <div class="text-4xl mb-4">🔍</div>
+                <h3 class="text-xl font-semibold mb-2 text-green-800">{% trans "Health Assessment" %}</h3>
+                <p class="text-gray-600">
+                    {% trans "Expert diagnosis and treatment plans for tree diseases." %}
+                </p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Why Choose Us -->
+<section class="py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto">
+            <h2 class="text-3xl font-bold text-center mb-8 text-green-800">
+                {% trans "Why Choose Arborist?" %}
+            </h2>
+            <div class="grid md:grid-cols-2 gap-8">
+                <div class="flex gap-4">
+                    <div class="text-green-600 text-2xl">✓</div>
+                    <div>
+                        <h3 class="font-semibold text-lg">{% trans "Certified Professionals" %}</h3>
+                        <p class="text-gray-600">{% trans "Our team holds industry-recognized certifications." %}</p>
+                    </div>
+                </div>
+                <div class="flex gap-4">
+                    <div class="text-green-600 text-2xl">✓</div>
+                    <div>
+                        <h3 class="font-semibold text-lg">{% trans "Fully Insured" %}</h3>
+                        <p class="text-gray-600">{% trans "Complete liability coverage for your peace of mind." %}</p>
+                    </div>
+                </div>
+                <div class="flex gap-4">
+                    <div class="text-green-600 text-2xl">✓</div>
+                    <div>
+                        <h3 class="font-semibold text-lg">{% trans "Local Expertise" %}</h3>
+                        <p class="text-gray-600">{% trans "Deep knowledge of Luxembourg's native trees and regulations." %}</p>
+                    </div>
+                </div>
+                <div class="flex gap-4">
+                    <div class="text-green-600 text-2xl">✓</div>
+                    <div>
+                        <h3 class="font-semibold text-lg">{% trans "Free Consultation" %}</h3>
+                        <p class="text-gray-600">{% trans "No-obligation assessment and quote for your project." %}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- CTA Section -->
+<section class="py-16 bg-green-800 text-white">
+    <div class="container mx-auto px-4 text-center">
+        <h2 class="text-3xl font-bold mb-4">
+            {% trans "Ready to Get Started?" %}
+        </h2>
+        <p class="text-xl mb-8">
+            {% trans "Contact us today for a free consultation and quote." %}
+        </p>
+        <a href="{% url 'arborist:contact' %}" class="btn" style="background: #fff; color: #2d5016;">
+            {% trans "Contact Us" %}
+        </a>
+    </div>
+</section>
+{% endblock %}

--- a/arborist/templates/arborist/partials/footer.html
+++ b/arborist/templates/arborist/partials/footer.html
@@ -1,0 +1,91 @@
+{% load i18n %}
+<footer class="bg-gray-900 text-white" style="background: #111827; color: #fff;">
+    <div class="container mx-auto px-4 py-12">
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 2rem;">
+            <!-- Brand -->
+            <div>
+                <div style="font-size: 1.5rem; font-weight: bold; margin-bottom: 1rem;">
+                    🌳 Arborist
+                </div>
+                <p style="color: #9ca3af; max-width: 20rem;">
+                    {% trans "Professional tree care services in Luxembourg. Expert arborists dedicated to preserving and maintaining your trees." %}
+                </p>
+            </div>
+
+            <!-- Navigation -->
+            <div>
+                <h3 style="font-size: 0.875rem; font-weight: 600; color: #d1d5db; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 1rem;">
+                    {% trans "Company" %}
+                </h3>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.75rem;">
+                        <a href="{% url 'arborist:about' %}" style="color: #9ca3af; transition: color 0.2s;"
+                           onmouseover="this.style.color='#fff'" onmouseout="this.style.color='#9ca3af'">
+                            {% trans "About" %}
+                        </a>
+                    </li>
+                    <li style="margin-bottom: 0.75rem;">
+                        <a href="{% url 'arborist:services' %}" style="color: #9ca3af; transition: color 0.2s;"
+                           onmouseover="this.style.color='#fff'" onmouseout="this.style.color='#9ca3af'">
+                            {% trans "Services" %}
+                        </a>
+                    </li>
+                    <li style="margin-bottom: 0.75rem;">
+                        <a href="{% url 'arborist:contact' %}" style="color: #9ca3af; transition: color 0.2s;"
+                           onmouseover="this.style.color='#fff'" onmouseout="this.style.color='#9ca3af'">
+                            {% trans "Contact" %}
+                        </a>
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Services -->
+            <div>
+                <h3 style="font-size: 0.875rem; font-weight: 600; color: #d1d5db; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 1rem;">
+                    {% trans "Services" %}
+                </h3>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.75rem; color: #9ca3af;">
+                        {% trans "Tree Pruning" %}
+                    </li>
+                    <li style="margin-bottom: 0.75rem; color: #9ca3af;">
+                        {% trans "Tree Removal" %}
+                    </li>
+                    <li style="margin-bottom: 0.75rem; color: #9ca3af;">
+                        {% trans "Health Assessment" %}
+                    </li>
+                    <li style="margin-bottom: 0.75rem; color: #9ca3af;">
+                        {% trans "Consultation" %}
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Contact -->
+            <div>
+                <h3 style="font-size: 0.875rem; font-weight: 600; color: #d1d5db; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 1rem;">
+                    {% trans "Contact" %}
+                </h3>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                    <li style="margin-bottom: 0.75rem; color: #9ca3af;">
+                        📍 Luxembourg
+                    </li>
+                    <li style="margin-bottom: 0.75rem; color: #9ca3af;">
+                        📧 info@arborist.lu
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Bottom bar -->
+        <div style="margin-top: 3rem; padding-top: 2rem; border-top: 1px solid #374151;">
+            <div style="display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 1rem;">
+                <p style="color: #9ca3af; font-size: 0.875rem;">
+                    &copy; {% now "Y" %} Arborist. {% trans "All rights reserved." %}
+                </p>
+                <p style="color: #6b7280; font-size: 0.875rem;">
+                    {% trans "Made in Luxembourg" %} 🇱🇺
+                </p>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/arborist/templates/arborist/partials/language_switcher.html
+++ b/arborist/templates/arborist/partials/language_switcher.html
@@ -1,0 +1,79 @@
+{% load i18n %}
+{# Language Switcher for Arborist #}
+
+{% get_current_language as CURRENT_LANGUAGE %}
+{% get_available_languages as AVAILABLE_LANGUAGES %}
+
+{% if mobile %}
+{# Mobile version - simple select dropdown #}
+<div style="padding: 0.5rem 0;">
+    <form action="{% url 'set_language' %}" method="post" style="display: flex; align-items: center; gap: 0.5rem;">
+        {% csrf_token %}
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="language-mobile" style="color: #4b5563; font-size: 0.875rem; display: flex; align-items: center; gap: 0.25rem;">
+            <svg style="width: 1rem; height: 1rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
+            </svg>
+        </label>
+        <select name="language" id="language-mobile"
+                onchange="this.form.submit()"
+                style="flex: 1; background: #f3f4f6; border: 1px solid #e5e7eb; color: #374151; border-radius: 0.5rem; padding: 0.375rem 0.75rem; font-size: 0.875rem;">
+            {% for lang_code, lang_name in AVAILABLE_LANGUAGES %}
+                <option value="{{ lang_code }}" {% if lang_code == CURRENT_LANGUAGE %}selected{% endif %}>
+                    {{ lang_name }}
+                </option>
+            {% endfor %}
+        </select>
+        <noscript>
+            <button type="submit" style="background: #2d5016; color: #fff; border-radius: 0.5rem; padding: 0.375rem 0.75rem; font-size: 0.875rem; border: none; cursor: pointer;">
+                {% trans "Go" %}
+            </button>
+        </noscript>
+    </form>
+</div>
+{% else %}
+{# Desktop version - dropdown #}
+<div style="position: relative;" class="lang-dropdown">
+    <button type="button"
+            style="color: #4b5563; font-weight: 500; display: flex; align-items: center; gap: 0.25rem; padding: 0.25rem 0.5rem; border-radius: 0.5rem; background: transparent; border: none; cursor: pointer;"
+            onclick="this.parentElement.classList.toggle('open')">
+        <svg style="width: 1rem; height: 1rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
+        </svg>
+        <span style="text-transform: uppercase; font-size: 0.75rem; font-weight: 500;">{{ CURRENT_LANGUAGE }}</span>
+        <svg style="width: 0.75rem; height: 0.75rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+    </button>
+
+    <div class="lang-menu" style="position: absolute; right: 0; margin-top: 0.5rem; width: 8rem; background: #fff; border-radius: 0.5rem; box-shadow: 0 10px 15px -3px rgba(0,0,0,.1); padding: 0.25rem 0; z-index: 50; display: none;">
+        {% for lang_code, lang_name in AVAILABLE_LANGUAGES %}
+            <form action="{% url 'set_language' %}" method="post" style="display: block;">
+                {% csrf_token %}
+                <input type="hidden" name="language" value="{{ lang_code }}">
+                <input type="hidden" name="next" value="{{ request.path }}">
+                <button type="submit"
+                        style="width: 100%; text-align: left; padding: 0.5rem 1rem; font-size: 0.875rem; color: #374151; background: {% if lang_code == CURRENT_LANGUAGE %}#f0fdf4{% else %}transparent{% endif %}; border: none; cursor: pointer; {% if lang_code == CURRENT_LANGUAGE %}font-weight: 600; color: #2d5016;{% endif %}"
+                        onmouseover="this.style.background='#f0fdf4'; this.style.color='#2d5016';"
+                        onmouseout="this.style.background='{% if lang_code == CURRENT_LANGUAGE %}#f0fdf4{% else %}transparent{% endif %}'; this.style.color='{% if lang_code == CURRENT_LANGUAGE %}#2d5016{% else %}#374151{% endif %}';">
+                    {{ lang_name }}
+                </button>
+            </form>
+        {% endfor %}
+    </div>
+</div>
+
+<style>
+    .lang-dropdown.open .lang-menu { display: block; }
+</style>
+<script>
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function(e) {
+        document.querySelectorAll('.lang-dropdown').forEach(function(dropdown) {
+            if (!dropdown.contains(e.target)) {
+                dropdown.classList.remove('open');
+            }
+        });
+    });
+</script>
+{% endif %}

--- a/arborist/templates/arborist/partials/navigation.html
+++ b/arborist/templates/arborist/partials/navigation.html
@@ -1,0 +1,85 @@
+{% load i18n %}
+<header style="background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.1); position: sticky; top: 0; z-index: 50;">
+    <nav class="container mx-auto px-4">
+        <!-- Mobile menu checkbox - must be before all elements that use peer-checked -->
+        <input type="checkbox" id="mobile-menu-toggle" class="hidden" style="display: none;">
+
+        <div class="flex justify-between items-center h-16">
+            <!-- Logo -->
+            <div>
+                <a href="{% url 'arborist:home' %}" style="display: flex; align-items: center; font-size: 1.5rem; font-weight: bold; color: #2d5016;">
+                    🌳 Arborist
+                </a>
+            </div>
+
+            <!-- Desktop Navigation -->
+            <div class="hidden md:flex" style="display: none; align-items: center; gap: 2rem;">
+                <a href="{% url 'arborist:about' %}"
+                   style="color: #4b5563; font-weight: 500; transition: color 0.2s;"
+                   onmouseover="this.style.color='#2d5016'" onmouseout="this.style.color='#4b5563'">
+                    {% trans "About" %}
+                </a>
+                <a href="{% url 'arborist:services' %}"
+                   style="color: #4b5563; font-weight: 500; transition: color 0.2s;"
+                   onmouseover="this.style.color='#2d5016'" onmouseout="this.style.color='#4b5563'">
+                    {% trans "Services" %}
+                </a>
+                <a href="{% url 'arborist:contact' %}"
+                   class="btn btn-primary">
+                    {% trans "Contact" %}
+                </a>
+                <!-- Language Switcher -->
+                {% include "arborist/partials/language_switcher.html" %}
+            </div>
+
+            <!-- Mobile menu button -->
+            <div class="md:hidden" style="display: block;">
+                <label for="mobile-menu-toggle" style="cursor: pointer; padding: 0.5rem;">
+                    <svg style="height: 1.5rem; width: 1.5rem; color: #4b5563;" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                </label>
+            </div>
+        </div>
+
+        <!-- Mobile Navigation -->
+        <div id="mobile-nav" class="md:hidden" style="display: none; padding-bottom: 1rem;">
+            <div style="display: flex; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;">
+                <a href="{% url 'arborist:about' %}" style="color: #4b5563; font-weight: 500; padding: 0.5rem 0;">
+                    {% trans "About" %}
+                </a>
+                <a href="{% url 'arborist:services' %}" style="color: #4b5563; font-weight: 500; padding: 0.5rem 0;">
+                    {% trans "Services" %}
+                </a>
+                <a href="{% url 'arborist:contact' %}" class="btn btn-primary" style="text-align: center;">
+                    {% trans "Contact" %}
+                </a>
+                <!-- Mobile Language Switcher -->
+                <div style="padding-top: 0.5rem; border-top: 1px solid #e5e7eb;">
+                    {% include "arborist/partials/language_switcher.html" with mobile=True %}
+                </div>
+            </div>
+        </div>
+    </nav>
+</header>
+
+<script>
+    // Simple mobile menu toggle
+    document.getElementById('mobile-menu-toggle').addEventListener('change', function() {
+        document.getElementById('mobile-nav').style.display = this.checked ? 'block' : 'none';
+    });
+    // Show desktop nav on larger screens
+    if (window.innerWidth >= 768) {
+        document.querySelectorAll('.md\\:flex').forEach(el => el.style.display = 'flex');
+        document.querySelectorAll('.md\\:hidden').forEach(el => el.style.display = 'none');
+    }
+    window.addEventListener('resize', function() {
+        if (window.innerWidth >= 768) {
+            document.querySelectorAll('.md\\:flex').forEach(el => el.style.display = 'flex');
+            document.querySelectorAll('.md\\:hidden').forEach(el => el.style.display = 'none');
+        } else {
+            document.querySelectorAll('.md\\:flex').forEach(el => el.style.display = 'none');
+            document.querySelectorAll('.md\\:hidden').forEach(el => el.style.display = 'block');
+        }
+    });
+</script>

--- a/arborist/templates/arborist/services.html
+++ b/arborist/templates/arborist/services.html
@@ -1,0 +1,134 @@
+{% extends "arborist/base.html" %}
+{% load i18n %}
+
+{% block content %}
+<!-- Header -->
+<section class="bg-green-800 text-white py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-4xl mx-auto text-center">
+            <h1 class="text-4xl font-bold mb-4">
+                {% trans "Our Services" %}
+            </h1>
+            <p class="text-xl">
+                {% trans "Comprehensive tree care solutions for residential and commercial properties." %}
+            </p>
+        </div>
+    </div>
+</section>
+
+<!-- Services Grid -->
+<section class="py-16">
+    <div class="container mx-auto px-4">
+        <div class="max-w-6xl mx-auto">
+            <div class="grid md:grid-cols-2 gap-8">
+                <!-- Tree Pruning -->
+                <div class="card">
+                    <div class="text-4xl mb-4">✂️</div>
+                    <h3 class="text-2xl font-bold mb-4 text-green-800">{% trans "Tree Pruning" %}</h3>
+                    <p class="text-gray-600 mb-4">
+                        {% trans "Professional pruning services to maintain tree health, improve appearance, and ensure safety. Our certified arborists use proper techniques to promote healthy growth." %}
+                    </p>
+                    <ul class="text-gray-600 list-none">
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Crown thinning and shaping" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Dead wood removal" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Clearance pruning" %}
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Tree Removal -->
+                <div class="card">
+                    <div class="text-4xl mb-4">🪓</div>
+                    <h3 class="text-2xl font-bold mb-4 text-green-800">{% trans "Tree Removal" %}</h3>
+                    <p class="text-gray-600 mb-4">
+                        {% trans "Safe and efficient removal of hazardous, dead, or unwanted trees. We handle complex removals in tight spaces with minimal impact to surrounding areas." %}
+                    </p>
+                    <ul class="text-gray-600 list-none">
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Hazardous tree removal" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Stump grinding" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Emergency services" %}
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Health Assessment -->
+                <div class="card">
+                    <div class="text-4xl mb-4">🔍</div>
+                    <h3 class="text-2xl font-bold mb-4 text-green-800">{% trans "Health Assessment" %}</h3>
+                    <p class="text-gray-600 mb-4">
+                        {% trans "Comprehensive tree health evaluations to identify diseases, pests, and structural issues. We provide detailed reports and treatment recommendations." %}
+                    </p>
+                    <ul class="text-gray-600 list-none">
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Disease diagnosis" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Pest identification" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Risk assessment" %}
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Consultation -->
+                <div class="card">
+                    <div class="text-4xl mb-4">💡</div>
+                    <h3 class="text-2xl font-bold mb-4 text-green-800">{% trans "Consultation" %}</h3>
+                    <p class="text-gray-600 mb-4">
+                        {% trans "Expert advice on tree selection, planting, and long-term care. We help you make informed decisions about your landscape." %}
+                    </p>
+                    <ul class="text-gray-600 list-none">
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Species selection" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Planting guidance" %}
+                        </li>
+                        <li class="flex gap-2 mb-2">
+                            <span class="text-green-600">•</span>
+                            {% trans "Maintenance planning" %}
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- CTA -->
+<section class="py-16 bg-green-800 text-white">
+    <div class="container mx-auto px-4 text-center">
+        <h2 class="text-3xl font-bold mb-4">
+            {% trans "Need Our Services?" %}
+        </h2>
+        <p class="text-xl mb-8">
+            {% trans "Contact us for a free quote on any of our services." %}
+        </p>
+        <a href="{% url 'arborist:contact' %}" class="btn" style="background: #fff; color: #2d5016;">
+            {% trans "Request a Quote" %}
+        </a>
+    </div>
+</section>
+{% endblock %}

--- a/arborist/tests.py
+++ b/arborist/tests.py
@@ -1,0 +1,132 @@
+"""
+Tests for Arborist informational site.
+
+Tests use Client(HTTP_HOST='arborist.lu') to ensure domain routing works correctly.
+This follows the established pattern in power_up/tests.py.
+
+Note: Arborist uses i18n_patterns, so user-facing pages are under /en/, /de/, /fr/.
+"""
+
+from django.test import TestCase, Client
+from django.contrib.sites.models import Site
+
+
+class ArboristRoutingTestCase(TestCase):
+    """Test that arborist.lu routes to the correct URL configuration."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up Site object for arborist.lu domain."""
+        cls.site, _ = Site.objects.update_or_create(
+            domain="arborist.lu", defaults={"name": "Arborist"}
+        )
+
+    def setUp(self):
+        """Create test client with arborist.lu host header."""
+        self.client = Client(HTTP_HOST="arborist.lu")
+
+    def test_home_page_returns_200(self):
+        """Home page returns 200 and uses correct template."""
+        response = self.client.get("/en/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "arborist/home.html")
+
+    def test_about_page_returns_200(self):
+        """About page returns 200 and uses correct template."""
+        response = self.client.get("/en/about/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "arborist/about.html")
+
+    def test_services_page_returns_200(self):
+        """Services page returns 200 and uses correct template."""
+        response = self.client.get("/en/services/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "arborist/services.html")
+
+    def test_contact_page_returns_200(self):
+        """Contact page returns 200 and uses correct template."""
+        response = self.client.get("/en/contact/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "arborist/contact.html")
+
+    def test_robots_txt_returns_200(self):
+        """robots.txt is accessible and has correct content type."""
+        response = self.client.get("/robots.txt")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/plain")
+        self.assertIn("arborist.lu", response.content.decode())
+
+    def test_health_check_returns_200(self):
+        """Health check endpoint returns 200."""
+        response = self.client.get("/healthz/")
+        self.assertEqual(response.status_code, 200)
+
+
+class ArboristI18nRedirectTestCase(TestCase):
+    """Verify that arborist.lu i18n redirects work correctly."""
+
+    def setUp(self):
+        """Create test client with arborist.lu host header."""
+        self.client = Client(HTTP_HOST="arborist.lu")
+        Site.objects.update_or_create(
+            domain="arborist.lu", defaults={"name": "Arborist"}
+        )
+
+    def test_home_redirects_to_language(self):
+        """Root path redirects to language-prefixed URL."""
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/en/", response["Location"])
+
+    def test_about_redirects_to_language(self):
+        """About path without language prefix redirects."""
+        response = self.client.get("/about/")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/en/about/", response["Location"])
+
+    def test_language_prefixed_pages_no_redirect(self):
+        """Language-prefixed pages return 200 (no redirect)."""
+        response = self.client.get("/en/")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get("/de/")
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get("/fr/")
+        self.assertEqual(response.status_code, 200)
+
+
+class ArboristSEOTestCase(TestCase):
+    """Test SEO-related elements are present."""
+
+    def setUp(self):
+        """Create test client with arborist.lu host header."""
+        self.client = Client(HTTP_HOST="arborist.lu")
+        Site.objects.update_or_create(
+            domain="arborist.lu", defaults={"name": "Arborist"}
+        )
+
+    def test_home_has_meta_description(self):
+        """Home page has meta description."""
+        response = self.client.get("/en/")
+        content = response.content.decode()
+        self.assertIn('name="description"', content)
+
+    def test_home_has_canonical_url(self):
+        """Home page has canonical URL."""
+        response = self.client.get("/en/")
+        content = response.content.decode()
+        self.assertIn('rel="canonical"', content)
+        self.assertIn("arborist.lu", content)
+
+    def test_robots_txt_allows_crawling(self):
+        """robots.txt allows crawling of public pages."""
+        response = self.client.get("/robots.txt")
+        content = response.content.decode()
+        self.assertIn("Allow: /", content)
+
+    def test_robots_txt_blocks_healthz(self):
+        """robots.txt blocks health check endpoint."""
+        response = self.client.get("/robots.txt")
+        content = response.content.decode()
+        self.assertIn("Disallow: /healthz/", content)

--- a/arborist/urls.py
+++ b/arborist/urls.py
@@ -1,0 +1,18 @@
+"""
+URL patterns for Arborist informational site app.
+
+These are included by azureproject/urls_arborist.py for the arborist.lu domain.
+"""
+
+from django.urls import path
+
+from . import views
+
+app_name = "arborist"
+
+urlpatterns = [
+    path("", views.home, name="home"),
+    path("about/", views.about, name="about"),
+    path("services/", views.services, name="services"),
+    path("contact/", views.contact, name="contact"),
+]

--- a/arborist/views.py
+++ b/arborist/views.py
@@ -1,0 +1,62 @@
+"""
+Views for Arborist informational site.
+
+All views are simple template renders - no forms, no authentication.
+This is a static informational site.
+"""
+
+from django.shortcuts import render
+from django.utils.translation import gettext_lazy as _
+from django.views.decorators.http import require_GET
+
+
+@require_GET
+def home(request):
+    """Landing page with hero and overview."""
+    context = {
+        "page_title": _("Arborist - Professional Tree Care Services"),
+        "meta_description": _(
+            "Professional arborist services in Luxembourg. "
+            "Tree care, pruning, removal, and consultation."
+        ),
+    }
+    return render(request, "arborist/home.html", context)
+
+
+@require_GET
+def about(request):
+    """Company story, team, and values."""
+    context = {
+        "page_title": _("About - Arborist"),
+        "meta_description": _(
+            "Learn about our team of certified arborists "
+            "and our commitment to professional tree care."
+        ),
+    }
+    return render(request, "arborist/about.html", context)
+
+
+@require_GET
+def services(request):
+    """Services showcase."""
+    context = {
+        "page_title": _("Our Services - Arborist"),
+        "meta_description": _(
+            "Explore our professional tree care services: "
+            "pruning, removal, health assessment, and consultation."
+        ),
+    }
+    return render(request, "arborist/services.html", context)
+
+
+@require_GET
+def contact(request):
+    """Contact information."""
+    context = {
+        "page_title": _("Contact Us - Arborist"),
+        "meta_description": _(
+            "Get in touch with Arborist. Contact information for "
+            "consultations and service inquiries."
+        ),
+    }
+    return render(request, "arborist/contact.html", context)

--- a/azureproject/domains.py
+++ b/azureproject/domains.py
@@ -12,6 +12,12 @@ To test a different site locally, change DEV_DEFAULT:
 """
 
 DOMAINS = {
+    'arborist.lu': {
+        'urlconf': 'azureproject.urls_arborist',
+        'name': 'Arborist',
+        'app': 'arborist',
+        'aliases': ['www.arborist.lu'],
+    },
     'delegations.lu': {
         'urlconf': 'azureproject.urls_delegations',
         'name': 'Delegations.lu',
@@ -57,6 +63,7 @@ DEV_DEFAULT = 'crush.lu'  # Change this to test different sites locally
 
 # Local development domain mappings (avoids HSTS issues with real domains)
 DEV_DOMAIN_MAPPINGS = {
+    'arborist.localhost': 'arborist.lu',
     'crush.localhost': 'crush.lu',
     'power-up.localhost': 'power-up.lu',
     'powerup.localhost': 'power-up.lu',

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -40,6 +40,7 @@ if 'CODESPACE_NAME' in os.environ:
 # Local development CSRF trusted origins (for .localhost domains)
 # These only apply locally - production uses real domains
 CSRF_TRUSTED_ORIGINS = getattr(globals(), 'CSRF_TRUSTED_ORIGINS', []) + [
+    'http://arborist.localhost:8000',
     'http://crush.localhost:8000',
     'http://power-up.localhost:8000',
     'http://powerup.localhost:8000',
@@ -70,6 +71,7 @@ INSTALLED_APPS = [
     'entreprinder',  # Includes merged: matching, finops, vibe_coding
     'power_up',  # Corporate/investor site for power-up.lu
     'tableau',  # AI Art e-commerce site for tableau.lu
+    'arborist',  # Tree care informational site for arborist.lu
     # Allauth apps
     'allauth',
     'allauth.account',

--- a/azureproject/urls_arborist.py
+++ b/azureproject/urls_arborist.py
@@ -1,0 +1,38 @@
+# azureproject/urls_arborist.py
+"""
+URL configuration for Arborist informational site.
+
+This is the URL config used when requests come from arborist.lu domain.
+Supports internationalization with language-prefixed URLs (/en/, /de/, /fr/).
+"""
+
+from django.contrib import admin
+from django.urls import path, include
+from django.conf.urls.i18n import i18n_patterns
+
+from arborist.admin import arborist_admin_site
+from .views_seo import robots_txt_arborist
+from .urls_shared import base_patterns
+
+
+# Language-neutral patterns (no /en/, /de/, /fr/ prefix)
+urlpatterns = base_patterns + [
+    # SEO - robots.txt
+    path("robots.txt", robots_txt_arborist, name="robots_txt"),
+
+    # Arborist custom admin panel (language-neutral)
+    path("arborist-admin/", arborist_admin_site.urls),
+
+    # Standard Django admin (language-neutral)
+    path("admin/", admin.site.urls),
+]
+
+# Language-prefixed patterns (user-facing pages)
+# URLs will be: /en/, /de/, /fr/, /en/about/, /de/about/, etc.
+urlpatterns += i18n_patterns(
+    # Arborist informational site pages
+    path("", include("arborist.urls", namespace="arborist")),
+
+    # Include /en/ prefix even for default language
+    prefix_default_language=True,
+)

--- a/azureproject/views_seo.py
+++ b/azureproject/views_seo.py
@@ -208,3 +208,34 @@ def robots_txt_tableau(request):
     ]
 
     return HttpResponse("\n".join(lines), content_type="text/plain")
+
+
+@require_GET
+@cache_page(60 * 60 * 24)  # Cache for 24 hours
+def robots_txt_arborist(request):
+    """
+    Generate robots.txt for Arborist informational site.
+
+    Simple static site - allow crawling of all public pages.
+    No auth, no API, no forms - just static content.
+    """
+    lines = [
+        "# Robots.txt for Arborist",
+        "# https://arborist.lu/robots.txt",
+        "",
+        "User-agent: *",
+        "",
+        "# Allow all public pages",
+        "Allow: /",
+        "",
+        "# Block health check endpoint",
+        "Disallow: /healthz/",
+        "",
+        "# Crawl delay (be nice to our server)",
+        "Crawl-delay: 1",
+        "",
+        "# No sitemap yet - static informational site",
+        "",
+    ]
+
+    return HttpResponse("\n".join(lines), content_type="text/plain")


### PR DESCRIPTION
## Summary
- Create new Django app `arborist` for arborist.lu domain
- Add multi-domain routing for arborist.lu and www.arborist.lu
- Add i18n support (EN/DE/FR) with language-prefixed URLs
- Create static informational site with home, about, services, contact pages
- Add custom admin site at `/arborist-admin/`
- Add robots.txt for SEO configuration
- Include comprehensive test suite following power_up pattern

## Files Added
- `arborist/` - New Django app (16 files)
- `azureproject/urls_arborist.py` - Domain URL configuration

## Files Modified
- `azureproject/domains.py` - Added arborist.lu domain config
- `azureproject/settings.py` - Added app to INSTALLED_APPS and CSRF origins
- `azureproject/views_seo.py` - Added robots.txt view for arborist

## Test plan
- [ ] Verify app loads correctly by changing `DEV_DEFAULT = 'arborist.lu'` in domains.py
- [ ] Test all pages: `/en/`, `/en/about/`, `/en/services/`, `/en/contact/`
- [ ] Test language switching (EN/DE/FR)
- [ ] Test custom admin at `/arborist-admin/`
- [ ] Test health check at `/healthz/`
- [ ] Test robots.txt at `/robots.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)