### PR TITLE
fix: CSRF cookie not set on signup (Safari) and entreprinder namespace error

### DIFF
--- a/crush_lu/static/crush_lu/sw-workbox.js
+++ b/crush_lu/static/crush_lu/sw-workbox.js
@@ -38,8 +38,7 @@ self.addEventListener("fetch", (event) => {
     }
 
     // TRUE HARD BYPASS: OAuth and auth-related URLs
-    // Using event.respondWith(fetch()) ensures NO other handler can intercept
-    if (
+    const isAuthUrl = (
         url.pathname.startsWith("/accounts/") || // All OAuth/auth routes
         url.pathname.startsWith("/oauth/") || // OAuth landing and callbacks
         url.pathname.includes("/login/callback") || // Explicit callback match
@@ -49,8 +48,17 @@ self.addEventListener("fetch", (event) => {
         url.pathname.includes("/logout") || // Logout page (incl. language prefixes)
         url.pathname.includes("/signup") || // Signup page (incl. language prefixes)
         url.pathname.includes("/api/csrf-token") // CSRF token refresh endpoint
-    ) {
-        // Direct network fetch - prevents any Workbox handler from intercepting
+    );
+    if (isAuthUrl) {
+        // Navigation requests (page loads): let the browser handle them completely.
+        // Safari/WebKit may not process Set-Cookie headers (including CSRF cookies)
+        // from responses that pass through event.respondWith(fetch()), so we must
+        // NOT intercept navigation requests to auth pages.
+        if (event.request.mode === "navigate") {
+            return; // Full browser bypass - cookies will be processed correctly
+        }
+        // Non-navigation requests (fetch/XHR): claim the request to prevent
+        // Workbox from caching it, but forward directly to the network.
         event.respondWith(fetch(event.request));
         return;
     }

--- a/crush_lu/templates/account/login.html
+++ b/crush_lu/templates/account/login.html
@@ -1,12 +1,11 @@
 {# Domain-aware login template router #}
 {# Routes to appropriate login template based on the request domain #}
-{# NOTE: This template is in crush_lu app, so default should be Crush to avoid cross-app dependencies #}
-{% if 'powerup.lu' in request.get_host or 'azurewebsites.net' in request.get_host %}
-{% include "account/login_powerup.html" %}
-{% elif 'vinsdelux.com' in request.get_host %}
+{# NOTE: login_powerup.html extends entreprinder's base.html which uses {% url 'entreprinder:...' %} #}
+{# so it can ONLY be used when the entreprinder namespace is registered (i.e. on entreprinder.lu) #}
+{% if 'entreprinder' in request.get_host %}
 {% include "account/login_powerup.html" %}
 {% else %}
-{# Default to Crush template - handles crush.lu, localhost, 127.0.0.1, and any unknown hosts #}
-{# This avoids errors when entreprinder namespace isn't available #}
+{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
+{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html which has no cross-app dependencies. #}
 {% include "account/login_crush.html" %}
 {% endif %}

--- a/crush_lu/templates/account/logout.html
+++ b/crush_lu/templates/account/logout.html
@@ -1,14 +1,13 @@
 {# Domain-aware logout template router #}
 {# Routes to appropriate logout template based on the request domain #}
+{# NOTE: logout_powerup.html extends entreprinder's base.html which uses {% url 'entreprinder:...' %} #}
+{# so it can ONLY be used when the entreprinder namespace is registered (i.e. on entreprinder.lu) #}
 {% if 'delegations.lu' in request.get_host %}
 {% include "account/logout_delegation.html" %}
-{% elif 'crush.lu' in request.get_host or request.get_host == 'localhost' or '127.0.0.1' in request.get_host %}
-{% include "account/logout_crush.html" %}
-{% elif 'powerup.lu' in request.get_host or 'azurewebsites.net' in request.get_host %}
-{% include "account/logout_powerup.html" %}
-{% elif 'vinsdelux.com' in request.get_host %}
+{% elif 'entreprinder' in request.get_host %}
 {% include "account/logout_powerup.html" %}
 {% else %}
-{# Default fallback to PowerUP template #}
-{% include "account/logout_powerup.html" %}
+{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
+{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html which has no cross-app dependencies. #}
+{% include "account/logout_crush.html" %}
 {% endif %}

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.db.models import Q
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.conf import settings
 import logging
 import uuid
@@ -949,6 +949,7 @@ def referral_redirect(request, code):
     return redirect(signup_url)
 
 
+@ensure_csrf_cookie
 @ratelimit(key="ip", rate="5/h", method="POST")
 def signup(request):
     """

--- a/crush_lu/views_profile.py
+++ b/crush_lu/views_profile.py
@@ -922,5 +922,23 @@ def get_csrf_token(request):
 
     No login required — anonymous users need fresh tokens on login/signup pages.
     get_token() is safe for anonymous users (same as {% csrf_token %} in templates).
+
+    The cookie is set explicitly on the response (belt-and-suspenders) because
+    Safari/WebKit may not process Set-Cookie headers from responses that pass
+    through a Service Worker via event.respondWith(fetch()).
     """
-    return JsonResponse({"csrfToken": get_token(request)})
+    from django.conf import settings
+
+    token = get_token(request)
+    response = JsonResponse({"csrfToken": token})
+    response.set_cookie(
+        settings.CSRF_COOKIE_NAME,
+        request.META["CSRF_COOKIE"],
+        max_age=settings.CSRF_COOKIE_AGE,
+        domain=settings.CSRF_COOKIE_DOMAIN,
+        path=settings.CSRF_COOKIE_PATH,
+        secure=settings.CSRF_COOKIE_SECURE,
+        httponly=settings.CSRF_COOKIE_HTTPONLY,
+        samesite=settings.CSRF_COOKIE_SAMESITE,
+    )
+    return response


### PR DESCRIPTION
## Summary\n\n- **Fix CSRF cookie not set on iPhone Safari signup**: Add `@ensure_csrf_cookie` to signup view, explicitly set CSRF cookie in `get_csrf_token` API response, and fix service worker to not intercept navigation requests to auth pages (Safari/WebKit may not process `Set-Cookie` headers from SW-forwarded responses)\n- **Fix `'entreprinder' is not a registered namespace` 500 error**: Update login and logout template routers to only use `login_powerup.html`/`logout_powerup.html` (which depend on entreprinder's `base.html`) when on entreprinder.lu domain, defaulting to `login_crush.html`/`logout_crush.html` for all other domains\n\n## Test plan\n\n- [ ] Deploy and test signup on iPhone Safari (both browser and PWA modes) - verify CSRF cookie is set and form submits successfully\n- [ ] Access `/accounts/login/` on crush.lu, power-up.lu, vinsdelux.com, and *.azurewebsites.net - verify no 500 error\n- [ ] Access `/accounts/logout/` on the same domains - verify no 500 error\n- [ ] Verify entreprinder.lu login/logout still uses its own styled templates\n- [ ] Run existing test suite to check for regressions\n\nhttps://claude.ai/code/session_01TFm4qawn6Tsxy6V6haAX6a