### PR TITLE
Add quiz night table scoring validation and coach reconnect support

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -148,6 +148,12 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             )
 
     async def handle_next_question(self):
+        # For quiz night events, ensure all tables are scored before advancing
+        unscored = await self.check_all_tables_scored()
+        if unscored is not None and not unscored:
+            await self.send_error("All tables must be scored before advancing.")
+            return
+
         question_data = await self.advance_question()
         if question_data:
             await self.channel_layer.group_send(
@@ -167,6 +173,9 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             return
 
         result = await self.set_current_round(round_id)
+        if result and result.get("error"):
+            await self.send_error(result["error"])
+            return
         if result:
             await self.channel_layer.group_send(
                 self.quiz_group,
@@ -435,6 +444,8 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             ],
         }
         if question and quiz.is_active:
+            from crush_lu.models.quiz import QuizTable, TableRoundScore
+
             questions = quiz.current_round.questions.order_by("sort_order")
             total = questions.count()
 
@@ -459,6 +470,7 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             data["time"] = quiz.current_round.time_per_question
             data["index"] = quiz.current_question_index
             data["total"] = total
+            data["question_count"] = total
             data["is_bonus"] = quiz.current_round.is_bonus
 
             # Calculate remaining time so refreshing doesn't reset the timer
@@ -468,6 +480,29 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                 data["time_remaining"] = int(remaining)
             else:
                 data["time_remaining"] = quiz.current_round.time_per_question
+
+            # Include scoring state so coach can resume after reconnect
+            total_tables = QuizTable.objects.filter(quiz=quiz).count()
+            scored_qs = TableRoundScore.objects.filter(
+                quiz=quiz, question=question
+            ).select_related("table")
+            scored_count = scored_qs.count()
+            all_scored = scored_count >= total_tables and total_tables > 0
+
+            data["total_tables"] = total_tables
+            data["scored_count"] = scored_count
+
+            # Build scored_tables map: {table_id: is_correct} if revealed,
+            # otherwise {table_id: "scored"}
+            scored_tables = {}
+            if all_scored:
+                for s in scored_qs:
+                    scored_tables[str(s.table_id)] = s.is_correct
+            else:
+                for s in scored_qs:
+                    scored_tables[str(s.table_id)] = "scored"
+            data["scored_tables"] = scored_tables
+
         return data
 
     @database_sync_to_async
@@ -539,6 +574,14 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
         except (QuizEvent.DoesNotExist, QuizRound.DoesNotExist):
             return None
 
+        # Block round changes during active play with a current question
+        if (
+            quiz.status == "active"
+            and quiz.current_question_index >= 0
+            and quiz.current_round_id != round_obj.id
+        ):
+            return {"error": "Cannot change rounds while a question is active."}
+
         quiz.current_round = round_obj
         # Set to -1 so the first next_question lands on index 0 (Issue #2)
         quiz.current_question_index = -1
@@ -569,6 +612,37 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
         quiz.question_started_at = None
         quiz.save(update_fields=["status", "question_started_at"])
         return {"status": status}
+
+    @database_sync_to_async
+    def check_all_tables_scored(self):
+        """Return True if all tables scored for current question, False if not.
+
+        Returns None for non-quiz-night events or if no active question.
+        """
+        from crush_lu.models.quiz import QuizEvent, QuizTable, TableRoundScore
+
+        try:
+            quiz = QuizEvent.objects.select_related("current_round", "event").get(
+                id=self.quiz_id
+            )
+        except QuizEvent.DoesNotExist:
+            return None
+
+        if quiz.event.event_type != "quiz_night":
+            return None  # No table scoring for non-quiz-night events
+
+        question = quiz.get_current_question()
+        if not question:
+            return None
+
+        total_tables = QuizTable.objects.filter(quiz=quiz).count()
+        if total_tables == 0:
+            return None
+
+        scored_count = TableRoundScore.objects.filter(
+            quiz=quiz, question=question
+        ).count()
+        return scored_count >= total_tables
 
     @database_sync_to_async
     def advance_question(self):

