### PR TITLE
Send welcome emails to new OAuth signup users

### DIFF
--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -747,6 +747,10 @@ def update_facebook_profile_on_login(sender, request, sociallogin, **kwargs):
     # Set flag to indicate this is a crush.lu Facebook login
     _thread_local.is_crush_facebook_login = True
 
+    # Store request for post_save handler (needed for welcome email)
+    if not sociallogin.is_existing:
+        _thread_local.oauth_signup_request = request
+
     # Track Crush.lu consent for OAuth signups (implicit consent via OAuth)
     if not sociallogin.is_existing:
         from crush_lu.models.profiles import UserDataConsent
@@ -876,6 +880,19 @@ def create_crush_profile_from_facebook(sender, instance, created, **kwargs):
             refresh_social_photo_cache(instance)
         except Exception as e:
             logger.warning(f"Failed to persist Facebook photo cache for new user: {e}")
+
+        # Send welcome email for new OAuth signups
+        if profile_created:
+            oauth_request = getattr(_thread_local, "oauth_signup_request", None)
+            if oauth_request:
+                try:
+                    from .email_helpers import send_welcome_email
+                    result = send_welcome_email(instance.user, oauth_request)
+                    logger.info(f"Welcome email sent to Facebook OAuth user {instance.user.email}: {result}")
+                except Exception as e:
+                    logger.error(f"Failed to send welcome email to Facebook OAuth user {instance.user.email}: {e}", exc_info=True)
+                finally:
+                    _thread_local.oauth_signup_request = None
 
     except Exception as e:
         logger.error(
@@ -1125,6 +1142,10 @@ def update_google_profile_on_login(sender, request, sociallogin, **kwargs):
     # Set flag to indicate this is a crush.lu Google login
     _thread_local.is_crush_google_login = True
 
+    # Store request for post_save handler (needed for welcome email)
+    if not sociallogin.is_existing:
+        _thread_local.oauth_signup_request = request
+
     # Track Crush.lu consent for OAuth signups (implicit consent via OAuth)
     if not sociallogin.is_existing:
         from crush_lu.models.profiles import UserDataConsent
@@ -1241,6 +1262,19 @@ def create_crush_profile_from_google(sender, instance, created, **kwargs):
         except Exception as e:
             logger.warning(f"Failed to persist Google photo cache for new user: {e}")
 
+        # Send welcome email for new OAuth signups
+        if profile_created:
+            oauth_request = getattr(_thread_local, "oauth_signup_request", None)
+            if oauth_request:
+                try:
+                    from .email_helpers import send_welcome_email
+                    result = send_welcome_email(instance.user, oauth_request)
+                    logger.info(f"Welcome email sent to Google OAuth user {instance.user.email}: {result}")
+                except Exception as e:
+                    logger.error(f"Failed to send welcome email to Google OAuth user {instance.user.email}: {e}", exc_info=True)
+                finally:
+                    _thread_local.oauth_signup_request = None
+
     except Exception as e:
         logger.error(
             f"Error in Google SocialAccount post_save handler: {str(e)}", exc_info=True
@@ -1296,6 +1330,10 @@ def update_microsoft_profile_on_login(sender, request, sociallogin, **kwargs):
 
     # Set flag to indicate this is a crush.lu Microsoft login
     _thread_local.is_crush_microsoft_login = True
+
+    # Store request for post_save handler (needed for welcome email)
+    if not sociallogin.is_existing:
+        _thread_local.oauth_signup_request = request
 
     # Track Crush.lu consent for OAuth signups (implicit consent via OAuth)
     if not sociallogin.is_existing:
@@ -1395,6 +1433,19 @@ def create_crush_profile_from_microsoft(sender, instance, created, **kwargs):
             refresh_social_photo_cache(instance)
         except Exception as e:
             logger.warning(f"Failed to persist Microsoft photo cache for new user: {e}")
+
+        # Send welcome email for new OAuth signups
+        if profile_created:
+            oauth_request = getattr(_thread_local, "oauth_signup_request", None)
+            if oauth_request:
+                try:
+                    from .email_helpers import send_welcome_email
+                    result = send_welcome_email(instance.user, oauth_request)
+                    logger.info(f"Welcome email sent to Microsoft OAuth user {instance.user.email}: {result}")
+                except Exception as e:
+                    logger.error(f"Failed to send welcome email to Microsoft OAuth user {instance.user.email}: {e}", exc_info=True)
+                finally:
+                    _thread_local.oauth_signup_request = None
 
     except Exception as e:
         logger.error(


### PR DESCRIPTION
## Purpose
* Add welcome email functionality for new users signing up via OAuth (Facebook, Google, Microsoft)
* Store the request object in thread-local storage during OAuth login to make it available to post-save handlers
* Send welcome emails after user profile creation for new OAuth signups

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Verify welcome emails are sent when new users sign up via Facebook OAuth
* Verify welcome emails are sent when new users sign up via Google OAuth
* Verify welcome emails are sent when new users sign up via Microsoft OAuth
* Verify existing users logging in via OAuth do not receive welcome emails
* Check logs for successful email delivery or any errors during the process

## What to Check
Verify that the following are valid
* Welcome emails are sent only for new OAuth signups (not existing users)
* Request object is properly stored and retrieved from thread-local storage
* Email sending errors are logged but don't break the signup flow
* Thread-local storage is cleaned up after email is sent
* All three OAuth providers (Facebook, Google, Microsoft) send welcome emails consistently

## Other Information
The implementation follows the same pattern across all three OAuth providers (Facebook, Google, Microsoft) for consistency. The request object is stored in thread-local storage during the pre-login signal and retrieved in the post-save handler to provide necessary context for the welcome email function.

https://claude.ai/code/session_0162RYkaqRnaxmjqPikTYayf