### PR TITLE
Add storage backend validation and Azure native extension fixes

### DIFF
--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -131,6 +131,14 @@ jobs:
           source antenv/bin/activate
           pip install -q -r requirements.txt
           python manage.py collectstatic --noinput
+          # Fix native extensions for Azure App Service (Debian 11 / GLIBC 2.31)
+          # CI runner (ubuntu-latest) has GLIBC 2.39 — cryptography's .abi3.so
+          # needs manylinux_2_28 (GLIBC 2.28) to run on Azure
+          echo "🔧 Replacing native extensions with Azure-compatible builds..."
+          SITE_PKGS="antenv/lib/python3.12/site-packages"
+          rm -rf $SITE_PKGS/cryptography* $SITE_PKGS/cffi* $SITE_PKGS/_cffi_backend*
+          pip install --no-deps --platform manylinux_2_28_x86_64 --only-binary=:all: \
+            --target $SITE_PKGS cryptography cffi
           deactivate
           zip -r deploy.zip . -x "*.git*" -x "*__pycache__*" -x "*.pyc" -x "node_modules/*" -x "tailwind-src/*" -x ".github/*" -x "tests/*" -x "*.md"
           echo "✅ Deployment package built locally (with antenv)"

--- a/azureproject/storage_shared.py
+++ b/azureproject/storage_shared.py
@@ -132,7 +132,16 @@ def shared_upload_path(subfolder: str = ''):
 
 def get_shared_media_storage():
     """Get shared media storage instance (lazy initialization)."""
-    return SharedMediaStorage()
+    try:
+        from django.core.files.storage.base import Storage
+        storage = SharedMediaStorage()
+        if not isinstance(storage, Storage):
+            from django.core.files.storage import default_storage
+            return default_storage
+        return storage
+    except Exception:
+        from django.core.files.storage import default_storage
+        return default_storage
 
 # Alias for backward compatibility and convenience
 shared_media_storage = get_shared_media_storage

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -24,9 +24,14 @@ def get_crush_photo_storage():
     callable reference, preventing false "model changes detected" warnings.
     """
     try:
-        # Try to get the crush_private storage (defined in production STORAGES)
-        return storages["crush_private"]
-    except (KeyError, Exception):
+        from django.core.files.storage.base import Storage
+        storage = storages["crush_private"]
+        # Validate the backend is a proper Storage instance (guards against
+        # broken native extensions where AzureStorage falls back to object)
+        if not isinstance(storage, Storage):
+            return default_storage
+        return storage
+    except Exception:
         # Fall back to default storage in development
         return default_storage
 

--- a/entreprinder/storage.py
+++ b/entreprinder/storage.py
@@ -128,7 +128,16 @@ def entreprinder_upload_path(subfolder: str = ''):
 
 def get_entreprinder_media_storage():
     """Get Entreprinder media storage instance (lazy initialization)."""
-    return EntreprinderMediaStorage()
+    try:
+        from django.core.files.storage.base import Storage
+        storage = EntreprinderMediaStorage()
+        if not isinstance(storage, Storage):
+            from django.core.files.storage import default_storage
+            return default_storage
+        return storage
+    except Exception:
+        from django.core.files.storage import default_storage
+        return default_storage
 
 # Alias for backward compatibility and convenience
 entreprinder_media_storage = get_entreprinder_media_storage

--- a/power_up/storage.py
+++ b/power_up/storage.py
@@ -170,11 +170,29 @@ def powerup_upload_path(subfolder: str = ''):
 
 def get_powerup_media_storage():
     """Get PowerUP media storage instance (lazy initialization)."""
-    return PowerUpMediaStorage()
+    try:
+        from django.core.files.storage.base import Storage
+        storage = PowerUpMediaStorage()
+        if not isinstance(storage, Storage):
+            from django.core.files.storage import default_storage
+            return default_storage
+        return storage
+    except Exception:
+        from django.core.files.storage import default_storage
+        return default_storage
 
 def get_finops_storage():
     """Get FinOps storage instance (lazy initialization)."""
-    return FinOpsStorage()
+    try:
+        from django.core.files.storage.base import Storage
+        storage = FinOpsStorage()
+        if not isinstance(storage, Storage):
+            from django.core.files.storage import default_storage
+            return default_storage
+        return storage
+    except Exception:
+        from django.core.files.storage import default_storage
+        return default_storage
 
 # Aliases for backward compatibility and convenience
 powerup_media_storage = get_powerup_media_storage

--- a/vinsdelux/storage.py
+++ b/vinsdelux/storage.py
@@ -214,11 +214,29 @@ def vinsdelux_upload_path(subfolder: str = ''):
 
 def get_vinsdelux_media_storage():
     """Get VinsDelux media storage instance (lazy initialization)."""
-    return VdlMediaStorage()
+    try:
+        from django.core.files.storage.base import Storage
+        storage = VdlMediaStorage()
+        if not isinstance(storage, Storage):
+            from django.core.files.storage import default_storage
+            return default_storage
+        return storage
+    except Exception:
+        from django.core.files.storage import default_storage
+        return default_storage
 
 def get_vinsdelux_private_storage():
     """Get VinsDelux private storage instance (lazy initialization)."""
-    return VdlPrivateStorage()
+    try:
+        from django.core.files.storage.base import Storage
+        storage = VdlPrivateStorage()
+        if not isinstance(storage, Storage):
+            from django.core.files.storage import default_storage
+            return default_storage
+        return storage
+    except Exception:
+        from django.core.files.storage import default_storage
+        return default_storage
 
 # Aliases for backward compatibility and convenience
 vinsdelux_media_storage = get_vinsdelux_media_storage


### PR DESCRIPTION
## Purpose
* Add defensive validation to storage backend initialization across multiple apps to handle cases where custom storage classes fail to properly inherit from Django's Storage base class
* Fix native extension compatibility issues for Azure App Service deployments by replacing GLIBC 2.39 binaries with manylinux_2_28 compatible versions
* Prevent runtime errors by falling back to default storage when custom storage backends are misconfigured or unavailable

## Does this introduce a breaking change?
```
[x] No
```

## Pull Request Type
```
[x] Bugfix
```

## How to Test
* Deploy to Azure App Service and verify collectstatic completes without errors
* Verify storage operations work correctly when custom storage backends are unavailable
* Confirm fallback to default_storage occurs gracefully when storage validation fails

## What to Check
Verify that the following are valid
* Storage initialization no longer crashes when custom backends are misconfigured
* Azure App Service deployments complete the native extension replacement step successfully
* File uploads work correctly with fallback storage when custom backends are unavailable
* Existing storage functionality remains unchanged when backends are properly configured

## Other Information
The changes add try-except blocks with isinstance validation to storage getter functions in:
- power_up/storage.py (2 functions)
- vinsdelux/storage.py (2 functions)
- azureproject/storage_shared.py (1 function)
- crush_lu/models/profiles.py (1 function)
- entreprinder/storage.py (1 function)

The deployment workflow now includes a step to replace cryptography and cffi native extensions with manylinux_2_28 compatible builds before packaging for Azure App Service, addressing GLIBC version mismatches between the CI runner and Azure's Debian 11 environment.

https://claude.ai/code/session_01AdxrEiF7RdxVZgeSCubkjp