### PR TITLE
Add Claude Code on the web bootstrap hook for Python 3.12

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Why this exists:
+#   The web sandbox image ships with Python 3.11 and Django 5.2 pre-installed,
+#   but this project requires Python 3.12+ and Django 6.0.4 (see requirements.txt).
+#   Without this hook, `python`, `pytest`, `django-admin`, etc. all resolve to
+#   the wrong stack and the test suite cannot run.
+#
+#   This hook builds a .venv from the system /usr/bin/python3.12, installs the
+#   project's pinned requirements, and prepends the venv to PATH for the rest
+#   of the session via $CLAUDE_ENV_FILE.
+#
+# Local devcontainer / laptop runs are unaffected: the script no-ops unless
+# CLAUDE_CODE_REMOTE=true.
+
+set -euo pipefail
+
+# Only run inside the Claude Code on the web sandbox.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+VENV_DIR="$PROJECT_DIR/.venv"
+PYTHON_BIN="/usr/bin/python3.12"
+UV_BIN="${UV_BIN:-/root/.local/bin/uv}"
+
+cd "$PROJECT_DIR"
+
+# Sanity check: Python 3.12 must be present in the sandbox image.
+if [ ! -x "$PYTHON_BIN" ]; then
+    echo "session-start hook: $PYTHON_BIN not found; cannot bootstrap Python 3.12 venv" >&2
+    exit 1
+fi
+
+# Decide whether the existing .venv is reusable (idempotency).
+needs_create=1
+if [ -x "$VENV_DIR/bin/python" ]; then
+    existing_version="$("$VENV_DIR/bin/python" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo "")"
+    if [ "$existing_version" = "3.12" ]; then
+        needs_create=0
+    else
+        echo "session-start hook: existing .venv is Python '$existing_version', recreating with 3.12"
+        rm -rf "$VENV_DIR"
+    fi
+fi
+
+# Create the venv with uv if available, otherwise fall back to stdlib venv.
+if [ "$needs_create" = "1" ]; then
+    if [ -x "$UV_BIN" ]; then
+        "$UV_BIN" venv --python "$PYTHON_BIN" "$VENV_DIR"
+    else
+        "$PYTHON_BIN" -m venv "$VENV_DIR"
+    fi
+fi
+
+# Install / sync dependencies. uv pip install is much faster than plain pip.
+# We also install the same test extras CI uses (see .github/workflows/test-and-validate.yml).
+if [ -x "$UV_BIN" ]; then
+    VIRTUAL_ENV="$VENV_DIR" "$UV_BIN" pip install -r "$PROJECT_DIR/requirements.txt"
+    VIRTUAL_ENV="$VENV_DIR" "$UV_BIN" pip install pytest-cov pytest-xdist
+else
+    "$VENV_DIR/bin/pip" install --upgrade pip
+    "$VENV_DIR/bin/pip" install -r "$PROJECT_DIR/requirements.txt"
+    "$VENV_DIR/bin/pip" install pytest-cov pytest-xdist
+fi
+
+# Persist environment for the rest of the session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    {
+        echo "export VIRTUAL_ENV=\"$VENV_DIR\""
+        echo "export PATH=\"$VENV_DIR/bin:\$PATH\""
+        echo 'export DJANGO_SETTINGS_MODULE="azureproject.settings"'
+        echo 'export SECRET_KEY="ci-test-key"'
+        echo 'export USE_AZURE_STORAGE="False"'
+    } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "session-start hook: ready ($("$VENV_DIR/bin/python" --version), Django $("$VENV_DIR/bin/python" -c 'import django; print(django.get_version())'))"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -35,13 +35,21 @@ if [ ! -x "$PYTHON_BIN" ]; then
 fi
 
 # Decide whether the existing .venv is reusable (idempotency).
+# If anything at $VENV_DIR isn't a working Python 3.12 venv, wipe it — uv venv
+# refuses to overwrite an existing directory, so a stale/partial .venv would
+# otherwise abort the whole bootstrap under `set -e`.
 needs_create=1
-if [ -x "$VENV_DIR/bin/python" ]; then
-    existing_version="$("$VENV_DIR/bin/python" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo "")"
-    if [ "$existing_version" = "3.12" ]; then
-        needs_create=0
+if [ -e "$VENV_DIR" ]; then
+    if [ -x "$VENV_DIR/bin/python" ]; then
+        existing_version="$("$VENV_DIR/bin/python" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo "")"
+        if [ "$existing_version" = "3.12" ]; then
+            needs_create=0
+        else
+            echo "session-start hook: existing .venv is Python '$existing_version', recreating with 3.12"
+            rm -rf "$VENV_DIR"
+        fi
     else
-        echo "session-start hook: existing .venv is Python '$existing_version', recreating with 3.12"
+        echo "session-start hook: existing .venv is not a valid virtualenv (no bin/python), recreating"
         rm -rf "$VENV_DIR"
     fi
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,13 @@ yarn-error.log*
 .azure
 .aider*
 .claude/
+# Track team-shared Claude Code on the web bootstrap (see .claude/hooks/session-start.sh)
+!.claude/
+/.claude/*
+!/.claude/settings.json
+!/.claude/hooks/
+/.claude/hooks/*
+!/.claude/hooks/session-start.sh
 .codex/
 
 # Apple Wallet test passes (generated locally)


### PR DESCRIPTION
## Purpose
* Add a session-start hook that automatically bootstraps a Python 3.12 virtual environment with project dependencies when running in Claude Code on the web
* The web sandbox ships with Python 3.11 and Django 5.2, but this project requires Python 3.12+ and Django 6.0.4
* Without this hook, `python`, `pytest`, `django-admin`, etc. resolve to the wrong stack and tests cannot run
* Local development (devcontainer/laptop) is unaffected as the hook only activates when `CLAUDE_CODE_REMOTE=true`

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test in Claude Code on the web sandbox
  - The session-start hook will automatically run when opening the project
  - Verify that `python --version` returns Python 3.12.x
  - Verify that `django-admin --version` returns 6.0.4
  - Run the test suite: `pytest` should execute without environment errors

* Test local development (no changes expected)
  - Existing devcontainer and local development workflows are unaffected
  - The hook only activates in the remote sandbox environment

## What to Check
Verify that the following are valid:
* Hook only runs when `CLAUDE_CODE_REMOTE=true` (no impact on local development)
* Virtual environment is created with Python 3.12 from `/usr/bin/python3.12`
* Project dependencies from `requirements.txt` are installed
* Test dependencies (`pytest-cov`, `pytest-xdist`) are installed
* Environment variables are properly persisted for the session
* Idempotency: re-running the hook doesn't recreate the venv if it's already Python 3.12
* `.claude/` directory is properly tracked in git (settings.json and hooks/session-start.sh only)

## Other Information
* The hook uses `uv` for faster dependency installation if available, with fallback to stdlib `pip`
* `.gitignore` is updated to selectively track only the necessary Claude Code configuration files while ignoring other generated files in `.claude/`

https://claude.ai/code/session_013D2n4NMPRVt8McRaFCvebF