--- a/crush_lu/static/crush_lu/js/quiz-live.js
+++ b/crush_lu/static/crush_lu/js/quiz-live.js
@@ -79,6 +79,9 @@ document.addEventListener("alpine:init", function () {
             get isFinished() {
                 return this.screen === "finished";
             },
+            get isReview() {
+                return this.screen === "review";
+            },
             get isConnected() {
                 return this.connected;
             },
@@ -349,6 +352,11 @@ document.addEventListener("alpine:init", function () {
                     this.tableScoredFeedback = "";
                 } else if (type === "quiz.reveal_scores") {
                     // All tables scored — reveal correct/incorrect to attendees
+                    // Stop the countdown timer
+                    if (this.countdownTimer) {
+                        clearInterval(this.countdownTimer);
+                        this.countdownTimer = null;
+                    }
                     var results = data.results || [];
                     for (var ri = 0; ri < results.length; ri++) {
                         if (results[ri].table_number === this.tableNumber) {
@@ -361,13 +369,15 @@ document.addEventListener("alpine:init", function () {
                             } else {
                                 this.tableScoredFeedback = "Incorrect";
                             }
-                            var self = this;
-                            if (this.tableScoredTimer) clearTimeout(this.tableScoredTimer);
-                            this.tableScoredTimer = setTimeout(function () {
-                                self.tableScoredFeedback = "";
-                            }, 3000);
                             break;
                         }
+                    }
+                    // Transition to review screen — persistent until next question
+                    this.screen = "review";
+                    // Clear any previous auto-hide timer (feedback stays until next question)
+                    if (this.tableScoredTimer) {
+                        clearTimeout(this.tableScoredTimer);
+                        this.tableScoredTimer = null;
                     }
                 } else if (type === "quiz.table_score") {
                     // Legacy table score update
@@ -400,6 +410,12 @@ document.addEventListener("alpine:init", function () {
                 this.answered = false;
                 this.lastResult = null;
                 this.isBonusRound = data.is_bonus || false;
+                // Clear review screen feedback from previous question
+                this.tableScoredFeedback = "";
+                if (this.tableScoredTimer) {
+                    clearTimeout(this.tableScoredTimer);
+                    this.tableScoredTimer = null;
+                }
                 this.screen = "question";
                 this._renderChoices();
                 this.startCountdown();
@@ -562,7 +578,12 @@ document.addEventListener("alpine:init", function () {
             },
 
             _renderTableLeaderboard: function () {
-                var container = this.$refs.tableboard;
+                // Render into both live leaderboard and finished screen containers
+                this._renderTableLeaderboardInto(this.$refs.tableboard_live);
+                this._renderTableLeaderboardInto(this.$refs.tableboard);
+            },
+
+            _renderTableLeaderboardInto: function (container) {
                 if (!container) return;
                 container.innerHTML = "";
                 for (var i = 0; i < this.tables.length; i++) {
@@ -596,7 +617,12 @@ document.addEventListener("alpine:init", function () {
             },
 
             _renderIndividualLeaderboard: function () {
-                var container = this.$refs.playerboard;
+                // Render into both live leaderboard and finished screen containers
+                this._renderIndividualLeaderboardInto(this.$refs.playerboard_live);
+                this._renderIndividualLeaderboardInto(this.$refs.playerboard);
+            },
+
+            _renderIndividualLeaderboardInto: function (container) {
                 if (!container) return;
                 container.innerHTML = "";
                 for (var i = 0; i < this.individuals.length; i++) {
@@ -789,8 +815,14 @@ document.addEventListener("alpine:init", function () {
             get canRotate() {
                 return this.isQuizNight && this.roundComplete;
             },
+            get allTablesScored() {
+                return this.totalTables > 0 && this.scoredCount >= this.totalTables;
+            },
             get showNextQuestion() {
-                return !this.roundComplete && !this.isFinished;
+                if (this.roundComplete || this.isFinished) return false;
+                // In quiz night mode, block advancing until all tables are scored
+                if (this.isQuizNight && this.hasCurrentQuestion && !this.allTablesScored) return false;
+                return true;
             },
             get hasCurrentQuestion() {
                 return this.currentQuestion !== null;
@@ -947,6 +979,17 @@ document.addEventListener("alpine:init", function () {
                     if (data.question) {
                         this.currentQuestion = data.question;
                         this.roundComplete = false;
+                        // Restore scoring state for reconnecting coach
+                        this.scoringQuestionId = data.question.id;
+                        this.questionCount = data.question_count || data.total || 0;
+                        this.scoredCount = data.scored_count || 0;
+                        this.totalTables = data.total_tables || 0;
+                        if (data.scored_tables) {
+                            this.scoredTables = data.scored_tables;
+                        } else {
+                            this.scoredTables = {};
+                        }
+                        this._updateTableButtons();
                     } else {
                         this.currentQuestion = null;
                         // Round complete only if active AND we've gone past index 0
@@ -1237,6 +1280,10 @@ document.addEventListener("alpine:init", function () {
                     if (this.rounds[i].id === roundId && this.rounds[i].status === "done") {
                         return;
                     }
+                }
+                // Prevent skipping to other rounds during active play
+                if (this.status === "active" && this.currentQuestion !== null && roundId !== this.selectedRoundId) {
+                    return;
                 }
                 this.selectedRoundId = roundId;
                 this.roundComplete = false;

--- a/crush_lu/templates/crush_lu/quiz_live.html
+++ b/crush_lu/templates/crush_lu/quiz_live.html
@@ -115,17 +115,38 @@
             </div>
         </div>
 
+        {# --- Review Screen (post-answer, waiting for next question) --- #}
+        <div x-show="isReview" class="space-y-4">
+            <div class="rounded-xl bg-slate-800 p-6 text-center shadow-lg">
+                <p class="text-lg font-medium text-white" x-text="questionText"></p>
+                <p class="mt-1 text-sm text-crush-purple" x-text="pointsLabel"></p>
+            </div>
+            <div x-show="hasTableScoredFeedback"
+                 x-bind:class="tableScoredFeedbackClass"
+                 class="rounded-xl p-6 text-center shadow-lg">
+                <p class="text-2xl font-bold" x-text="tableScoredFeedback"></p>
+            </div>
+            <div class="rounded-xl bg-slate-800 p-4 text-center">
+                <div class="mx-auto mb-2 h-8 w-8 animate-pulse rounded-full bg-crush-purple/30 flex items-center justify-center">
+                    <svg class="h-4 w-4 text-crush-purple" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    </svg>
+                </div>
+                <p class="text-gray-400">{% trans "Waiting for the next question..." %}</p>
+            </div>
+        </div>
+
         {# --- Leaderboard Screen --- #}
         <div x-show="isLeaderboard" class="space-y-4">
             <h2 class="text-center text-xl font-bold text-white">{% trans "Leaderboard" %}</h2>
 
             {# Table rankings (rendered via JS for CSP compliance) #}
-            <div class="space-y-2" x-ref="tableboard"></div>
+            <div class="space-y-2" x-ref="tableboard_live"></div>
 
             {# Individual top scorers (rendered via JS for CSP compliance) #}
             <div x-show="hasIndividualScores">
                 <h3 class="mb-2 text-center text-sm font-semibold uppercase tracking-wider text-gray-400">{% trans "Top Players" %}</h3>
-                <div class="space-y-1" x-ref="playerboard"></div>
+                <div class="space-y-1" x-ref="playerboard_live"></div>
             </div>
         </div>
 


### PR DESCRIPTION
## Purpose
* Prevent advancing to the next question in quiz night events until all tables have been scored
* Restore scoring state when a coach reconnects mid-question, allowing them to resume scoring without losing progress
* Block round changes during active play to prevent accidental quiz disruption
* Add a review screen that displays answer feedback and persists until the next question loads
* Improve UX by stopping the countdown timer when scores are revealed

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
# For quiz night events:
1. Start a quiz night event with multiple tables
2. Load a question and verify the "Next Question" button is disabled
3. Score all tables and verify the button becomes enabled
4. Disconnect and reconnect as coach mid-question
5. Verify scoring state is restored (scored tables and counts are visible)
6. Verify the review screen displays after all tables are scored
7. Attempt to change rounds during active play and verify it's blocked
```

## What to Check
Verify that the following are valid:
* Quiz night events block question advancement until all tables are scored
* Coach reconnection restores the current question and scoring progress
* The review screen displays feedback and persists until the next question
* Round changes are prevented during active play with a current question
* Non-quiz-night events are unaffected by table scoring validation
* Countdown timer stops when scores are revealed
* Leaderboards render correctly in both live and finished screens

## Other Information
The changes maintain backward compatibility with non-quiz-night event types. The scoring validation only applies to events with `event_type == "quiz_night"`. All existing functionality for standard quiz events remains unchanged.

https://claude.ai/code/session_01JjbVfB2pWug9tAN2TVRWeQ