### PR TITLE
feat: Add staging environment banner for test.* subdomains

### DIFF
--- a/arborist/templates/arborist/base.html
+++ b/arborist/templates/arborist/base.html
@@ -206,6 +206,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="bg-white text-gray-900">
+    {% include "includes/staging_banner.html" %}
     {% include "arborist/partials/navigation.html" %}
 
     <main>

--- a/azureproject/context_processors.py
+++ b/azureproject/context_processors.py
@@ -2,9 +2,35 @@
 Context processors for global admin navigation across all platforms.
 
 This module provides the admin navigation context processor that enables
-superusers to switch between different platform admin panels.
+superusers to switch between different platform admin panels, and staging
+environment detection for the staging banner.
 """
 from django.conf import settings
+
+
+def staging_environment(request):
+    """
+    Context processor that detects if the request is on a staging subdomain.
+
+    Staging subdomains follow the pattern test.* (e.g., test.crush.lu).
+    This enables displaying a visual staging banner on all pages.
+
+    Context variables:
+        - is_staging: Boolean indicating if on staging subdomain
+        - staging_domain: The production domain (without test. prefix)
+    """
+    host = request.META.get('HTTP_HOST', '').split(':')[0].lower()
+
+    if host.startswith('test.'):
+        return {
+            'is_staging': True,
+            'staging_domain': host[5:],  # Remove 'test.' prefix
+        }
+
+    return {
+        'is_staging': False,
+        'staging_domain': None,
+    }
 
 
 # Platform configurations for admin navigation

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -152,6 +152,7 @@ TEMPLATES = [
                 'azureproject.content_images_context.content_images_context',  # Content images (Azure Blob)
                 'azureproject.analytics_context.analytics_ids',  # Domain-specific GA4/FB Pixel IDs
                 'azureproject.context_processors.admin_navigation',  # Global admin panel navigation
+                'azureproject.context_processors.staging_environment',  # Staging banner detection
             ],
             'builtins': [
                 'heroicons.templatetags.heroicons',  # Heroicons available in all templates

--- a/core/templates/includes/staging_banner.html
+++ b/core/templates/includes/staging_banner.html
@@ -1,0 +1,35 @@
+{% if is_staging %}
+{# Staging Environment Banner - Fixed position at top of page #}
+<div id="staging-banner" style="
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 99999;
+    background: linear-gradient(135deg, #ff6b35 0%, #f7931e 100%);
+    color: white;
+    text-align: center;
+    padding: 8px 16px;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+">
+    <span style="font-size: 16px;">&#9888;</span>
+    <span>STAGING ENVIRONMENT</span>
+    <span style="
+        background: rgba(255, 255, 255, 0.2);
+        padding: 2px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 500;
+    ">{{ staging_domain }}</span>
+    <span style="font-size: 12px; opacity: 0.9;">&#8594; Changes are NOT live</span>
+</div>
+{# Spacer to push page content below the fixed banner #}
+<div style="height: 42px;"></div>
+{% endif %}

--- a/crush_lu/templates/crush_lu/base.html
+++ b/crush_lu/templates/crush_lu/base.html
@@ -147,6 +147,7 @@
     {% block extra_css %}{% endblock %}
 </head>
 <body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+    {% include "includes/staging_banner.html" %}
     {% analytics_body %}
     <!-- Skip to main content link for keyboard/screen reader users -->
     <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:text-crush-purple focus:px-4 focus:py-2 focus:rounded-lg focus:shadow-lg focus:font-semibold">

--- a/delegations/templates/delegations/base.html
+++ b/delegations/templates/delegations/base.html
@@ -119,6 +119,7 @@
     {% block extra_css %}{% endblock %}
 </head>
 <body>
+    {% include "includes/staging_banner.html" %}
     {% analytics_body %}
     {% if user.is_authenticated %}
     <nav class="navbar navbar-expand-lg navbar-delegation">

--- a/entreprinder/templates/base.html
+++ b/entreprinder/templates/base.html
@@ -43,6 +43,7 @@
     {% endblock %}
 </head>
 <body data-default-profile-url="{{ POWERUP_DEFAULT_PROFILE_URL }}">
+    {% include "includes/staging_banner.html" %}
     {% analytics_body %}
     <header>
         <nav class="navbar navbar-expand-lg navbar-custom">

--- a/power_up/templates/power_up/base.html
+++ b/power_up/templates/power_up/base.html
@@ -48,6 +48,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="bg-white text-gray-900 antialiased">
+    {% include "includes/staging_banner.html" %}
     {% include "power_up/partials/navigation.html" %}
 
     <main>

--- a/tableau/templates/tableau/base.html
+++ b/tableau/templates/tableau/base.html
@@ -24,6 +24,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="bg-gray-950 text-gray-100 antialiased">
+    {% include "includes/staging_banner.html" %}
     {% include "tableau/partials/navigation.html" %}
 
     <main>

--- a/vinsdelux/templates/vinsdelux/base.html
+++ b/vinsdelux/templates/vinsdelux/base.html
@@ -45,7 +45,8 @@
 <body class="vinsdelux-page"
       data-vineyard-defaults-url="{{ VINSDELUX_VINEYARD_DEFAULTS_URL }}"
       data-journey-base-url="{{ VINSDELUX_JOURNEY_BASE_URL }}">
-    {% analytics_body %}   
+    {% include "includes/staging_banner.html" %}
+    {% analytics_body %}
     <header>
         <nav class="navbar navbar-expand-lg navbar-custom">
             <div class="container">


### PR DESCRIPTION
## Summary
- Add visual staging banner that appears on all `test.*` subdomains
- Banner is fixed at top of page with orange gradient background
- Shows "STAGING ENVIRONMENT" with the production domain name
- Reminds users that "Changes are NOT live"

## Changes
- **Context processor**: `staging_environment()` detects `test.*` hosts
- **Template**: `core/templates/includes/staging_banner.html` 
- **Updated 8 base templates** to include the banner

## Test plan
- [ ] Deploy to staging and verify banner appears on `test.crush.lu`, `test.powerup.lu`, etc.
- [ ] Verify banner does NOT appear on production domains
- [ ] Check banner displays correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)