### PR TITLE
Replace database cache with Redis for improved performance

### DIFF
--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -306,24 +306,33 @@ DATABASES = {
 # ============================================================================
 # CACHE CONFIGURATION
 # ============================================================================
-# Using database-backed cache for rate limiting consistency across instances.
-# Azure App Service can run multiple instances behind load balancer - LocMemCache
-# would fail to enforce rate limits across instances. Database cache is slower
-# but works correctly and doesn't require Redis (which adds Azure cost).
+# Using Redis cache backend (django-redis) for sub-millisecond cache operations.
+# Azure App Service runs multiple instances behind a load balancer — Redis is
+# shared across all instances, ensuring rate limiting, site detection, and
+# session reads are consistent and fast.
 #
-# OPTIMIZATION: Increased timeout from 300s to 600s (10 minutes) and MAX_ENTRIES
-# from 1000 to 5000 for better cache hit rates and fewer database queries.
+# AZURE_REDIS_CONNECTIONSTRING is already configured in Azure App Service for
+# both production (DB 0) and staging (DB 1) slots. KEY_PREFIX provides namespace
+# isolation from Django Channels keys on the same Redis DB.
 #
-# IMPORTANT: Run `python manage.py createcachetable` in deployment to create
-# the cache table. This is handled in the Azure startup script.
+# IGNORE_EXCEPTIONS=True ensures graceful degradation: if Redis is unreachable,
+# cache operations return None/fail silently instead of raising 500 errors.
+# Rate limiting and site detection already handle cache misses gracefully.
+#
+# NOTE: The legacy django_cache DB table is no longer used and can be dropped
+# in a future migration. `python manage.py createcachetable` is no longer needed.
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "django_cache",  # Table name for cache entries
-        "TIMEOUT": 600,  # Increased from 300 to 600 seconds (10 minutes)
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.environ.get(
+            "AZURE_REDIS_CONNECTIONSTRING", "redis://localhost:6379/0"
+        ),
+        "TIMEOUT": 600,  # 10 minutes
+        "KEY_PREFIX": "cache",
         "OPTIONS": {
-            "MAX_ENTRIES": 5000,  # Increased from 1000 for better cache retention
-            "CULL_FREQUENCY": 4,  # More aggressive culling (remove 25% when max reached)
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "CONNECTION_POOL_KWARGS": {"max_connections": 50},
+            "IGNORE_EXCEPTIONS": True,
         },
     }
 }
@@ -342,7 +351,9 @@ CHANNEL_LAYERS = {
     },
 }
 
-SESSION_ENGINE = "django.contrib.sessions.backends.db"  # Changed from signed_cookies to db for PWA persistence
+# cached_db: reads from Redis (fast), writes to both Redis + DB (durable).
+# If Redis is down, falls back to DB reads automatically.
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
 # Override session settings from base settings.py for PWA
 SESSION_COOKIE_AGE = 1209600  # 14 days (2 weeks) - longer session for PWA

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -236,6 +236,21 @@ else:
         },
     }
 
+# Cache - Redis if REDIS_URL is set, otherwise default LocMemCache
+if os.environ.get("REDIS_URL"):
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": os.environ["REDIS_URL"],
+            "TIMEOUT": 600,
+            "KEY_PREFIX": "cache",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                "IGNORE_EXCEPTIONS": True,
+            },
+        }
+    }
+
 
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ msgraph-core==1.3.8
 gunicorn==25.3.0
 channels==4.3.2
 channels-redis==4.3.0
+django-redis==6.0.0  # Redis cache backend for Django 6.0
 uvicorn[standard]==0.43.0
 
 # Utilities


### PR DESCRIPTION
## Purpose
* Migrate from Django's database-backed cache to Redis (via django-redis) for significantly faster cache operations across Azure App Service instances
* Improve rate limiting, site detection, and session consistency by using a shared Redis backend instead of per-instance database cache
* Simplify deployment by eliminating the need to run `createcachetable` management command
* Enable graceful degradation when Redis is unavailable through `IGNORE_EXCEPTIONS=True`

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Changes Made
* **production.py**: Replaced `DatabaseCache` backend with `RedisCache` backend, configured to use `AZURE_REDIS_CONNECTIONSTRING` environment variable with fallback to localhost
* **production.py**: Updated `SESSION_ENGINE` from `db` to `cached_db` for faster reads from Redis with database durability fallback
* **settings.py**: Added conditional Redis cache configuration that activates when `REDIS_URL` environment variable is set
* **requirements.txt**: Added `django-redis==6.0.0` dependency

## How to Test
* Verify Redis connection string is properly configured in Azure App Service environment variables
* Test that cache operations work correctly with `IGNORE_EXCEPTIONS=True` enabled
* Confirm session persistence works with the `cached_db` backend
* Verify graceful degradation if Redis becomes temporarily unavailable

## What to Check
Verify that the following are valid:
* Cache operations complete with sub-millisecond latency
* Rate limiting is consistently enforced across multiple App Service instances
* Sessions persist correctly and are readable from Redis cache
* Application continues functioning if Redis is unreachable (graceful degradation)
* No `createcachetable` command is needed during deployment

## Other Information
The legacy `django_cache` database table is no longer used and can be dropped in a future migration. The configuration maintains backward compatibility by falling back to localhost Redis in development environments where `AZURE_REDIS_CONNECTIONSTRING` is not set.

https://claude.ai/code/session_01UYfsoSp2A6tMW54BA5boFB