### PR TITLE
Add POST request handling to coach quiz question edit view

### DIFF
--- a/crush_lu/views_quiz_config.py
+++ b/crush_lu/views_quiz_config.py
@@ -242,6 +242,9 @@ def coach_quiz_question_edit(request, event_id, question_id):
     quiz = get_object_or_404(QuizEvent, event=event)
     question = get_object_or_404(QuizQuestion, id=question_id, round__quiz=quiz)
 
+    if request.method == "POST":
+        return _save_question(request, event, question.round, question=question)
+
     # Build per-language choices JSON for the Alpine component
     choices_by_lang = {}
     for lang in LANGUAGES:


### PR DESCRIPTION
## Purpose
* Add POST request handling to the `coach_quiz_question_edit` view to enable saving quiz question edits
* Delegate POST request processing to the existing `_save_question` helper function for consistency with other question management endpoints

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
# Navigate to a quiz event's question edit page and submit the form to verify the POST request is processed correctly
```

## What to Check
Verify that the following are valid
* Quiz question edits can be saved via POST request to the coach quiz question edit endpoint
* The `_save_question` helper function correctly processes the request and updates the question
* Existing GET request functionality (displaying the edit form) remains unchanged

## Other Information
This change follows the existing pattern used in other quiz configuration views by delegating POST handling to the `_save_question` utility function.

https://claude.ai/code/session_01EEHjLP7wNeq8XZBsQLBvDs