### PR TITLE
Add Crush.lu branded password reset flow templates

### DIFF
--- a/crush_lu/templates/account/email/password_reset_key_message.html
+++ b/crush_lu/templates/account/email/password_reset_key_message.html
@@ -1,0 +1,36 @@
+{% extends "crush_lu/emails/base_email.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Reset your Crush.lu password" %}{% endblock %}
+{% block header_title %}{% trans "Reset your password" %}{% endblock %}
+
+{% block content %}
+    <h2>{% trans "Hello," %}</h2>
+
+    <p>
+        {% blocktrans %}We received a request to reset the password for your Crush.lu account (<strong>{{ email }}</strong>).{% endblocktrans %}
+    </p>
+
+    <p>{% trans "To choose a new password, click the button below:" %}</p>
+
+    <p style="text-align: center;">
+        <a href="{{ password_reset_url }}" class="button" style="display: inline-block; padding: 12px 30px; background-color: #9B59B6; background: linear-gradient(135deg, #9B59B6, #FF6B9D); color: #ffffff !important; text-decoration: none; border-radius: 5px; font-weight: 600;">
+            {% trans "Reset my password" %}
+        </a>
+    </p>
+
+    <div class="info-box">
+        <p style="margin: 0; font-size: 14px;">
+            {% trans "If the button above doesn't work, copy and paste this link into your browser:" %}<br>
+            <a href="{{ password_reset_url }}" style="color: #9B59B6; word-break: break-all;">{{ password_reset_url }}</a>
+        </p>
+    </div>
+
+    <p style="font-size: 14px; color: #777;">
+        {% blocktrans %}This link will expire in a few hours for security reasons. If you didn't request a password reset, you can safely ignore this email - your password will not be changed.{% endblocktrans %}
+    </p>
+{% endblock %}
+
+{% block footer_message %}
+    {% trans "You're receiving this email because a password reset was requested for your Crush.lu account." %}<br>
+{% endblock %}

--- a/crush_lu/templates/account/email/password_reset_key_message.txt
+++ b/crush_lu/templates/account/email/password_reset_key_message.txt
@@ -1,0 +1,13 @@
+{% load i18n %}{% blocktrans %}Hello,
+
+We received a request to reset the password for your Crush.lu account ({{ email }}).
+
+To choose a new password, click the link below:
+
+{{ password_reset_url }}
+
+This link will expire in a few hours for security reasons. If you didn't request a password reset, you can safely ignore this email - your password will not be changed.
+
+Thanks,
+The Crush.lu team
+{% endblocktrans %}

--- a/crush_lu/templates/account/email/password_reset_key_subject.txt
+++ b/crush_lu/templates/account/email/password_reset_key_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Reset your Crush.lu password" %}

