### PR TITLE
Add CDN/Front Door support and improve photo access security

### DIFF
--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -230,9 +230,10 @@ else:
 # - vinsdelux-media/journey/step_01.png
 # - powerup-media/defaults/profile.png
 
-# CDN support: if AZURE_CDN_DOMAIN is set, serve public media through CDN
-# Private containers (crush-lu-private, vinsdelux-private) are NOT served via CDN
-# because SAS token signatures are tied to the storage account hostname.
+# CDN support: if AZURE_CDN_DOMAIN is set, serve media through CDN/Front Door.
+# Private containers (crush-lu-private) are also served via CDN/Front Door.
+# SAS tokens are tied to the storage account name (not the access hostname),
+# so Front Door passes query strings (including SAS tokens) to the blob storage origin.
 _CDN_DOMAIN = os.getenv("AZURE_CDN_DOMAIN")  # e.g., "cdn.crush.lu"
 if _CDN_DOMAIN:
     _MEDIA_ORIGIN = f"https://{_CDN_DOMAIN}"

--- a/crush_lu/storage.py
+++ b/crush_lu/storage.py
@@ -81,6 +81,11 @@ class PrivateAzureStorage(AzureStorage):
         )
         self.azure_container = container_name
 
+        # CDN/Front Door support for private containers
+        # SAS tokens are tied to the storage account name, not the access hostname,
+        # so Front Door can pass query strings (including SAS tokens) to the origin.
+        self._cdn_domain = os.getenv('AZURE_CDN_DOMAIN')
+
         # Azurite-specific configuration
         self._is_azurite = is_azurite_mode()
         if self._is_azurite:
@@ -126,8 +131,15 @@ class PrivateAzureStorage(AzureStorage):
                 f"http://{self._azurite_host}/{self.account_name}/"
                 f"{self.azure_container}/{name}?{sas_token}"
             )
+        elif self._cdn_domain:
+            # CDN/Front Door URL: https://cdn-domain/container/blob?sas
+            # Front Door forwards query strings (including SAS token) to blob storage origin
+            return (
+                f"https://{self._cdn_domain}/"
+                f"{self.azure_container}/{name}?{sas_token}"
+            )
         else:
