### PR TITLE
fix(i18n): wrap hardcoded English strings in gettext

### DIFF
--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -530,7 +530,9 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
 
         total_events = queryset.count()
         django_messages.success(
-            request, f"Exported attendees from {total_events} event(s) to CSV."
+            request,
+            _("Exported attendees from %(count)d event(s) to CSV.")
+            % {"count": total_events},
         )
         return response
 

--- a/crush_lu/admin/quiz.py
+++ b/crush_lu/admin/quiz.py
@@ -105,7 +105,7 @@ def generate_quiz_night_tables(modeladmin, request, queryset):
                 men, women, num_rounds, num_tables=quiz.num_tables
             )
         except Exception as e:
-            messages.error(request, f"'{event}': {e}")
+            messages.error(request, _("'%(event)s': %(error)s") % {"event": event, "error": e})
             continue
 
         schedule = result["schedule"]
@@ -113,7 +113,7 @@ def generate_quiz_night_tables(modeladmin, request, queryset):
 
         # Display any warnings from the algorithm
         for warning in result["warnings"]:
-            messages.warning(request, f"'{event}': {warning}")
+            messages.warning(request, _("'%(event)s': %(warning)s") % {"event": event, "warning": warning})
 
         # Clear existing rotation data and memberships (but preserve tables
         # to avoid cascade-deleting TableRoundScore records)

--- a/crush_lu/admin_views.py
+++ b/crush_lu/admin_views.py
@@ -11,6 +11,7 @@ from django.contrib.auth import get_user_model
 from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
 from django.http import JsonResponse
 from django.utils import timezone
+from django.utils.translation import gettext as _
 from datetime import timedelta
 import logging
 import traceback
@@ -2015,7 +2016,7 @@ def merge_accounts_confirm(request):
 
         except Exception as e:
             logger.error(f"[ACCOUNT-MERGE] Error: {e}", exc_info=True)
-            django_messages.error(request, f"Merge failed: {e}")
+            django_messages.error(request, _("Merge failed: %(error)s") % {"error": e})
             return redirect('/crush-admin/merge-accounts/')
 
     return render(request, 'admin/crush_lu/crushprofile/merge_confirmation.html', {

--- a/entreprinder/views.py
+++ b/entreprinder/views.py
@@ -3,6 +3,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
+from django.utils.translation import gettext as _
 from .forms import EntrepreneurProfileForm
 from .models import EntrepreneurProfile
 from django.conf import settings
@@ -61,10 +62,10 @@ def profile(request):
         if form.is_valid():
             profile = form.save(commit=False)
             profile.save()
-            messages.success(request, 'Profile updated successfully.')
+            messages.success(request, _('Profile updated successfully.'))
             return redirect('entreprinder:profile')
         else:
-            messages.error(request, 'Error updating profile. Please check the form.')
+            messages.error(request, _('Error updating profile. Please check the form.'))
     else:
         form = EntrepreneurProfileForm(instance=profile)
 

--- a/power_up/crm/views.py
+++ b/power_up/crm/views.py
@@ -4,6 +4,7 @@ from django.db.models import Count, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.utils.translation import gettext as _
 
 from .forms import TicketCommentForm, TicketCreateForm, TicketUpdateForm
 from .models import (
@@ -424,7 +425,7 @@ def ticket_update(request, pk):
                 ticket.closed_at = now
 
             ticket.save()
-            messages.success(request, f"Ticket {ticket.reference_number} updated.")
+            messages.success(request, _("Ticket %(ref)s updated.") % {"ref": ticket.reference_number})
             return redirect("crm:ticket_detail", pk=ticket.pk)
 
     return redirect("crm:ticket_detail", pk=ticket.pk)
@@ -445,6 +446,6 @@ def ticket_comment_add(request, pk):
                 message=form.cleaned_data["message"],
                 is_internal=form.cleaned_data["is_internal"],
             )
-            messages.success(request, "Comment added.")
+            messages.success(request, _("Comment added."))
 
     return redirect("crm:ticket_detail", pk=ticket.pk)


### PR DESCRIPTION
## Summary
- Wrap 8 hardcoded English user-facing strings in `_()` / `gettext` across 5 files
- **#313** crush_lu admin CSV export message
- **#314** crush_lu quiz admin error/warning messages
- **#315** crush_lu admin merge failure message
- **#316, #317** entreprinder profile update messages
- **#320** power_up CRM ticket/comment messages
- **#318, #319** already resolved (views_matching.py deleted in prior commit)
- **#321** (JS strings in alpine-components.js) deferred — requires `JavaScriptCatalog` setup, tracked separately

After merging, run `makemessages` to generate new .po entries for translation.

## Test plan
- [ ] Run `makemessages -l de -l fr` — verify new entries appear in .po files
- [ ] Verify admin export message shows correctly
- [ ] Verify entreprinder profile update messages
- [ ] Verify CRM ticket update messages

Closes #313, Closes #314, Closes #315, Closes #316, Closes #317, Closes #318, Closes #319, Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)