--- a/crush_lu/templates/account/password_reset.html
+++ b/crush_lu/templates/account/password_reset.html
@@ -1,0 +1,78 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Reset Password - Crush.lu" %}{% endblock %}
+
+{% block content %}
+<div class="flex justify-center py-8 px-4">
+    <div class="w-full max-w-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20">
+            <div class="border-b border-gray-100 dark:border-gray-700 px-6 py-4">
+                <h5 class="font-semibold flex items-center gap-2 dark:text-white">
+                    {% include "shared/icons/key.html" with class="w-5 h-5" %}
+                    {% trans "Reset your password" %}
+                </h5>
+            </div>
+            <div class="p-6">
+                {% if user.is_authenticated %}
+                <div class="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-300 rounded-lg p-4 mb-6 text-sm">
+                    {% blocktrans %}You are already logged in. You can change your password from your account settings instead.{% endblocktrans %}
+                </div>
+                {% endif %}
+
+                <p class="text-gray-600 dark:text-gray-300 mb-6">
+                    {% trans "Forgot your password? Enter the email address associated with your Crush.lu account and we'll send you a link to reset it." %}
+                </p>
+
+                <form method="post" action="{% url 'account_reset_password' %}" novalidate>
+                    {% csrf_token %}
+
+                    {% if form.non_field_errors %}
+                    <div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-800 dark:text-red-300 rounded-lg p-4 mb-4">
+                        {% for error in form.non_field_errors %}
+                            {{ error }}
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+
+                    <div class="mb-6">
+                        <label for="id_email" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                            {% trans "Email address" %}
+                        </label>
+                        <input type="email"
+                               class="w-full px-4 py-3 border {% if form.email.errors %}border-red-500{% else %}border-gray-300 dark:border-gray-600{% endif %} rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 dark:bg-gray-700 dark:text-white"
+                               id="id_email" name="email"
+                               value="{{ form.email.value|default:'' }}"
+                               required autofocus
+                               placeholder="your@email.com">
+                        {% if form.email.errors %}
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ form.email.errors.0 }}</p>
+                        {% endif %}
+                    </div>
+
+                    <button type="submit" class="btn-crush-primary w-full py-3 inline-flex items-center justify-center gap-2">
+                        {% include "shared/icons/envelope.html" with class="w-5 h-5" %}
+                        {% trans "Send reset link" %}
+                    </button>
+                </form>
+
+                <hr class="my-6 border-gray-200 dark:border-gray-700">
+
+                <div class="text-center">
+                    <a href="{% url 'crush_lu:login' %}" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors">
+                        {% include "shared/icons/arrow-left.html" with class="w-4 h-4" %}
+                        {% trans "Back to login" %}
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div class="text-center mt-4">
+            <small class="text-gray-500 dark:text-gray-400 flex items-center justify-center gap-1">
+                {% include "shared/icons/shield-check.html" with class="w-4 h-4" %}
+                {% trans "We never share your email address" %}
+            </small>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/account/password_reset_done.html
+++ b/crush_lu/templates/account/password_reset_done.html
@@ -1,0 +1,48 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Check your email - Crush.lu" %}{% endblock %}
+
+{% block content %}
+<div class="flex justify-center py-8 px-4">
+    <div class="w-full max-w-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20">
+            <div class="border-b border-gray-100 dark:border-gray-700 px-6 py-4">
+                <h5 class="font-semibold flex items-center gap-2 dark:text-white">
+                    {% include "shared/icons/envelope.html" with class="w-5 h-5" %}
+                    {% trans "Check your email" %}
+                </h5>
+            </div>
+            <div class="p-6">
+                <div class="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 text-green-800 dark:text-green-300 rounded-lg p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            {% include "shared/icons/check-circle.html" with class="w-5 h-5" %}
+                        </div>
+                        <div class="ml-3">
+                            <h6 class="font-semibold mb-2">{% trans "Password reset email sent" %}</h6>
+                            <p class="text-sm">
+                                {% blocktrans %}If an account exists for the email you entered, we've sent a link to reset your password. Please check your inbox (and your spam folder, just in case).{% endblocktrans %}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <p class="text-sm text-gray-600 dark:text-gray-300 mb-6">
+                    {% blocktrans %}The link will expire in a few hours for security reasons. If you don't receive the email, you can request another one.{% endblocktrans %}
+                </p>
+
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <a href="{% url 'crush_lu:login' %}" class="btn-crush-primary flex-1 py-3 inline-flex items-center justify-center gap-2">
+                        {% include "shared/icons/arrow-left.html" with class="w-4 h-4" %}
+                        {% trans "Back to login" %}
+                    </a>
+                    <a href="{% url 'account_reset_password' %}" class="flex-1 py-3 inline-flex items-center justify-center gap-2 text-sm font-medium border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors">
+                        {% trans "Try a different email" %}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/account/password_reset_from_key.html
+++ b/crush_lu/templates/account/password_reset_from_key.html
@@ -1,0 +1,99 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Choose a new password - Crush.lu" %}{% endblock %}
+
+{% block content %}
+<div class="flex justify-center py-8 px-4">
+    <div class="w-full max-w-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20">
+            <div class="border-b border-gray-100 dark:border-gray-700 px-6 py-4">
+                <h5 class="font-semibold flex items-center gap-2 dark:text-white">
+                    {% include "shared/icons/key.html" with class="w-5 h-5" %}
+                    {% if token_fail %}
+                        {% trans "Invalid reset link" %}
+                    {% else %}
+                        {% trans "Choose a new password" %}
+                    {% endif %}
+                </h5>
+            </div>
+            <div class="p-6">
+                {% if token_fail %}
+                    <div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-800 dark:text-red-300 rounded-lg p-4 mb-6">
+                        <div class="flex">
+                            <div class="flex-shrink-0">
+                                {% include "shared/icons/exclamation-triangle.html" with class="w-5 h-5" %}
+                            </div>
+                            <div class="ml-3">
+                                <h6 class="font-semibold mb-2">{% trans "This password reset link is invalid or has expired" %}</h6>
+                                <p class="text-sm">
+                                    {% blocktrans %}Reset links are only valid for a limited time. Please request a new one and try again.{% endblocktrans %}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <a href="{% url 'account_reset_password' %}" class="btn-crush-primary w-full py-3 inline-flex items-center justify-center gap-2">
+                        {% include "shared/icons/envelope.html" with class="w-5 h-5" %}
+                        {% trans "Request a new reset link" %}
+                    </a>
+                {% else %}
+                    <p class="text-gray-600 dark:text-gray-300 mb-6">
+                        {% trans "Pick a strong password you haven't used before. Once you save it, you'll be able to log in with your new password immediately." %}
+                    </p>
+
+                    <form method="post" novalidate>
+                        {% csrf_token %}
+
+                        {% if form.non_field_errors %}
+                        <div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 text-red-800 dark:text-red-300 rounded-lg p-4 mb-4">
+                            {% for error in form.non_field_errors %}
+                                {{ error }}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
+
+                        <div class="mb-4">
+                            <label for="{{ form.password1.id_for_label }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                                {% trans "New password" %}
+                            </label>
+                            {{ form.password1 }}
+                            {% if form.password1.errors %}
+                                <div class="text-red-500 dark:text-red-400 text-sm mt-1">
+                                    {% for error in form.password1.errors %}{{ error }} {% endfor %}
+                                </div>
+                            {% endif %}
+                            {% if form.password1.help_text %}
+                                <small class="text-gray-500 dark:text-gray-400 text-sm mt-1 block">{{ form.password1.help_text|safe }}</small>
+                            {% endif %}
+                        </div>
+
+                        <div class="mb-6">
+                            <label for="{{ form.password2.id_for_label }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                                {% trans "Confirm new password" %}
+                            </label>
+                            {{ form.password2 }}
+                            {% if form.password2.errors %}
+                                <div class="text-red-500 dark:text-red-400 text-sm mt-1">
+                                    {% for error in form.password2.errors %}{{ error }} {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        <button type="submit" class="btn-crush-primary w-full py-3 inline-flex items-center justify-center gap-2">
+                            {% include "shared/icons/check.html" with class="w-5 h-5" %}
+                            {% trans "Change password" %}
+                        </button>
+                    </form>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="text-center mt-4">
+            <small class="text-gray-500 dark:text-gray-400 flex items-center justify-center gap-1">
+                {% include "shared/icons/shield-check.html" with class="w-4 h-4" %}
+                {% trans "Your password is securely encrypted" %}
+            </small>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/account/password_reset_from_key_done.html
+++ b/crush_lu/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,38 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Password changed - Crush.lu" %}{% endblock %}
+
+{% block content %}
+<div class="flex justify-center py-8 px-4">
+    <div class="w-full max-w-lg">
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20">
+            <div class="border-b border-gray-100 dark:border-gray-700 px-6 py-4">
+                <h5 class="font-semibold flex items-center gap-2 dark:text-white">
+                    {% include "shared/icons/check-circle.html" with class="w-5 h-5" %}
+                    {% trans "Password changed" %}
+                </h5>
+            </div>
+            <div class="p-6">
+                <div class="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 text-green-800 dark:text-green-300 rounded-lg p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            {% include "shared/icons/check-circle.html" with class="w-5 h-5" %}
+                        </div>
+                        <div class="ml-3">
+                            <p class="text-sm">
+                                {% trans "Your password has been successfully changed. You can now log in with your new password." %}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <a href="{% url 'crush_lu:login' %}" class="btn-crush-primary w-full py-3 inline-flex items-center justify-center gap-2">
+                    {% trans "Log in" %}
+                    {% include "shared/icons/arrow-right.html" with class="w-5 h-5" %}
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/crush_lu/auth.html
+++ b/crush_lu/templates/crush_lu/auth.html
@@ -125,13 +125,19 @@
                                 {% endif %}
                             </div>
 
-                            <div class="mb-6">
+                            <div class="mb-2">
                                 <label for="id_password" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{% trans "Password" %}</label>
                                 <input type="password" class="w-full px-4 py-3 border {% if login_form.password.errors %}border-red-500{% else %}border-gray-300 dark:border-gray-600{% endif %} rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 dark:bg-gray-700 dark:text-white"
                                        id="id_password" name="password" required>
                                 {% if login_form.password.errors %}
                                     <p class="mt-1 text-sm text-red-600">{{ login_form.password.errors.0 }}</p>
                                 {% endif %}
+                            </div>
+
+                            <div class="mb-6 text-right">
+                                <a href="{% url 'account_reset_password' %}" class="text-sm text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300">
+                                    {% trans "Forgot your password?" %}
+                                </a>
                             </div>
 
                             {% if redirect_field_value %}

--- a/crush_lu/tests/test_security.py
+++ b/crush_lu/tests/test_security.py
@@ -282,3 +282,98 @@ class TestThrottleClasses(TestCase):
         self.assertIn('login', rates)
         self.assertIn('signup', rates)
         self.assertIn('password_reset', rates)
+
+
+class TestPasswordReset(SiteTestCase):
+    """Tests for the Crush.lu password reset flow (via allauth)."""
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        cache.clear()
+        self.user = User.objects.create_user(
+            username="resetuser@example.com",
+            email="resetuser@example.com",
+            password="OldPassword123!",
+        )
+
+    def test_password_reset_form_renders_crush_branded_template(self):
+        """GET /accounts/password/reset/ renders the crush-branded template."""
+        response = self.client.get('/accounts/password/reset/')
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # Strings unique to the crush-branded template
+        self.assertIn("Send reset link", content)
+        # The crush base template should be used (Tailwind class)
+        self.assertIn("btn-crush-primary", content)
+
+    def test_password_reset_sends_email_for_existing_user(self):
+        """POST with an existing email sends a password reset email."""
+        from django.core import mail
+
+        mail.outbox = []
+        response = self.client.post(
+            '/accounts/password/reset/',
+            {'email': 'resetuser@example.com'},
+        )
+        # Allauth redirects to the done page on success
+        self.assertIn(response.status_code, (200, 302))
+        self.assertEqual(len(mail.outbox), 1)
+        sent = mail.outbox[0]
+        self.assertIn('resetuser@example.com', sent.to)
+        self.assertIn('Crush.lu', sent.subject)
+        # The body should include a reset URL (password/reset/key/)
+        body = sent.body or ''
+        for alt in getattr(sent, 'alternatives', []) or []:
+            body += alt[0]
+        self.assertIn('password/reset/key/', body)
+
+    def test_password_reset_no_email_for_unknown_user(self):
+        """POST with an unknown email does not send any email (privacy)."""
+        from django.core import mail
+
+        mail.outbox = []
+        response = self.client.post(
+            '/accounts/password/reset/',
+            {'email': 'nobody-here@example.com'},
+        )
+        self.assertIn(response.status_code, (200, 302))
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_password_reset_confirm_changes_password(self):
+        """End-to-end: request reset, follow link, set new password, log in."""
+        import re
+        from django.core import mail
+
+        mail.outbox = []
+        self.client.post(
+            '/accounts/password/reset/',
+            {'email': 'resetuser@example.com'},
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body or ''
+        for alt in getattr(mail.outbox[0], 'alternatives', []) or []:
+            body += alt[0]
+
+        # Extract the reset URL from the email body
+        match = re.search(r'(/accounts/password/reset/key/[^\s"<>]+)', body)
+        self.assertIsNotNone(match, "Reset URL not found in email body")
+        reset_url = match.group(1)
+
+        # GET the reset URL first - allauth redirects to a /set-password/ URL
+        # with the token stored in session
+        get_response = self.client.get(reset_url, follow=True)
+        self.assertEqual(get_response.status_code, 200)
+
+        # The final URL after redirect is where we POST the new password
+        final_url = get_response.request['PATH_INFO']
+        new_password = 'BrandNewPassword456!'
+        post_response = self.client.post(
+            final_url,
+            {'password1': new_password, 'password2': new_password},
+        )
+        self.assertIn(post_response.status_code, (200, 302))
+
+        # Verify password was actually changed
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password(new_password))

--- a/crush_lu/tests/test_security.py
+++ b/crush_lu/tests/test_security.py
@@ -328,8 +328,15 @@ class TestPasswordReset(SiteTestCase):
             body += alt[0]
         self.assertIn('password/reset/key/', body)
 
-    def test_password_reset_no_email_for_unknown_user(self):
-        """POST with an unknown email does not send any email (privacy)."""
+    def test_password_reset_no_reset_link_for_unknown_user(self):
+        """POST with an unknown email must not leak a real reset link (privacy).
+
+        With allauth's ACCOUNT_PREVENT_ENUMERATION=True (default), allauth sends
+        a generic "account not found" email to prevent account enumeration via
+        timing/response differences. That's fine — but the email must NOT
+        contain a real password-reset URL, otherwise an attacker could use the
+        response to probe for valid accounts.
+        """
         from django.core import mail
 
         mail.outbox = []
@@ -338,7 +345,15 @@ class TestPasswordReset(SiteTestCase):
             {'email': 'nobody-here@example.com'},
         )
         self.assertIn(response.status_code, (200, 302))
