### PR TITLE
Defer score reveal until all tables scored in quiz night

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -205,7 +205,11 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
         if result is None:
             return
 
-        # Broadcast table scored event
+        # Already scored — silently ignore re-scores
+        if result.get("already_scored"):
+            return
+
+        # Broadcast table scored event (no correctness info — deferred until all scored)
         await self.channel_layer.group_send(
             self.quiz_group,
             {
@@ -214,11 +218,24 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                     "table_id": table_id,
                     "table_number": result["table_number"],
                     "question_id": question_id,
-                    "is_correct": is_correct,
-                    "points_awarded": result["points_awarded"],
+                    "scored_count": result["scored_count"],
+                    "total_tables": result["total_tables"],
                 },
             },
         )
+
+        # When all tables scored, reveal results to everyone
+        if result.get("all_scored"):
+            await self.channel_layer.group_send(
+                self.quiz_group,
+                {
+                    "type": "quiz.reveal_scores",
+                    "data": {
+                        "question_id": question_id,
+                        "results": result["reveal_results"],
+                    },
+                },
+            )
 
     async def handle_rotate(self):
         rotation_data = await self.advance_round_and_rotate()
@@ -283,6 +300,9 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
 
     async def quiz_table_scored(self, event):
         await self.send_json({"type": "quiz.table_scored", "data": event["data"]})
+
+    async def quiz_reveal_scores(self, event):
+        await self.send_json({"type": "quiz.reveal_scores", "data": event["data"]})
 
     async def quiz_answer_result(self, event):
         await self.send_json({"type": "quiz.answer_result", "data": event["data"]})
@@ -603,7 +623,12 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
 
     @database_sync_to_async
     def score_table_for_question(self, table_id, question_id, is_correct):
-        """Host scores a table. Creates IndividualScores for all table members."""
+        """Host scores a table. Creates IndividualScores for all table members.
+
+        Returns None on error, {"already_scored": True} if table was already
+        scored for this question, or a dict with scoring results including
+        whether all tables have now been scored.
+        """
         from crush_lu.models.quiz import (
             IndividualScore,
             QuizEvent,
@@ -629,13 +654,15 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
         ):
             return None
 
-        # Create or update TableRoundScore
-        TableRoundScore.objects.update_or_create(
+        # Only allow scoring once per table per question (no re-scores)
+        _obj, created = TableRoundScore.objects.get_or_create(
             quiz=quiz,
             table=table,
             question=question,
             defaults={"is_correct": is_correct},
         )
+        if not created:
+            return {"already_scored": True}
 
         # Issue #4: Read bonus from question's own round, not quiz.current_round
         points = question.points if is_correct else 0
@@ -676,11 +703,43 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                 },
             )
 
