### PR TITLE
Add persistent social photo cache for expired OAuth tokens

### DIFF
--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -742,6 +742,16 @@ def update_facebook_profile_on_login(sender, request, sociallogin, **kwargs):
                     f"No CrushProfile exists yet for user {sociallogin.user.email}"
                 )
 
+        # Refresh persisted social photo cache (fresh token available now)
+        # Only for existing users - new users are handled in post_save
+        if hasattr(sociallogin.user, "id") and sociallogin.user.id:
+            try:
+                from .social_photos import refresh_social_photo_cache
+                token = sociallogin.token if sociallogin.token else None
+                refresh_social_photo_cache(sociallogin.account, token)
+            except Exception as e:
+                logger.warning(f"Failed to refresh Facebook photo cache: {e}")
+
     except Exception as e:
         logger.error(f"Error in pre_social_login handler: {str(e)}", exc_info=True)
 
@@ -806,6 +816,13 @@ def create_crush_profile_from_facebook(sender, instance, created, **kwargs):
 
         profile.save()
         logger.info(f"Updated CrushProfile from Facebook data in post_save")
+
+        # Persist social photo to cache for token-expiry fallback
+        try:
+            from .social_photos import refresh_social_photo_cache
+            refresh_social_photo_cache(instance)
+        except Exception as e:
+            logger.warning(f"Failed to persist Facebook photo cache for new user: {e}")
 
     except Exception as e:
         logger.error(
@@ -1097,6 +1114,15 @@ def update_google_profile_on_login(sender, request, sociallogin, **kwargs):
                     f"No CrushProfile exists yet for user {sociallogin.user.email}"
                 )
 
