### PR TITLE
Add environment-aware cloud_RoleName configuration for Azure Monitor

### DIFF
--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -1,5 +1,11 @@
 import os
 
+# ─── Environment detection ─────────────────────────────────────────────────────
+# Set DJANGO_ENV as a slot-sticky App Service setting:
+#   Staging slot  → DJANGO_ENV=staging
+#   Production    → DJANGO_ENV=production  (or omit; defaults to "production")
+DJANGO_ENV = os.environ.get("DJANGO_ENV", "production")
+
 # ============================================================================
 # Azure Internal IP Support (MUST be before ALLOWED_HOSTS)
 # ============================================================================
@@ -406,8 +412,9 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "production": {
-            "format": "{levelname} [{name}] {message}",
+            "format": "{levelname} [{name}] [{environment}] {message}",
             "style": "{",
+            "defaults": {"environment": DJANGO_ENV},
         },
     },
     "filters": {
@@ -539,7 +546,7 @@ if "WEBSITE_HOSTNAME" in os.environ:
 # The SDK automatically instruments: Django, requests, urllib, psycopg2
 from azureproject.telemetry_config import configure_azure_monitor_telemetry
 
-telemetry_ok = configure_azure_monitor_telemetry()
+telemetry_ok = configure_azure_monitor_telemetry(environment=DJANGO_ENV)
 if not telemetry_ok:
     import sys
     print(

--- a/azureproject/telemetry_config.py
+++ b/azureproject/telemetry_config.py
@@ -201,7 +201,7 @@ class ExceptionFilteringProcessor:
         return True
 
 
-def configure_azure_monitor_telemetry():
+def configure_azure_monitor_telemetry(environment="production"):
     """
     Configure Azure Monitor OpenTelemetry SDK with exception filtering and sampling.
 
@@ -210,9 +210,14 @@ def configure_azure_monitor_telemetry():
     2. Configures azure-monitor-opentelemetry with custom span processor
     3. Sets up Django instrumentation automatically
     4. Configures sampling to reduce data ingestion costs
-    5. Falls back gracefully if connection string is missing (local dev)
+    5. Sets cloud_RoleName via service.name resource attribute
+    6. Falls back gracefully if connection string is missing (local dev)
 
     Call this once at application startup (in production.py).
+
+    Args:
+        environment: Deployment environment name ("production" or "staging").
+                     Sets cloud_RoleName to "crush.lu-{environment}" in App Insights.
 
     Environment Variables:
         APPLICATIONINSIGHTS_CONNECTION_STRING: Required for telemetry
@@ -237,15 +242,23 @@ def configure_azure_monitor_telemetry():
 
     try:
         from azure.monitor.opentelemetry import configure_azure_monitor
+        from opentelemetry.sdk.resources import Resource
 
         # Create filtering processors
         exception_filter = ExceptionFilteringProcessor()
         dependency_filter = DependencyFilteringProcessor()
 
+        # Set cloud_RoleName via service.name resource attribute.
+        # This overrides the Azure App Service resource detector default
+        # and enables filtering by environment in App Insights dashboards/alerts.
+        service_name = f"crush.lu-{environment}"
+        resource = Resource.create({"service.name": service_name})
+
         # Configure Azure Monitor with our custom processors and sampling
         # The SDK automatically instruments Django, requests, urllib, psycopg2
         configure_azure_monitor(
             connection_string=connection_string,
+            resource=resource,
             # Add our custom span processors for filtering
             span_processors=[dependency_filter, exception_filter],
             # Use Azure Monitor's ApplicationInsightsSampler (NOT TraceIdRatioBased).
@@ -265,7 +278,8 @@ def configure_azure_monitor_telemetry():
         )
 
         logger.info(
-            f"Azure Monitor OpenTelemetry configured with exception filtering, "
+            f"Azure Monitor OpenTelemetry configured for '{environment}' "
+            f"(cloud_RoleName: {service_name}) with exception filtering, "
             f"{sampling_rate*100:.0f}% sampling, performance counters disabled "
             f"(Live Metrics: {'enabled' if enable_live_metrics else 'disabled'}). "
             "Auto-instrumentation should be DISABLED in Azure App Service."
@@ -285,13 +299,13 @@ def configure_azure_monitor_telemetry():
 
 
 # Legacy function for backward compatibility
-def configure_exception_filtering():
+def configure_exception_filtering(environment="production"):
     """
     Legacy function - now calls configure_azure_monitor_telemetry().
 
     Kept for backward compatibility with existing imports.
     """
-    return configure_azure_monitor_telemetry()
+    return configure_azure_monitor_telemetry(environment=environment)
 
 
 class SuppressedExceptionFilter(logging.Filter):


### PR DESCRIPTION
## Purpose
* Add support for environment-specific telemetry configuration in Azure Monitor OpenTelemetry
* Enable cloud_RoleName to be set dynamically based on deployment environment (production/staging)
* Improve telemetry filtering and dashboarding by distinguishing between environments in App Insights
* Include environment context in log messages for better observability

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Changes Made

### `azureproject/telemetry_config.py`
- Added `environment` parameter to `configure_azure_monitor_telemetry()` function (defaults to "production")
- Create OpenTelemetry `Resource` with `service.name` set to `crush.lu-{environment}` to override default cloud_RoleName
- Pass resource to `configure_azure_monitor()` configuration
- Updated docstring with environment parameter documentation
- Enhanced log message to include environment and cloud_RoleName for clarity
- Updated legacy `configure_exception_filtering()` to accept and forward environment parameter

### `azureproject/production.py`
- Added `DJANGO_ENV` environment variable detection (defaults to "production", can be set to "staging")
- Pass `DJANGO_ENV` to `configure_azure_monitor_telemetry()` call
- Enhanced logging formatter to include environment context in all log messages via `defaults` parameter

## How to Test
* Deploy to Azure App Service with `DJANGO_ENV` slot-sticky setting configured
* Verify in Application Insights that cloud_RoleName appears as "crush.lu-production" or "crush.lu-staging"
* Confirm log messages include environment context in the format: `LEVEL [logger_name] [environment] message`
* Verify telemetry is properly filtered and grouped by environment in App Insights dashboards

## What to Check
Verify that the following are valid:
* Azure Monitor telemetry initializes successfully with environment parameter
* cloud_RoleName is correctly set in Application Insights based on DJANGO_ENV
* Log messages include environment context
* Backward compatibility is maintained (environment parameter defaults to "production")
* Staging and production deployments can be distinguished in App Insights

## Other Information
The `DJANGO_ENV` environment variable should be configured as a slot-sticky setting in Azure App Service to ensure it persists across deployments and is environment-specific (different values for staging vs. production slots).

https://claude.ai/code/session_01ENEs6wA9oufLoAmfCsfnZv