-        return {
+        # Check if all tables have been scored for this question
+        total_tables = QuizTable.objects.filter(quiz=quiz).count()
+        scored_count = TableRoundScore.objects.filter(
+            quiz=quiz, question=question
+        ).count()
+        all_scored = scored_count >= total_tables
+
+        result = {
             "table_number": table.table_number,
             "points_awarded": points,
             "members_scored": len(rotation_users),
+            "scored_count": scored_count,
+            "total_tables": total_tables,
+            "all_scored": all_scored,
         }
+
+        # When all tables scored, include full results for the reveal
+        if all_scored:
+            all_scores = TableRoundScore.objects.filter(
+                quiz=quiz, question=question
+            ).select_related("table", "question", "question__round")
+            reveal_results = []
+            for score in all_scores:
+                pts = score.question.points if score.is_correct else 0
+                if score.is_correct and score.question.round.is_bonus:
+                    pts *= 2
+                reveal_results.append(
+                    {
+                        "table_id": score.table_id,
+                        "table_number": score.table.table_number,
+                        "is_correct": score.is_correct,
+                        "points_awarded": pts,
+                    }
+                )
+            result["reveal_results"] = reveal_results
+
+        return result
 
     @database_sync_to_async
     def advance_round_and_rotate(self):

--- a/crush_lu/static/crush_lu/js/quiz-live.js
+++ b/crush_lu/static/crush_lu/js/quiz-live.js
@@ -345,21 +345,29 @@ document.addEventListener("alpine:init", function () {
                         this.screen = "waiting";
                     }
                 } else if (type === "quiz.table_scored") {
-                    // Show feedback when host scores our table
-                    if (data.table_number === this.tableNumber) {
-                        this._tableScoredCorrect = data.is_correct;
-                        if (data.is_correct) {
-                            var pts = data.points_awarded || 0;
-                            this.tableScoredFeedback = "+" + pts + " pts!";
-                            this.personalScore += pts;
-                        } else {
-                            this.tableScoredFeedback = "Incorrect";
+                    // Scoring in progress — no correctness info yet (deferred until all tables scored)
+                    this.tableScoredFeedback = "";
+                } else if (type === "quiz.reveal_scores") {
+                    // All tables scored — reveal correct/incorrect to attendees
+                    var results = data.results || [];
+                    for (var ri = 0; ri < results.length; ri++) {
+                        if (results[ri].table_number === this.tableNumber) {
+                            var r = results[ri];
+                            this._tableScoredCorrect = r.is_correct;
+                            if (r.is_correct) {
+                                var pts = r.points_awarded || 0;
+                                this.tableScoredFeedback = "+" + pts + " pts!";
+                                this.personalScore += pts;
+                            } else {
+                                this.tableScoredFeedback = "Incorrect";
+                            }
+                            var self = this;
+                            if (this.tableScoredTimer) clearTimeout(this.tableScoredTimer);
+                            this.tableScoredTimer = setTimeout(function () {
+                                self.tableScoredFeedback = "";
+                            }, 3000);
+                            break;
                         }
-                        var self = this;
-                        if (this.tableScoredTimer) clearTimeout(this.tableScoredTimer);
-                        this.tableScoredTimer = setTimeout(function () {
-                            self.tableScoredFeedback = "";
-                        }, 3000);
                     }
                 } else if (type === "quiz.table_score") {
                     // Legacy table score update
@@ -727,8 +735,10 @@ document.addEventListener("alpine:init", function () {
 
             // Scoring
             tableCount: 0,
-            scoredTables: {}, // { tableId: true/false }
+            scoredTables: {}, // { tableId: "pending"|"scored"|true|false }
             scoringQuestionId: null,
+            scoredCount: 0,
+            totalTables: 0,
 
             // Table overview (who sits where)
             tableMembers: [], // [{ table_number, members: [{display_name, role}], total_score }]
@@ -787,6 +797,9 @@ document.addEventListener("alpine:init", function () {
             },
             get hasLeaderboard() {
                 return this.tables.length > 0;
+            },
+            get scoringProgress() {
+                return this.scoredCount + " / " + this.totalTables;
             },
             get showScoringGrid() {
                 return this.isQuizNight && this.hasCurrentQuestion;
@@ -948,6 +961,7 @@ document.addEventListener("alpine:init", function () {
                     this.roundComplete = false;
                     // Reset scoring state for new question
                     this.scoredTables = {};
+                    this.scoredCount = 0;
                     this.scoringQuestionId = data.id;
                 } else if (type === "quiz.leaderboard") {
                     this.tables = data.tables || [];
@@ -990,11 +1004,20 @@ document.addEventListener("alpine:init", function () {
                         this._advanceRoundsByNumber(data.round_number);
                     }
                 } else if (type === "quiz.table_scored") {
-                    // Track which tables have been scored
+                    // Track which tables have been scored (no correctness info yet)
                     if (data.table_id) {
-                        this.scoredTables[data.table_id] = data.is_correct;
+                        this.scoredTables[data.table_id] = "scored";
+                        if (data.scored_count !== undefined) this.scoredCount = data.scored_count;
+                        if (data.total_tables !== undefined) this.totalTables = data.total_tables;
                         this._updateTableButtons();
                     }
+                } else if (type === "quiz.reveal_scores") {
+                    // All tables scored — reveal correct/incorrect
+                    var results = data.results || [];
+                    for (var i = 0; i < results.length; i++) {
+                        this.scoredTables[results[i].table_id] = results[i].is_correct;
+                    }
+                    this._updateTableButtons();
                 } else if (type === "quiz.error") {
                     this.showError(data.message || "An error occurred");
                 }
@@ -1120,6 +1143,8 @@ document.addEventListener("alpine:init", function () {
 
             _scoreTable: function (tableId, isCorrect) {
                 if (!this.ws || !this.connected || !this.currentQuestion) return;
+                // Prevent re-scoring a table that has already been scored
+                if (this.scoredTables[tableId] !== undefined) return;
                 this.ws.send(
                     JSON.stringify({
                         action: "score_table",
@@ -1128,7 +1153,7 @@ document.addEventListener("alpine:init", function () {
                         is_correct: isCorrect,
                     }),
                 );
-                this.scoredTables[tableId] = isCorrect;
+                this.scoredTables[tableId] = "pending";
                 this._updateTableButtons();
             },
 
@@ -1153,10 +1178,7 @@ document.addEventListener("alpine:init", function () {
                 }
             },
 
-            clearScoring: function () {
-                this.scoredTables = {};
-                this._updateTableButtons();
-            },
+            // clearScoring removed — scoring is locked after reveal
 
             _updateTableButtons: function () {
                 var root = this._root;
@@ -1168,19 +1190,37 @@ document.addEventListener("alpine:init", function () {
                         .replace(/ring-\S+/g, "")
                         .replace(/text-\S+/g, "")
                         .replace(/hover:\S+/g, "")
+                        .replace(/opacity-\S+/g, "")
+                        .replace(/cursor-\S+/g, "")
                         .replace(/\s+/g, " ")
                         .trim();
+                    var state = this.scoredTables[tid];
                     var cls;
-                    if (this.scoredTables[tid] === true) {
-                        cls = "bg-green-700 ring-2 ring-green-400 text-white";
-                    } else if (this.scoredTables[tid] === false) {
-                        cls = "bg-red-700 ring-2 ring-red-400 text-white";
+                    if (state === true) {
+                        cls = "bg-green-700 ring-2 ring-green-400 text-white opacity-60 cursor-not-allowed";
+                    } else if (state === false) {
+                        cls = "bg-red-700 ring-2 ring-red-400 text-white opacity-60 cursor-not-allowed";
+                    } else if (state === "pending" || state === "scored") {
+                        cls = "bg-amber-700 ring-2 ring-amber-400 text-white opacity-60 cursor-not-allowed";
                     } else {
                         cls = "bg-slate-700 text-gray-300 hover:bg-slate-600";
                     }
                     var parts = cls.split(" ");
                     for (var j = 0; j < parts.length; j++) {
                         buttons[i].classList.add(parts[j]);
+                    }
+                    // Disable buttons for already-scored tables
+                    buttons[i].disabled = state !== undefined;
+                }
+                // Also disable the wrong (✗) buttons for scored tables
+                var wrongBtns = root.querySelectorAll("button[x-on\\:click='scoreTableWrongFromEl'][data-table-id]");
+                for (var k = 0; k < wrongBtns.length; k++) {
+                    var wtid = parseInt(wrongBtns[k].getAttribute("data-table-id"), 10);
+                    wrongBtns[k].disabled = this.scoredTables[wtid] !== undefined;
+                    if (wrongBtns[k].disabled) {
+                        wrongBtns[k].classList.add("opacity-30", "cursor-not-allowed");
+                    } else {
+                        wrongBtns[k].classList.remove("opacity-30", "cursor-not-allowed");
                     }
                 }
             },

--- a/crush_lu/templates/crush_lu/quiz_coach.html
+++ b/crush_lu/templates/crush_lu/quiz_coach.html
@@ -115,8 +115,11 @@
 
         {# --- Table Scoring Grid (Quiz Night) --- #}
         <div x-show="showScoringGrid" class="mb-6 rounded-xl bg-slate-800 p-4 shadow-lg">
-            <h2 class="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-400">{% trans "Score Tables" %}</h2>
-            <p class="mb-3 text-xs text-gray-500">{% trans "Click table to mark correct, click again for incorrect" %}</p>
+            <div class="mb-3 flex items-center justify-between">
+                <h2 class="text-sm font-semibold uppercase tracking-wider text-gray-400">{% trans "Score Tables" %}</h2>
+                <span x-show="totalTables > 0" x-text="scoringProgress" class="text-sm font-medium text-amber-400"></span>
+            </div>
+            <p class="mb-3 text-xs text-gray-500">{% trans "Click table to mark correct, ✗ for incorrect. Results reveal when all tables are scored." %}</p>
 
             <div class="grid grid-cols-3 gap-3 sm:grid-cols-4">
                 {% for table in tables %}
@@ -137,15 +140,11 @@
                 {% endfor %}
             </div>
 
-            {# Convenience buttons #}
-            <div class="mt-4 flex gap-3">
+            {# Convenience button #}
+            <div class="mt-4">
                 <button x-on:click="scoreAllCorrect"
-                        class="flex-1 rounded-lg bg-green-700 py-2 text-sm font-medium text-white hover:bg-green-600 transition-all">
+                        class="w-full rounded-lg bg-green-700 py-2 text-sm font-medium text-white hover:bg-green-600 transition-all">
                     {% trans "Score All Correct" %}
-                </button>
-                <button x-on:click="clearScoring"
-                        class="flex-1 rounded-lg bg-slate-700 py-2 text-sm font-medium text-gray-300 hover:bg-slate-600 transition-all">
-                    {% trans "Clear" %}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Purpose
* Implement a two-phase scoring system for quiz night where table scoring is tracked in real-time, but correctness/points are only revealed to attendees once all tables have been scored
* Prevent re-scoring of tables by tracking scoring state ("pending", "scored", or final boolean result)
* Add visual progress indicator showing how many tables have been scored
* Disable scoring buttons after a table has been scored to prevent accidental re-scoring
* Remove the "Clear" button since scoring is now locked after reveal

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
  1. Start a quiz night session as host
  2. Ask a question and verify the scoring grid appears
  3. Score individual tables and verify:
     - Scoring progress counter updates (e.g., "1 / 4")
     - Buttons turn amber and become disabled after scoring
     - Attendees see empty feedback during scoring phase
  4. Score the final table and verify:
     - All attendees receive reveal_scores message
     - Correct/incorrect feedback displays to attendees
     - Buttons show green (correct) or red (incorrect) with disabled state
     - Feedback clears after 3 seconds
  5. Attempt to re-score a table and verify it's silently ignored

## What to Check
Verify that the following are valid:
* Scoring progress counter displays correctly (scored_count / total_tables)
* Table buttons are disabled after being scored
* Attendees don't see correctness feedback until all tables are scored
* Re-scoring attempts are prevented both client-side and server-side
* The "Clear" button has been removed from the UI
* Bonus point multiplier is correctly applied when revealing scores

## Other Information
* Added new WebSocket message type `quiz.reveal_scores` for batch score revelation
* Modified `TableRoundScore` to use `get_or_create` instead of `update_or_create` to prevent re-scoring
* Enhanced button styling with opacity and cursor changes to indicate disabled state
* Scoring state now tracked as "pending"/"scored" during phase 1, then boolean on reveal

https://claude.ai/code/session_01NcHvEdWFSaRSuRkNUDFTzL