### PR TITLE
Fix staticfiles manifest generation in Azure App Service CI build

### DIFF
--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -126,11 +126,16 @@ jobs:
       - name: Build deployment package locally
         env:
           SECRET_KEY: 'ci-build-key'
+          # Use production settings so collectstatic generates the manifest (staticfiles.json)
+          # required by WhiteNoise's CompressedManifestStaticFilesStorage at runtime
+          WEBSITE_HOSTNAME: 'ci-build'
+          POSTGRESQLCONNSTR_CI: 'dbname=ci host=localhost user=ci password=ci'
         run: |
           python -m venv antenv
           source antenv/bin/activate
           pip install -q -r requirements.txt
           python manage.py collectstatic --noinput
+          test -f staticfiles/staticfiles.json || { echo "❌ staticfiles manifest missing"; exit 1; }
           # Fix native extensions for Azure App Service (Debian 11 / GLIBC 2.31)
           # CI runner (ubuntu-latest) has GLIBC 2.39 — cryptography's .abi3.so
           # needs manylinux_2_28 (GLIBC 2.28) to run on Azure


### PR DESCRIPTION
## Purpose
* Ensure that Django's `collectstatic` command generates the required `staticfiles.json` manifest file during CI builds for Azure App Service deployments
* Add validation to fail the build if the manifest is missing, preventing runtime errors with WhiteNoise's `CompressedManifestStaticFilesStorage`
* Configure necessary environment variables (`WEBSITE_HOSTNAME` and `POSTGRESQLCONNSTR_CI`) to enable production-like settings during the build process

## Does this introduce a breaking change?
```
[x] No
```

## Pull Request Type
```
[x] Bugfix
```

## How to Test
The fix is validated automatically during the CI/CD pipeline:
1. The GitHub Actions workflow builds the deployment package with the updated environment configuration
2. The new validation check (`test -f staticfiles/staticfiles.json`) ensures the manifest is generated
3. If the manifest is missing, the build fails with a clear error message
4. Successful workflow completion confirms the fix works as intended

## What to Check
Verify that:
* The CI workflow completes successfully with the staticfiles manifest generated
* The `staticfiles/staticfiles.json` file is present in the deployment package
* Azure App Service deployments can properly serve static files with WhiteNoise's compressed manifest storage

## Other Information
This fix addresses a potential runtime issue where WhiteNoise's `CompressedManifestStaticFilesStorage` requires a pre-generated manifest file. By adding the necessary environment variables and validation check, we ensure the manifest is created during the build phase rather than failing at runtime on Azure App Service.

https://claude.ai/code/session_01AddoVXXio14PUxa1zmfbef