### PR TITLE
Add real-time table and attendance updates to quiz display

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -758,6 +758,19 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             )
             data["rounds"].append(r_data)
 
+        # Include table and attendance data for display page
+        from crush_lu.views_quiz import _get_table_members_json
+        from crush_lu.models.events import EventRegistration
+
+        round_number = quiz.get_round_number()
+        data["tables"] = _get_table_members_json(quiz, round_number)
+        data["attended_count"] = EventRegistration.objects.filter(
+            event_id=quiz.event_id, status="attended"
+        ).count()
+        data["confirmed_count"] = EventRegistration.objects.filter(
+            event_id=quiz.event_id, status__in=["confirmed", "attended"]
+        ).count()
+
         if question and quiz.is_active:
             from crush_lu.models.quiz import QuizTable, TableRoundScore
 

--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -108,9 +108,11 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                 self.is_display = True
                 self.quiz_id = quiz_id
                 self.quiz_group = f"quiz_{quiz_id}"
+                self.display_group = f"quiz_{quiz_id}_display"
                 self.table_group = None
 
                 await self.channel_layer.group_add(self.quiz_group, self.channel_name)
+                await self.channel_layer.group_add(self.display_group, self.channel_name)
                 await self.accept()
 
                 try:
@@ -137,6 +139,13 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                             if not k.startswith("choices_with_answers")
                             and not k.startswith("correct_answer")
                         }
+                    # Enrich with table roster data (display-only)
+                    try:
+                        table_data = await self.get_table_display_data()
+                        if table_data:
+                            state.update(table_data)
+                    except Exception:
+                        pass
                     await self.send_json({"type": "quiz.state", "data": state})
                 return
 
@@ -205,6 +214,8 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
     async def disconnect(self, close_code):
         if hasattr(self, "quiz_group"):
             await self.channel_layer.group_discard(self.quiz_group, self.channel_name)
+        if getattr(self, "display_group", None):
+            await self.channel_layer.group_discard(self.display_group, self.channel_name)
         if getattr(self, "table_group", None):
             await self.channel_layer.group_discard(self.table_group, self.channel_name)
 
@@ -618,6 +629,28 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
     # --- Database helpers ---
 
     @database_sync_to_async
+    def get_table_display_data(self):
+        """Return table roster and attendance counts (display-only)."""
+        from crush_lu.views_quiz import _get_table_members_json
+        from crush_lu.models.events import EventRegistration
+        from crush_lu.models.quiz import QuizEvent
+
+        try:
+            quiz = QuizEvent.objects.get(id=self.quiz_id)
+        except QuizEvent.DoesNotExist:
+            return None
+        round_number = quiz.get_round_number()
+        return {
+            "tables": _get_table_members_json(quiz, round_number),
+            "attended_count": EventRegistration.objects.filter(
+                event_id=quiz.event_id, status="attended"
+            ).count(),
+            "confirmed_count": EventRegistration.objects.filter(
+                event_id=quiz.event_id, status__in=["confirmed", "attended"]
+            ).count(),
+        }
+
+    @database_sync_to_async
     def _verify_display_token(self, quiz_id, token):
         """Verify a display_token for projector display WebSocket auth."""
         from crush_lu.models.quiz import QuizEvent
@@ -757,19 +790,6 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                 )
             )
             data["rounds"].append(r_data)
-
-        # Include table and attendance data for display page
-        from crush_lu.views_quiz import _get_table_members_json
-        from crush_lu.models.events import EventRegistration
-
-        round_number = quiz.get_round_number()
-        data["tables"] = _get_table_members_json(quiz, round_number)
-        data["attended_count"] = EventRegistration.objects.filter(
-            event_id=quiz.event_id, status="attended"
-        ).count()
-        data["confirmed_count"] = EventRegistration.objects.filter(
-            event_id=quiz.event_id, status__in=["confirmed", "attended"]
-        ).count()
 
         if question and quiz.is_active:
             from crush_lu.models.quiz import QuizTable, TableRoundScore

--- a/crush_lu/static/crush_lu/js/quiz-display.js
+++ b/crush_lu/static/crush_lu/js/quiz-display.js
@@ -439,6 +439,8 @@ document.addEventListener("alpine:init", function () {
                     this.handleLeaderboard(data);
                 } else if (type === "quiz.rotate") {
                     this.handleRotate(data);
+                } else if (type === "quiz.table_update") {
+                    this.handleTableUpdate(data);
                 }
             },
 
@@ -461,6 +463,17 @@ document.addEventListener("alpine:init", function () {
 
                 if (data.total_tables) {
                     this.totalTables = data.total_tables;
+                }
+
+                // Extract table and attendance data
+                if (data.tables) {
+                    this.tables = data.tables;
+                }
+                if (data.attended_count !== undefined) {
+                    this.attendedCount = data.attended_count;
+                }
+                if (data.confirmed_count !== undefined) {
+                    this.confirmedCount = data.confirmed_count;
                 }
 
                 // Determine screen based on state
@@ -623,6 +636,11 @@ document.addEventListener("alpine:init", function () {
                         }
                     }, 8000);
                 }
+            },
+
+            handleTableUpdate: function (data) {
+                // Refresh table and attendance data from the API
+                this.fetchDisplayData();
             },
 
             // ============================================================

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -298,6 +298,14 @@ def _broadcast_quiz_table_update(event, table_assignment):
                 "data": {"table_number": table_number},
             },
         )
+        # Also broadcast to main quiz group so the display page receives the update
+        async_to_sync(channel_layer.group_send)(
+            f"quiz_{quiz_event.id}",
+            {
+                "type": "quiz.table_update",
+                "data": {"table_number": table_number},
+            },
+        )
     except Exception:
         logger.exception("Failed to broadcast quiz table update for event %s", event.id)
 

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -298,9 +298,9 @@ def _broadcast_quiz_table_update(event, table_assignment):
                 "data": {"table_number": table_number},
             },
         )
-        # Also broadcast to main quiz group so the display page receives the update
+        # Also broadcast to display-specific group so the projector page updates
         async_to_sync(channel_layer.group_send)(
-            f"quiz_{quiz_event.id}",
+            f"quiz_{quiz_event.id}_display",
             {
                 "type": "quiz.table_update",
                 "data": {"table_number": table_number},


### PR DESCRIPTION
## Purpose
* Implement real-time synchronization of table assignments and attendance counts on the quiz display page
* Add a new WebSocket message type (`quiz.table_update`) to notify the display page when table assignments change
* Include table and attendance data in the quiz state to ensure the display page always has current information
* Trigger display data refresh when table updates are received via WebSocket

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
1. Start the application with WebSocket support enabled
2. Open the quiz display page in a browser
3. Check in a participant at an event with table assignments
4. Verify that the display page updates in real-time to show:
   - Updated table member lists
   - Updated attendance count
   - Updated confirmed count
5. Verify that the display page continues to function normally with the new data fields
```

## What to Check
Verify that the following are valid
* Table and attendance data is correctly included in the quiz state
* The `quiz.table_update` WebSocket message is properly broadcast to the quiz display group
* The display page receives and processes table update messages
* Display data is refreshed when table updates occur
* Existing quiz display functionality remains unaffected

## Other Information
The changes ensure that when participants check in and are assigned to tables, the quiz display page receives real-time updates without requiring manual page refresh. The implementation reuses existing data fetching mechanisms (`fetchDisplayData`) to maintain consistency.

https://claude.ai/code/session_01Baib9vw26sHdeoEUHyj9hH