### PR TITLE
Make leaderboard persistent across quiz screens

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -148,13 +148,13 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             logger.exception("Failed to get quiz state for quiz %s", self.quiz_id)
             state = None
         if state:
-            # Include leaderboard for finished quizzes so attendees see final results
-            if state.get("status") == "finished":
+            # Include leaderboard so attendees/coaches always see current standings
+            if state.get("status") in ("active", "paused", "finished"):
                 try:
                     state["leaderboard"] = await self.get_leaderboard()
                 except Exception:
                     logger.exception(
-                        "Failed to get leaderboard for finished quiz %s",
+                        "Failed to get leaderboard for quiz %s",
                         self.quiz_id,
                     )
             # CLIENT-02: Strip answer data from quiz state for non-host users
@@ -370,6 +370,13 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                 },
             )
 
+            # Auto-broadcast updated leaderboard
+            leaderboard = await self.get_leaderboard()
+            await self.channel_layer.group_send(
+                self.quiz_group,
+                {"type": "quiz.leaderboard", "data": leaderboard},
+            )
+
     async def handle_rotate(self):
         rotation_data = await self.advance_round_and_rotate()
         if rotation_data.get("finished"):
@@ -388,6 +395,7 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
 
     async def handle_leaderboard(self):
         leaderboard = await self.get_leaderboard()
