### PR TITLE
Update event date field references from event_date to date_time

### DIFF
--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -428,8 +428,8 @@ class MeetupEventAdmin(TranslationAdmin):
             if event.is_cancelled:
                 continue
 
-            if event.event_date:
-                days_until = (event.event_date - timezone.now().date()).days
+            if event.date_time:
+                days_until = (event.date_time.date() - timezone.now().date()).days
             else:
                 days_until = 1
 

--- a/crush_lu/management/commands/send_event_reminders.py
+++ b/crush_lu/management/commands/send_event_reminders.py
@@ -59,8 +59,8 @@ class Command(BaseCommand):
 
         # Build query for upcoming events
         events_query = MeetupEvent.objects.filter(
-            event_date__gte=target_start.date(),
-            event_date__lt=target_end.date(),
+            date_time__date__gte=target_start.date(),
+            date_time__date__lt=target_end.date(),
             status='published',
         )
 


### PR DESCRIPTION
## Purpose
* Update event reminder logic to use the `date_time` field instead of the deprecated `event_date` field
* Ensures event reminders are calculated and queried using the correct datetime field
* Maintains consistency across the admin interface and management commands

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Refactoring (no functional changes, no api changes)
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Verify that event reminders are still sent correctly for upcoming events
* Check that the admin action "send_event_reminders" calculates days_until properly
* Confirm that the management command `send_event_reminders` queries events with the correct date range

## What to Check
Verify that the following are valid
* Event reminders are sent for events scheduled within the target date range
* Days until event calculation is accurate for reminder timing
* No errors occur when running the reminder commands

## Other Information
This change updates two locations where event date information is accessed:
1. `crush_lu/admin/events.py` - Admin action for sending reminders
2. `crush_lu/management/commands/send_event_reminders.py` - Management command for batch reminder sending

Both now reference `date_time` field with appropriate date conversions instead of the `event_date` field.

https://claude.ai/code/session_01ATwQR9xoLJJCGXZZrJqpLL