+        # Refresh persisted social photo cache
+        # Only for existing users - new users are handled in post_save
+        if hasattr(sociallogin.user, "id") and sociallogin.user.id:
+            try:
+                from .social_photos import refresh_social_photo_cache
+                refresh_social_photo_cache(sociallogin.account)
+            except Exception as e:
+                logger.warning(f"Failed to refresh Google photo cache: {e}")
+
     except Exception as e:
         logger.error(
             f"Error in Google pre_social_login handler: {str(e)}", exc_info=True
@@ -1154,6 +1180,13 @@ def create_crush_profile_from_google(sender, instance, created, **kwargs):
 
         profile.save()
         logger.info(f"Updated CrushProfile from Google data in post_save")
+
+        # Persist social photo to cache for consistency
+        try:
+            from .social_photos import refresh_social_photo_cache
+            refresh_social_photo_cache(instance)
+        except Exception as e:
+            logger.warning(f"Failed to persist Google photo cache for new user: {e}")
 
     except Exception as e:
         logger.error(
@@ -1246,6 +1279,16 @@ def update_microsoft_profile_on_login(sender, request, sociallogin, **kwargs):
                     f"No CrushProfile exists yet for user {sociallogin.user.email}"
                 )
 
+        # Refresh persisted social photo cache (fresh token available now)
+        # Only for existing users - new users are handled in post_save
+        if hasattr(sociallogin.user, "id") and sociallogin.user.id:
+            try:
+                from .social_photos import refresh_social_photo_cache
+                token = sociallogin.token if sociallogin.token else None
+                refresh_social_photo_cache(sociallogin.account, token)
+            except Exception as e:
+                logger.warning(f"Failed to refresh Microsoft photo cache: {e}")
+
     except Exception as e:
         logger.error(
             f"Error in Microsoft pre_social_login handler: {str(e)}", exc_info=True
@@ -1292,6 +1335,13 @@ def create_crush_profile_from_microsoft(sender, instance, created, **kwargs):
 
         profile.save()
         logger.info(f"Updated CrushProfile from Microsoft data in post_save")
+
+        # Persist social photo to cache for token-expiry fallback
+        try:
+            from .social_photos import refresh_social_photo_cache
+            refresh_social_photo_cache(instance)
+        except Exception as e:
+            logger.warning(f"Failed to persist Microsoft photo cache for new user: {e}")
 
     except Exception as e:
         logger.error(

--- a/crush_lu/social_photos.py
+++ b/crush_lu/social_photos.py
@@ -10,6 +10,8 @@ Key features:
 - Download and save social photos to any profile photo slot
 - Unified interface for all OAuth providers
 - Caching to avoid slow API calls on every page load
+- Persistent photo cache: photos are saved to storage on login so they
+  remain available even after OAuth tokens expire
 """
 
 import logging
@@ -25,6 +27,9 @@ logger = logging.getLogger(__name__)
 # Cache timeout for social photo URLs (1 hour)
 # Profile pictures rarely change, and longer caching reduces slow Facebook API calls
 SOCIAL_PHOTO_CACHE_TIMEOUT = 3600
+
+# Shorter cache timeout for persisted storage URLs (SAS tokens expire in 30 min)
+PERSISTED_PHOTO_CACHE_TIMEOUT = 1500  # 25 minutes
 
 # Provider display names
 PROVIDER_DISPLAY_NAMES = {
@@ -59,12 +64,208 @@ def _is_token_expired(token):
     return False
 
 
+# =============================================================================
+# PERSISTENT SOCIAL PHOTO CACHE
+# =============================================================================
+# Social photo URLs (especially Facebook and Microsoft) expire when OAuth
+# tokens expire. To keep photos available, we persist a copy to storage
+# on each login (when we have a fresh token) and fall back to it when
+# the live API is unavailable.
+
+
+def _get_social_cache_path(social_account):
+    """Get the storage path for a cached social photo."""
+    return f"users/{social_account.user_id}/social_cache/{social_account.provider}.jpg"
+
+
+def _get_photo_storage():
+    """Get the storage backend for social photo cache."""
+    from .models.profiles import get_crush_photo_storage
+    return get_crush_photo_storage()
+
+
+def _persist_social_photo(social_account, image_data):
+    """
+    Persist social photo binary data to storage for token-expiry fallback.
+
+    Saves the image to: users/{user_id}/social_cache/{provider}.jpg
+    This file persists independently of OAuth tokens.
+
+    Args:
+        social_account: SocialAccount instance
+        image_data: Raw image bytes
+
+    Returns:
+        bool: True if saved successfully
+    """
+    storage = _get_photo_storage()
+    path = _get_social_cache_path(social_account)
+
+    try:
+        # Process image (fix orientation, strip EXIF, resize)
+        filename = f"{social_account.provider}_cache.jpg"
+        raw_file = ContentFile(image_data, name=filename)
+        processed = process_uploaded_image(raw_file, filename)
+
+        # Delete existing cached file
+        try:
+            if storage.exists(path):
+                storage.delete(path)
+        except Exception:
+            pass
+
+        storage.save(path, processed)
+
+        # Mark that persisted photo exists (avoids storage.exists() checks)
+        cache.set(
+            f"social_photo_persisted_exists_{social_account.id}",
+            True,
+            SOCIAL_PHOTO_CACHE_TIMEOUT * 24,  # 24 hours
+        )
+
+        logger.info(
+            f"Persisted {social_account.provider} photo to storage "
+            f"for user {social_account.user_id}"
+        )
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to persist social photo: {e}")
+        return False
+
+
+def _get_persisted_social_photo_url(social_account):
+    """
+    Get a fresh storage URL for the persisted social photo.
+
+    Returns a URL with a fresh SAS token (for Azure) or a local file URL.
+    Uses a short cache timeout since SAS tokens expire in 30 minutes.
+
+    Args:
+        social_account: SocialAccount instance
+
+    Returns:
+        str: Storage URL or None if no persisted photo exists
+    """
+    # Quick check: do we know a persisted photo exists?
+    exists_key = f"social_photo_persisted_exists_{social_account.id}"
+    known_exists = cache.get(exists_key)
+
+    if known_exists is False:
+        return None
+
+    storage = _get_photo_storage()
+    path = _get_social_cache_path(social_account)
+
+    try:
+        if known_exists is True or storage.exists(path):
+            cache.set(exists_key, True, SOCIAL_PHOTO_CACHE_TIMEOUT * 24)
+            return storage.url(path)
+        else:
+            cache.set(exists_key, False, SOCIAL_PHOTO_CACHE_TIMEOUT * 24)
+    except Exception as e:
+        logger.debug(f"Error checking persisted social photo: {e}")
+
+    return None
+
+
+def refresh_social_photo_cache(social_account, token=None):
+    """
+    Download and persist the social photo for a given account.
+
+    Should be called during social login when we have a fresh token.
+    This ensures the persisted copy stays up-to-date.
+
+    Args:
+        social_account: SocialAccount instance
+        token: Optional SocialToken (if not provided, will be looked up)
+
+    Returns:
+        bool: True if photo was persisted successfully
+    """
+    provider = social_account.provider
+
+    if provider == 'google':
+        # Google photo URLs are public and don't expire, but we persist
+        # them too for consistency
+        extra_data = social_account.extra_data
+        picture_url = extra_data.get('picture')
+        if not picture_url:
+            return False
+
+        # Get high-res URL
+        if '=s' in picture_url:
+            picture_url = re.sub(r'=s\d+(-c)?', '=s720-c', picture_url)
+
+        try:
+            response = requests.get(picture_url, timeout=10)
+            response.raise_for_status()
+            if response.headers.get('Content-Type', '').startswith('image/'):
+                return _persist_social_photo(social_account, response.content)
+        except Exception as e:
+            logger.warning(f"Failed to refresh Google photo cache: {e}")
+        return False
+
+    elif provider == 'facebook':
+        if not token:
+            token = _get_token_for_account(social_account)
+        if not token or _is_token_expired(token):
+            return False
+
+        facebook_id = social_account.extra_data.get('id')
+        if not facebook_id:
+            return False
+
+        # Fetch high-res photo URL from Graph API
+        url = (
+            f"https://graph.facebook.com/v24.0/{facebook_id}/picture"
+            f"?width=720&height=720&redirect=false"
+            f"&access_token={token.token}"
+        )
+        try:
+            resp = requests.get(url, timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            photo_url = data.get('data', {}).get('url')
+            if not photo_url:
+                return False
+
+            # Download the actual image
+            img_resp = requests.get(photo_url, timeout=10)
+            img_resp.raise_for_status()
+            if img_resp.headers.get('Content-Type', '').startswith('image/'):
+                return _persist_social_photo(social_account, img_resp.content)
+        except Exception as e:
+            logger.warning(f"Failed to refresh Facebook photo cache: {e}")
+        return False
+
+    elif provider == 'microsoft':
+        if not token:
+            token = _get_token_for_account(social_account)
+        if not token or _is_token_expired(token):
+            return False
+
+        try:
+            response = requests.get(
+                'https://graph.microsoft.com/v1.0/me/photo/$value',
+                headers={'Authorization': f'Bearer {token.token}'},
+                timeout=5,
+            )
+            if response.status_code == 200:
+                return _persist_social_photo(social_account, response.content)
+        except Exception as e:
+            logger.warning(f"Failed to refresh Microsoft photo cache: {e}")
+        return False
+
+    return False
+
+
 def get_facebook_photo_url(social_account):
     """
     Get Facebook profile photo URL from social account.
 
-    Tries high-resolution first (720x720), falls back to standard picture.
-    Results are cached for 1 hour to avoid slow API calls.
+    Tries high-resolution first (720x720), falls back to standard picture,
+    then falls back to persisted cache when token is expired.
+    Results are cached to avoid slow API calls.
 
     Args:
         social_account: SocialAccount instance for Facebook
@@ -112,6 +313,15 @@ def get_facebook_photo_url(social_account):
         else:
             result_url = extra_data['picture']
 
+    # Fallback to persisted cache (works even when token is expired)
+    if not result_url:
+        result_url = _get_persisted_social_photo_url(social_account)
+        if result_url:
+            logger.info(f"Using persisted cache for Facebook account {social_account.id}")
+            # Use shorter cache timeout for storage SAS URLs
+            cache.set(cache_key, result_url, PERSISTED_PHOTO_CACHE_TIMEOUT)
+            return result_url
+
     # Cache the result (use '' for None to distinguish from cache miss)
     cache.set(cache_key, result_url if result_url else '', SOCIAL_PHOTO_CACHE_TIMEOUT)
     return result_url
@@ -154,7 +364,8 @@ def get_microsoft_photo_url(social_account):
 
     Microsoft doesn't include photo URL in OAuth extra_data.
     We need to fetch it using the stored access token.
-    Results are cached for 1 hour to avoid slow API calls.
+    Falls back to persisted cache when token is expired.
+    Results are cached to avoid slow API calls.
 
     Requires: ProfilePhoto.Read.All permission on Azure app registration.
 
@@ -162,7 +373,7 @@ def get_microsoft_photo_url(social_account):
         social_account: SocialAccount instance for Microsoft
 
     Returns:
-        str: Base64 data URL or None if unavailable
+        str: Base64 data URL, storage URL, or None if unavailable
     """
     # Check cache first
     cache_key = f"social_photo_microsoft_{social_account.id}"
@@ -176,6 +387,12 @@ def get_microsoft_photo_url(social_account):
 
         if not token or _is_token_expired(token):
             logger.warning(f"No valid token for Microsoft account {social_account.id}")
+            # Fall back to persisted cache
+            result_url = _get_persisted_social_photo_url(social_account)
+            if result_url:
+                logger.info(f"Using persisted cache for Microsoft account {social_account.id}")
+                cache.set(cache_key, result_url, PERSISTED_PHOTO_CACHE_TIMEOUT)
+                return result_url
             cache.set(cache_key, '', SOCIAL_PHOTO_CACHE_TIMEOUT)
             return None
 
@@ -201,6 +418,14 @@ def get_microsoft_photo_url(social_account):
 
     except Exception as e:
         logger.error(f"Error fetching Microsoft photo: {str(e)}")
+
+    # If API failed, try persisted cache as last resort
+    if not result_url:
+        result_url = _get_persisted_social_photo_url(social_account)
+        if result_url:
+            logger.info(f"Using persisted cache for Microsoft account {social_account.id}")
+            cache.set(cache_key, result_url, PERSISTED_PHOTO_CACHE_TIMEOUT)
+            return result_url
 
     # Cache the result (use '' for None to distinguish from cache miss)
     cache.set(cache_key, result_url if result_url else '', SOCIAL_PHOTO_CACHE_TIMEOUT)
@@ -271,6 +496,11 @@ def get_all_social_photos(user):
 
         photo_url = get_social_photo_url(account)
 
+        # Detect if the photo is from persisted cache (storage URL vs live URL)
+        is_cached = False
+        if photo_url and token_expired and account.provider in ('facebook', 'microsoft'):
+            is_cached = True
+
         photo_info = {
             'provider': account.provider,
             'provider_display': PROVIDER_DISPLAY_NAMES.get(account.provider, account.provider.title()),
@@ -278,6 +508,7 @@ def get_all_social_photos(user):
             'available': photo_url is not None,
             'account_id': account.id,
             'token_expired': token_expired,
+            'is_cached': is_cached,
         }
 
         # Add reason if not available
@@ -288,6 +519,8 @@ def get_all_social_photos(user):
                 photo_info['reason'] = 'No photo set'
             else:
                 photo_info['reason'] = 'No photo available'
+        elif is_cached:
+            photo_info['reason'] = 'Showing saved copy - log in again to refresh'
 
         photos.append(photo_info)
 

--- a/crush_lu/templates/crush_lu/account_settings.html
+++ b/crush_lu/templates/crush_lu/account_settings.html
@@ -194,9 +194,15 @@
                         <div class="social-photo-preview">
                             <img src="{{ photo.photo_url }}" alt="{{ photo.provider_display }} photo" loading="lazy">
                         </div>
+                        {% if photo.is_cached %}
+                        <small class="text-amber-600 mt-2 block">
+                            {% include "shared/icons/check-circle.html" with class="w-5 h-5" %} {% trans "Saved copy" %} &mdash; {% trans "log in again to refresh" %}
+                        </small>
+                        {% else %}
                         <small class="text-green-600 mt-2 block">
                             {% include "shared/icons/check-circle.html" with class="w-5 h-5" %} {% trans "Available" %}
                         </small>
+                        {% endif %}
                         {% else %}
                         <div class="no-photo-placeholder">
                             {% include "shared/icons/photo.html" with class="w-5 h-5" %}


### PR DESCRIPTION
## Purpose
* Implement persistent caching of social profile photos to storage so they remain available even after OAuth tokens expire
* Add fallback mechanism to display cached photos when live API calls fail due to token expiration
* Automatically refresh and persist photos during social login when fresh tokens are available
* Support Facebook, Google, and Microsoft OAuth providers with consistent caching behavior

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Verify social photos display correctly during active OAuth sessions
* Test that photos persist after OAuth tokens expire by:
  - Logging in with Facebook/Google/Microsoft
  - Waiting for token to expire (or manually expiring it)
  - Confirming cached photo still displays in account settings
* Verify UI shows "Saved copy" indicator when displaying cached photos
* Confirm new users have photos persisted on first login
* Verify existing users have photos refreshed on subsequent logins

## What to Check
Verify that the following are valid:
* Social photos display from live API when tokens are valid
* Cached photos display when tokens expire (fallback works)
* UI correctly indicates when a cached copy is being shown
* Photo persistence doesn't break existing photo retrieval logic
* Cache timeouts are appropriate (25 min for storage URLs, 1 hour for API)
* Signal handlers properly trigger photo refresh on login for all providers
* No errors in logs when persisting or retrieving cached photos

## Other Information
* Added `PERSISTED_PHOTO_CACHE_TIMEOUT` constant (25 minutes) for storage URL caching since SAS tokens expire in 30 minutes
* New helper functions: `_persist_social_photo()`, `_get_persisted_social_photo_url()`, `refresh_social_photo_cache()`
* Updated `get_facebook_photo_url()` and `get_microsoft_photo_url()` to fall back to persisted cache
* Integrated photo refresh into social login signals for Facebook, Google, and Microsoft
* Updated account settings template to display "Saved copy" indicator for cached photos

https://claude.ai/code/session_01DxJTFn7Tc6eg5Rq3JgKF8V