-            # Production Azure URL format: https://account.blob.core.windows.net/container/blob?sas
+            # Direct Azure URL: https://account.blob.core.windows.net/container/blob?sas
             return (
                 f"https://{self.account_name}.blob.core.windows.net/"
                 f"{self.azure_container}/{name}?{sas_token}"

--- a/crush_lu/templates/crush_lu/create_profile.html
+++ b/crush_lu/templates/crush_lu/create_profile.html
@@ -1,5 +1,5 @@
 {% extends 'crush_lu/base.html' %}
-{% load static i18n analytics %}
+{% load static i18n analytics crush_media %}
 
 {% block title %}{% trans "Create Your Profile - Crush.lu" %}{% endblock %}
 
@@ -766,11 +766,11 @@
                 <div class="grid grid-cols-3 gap-2 sm:gap-4 mb-6"
                      x-data="photoUpload"
                      data-photo-1-exists="{% if profile and profile.photo_1 %}true{% else %}false{% endif %}"
-                     data-photo-1-url="{% if profile and profile.photo_1 %}{{ profile.photo_1.url }}{% endif %}"
+                     data-photo-1-url="{% if profile and profile.photo_1 %}{% profile_photo_url profile 'photo_1' %}{% endif %}"
                      data-photo-2-exists="{% if profile and profile.photo_2 %}true{% else %}false{% endif %}"
-                     data-photo-2-url="{% if profile and profile.photo_2 %}{{ profile.photo_2.url }}{% endif %}"
+                     data-photo-2-url="{% if profile and profile.photo_2 %}{% profile_photo_url profile 'photo_2' %}{% endif %}"
                      data-photo-3-exists="{% if profile and profile.photo_3 %}true{% else %}false{% endif %}"
-                     data-photo-3-url="{% if profile and profile.photo_3 %}{{ profile.photo_3.url }}{% endif %}">
+                     data-photo-3-url="{% if profile and profile.photo_3 %}{% profile_photo_url profile 'photo_3' %}{% endif %}">
                     <!-- Photo 1 -->
                     <div class="relative aspect-square">
                         <input type="file" name="photo_1" id="photo1" accept="image/*" class="hidden"

--- a/crush_lu/templates/crush_lu/matches.html
+++ b/crush_lu/templates/crush_lu/matches.html
@@ -1,5 +1,5 @@
 {% extends 'crush_lu/base.html' %}
-{% load i18n %}
+{% load i18n crush_media %}
 
 {% block title %}{% trans "Your Matches - Crush.lu" %}{% endblock %}
 {% block meta_robots %}noindex, nofollow{% endblock %}
@@ -41,8 +41,8 @@
         <div class="section-card flex items-center gap-4">
             <!-- Profile photo -->
             <div class="flex-shrink-0 w-16 h-16 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700">
-                {% if match.profile.photo_1 %}
-                    <img src="{{ match.profile.photo_1.url }}" alt="" class="w-full h-full object-cover">
+                {% if match.profile|has_photo:'photo_1' %}
+                    <img src="{% profile_photo_url match.profile 'photo_1' %}" alt="" class="w-full h-full object-cover">
                 {% else %}
                 <div class="w-full h-full bg-gradient-to-br from-purple-300 to-pink-300 dark:from-purple-700 dark:to-pink-700 flex items-center justify-center">
                     <svg class="w-8 h-8 text-white/60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>

--- a/crush_lu/views_quiz.py
+++ b/crush_lu/views_quiz.py
@@ -409,13 +409,17 @@ def quiz_table_display_data(request, event_id):
     return JsonResponse(data)
 
 
+@login_required
 def quiz_display_photo(request, user_id):
-    """Serve photo_1 for quiz display without authentication.
+    """Serve photo_1 for quiz display.
 
     Only serves photos for users who have an approved CrushProfile.
-    Returns a small cache-friendly response suitable for projector displays.
+    Returns a cache-friendly response suitable for projector displays.
     """
     profile = get_object_or_404(CrushProfile, user_id=user_id)
+
+    if not profile.is_approved:
+        raise Http404("Profile not approved")
 
     photo = getattr(profile, "photo_1", None)
     if not photo:
@@ -427,9 +431,9 @@ def quiz_display_photo(request, user_id):
         from django.shortcuts import redirect
 
         storage = CrushProfilePhotoStorage()
-        secure_url = storage.url(photo.name, expire=3600)
+        secure_url = storage.url(photo.name, expire=1800)
         response = redirect(secure_url)
-        response["Cache-Control"] = "public, max-age=1800"
+        response["Cache-Control"] = "private, max-age=1800"
         return response
 
     # Local filesystem
@@ -445,5 +449,5 @@ def quiz_display_photo(request, user_id):
             content_type = "image/webp"
         response = HttpResponse(f.read(), content_type=content_type)
         response["Content-Disposition"] = "inline"
-        response["Cache-Control"] = "public, max-age=1800"
+        response["Cache-Control"] = "private, max-age=1800"
         return response


### PR DESCRIPTION
## Purpose
* Add support for serving media through Azure CDN/Front Door while maintaining security for private containers
* Enforce authentication and approval checks for quiz photo display endpoint
* Implement secure photo URL generation through custom template tags
* Update cache control headers from public to private for authenticated content

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Changes Made

### Azure Storage & CDN Support
- Added `AZURE_CDN_DOMAIN` environment variable support in `storage.py` to enable CDN/Front Door routing
- Implemented CDN URL generation that leverages SAS tokens tied to storage account name (not hostname), allowing Front Door to forward query strings to blob storage origin
- Updated production settings documentation to clarify that private containers can now be served via CDN/Front Door

### Photo Access Security
- Added `@login_required` decorator to `quiz_display_photo` view to enforce authentication
- Added explicit approval check (`is_approved`) for CrushProfile before serving photos
- Changed cache control headers from `public` to `private` for photo responses (both Azure and local storage paths)
- Reduced SAS token expiration from 3600s to 1800s for tighter security

### Template Updates
- Added `crush_media` template tag loader to `create_profile.html` and `matches.html`
- Replaced direct `.url` property access with `profile_photo_url` custom template tag for centralized photo URL generation
- Updated photo existence checks to use `has_photo` custom filter for consistency

## How to Test
* Verify CDN domain configuration works when `AZURE_CDN_DOMAIN` environment variable is set
* Test that unauthenticated requests to `quiz_display_photo` are redirected to login
* Test that requests for non-approved profiles return 404
* Verify cache headers are set to `private` for authenticated photo responses
* Confirm photo URLs in templates use the custom tag for proper URL generation

## What to Check
Verify that the following are valid:
* Photo URLs in templates render correctly with the new `profile_photo_url` tag
* Unauthenticated users cannot access quiz photos
* Non-approved profiles cannot have their photos accessed
* Cache headers are appropriately set to private for authenticated content
* CDN/Front Door URLs are generated correctly when configured
* SAS token expiration is properly set to 1800 seconds

## Other Information
The changes maintain backward compatibility - when `AZURE_CDN_DOMAIN` is not set, the system falls back to direct Azure blob storage URLs as before.

https://claude.ai/code/session_019vyYiDA5rxj4hydZYJzRRt