### PR TITLE
fix(security): critical audit fixes — CSRF, race condition, photo validation

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -299,7 +299,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # In settings.py
 
 # These settings optimize the login experience
-SOCIALACCOUNT_LOGIN_ON_GET = True
+SOCIALACCOUNT_LOGIN_ON_GET = False
 SOCIALACCOUNT_STORE_TOKENS = True
 SOCIALACCOUNT_AUTO_SIGNUP = True
 
@@ -411,8 +411,6 @@ ACCOUNT_EMAIL_VERIFICATION = "optional"
 ACCOUNT_SESSION_REMEMBER = True
 
 LOGIN_REDIRECT_URL = "/profile/"
-
-SOCIALACCOUNT_LOGIN_ON_GET = True
 
 # Don't send email verification for social account signups (email already verified by provider)
 SOCIALACCOUNT_EMAIL_VERIFICATION = "none"

--- a/crush_lu/api_coach_push.py
+++ b/crush_lu/api_coach_push.py
@@ -9,7 +9,6 @@ import logging
 from django.db.models import Q
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import csrf_exempt
 from django.conf import settings
 from .decorators import crush_login_required, ratelimit
 from .models import CrushCoach, CoachPushSubscription, PushSubscription
@@ -58,7 +57,6 @@ def get_vapid_public_key(request):
 
 @crush_login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def subscribe_push(request):
     """
@@ -167,7 +165,6 @@ def subscribe_push(request):
 
 @crush_login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def unsubscribe_push(request):
     """
@@ -234,7 +231,6 @@ def unsubscribe_push(request):
 
 @crush_login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def delete_push_subscription(request):
     """
@@ -320,7 +316,6 @@ def list_subscriptions(request):
 
 @crush_login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def update_subscription_preferences(request):
     """