+        leaderboard["spotlight"] = True
         await self.channel_layer.group_send(
             self.quiz_group,
             {"type": "quiz.leaderboard", "data": leaderboard},

--- a/crush_lu/static/crush_lu/js/quiz-live.js
+++ b/crush_lu/static/crush_lu/js/quiz-live.js
@@ -261,6 +261,9 @@ document.addEventListener("alpine:init", function () {
             get hasIndividualScores() {
                 return this.individuals.length > 0;
             },
+            get hasLeaderboardData() {
+                return this.tables.length > 0;
+            },
 
             // --- Init ---
 
@@ -382,20 +385,29 @@ document.addEventListener("alpine:init", function () {
                 if (type === "quiz.state") {
                     if (data.event_type)
                         this.isQuizNight = data.event_type === "quiz_night";
+                    // Process leaderboard data for any state (persistent panel)
+                    if (data.leaderboard) {
+                        this.tables = data.leaderboard.tables || [];
+                        this.individuals = data.leaderboard.individuals || [];
+                    }
                     if (data.status === "finished") {
                         // Quiz already finished — show finished screen with leaderboard
-                        if (data.leaderboard) {
-                            this.tables = data.leaderboard.tables || [];
-                            this.individuals = data.leaderboard.individuals || [];
-                        }
                         this.screen = "finished";
                         this._renderTableLeaderboard();
                         this._renderIndividualLeaderboard();
                     } else if (data.status === "active" && data.question) {
                         this.showQuestion(data);
-                    } else if (data.current_round) {
-                        this.roundName = _localized(data.current_round, "title");
-                        this.isBonusRound = data.current_round.is_bonus || false;
+                        // Render persistent leaderboard after question setup
+                        this._renderTableLeaderboard();
+                        this._renderIndividualLeaderboard();
+                    } else {
+                        if (data.current_round) {
+                            this.roundName = _localized(data.current_round, "title");
+                            this.isBonusRound = data.current_round.is_bonus || false;
+                        }
+                        // Render persistent leaderboard
+                        this._renderTableLeaderboard();
+                        this._renderIndividualLeaderboard();
                     }
                 } else if (type === "quiz.question") {
                     this.showQuestion(data);
@@ -404,9 +416,13 @@ document.addEventListener("alpine:init", function () {
                 } else if (type === "quiz.leaderboard") {
                     this.tables = data.tables || [];
                     this.individuals = data.individuals || [];
-                    this.screen = "leaderboard";
                     this._renderTableLeaderboard();
                     this._renderIndividualLeaderboard();
+                    // Spotlight: scroll persistent panel into view when host triggers it
+                    if (data.spotlight) {
+                        var panel = this.$refs.tableboard_persistent;
+                        if (panel) panel.scrollIntoView({ behavior: "smooth" });
+                    }
                 } else if (type === "quiz.rotate") {
                     // Defensive: finished state may arrive via quiz.rotate
                     if (data.finished || data.status === "finished") {
@@ -676,9 +692,9 @@ document.addEventListener("alpine:init", function () {
             },
 
             _renderTableLeaderboard: function () {
-                // Render into both live leaderboard and finished screen containers
-                this._renderTableLeaderboardInto(this.$refs.tableboard_live);
+                // Render into finished screen and persistent panel containers
                 this._renderTableLeaderboardInto(this.$refs.tableboard);
+                this._renderTableLeaderboardInto(this.$refs.tableboard_persistent);
             },
 
             _renderTableLeaderboardInto: function (container) {
@@ -715,9 +731,9 @@ document.addEventListener("alpine:init", function () {
             },
 
             _renderIndividualLeaderboard: function () {
-                // Render into both live leaderboard and finished screen containers
-                this._renderIndividualLeaderboardInto(this.$refs.playerboard_live);
+                // Render into finished screen and persistent panel containers
                 this._renderIndividualLeaderboardInto(this.$refs.playerboard);
+                this._renderIndividualLeaderboardInto(this.$refs.playerboard_persistent);
             },
 
             _renderIndividualLeaderboardInto: function (container) {
@@ -1103,6 +1119,12 @@ document.addEventListener("alpine:init", function () {
                     }
                     // STATE-03: Preserve -1 sentinel (|| would coerce it to 0)
                     this.questionIdx = data.question_index !== undefined ? data.question_index : 0;
+                    // Process leaderboard data (always-visible standings)
+                    if (data.leaderboard) {
+                        this.tables = data.leaderboard.tables || [];
+                        this._renderTableLeaderboard();
+                        this._updateTableScores();
+                    }
                 } else if (type === "quiz.question") {
                     this.currentQuestion = data;
                     this.questionIdx = data.index || 0;

--- a/crush_lu/templates/crush_lu/quiz_coach.html
+++ b/crush_lu/templates/crush_lu/quiz_coach.html
@@ -224,11 +224,14 @@
             </div>
         </div>
 
-        {# --- Live leaderboard preview --- #}
-        <div x-show="hasLeaderboard" class="mt-6 rounded-xl bg-slate-800 p-4 shadow-lg">
+        {# --- Live leaderboard preview (always visible) --- #}
+        <div class="mt-6 rounded-xl bg-slate-800 p-4 shadow-lg">
             <h2 class="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-400">{% trans "Current Standings" %}</h2>
             {# Rendered via JS for CSP compliance #}
             <div x-ref="tableboard" class="space-y-2"></div>
+            <p x-show="!hasLeaderboard" class="text-center text-sm text-gray-500 py-4">
+                {% trans "Standings will appear after the first question is scored." %}
+            </p>
         </div>
     </div>
 </div>

--- a/crush_lu/templates/crush_lu/quiz_live.html
+++ b/crush_lu/templates/crush_lu/quiz_live.html
@@ -142,19 +142,7 @@
             </div>
         </div>
 
-        {# --- Leaderboard Screen --- #}
-        <div x-show="isLeaderboard" class="space-y-4">
-            <h2 class="text-center text-xl font-bold text-white">{% trans "Leaderboard" %}</h2>
-
-            {# Table rankings (rendered via JS for CSP compliance) #}
-            <div class="space-y-2" x-ref="tableboard_live"></div>
-
-            {# Individual top scorers (rendered via JS for CSP compliance) #}
-            <div x-show="hasIndividualScores">
-                <h3 class="mb-2 text-center text-sm font-semibold uppercase tracking-wider text-gray-400">{% trans "Top Players" %}</h3>
-                <div class="space-y-1" x-ref="playerboard_live"></div>
-            </div>
-        </div>
+        {# --- Leaderboard Screen removed: now a persistent panel below --- #}
 
         {# --- Finished Screen --- #}
         <div x-show="isFinished" class="space-y-4">
@@ -194,6 +182,22 @@
             <h2 class="text-xl font-semibold text-white">{% trans "Time to rotate!" %}</h2>
             <p class="mt-2 text-lg font-bold text-crush-pink" x-text="rotateMessage"></p>
             <p x-show="hasNextTable" class="mt-1 text-sm text-gray-400" x-text="nextTableLabel"></p>
+        </div>
+
+        {# --- Persistent Leaderboard Panel --- #}
+        <div x-show="hasLeaderboardData" class="mt-4 rounded-xl bg-slate-800 p-4 shadow-lg">
+            <h2 class="mb-3 text-center text-sm font-semibold uppercase tracking-wider text-gray-400">
+                {% trans "Leaderboard" %}
+            </h2>
+            {# Table rankings (rendered via JS for CSP compliance) #}
+            <div class="space-y-2" x-ref="tableboard_persistent"></div>
+            {# Individual top scorers (rendered via JS for CSP compliance) #}
+            <div x-show="hasIndividualScores">
+                <h3 class="mb-2 mt-3 text-center text-sm font-semibold uppercase tracking-wider text-gray-400">
+                    {% trans "Top Players" %}
+                </h3>
+                <div class="space-y-1" x-ref="playerboard_persistent"></div>
+            </div>
         </div>
 
         {# --- Connection status --- #}


### PR DESCRIPTION
## Purpose
* Refactor leaderboard display from a dedicated screen to a persistent panel visible throughout the quiz
* Ensure attendees and coaches always see current standings during active, paused, and finished quiz states
* Auto-broadcast updated leaderboard when scores are recorded
* Add spotlight feature to scroll leaderboard into view when host triggers it

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
1. Start a quiz and progress through questions
2. Verify leaderboard panel appears below the main content area once scores are recorded
3. Verify leaderboard updates automatically when scores are submitted
4. Verify leaderboard persists across question screens, waiting screens, and finished screen
5. As a coach, trigger the leaderboard spotlight and verify smooth scroll to the persistent panel
6. Verify individual top players section appears when applicable
```

## What to Check
Verify that the following are valid
* Leaderboard panel displays correctly on attendee view during active quiz
* Leaderboard updates in real-time when scores are recorded
* Leaderboard persists across all quiz states (active, paused, finished)
* Coach spotlight feature scrolls to leaderboard panel smoothly
* Finished screen still displays leaderboard correctly
* No console errors or broken references to removed `tableboard_live` and `playerboard_live` elements

## Other Information
* Removed dedicated leaderboard screen (`isLeaderboard` state) in favor of persistent panel
* Updated `_renderTableLeaderboard()` and `_renderIndividualLeaderboard()` to render into persistent panel refs instead of live screen refs
* Modified consumer to include leaderboard data for active and paused states, not just finished
* Added auto-broadcast of leaderboard after score updates
* Added `hasLeaderboardData` computed property to control panel visibility
* Coach view now shows placeholder text when no standings are available yet

https://claude.ai/code/session_016XTe5YaohjyXy3XqzHhwhq