### PR TITLE
feat(telemetry): SDK-based App Insights with exception filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,9 +64,9 @@ SECRET_KEY=your-development-secret-key-change-in-production
 # AZURE_ACCOUNT_KEY=xxxxx
 # AZURE_CONTAINER_NAME=media
 
-# --- Application Insights (Manual SDK - recommended) ---
+# --- Application Insights (SDK-based with exception filtering) ---
 # APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/
-# ApplicationInsightsAgent_EXTENSION_VERSION=disabled  # Disable autoinstrumentation, use SDK
+# ApplicationInsightsAgent_EXTENSION_VERSION=disabled  # REQUIRED: Disable autoinstrumentation for SDK filtering to work
 
 # --- Email (Microsoft Graph API) ---
 # GRAPH_TENANT_ID=xxx

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,9 @@ heroicons[django]==2.13.0
 py-vapid==1.9.4
 pywebpush==2.2.0
 
-# Azure Application Insights - using auto-instrumentation instead of SDK
-# Set ApplicationInsightsAgent_EXTENSION_VERSION=~3 in Azure App Service
+# Azure Application Insights - SDK-based for exception filtering
+# IMPORTANT: Set ApplicationInsightsAgent_EXTENSION_VERSION=disabled in Azure App Service
+azure-monitor-opentelemetry==1.8.4
 
 # Cookie Consent (GDPR/ePrivacy)
 django-cookie-consent==0.9.0


### PR DESCRIPTION
## Summary
- Switch from Azure auto-instrumentation to `azure-monitor-opentelemetry` SDK
- Filter cache race condition exceptions (`UniqueViolation` on `django_cache_pkey`) from Application Insights
- Reduces noise in "Top Server Exceptions" dashboard

## Changes
- Add `azure-monitor-opentelemetry==1.8.4` to requirements.txt
- Rewrite `telemetry_config.py` with `ExceptionFilteringProcessor`
- Update `production.py` initialization

## Azure Configuration
Already updated via CLI:
- `ApplicationInsightsAgent_EXTENSION_VERSION` = `disabled` ✅

## Test plan
- [ ] Deploy and verify app starts correctly
- [ ] Check Application Insights - cache exceptions should no longer appear
- [ ] Verify normal telemetry (requests, dependencies) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)