-        self.assertEqual(len(mail.outbox), 0)
+        for sent in mail.outbox:
+            body = sent.body or ''
+            for alt in getattr(sent, 'alternatives', []) or []:
+                body += alt[0]
+            self.assertNotIn(
+                'password/reset/key/',
+                body,
+                "Unknown-email response leaked a real reset link",
+            )
 
     def test_password_reset_confirm_changes_password(self):
         """End-to-end: request reset, follow link, set new password, log in."""


### PR DESCRIPTION
## Purpose
Implement a complete, branded password reset flow for Crush.lu by adding custom templates that override django-allauth's default password reset pages. This ensures a consistent user experience across all authentication flows with Crush.lu's design system (Tailwind CSS, dark mode support, custom icons).

The implementation includes:
- Password reset request form (`password_reset.html`)
- Confirmation page after reset email sent (`password_reset_done.html`)
- Password change form with token validation (`password_reset_from_key.html`)
- Success confirmation page (`password_reset_from_key_done.html`)
- Branded email templates for password reset notifications (HTML and plain text)
- Comprehensive end-to-end tests for the password reset flow
- Minor UI adjustment to login form spacing

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Run the test suite
```
python manage.py test crush_lu.tests.test_security.TestPasswordReset
```

* Manual testing
  1. Navigate to `/accounts/password/reset/`
  2. Enter an email address and submit the form
  3. Check email for password reset link
  4. Click the link and verify the password change form renders correctly
  5. Enter a new password and confirm
  6. Verify you can log in with the new password

## What to Check
Verify that the following are valid:
* Password reset request page renders with Crush.lu branding
* Reset email is sent with properly formatted HTML and plain text versions
* Invalid/expired reset tokens show appropriate error message
* Password change form validates and updates user password
* All pages support dark mode
* Email contains clickable reset link that works end-to-end
* Existing tests pass and new test suite covers the complete flow

## Other Information
The implementation leverages django-allauth's built-in password reset functionality while providing complete template overrides for branding. All templates follow the existing Crush.lu design patterns with Tailwind CSS utilities, dark mode support via `dark:` prefixes, and consistent use of custom icon components.

https://claude.ai/code/session_015eYPCSe8QaJHPN7irzV4Fu