### PR TITLE
Fix phone verification: prevent duplicates and handle intl-tel-input edge cases

### DIFF
--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -75,6 +75,7 @@ urlpatterns = base_patterns + api_patterns + [
 
     # Phone verification API (language-neutral - called by JavaScript with hardcoded paths)
     path('api/phone/mark-verified/', views_phone_verification.mark_phone_verified, name='api_phone_mark_verified'),
+    path('api/phone/check-available/', views_phone_verification.check_phone_available, name='api_phone_check_available'),
     path('api/phone/status/', views_phone_verification.phone_verification_status, name='api_phone_status'),
 
     # ============================================================================

--- a/crush_lu/forms.py
+++ b/crush_lu/forms.py
@@ -308,6 +308,22 @@ class CrushProfileForm(forms.ModelForm):
         # Remove all whitespace and dashes for validation
         phone_clean = re.sub(r'[\s\-\(\)]', '', phone)
 
+        # Skip format validation for already-verified phones: the number was
+        # validated by Firebase in E.164 format during verification, so we
+        # trust the DB value.  This prevents false negatives caused by
+        # intl-tel-input's separateDialCode stripping the dial code from
+        # input.value on re-submission.
+        if self.instance and self.instance.pk:
+            from .models import CrushProfile
+            try:
+                db_profile = CrushProfile.objects.get(pk=self.instance.pk)
+                if db_profile.phone_verified:
+                    # Return the verified phone from DB (normalized E.164)
+                    db_phone_clean = re.sub(r'[\s\-\(\)]', '', db_profile.phone_number)
+                    return db_phone_clean
+            except CrushProfile.DoesNotExist:
+                pass
+
         # Must start with + for international format
         if not phone_clean.startswith('+'):
             raise forms.ValidationError(
@@ -343,7 +359,8 @@ class CrushProfileForm(forms.ModelForm):
                 _("Phone number can only contain digits after the country code.")
             )
 
-        return phone
+        # Return normalized phone (no spaces/dashes) for consistent DB storage
+        return phone_clean
 
     def clean(self):
         """Additional cross-field validation"""

--- a/crush_lu/migrations/0112_require_plus_prefix_phone_validator.py
+++ b/crush_lu/migrations/0112_require_plus_prefix_phone_validator.py
@@ -1,0 +1,29 @@
+# Generated manually
+
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('crush_lu', '0111_quizevent_num_tables_and_generated'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='crushprofile',
+            name='phone_number',
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                max_length=20,
+                validators=[
+                    django.core.validators.RegexValidator(
+                        message='Enter a valid phone number (e.g., +352 621 123 456).',
+                        regex='^\\+[\\d\\s\\-().]{7,20}$',
+                    )
+                ],
+            ),
+        ),
+    ]

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -374,7 +374,7 @@ class CrushProfile(models.Model):
     phone_number = models.CharField(
         max_length=20, blank=True, db_index=True,
         validators=[RegexValidator(
-            regex=r'^\+?[\d\s\-().]{7,20}$',
+            regex=r'^\+[\d\s\-().]{7,20}$',
             message=_("Enter a valid phone number (e.g., +352 621 123 456)."),
         )],
     )  # Required in form, not model

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -2174,15 +2174,19 @@ document.addEventListener('alpine:init', function() {
                 // CRITICAL: Before form submission, ensure phone number input has full international number
                 // intlTelInput with separateDialCode=true stores only national number in input.value
                 // We need to set the full number so Django form receives it correctly
-                if (window.itiInstance) {
-                    var phoneInput = document.querySelector('[name="phone_number"]');
-                    if (phoneInput && !phoneInput.readOnly) {
-                        // Get full international number from intlTelInput
+                var phoneInput = document.querySelector('[name="phone_number"]');
+                if (phoneInput) {
+                    if (window.itiInstance) {
+                        // Get full international number from intlTelInput (works for both
+                        // readOnly/verified and editable phones)
                         var fullNumber = window.itiInstance.getNumber();
                         if (fullNumber) {
                             phoneInput.value = fullNumber;
                         }
                     }
+                    // Safety net: if value still lacks '+' prefix and looks like a
+                    // national number, the backend clean_phone_number will handle it
+                    // for verified phones by returning the DB value.
                 }
             },
 
@@ -3841,8 +3845,25 @@ document.addEventListener('alpine:init', function() {
                     self.verified = true;
                     var phoneInput = document.getElementById(self.phoneInputId);
                     if (phoneInput && e.detail) {
+                        if (self.iti) {
+                            // Use setNumber() to keep intl-tel-input in sync, then
+                            // destroy the instance so it can't strip the dial code later
+                            self.iti.setNumber(e.detail);
+                        }
+                        // Set the raw input value to full E.164 number as a safety net
                         phoneInput.value = e.detail;
                         phoneInput.readOnly = true;
+                        // Destroy intl-tel-input instance - phone is now verified and locked,
+                        // we don't want the library interfering with the value on form submit
+                        if (self.iti) {
+                            try {
+                                self.iti.destroy();
+                            } catch (err) {
+                                console.warn('intl-tel-input: Could not destroy after verification', err);
+                            }
+                            self.iti = null;
+                            window.itiInstance = null;
+                        }
                     }
                 });
             },
@@ -3879,11 +3900,40 @@ document.addEventListener('alpine:init', function() {
                     return;
                 }
 
-                // Dispatch event to open modal
-                window.dispatchEvent(new CustomEvent('open-phone-modal'));
-
                 // Get phone number
                 var phoneNumber = this.iti ? this.iti.getNumber() : document.getElementById(this.phoneInputId).value;
+
+                // Check if phone is already taken BEFORE sending SMS
+                var csrfToken = document.querySelector('input[name="csrfmiddlewaretoken"]');
+                fetch('/api/phone/check-available/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfToken ? csrfToken.value : ''
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ phone_number: phoneNumber })
+                })
+                .then(function(response) { return response.json(); })
+                .then(function(data) {
+                    if (!data.available) {
+                        self.errorMessage = data.error || 'This phone number is already in use';
+                        return;
+                    }
+                    // Phone is available - open modal and send SMS
+                    self._doStartVerification(phoneNumber);
+                })
+                .catch(function() {
+                    // If check fails, proceed anyway (backend will still catch duplicates)
+                    self._doStartVerification(phoneNumber);
+                });
+            },
+
+            _doStartVerification: function(phoneNumber) {
+                var self = this;
+
+                // Dispatch event to open modal
+                window.dispatchEvent(new CustomEvent('open-phone-modal'));
 
                 // Initialize phone verification
                 if (window.phoneVerification) {
@@ -4357,6 +4407,38 @@ document.addEventListener('alpine:init', function() {
                 this.displayPhone = phoneNumber;
                 this.isLoading = true;
 
+                // Check if phone is already taken BEFORE sending the SMS
+                // (saves Firebase SMS credits)
+                var csrfToken = document.querySelector('input[name="csrfmiddlewaretoken"]');
+                fetch('/api/phone/check-available/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': csrfToken ? csrfToken.value : ''
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ phone_number: phoneNumber })
+                })
+                .then(function(response) { return response.json(); })
+                .then(function(data) {
+                    if (!data.available) {
+                        self.isLoading = false;
+                        self.phoneAlreadyInUse = true;
+                        self.error = data.error || 'This phone number is already in use';
+                        return;
+                    }
+                    // Phone is available - proceed with Firebase SMS
+                    self._sendFirebaseSms(phoneNumber);
+                })
+                .catch(function() {
+                    // If check fails (network error), proceed with SMS anyway
+                    // The backend mark_phone_verified will still catch duplicates
+                    self._sendFirebaseSms(phoneNumber);
+                });
+            },
+
+            _sendFirebaseSms: function(phoneNumber) {
+                var self = this;
                 if (window.phoneVerification) {
                     window.phoneVerification.sendVerificationCode(phoneNumber).then(function(result) {
                         self.isLoading = false;

--- a/crush_lu/templates/crush_lu/create_profile.html
+++ b/crush_lu/templates/crush_lu/create_profile.html
@@ -1331,7 +1331,7 @@
 
                     <!-- OTP Inputs - CSP-compatible: using :value + @input with method names only (no $event) -->
                     <div class="flex justify-center gap-2 mb-4">
-                        <input type="text" id="otp-0" x-ref="otp0" maxlength="1" inputmode="numeric" pattern="[0-9]" data-index="0"
+                        <input type="text" id="otp-0" x-ref="otp0" maxlength="1" inputmode="numeric" pattern="[0-9]" autocomplete="one-time-code" data-index="0"
                                :value="otp0" @input="handleOtp0Input" @keydown.backspace="handleOtpBackspace" @paste="handleOtpPaste"
                                class="w-12 h-14 text-center text-xl font-semibold border-2 border-gray-300 rounded-lg focus:border-purple-500 focus:ring-2 focus:ring-purple-200 outline-none transition dark:bg-gray-700 dark:text-white dark:border-gray-600">
                         <input type="text" id="otp-1" x-ref="otp1" maxlength="1" inputmode="numeric" pattern="[0-9]" data-index="1"

--- a/crush_lu/templates/crush_lu/verify_phone.html
+++ b/crush_lu/templates/crush_lu/verify_phone.html
@@ -95,7 +95,7 @@
                                 {% trans "Verification Code" %}
                             </label>
                             <div class="flex justify-center gap-2">
-                                <input type="text" id="otp-0" maxlength="1" inputmode="numeric"
+                                <input type="text" id="otp-0" maxlength="1" inputmode="numeric" autocomplete="one-time-code"
                                        class="w-12 h-14 text-center text-2xl font-bold border-2 border-gray-300 dark:border-gray-600 rounded-lg focus:border-purple-500 focus:ring-2 focus:ring-purple-200 dark:bg-gray-700 dark:text-white"
                                        :value="otp0"
                                        @input="handleOtpInput(0, $event)"

--- a/crush_lu/views_phone_verification.py
+++ b/crush_lu/views_phone_verification.py
@@ -181,6 +181,50 @@ def mark_phone_verified(request):
 
 
 @login_required
+@require_POST
+@csrf_protect
+@ratelimit(key='user', rate='10/m', method='POST')
+def check_phone_available(request):
+    """
+    Check if a phone number is available (not already verified by another user).
+
+    Call this BEFORE sending the Firebase SMS to avoid wasting SMS credits
+    on phone numbers that are already taken.
+
+    Returns:
+        JsonResponse with:
+        - available: bool (True if phone can be used)
+        - error: str (only when available is False)
+    """
+    try:
+        data = json.loads(request.body)
+        phone_number = data.get('phone_number', '').strip()
+    except (json.JSONDecodeError, AttributeError):
+        return JsonResponse({"available": False, "error": "Invalid request"}, status=400)
+
+    if not phone_number:
+        return JsonResponse({"available": False, "error": "Phone number is required"}, status=400)
+
+    # Normalize: remove spaces/dashes for comparison
+    import re
+    phone_clean = re.sub(r'[\s\-\(\)]', '', phone_number)
+
+    # Check if this phone is already verified by a different user
+    already_taken = CrushProfile.objects.filter(
+        phone_number=phone_clean,
+        phone_verified=True,
+    ).exclude(user=request.user).exists()
+
+    if already_taken:
+        return JsonResponse({
+            "available": False,
+            "error": _("This phone number is already associated with another account."),
+        })
+
+    return JsonResponse({"available": True})
+
+
+@login_required
 @require_GET
 def phone_verification_status(request):
     """


### PR DESCRIPTION
## Purpose
This PR addresses critical issues with phone number verification:

1. **Prevent duplicate phone registrations**: Add a pre-SMS availability check (`/api/phone/check-available/`) to prevent wasting Firebase SMS credits on phone numbers already verified by other users.

2. **Fix intl-tel-input interference**: When a phone is verified and locked as read-only, destroy the intl-tel-input instance to prevent it from stripping the dial code on form re-submission. This was causing form validation failures when users edited other profile fields after phone verification.

3. **Enforce E.164 format in database**: Update the phone number validator to require the `+` prefix (`^\+[\d\s\-().]{7,20}$`), ensuring all stored phone numbers are in proper international format.

4. **Improve form validation logic**: Skip format re-validation for already-verified phones by returning the trusted DB value, preventing false negatives from intl-tel-input's dial code stripping behavior.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
# Run Django tests
python manage.py test crush_lu.tests

# Manual testing:
# 1. Create a profile with phone verification
# 2. Verify the phone number via SMS
# 3. Edit the profile (change name, email, etc.) and submit
# 4. Verify the phone number persists correctly without validation errors
# 5. Try to register another account with the same verified phone
# 6. Verify the "already in use" error appears before SMS is sent
```

## What to Check
Verify that the following are valid:
* Phone verification completes successfully and phone is locked as read-only
* Editing other profile fields after phone verification doesn't cause validation errors
* Attempting to register with a phone number already verified by another user shows an error before SMS is sent
* The phone number is stored in E.164 format (+country code + number) in the database
* Form submission includes the full international number (with + prefix) for Django validation

## Other Information
* Added new migration `0112_require_plus_prefix_phone_validator.py` to enforce `+` prefix in phone validator
* Added new API endpoint `/api/phone/check-available/` with rate limiting (10 requests/minute per user)
* Refactored phone verification logic into `_doStartVerification()` and `_sendFirebaseSms()` helper methods for code reuse
* The availability check gracefully falls back to proceeding with SMS if the check fails (network error), allowing the backend to catch duplicates as a safety net

https://claude.ai/code/session_013kLdfPQ7KFmvocxiUKXn8x