### PR TITLE
fix(ci): include antenv in deploy zip to fix missing packages

### DIFF
--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -127,10 +127,13 @@ jobs:
         env:
           SECRET_KEY: 'ci-build-key'
         run: |
+          python -m venv antenv
+          source antenv/bin/activate
           pip install -q -r requirements.txt
           python manage.py collectstatic --noinput
+          deactivate
           zip -r deploy.zip . -x "*.git*" -x "*__pycache__*" -x "*.pyc" -x "node_modules/*" -x "tailwind-src/*" -x ".github/*" -x "tests/*" -x "*.md"
-          echo "✅ Deployment package built locally"
+          echo "✅ Deployment package built locally (with antenv)"
 
       - name: Login to Azure
         uses: azure/login@v3
@@ -138,12 +141,14 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy to Staging Slot
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: 'django-app-ajfffwjb5ie3s-app-service'
-          slot-name: 'staging'
-          package: deploy.zip
-          clean: false
+        run: |
+          az webapp deploy \
+            --name django-app-ajfffwjb5ie3s-app-service \
+            --resource-group django-app-rg \
+            --slot staging \
+            --src-path deploy.zip \
+            --type zip \
+            --restart true
 
       - name: Verify Deployment
         run: |

--- a/startup.sh
+++ b/startup.sh
@@ -6,8 +6,8 @@ echo "🚀 Starting deployment..."
 echo "📍 Working directory: $(pwd)"
 echo "🐍 Python version: $(python --version)"
 
-# Note: collectstatic is handled by Oryx during Azure build (SCM_DO_BUILD_DURING_DEPLOYMENT=true)
-# Oryx generates the staticfiles manifest + compressed files for WhiteNoise
+# Note: collectstatic is handled during CI/CD build (GitHub Actions workflow)
+# The antenv virtual environment and static files are pre-built and included in the deployment zip
 # Do NOT run collectstatic here — running it twice causes manifest conflicts
 
 # Run migrations with no-input for faster execution


### PR DESCRIPTION
## Summary

Fixes `ModuleNotFoundError: No module named 'dotenv'` on Azure App Service startup after #223 disabled Oryx remote build.

### Changes
- **Build step**: Creates `antenv` virtual environment, installs packages into it, and includes it in the deployment zip
- **Deploy step**: Replaces `azure/webapps-deploy@v3` with `az webapp deploy` CLI to avoid OneDeploy re-triggering Oryx
- **startup.sh**: Updated comments to reflect new build process

### Root cause
With Oryx disabled, no virtual environment was being created on the server. Azure's startup script expects `antenv` at `/home/site/wwwroot/antenv`.

## Test plan
- [ ] CI checks pass
- [ ] After merge, Deploy to Azure Staging workflow completes successfully
- [ ] App starts without ModuleNotFoundError
- [ ] Staging endpoints respond: test.crush.lu, test.powerup.lu, test.vinsdelux.com

https://claude.ai/code/session_019q6AygLjh9MKZF77bQQ9LR