@@ -389,7 +384,6 @@ def update_subscription_preferences(request):
 
 @crush_login_required
 @ratelimit(key='user', rate='5/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def send_test_push(request):
     """

--- a/crush_lu/api_push.py
+++ b/crush_lu/api_push.py
@@ -65,7 +65,6 @@ def get_vapid_public_key(request):
 
 @login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt  # Push subscriptions use their own authentication via login_required
 @require_http_methods(["POST"])
 def subscribe_push(request):
     """
@@ -170,7 +169,6 @@ def subscribe_push(request):
 
 @login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def refresh_subscription(request):
     """
@@ -285,7 +283,6 @@ def refresh_subscription(request):
 
 @login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def validate_subscription(request):
     """
@@ -367,7 +364,6 @@ def validate_subscription(request):
 
 @login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def unsubscribe_push(request):
     """
@@ -435,7 +431,6 @@ def unsubscribe_push(request):
 
 @login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def delete_push_subscription(request):
     """
@@ -513,7 +508,6 @@ def list_subscriptions(request):
 
 @login_required
 @ratelimit(key='user', rate='20/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def update_subscription_preferences(request):
     """
@@ -578,7 +572,6 @@ def update_subscription_preferences(request):
 
 @login_required
 @ratelimit(key='user', rate='5/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def send_test_push(request):
     """
@@ -602,7 +595,6 @@ def send_test_push(request):
 
 @login_required
 @ratelimit(key='user', rate='10/m', method='POST')
-@csrf_exempt
 @require_http_methods(["POST"])
 def mark_pwa_user(request):
     """

--- a/crush_lu/api_views.py
+++ b/crush_lu/api_views.py
@@ -2,7 +2,8 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
-from django.views.decorators.csrf import csrf_exempt
+from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 from .models import (
@@ -103,12 +104,7 @@ def submit_vote_api(request, event_id):
             event=event,
             user=request.user
         )
-        if user_registration.status not in ['confirmed', 'attended']:
-            return JsonResponse({
-                'success': False,
-                'error': 'Only confirmed attendees can vote'
-            }, status=403)
-        if user_registration.status == 'confirmed':
+        if user_registration.status != 'attended':
             return JsonResponse({
                 'success': False,
                 'error': 'You must check in at the event before you can vote'
@@ -160,32 +156,29 @@ def submit_vote_api(request, event_id):
             'error': 'Invalid activity option'
         }, status=400)
 
-    # Check for existing vote
-    existing_vote = EventActivityVote.objects.filter(
-        event=event,
-        user=request.user
-    ).first()
-
-    if existing_vote:
-        # Update existing vote
-        existing_vote.selected_option = selected_option
-        existing_vote.save()
-
-        action = 'updated'
-    else:
-        # Create new vote
-        EventActivityVote.objects.create(
+    # Atomic vote creation/update to prevent race conditions
+    with transaction.atomic():
+        existing_vote = EventActivityVote.objects.filter(
             event=event,
-            user=request.user,
-            selected_option=selected_option
-        )
+            user=request.user
+        ).select_for_update().first()
 
-        voting_session.total_votes += 1
-        voting_session.save()
+        if existing_vote:
+            existing_vote.selected_option = selected_option
+            existing_vote.save()
+            action = 'updated'
+        else:
+            EventActivityVote.objects.create(
+                event=event,
+                user=request.user,
+                selected_option=selected_option
+            )
+            EventVotingSession.objects.filter(
+                event=event
+            ).update(total_votes=F('total_votes') + 1)
+            voting_session.refresh_from_db()
+            action = 'created'
 
-        action = 'created'
-
-    # Get current vote count from actual votes
     vote_count = EventActivityVote.objects.filter(
         event=event, selected_option=selected_option
     ).count()

--- a/crush_lu/static/crush_lu/js/push-notifications.js
+++ b/crush_lu/static/crush_lu/js/push-notifications.js
@@ -13,20 +13,17 @@
         return;
     }
 
-    // CSRF token helper
-    function getCookie(name) {
-        let cookieValue = null;
-        if (document.cookie && document.cookie !== "") {
-            const cookies = document.cookie.split(";");
-            for (let i = 0; i < cookies.length; i++) {
-                const cookie = cookies[i].trim();
-                if (cookie.substring(0, name.length + 1) === name + "=") {
-                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                    break;
-                }
-            }
+    // CSRF token helper — reads from hidden input (works with CSRF_COOKIE_HTTPONLY=True)
+    function getCSRFToken() {
+        var input = document.getElementById("csrf-token-input");
+        if (input && input.value) {
+            return input.value;
         }
-        return cookieValue;
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (meta) {
+            return meta.getAttribute("content");
+        }
+        return null;
     }
 
     // Convert base64 VAPID key to Uint8Array
@@ -168,7 +165,7 @@
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    "X-CSRFToken": getCookie("csrftoken"),
+                    "X-CSRFToken": getCSRFToken(),
                 },
                 body: JSON.stringify({
                     endpoint: subscription.endpoint,
@@ -248,7 +245,7 @@
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    "X-CSRFToken": getCookie("csrftoken"),
+                    "X-CSRFToken": getCSRFToken(),
                 },
                 body: JSON.stringify({
                     endpoint: subscription.endpoint,
@@ -300,7 +297,7 @@
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    "X-CSRFToken": getCookie("csrftoken"),
+                    "X-CSRFToken": getCSRFToken(),
                 },
                 body: JSON.stringify({
                     endpoint: subscription.endpoint,
@@ -383,7 +380,7 @@
             const response = await fetch("/api/push/test/", {
                 method: "POST",
                 headers: {
-                    "X-CSRFToken": getCookie("csrftoken"),
+                    "X-CSRFToken": getCSRFToken(),
                 },
             });
 

--- a/crush_lu/static/crush_lu/js/pwa-detector.js
+++ b/crush_lu/static/crush_lu/js/pwa-detector.js
@@ -113,9 +113,17 @@
     }
 
     /**
-     * Get cookie value by name
+     * Get CSRF token from hidden input (works with CSRF_COOKIE_HTTPONLY=True)
      */
     function getCookie(name) {
+        var input = document.getElementById("csrf-token-input");
+        if (input && input.value) {
+            return input.value;
+        }
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (meta) {
+            return meta.getAttribute("content");
+        }
         let cookieValue = null;
         if (document.cookie && document.cookie !== "") {
             const cookies = document.cookie.split(";");

--- a/crush_lu/views_profile.py
+++ b/crush_lu/views_profile.py
@@ -841,15 +841,13 @@ def upload_profile_photo(request, slot):
                     'error': 'Photo validation failed. Please try a different image.',
                 })
 
-        # Fallback - save without validation (shouldn't happen)
-        setattr(profile, photo_field_name, photo_file)
-        profile.save(update_fields=[photo_field_name])
-
+        # No valid form field found for this slot -- reject the upload
+        logger.error(f"No form field found for photo slot {slot}")
         return render(request, 'crush_lu/partials/photo_card.html', {
             'slot': slot,
             'photo': getattr(profile, photo_field_name),
             'is_main': slot == 1,
-            'just_uploaded': True,
+            'error': 'Unable to process photo upload. Please try again.',
         })
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- **#264** Fix race condition in vote submission API with `transaction.atomic()`, `select_for_update()`, and `F()` expression for counter increment
- **#265** Remove `@csrf_exempt` from 13 browser-called push notification endpoints in `api_push.py` and `api_coach_push.py`. Update JS to read CSRF token from hidden input (compatible with `CSRF_COOKIE_HTTPONLY=True`)
- **#266** Replace unvalidated photo upload fallback in `views_profile.py` with error response
- **#269** Set `SOCIALACCOUNT_LOGIN_ON_GET = False` to prevent login CSRF, remove duplicate setting
- **#267** Simplify vote status check — only `attended` users can vote (fixes misleading double-check logic)

Legitimate `@csrf_exempt` usages are preserved: health check endpoint (Bearer token auth), Facebook data deletion callback (signed request), Apple/Google Wallet callbacks, external webhooks.

## Test plan
- [ ] Run full test suite
- [ ] Verify push notification subscribe/unsubscribe still works (CSRF token now required)
- [ ] Verify social login flow still works with `SOCIALACCOUNT_LOGIN_ON_GET=False` (users see confirmation page)
- [ ] Test photo upload — invalid files should be rejected, not silently saved
- [ ] Test concurrent vote submissions don't produce incorrect total_votes count

Closes #264, Closes #265, Closes #266, Closes #269, Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)