### PR TITLE
refactor: remove dead code — Crush Connect waitlist and unused models

### DIFF
--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -34,7 +34,7 @@ from crush_lu.admin_views import (
     email_template_load_invitations,
     email_template_load_gifts,
 )
-from crush_lu import api_views, api_push, api_coach_push, api_pwa, views_oauth_popup, api_journey, views_wallet, api_referral, api_admin_sync, views_crush_spark, views_checkin, api_crush_connect, views_coach, api_quiz, views_quiz
+from crush_lu import api_views, api_push, api_coach_push, api_pwa, views_oauth_popup, api_journey, views_wallet, api_referral, api_admin_sync, views_crush_spark, views_checkin, views_coach, api_quiz, views_quiz
 from crush_lu.wallet import passkit_service, google_callback
 from crush_lu.sitemaps import crush_sitemaps
 from crush_lu.views_seo import robots_txt
@@ -135,8 +135,6 @@ urlpatterns = base_patterns + api_patterns + [
     path('api/sparks/<int:spark_id>/status/', views_crush_spark.api_spark_status, name='api_spark_status'),
 
     # Crush Connect Waitlist API (language-neutral for JS calls)
-    path('api/crush-connect/join/', api_crush_connect.join_waitlist, name='crush_connect_join'),
-    path('api/crush-connect/status/', api_crush_connect.waitlist_status, name='crush_connect_status'),
 
     # Journey Reward APIs (called from photo_reveal.html with hardcoded paths)
     path('api/journey/unlock-puzzle-piece/', api_journey.unlock_puzzle_piece, name='api_unlock_puzzle_piece'),

--- a/crush_lu/admin/__init__.py
+++ b/crush_lu/admin/__init__.py
@@ -171,8 +171,6 @@ from .event_polls import (
     EventPollVoteAdmin,
 )
 
-from .crush_connect import CrushConnectWaitlistAdmin
-
 from .matching import TraitAdmin, MatchScoreAdmin
 
 from .quiz import (
@@ -238,7 +236,6 @@ from crush_lu.models import (
     EventPoll,
     EventPollOption,
     EventPollVote,
-    CrushConnectWaitlist,
     Trait,
     MatchScore,
     QuizEvent,
@@ -348,8 +345,7 @@ crush_admin_site.register(EventPollVote, EventPollVoteAdmin)
 # Site Configuration (singleton)
 crush_admin_site.register(CrushSiteConfig, CrushSiteConfigAdmin)
 
-# Crush Connect Waitlist
-crush_admin_site.register(CrushConnectWaitlist, CrushConnectWaitlistAdmin)
+
 
 # Matching System
 crush_admin_site.register(Trait, TraitAdmin)
@@ -510,8 +506,6 @@ __all__ = [
     'EventPollAdmin',
     'EventPollVoteAdmin',
 
-    # Crush Connect
-    'CrushConnectWaitlistAdmin',
 
     # Matching
     'TraitAdmin',

--- a/crush_lu/models/__init__.py
+++ b/crush_lu/models/__init__.py
@@ -11,6 +11,5 @@ from .site_config import *
 from .crush_spark import *
 from .newsletter import *
 from .event_polls import *
-from .crush_connect import *
 from .matching import *
 from .quiz import *

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -107,7 +107,6 @@ urlpatterns = [
     path('about/', views.about, name='about'),
     path('how-it-works/', views.how_it_works, name='how_it_works'),
     path('crush-coach/', views.crush_coach, name='crush_coach'),
-    path('crush-connect/', views.crush_connect_teaser, name='crush_connect_teaser'),
     path('membership/', views.membership, name='membership'),
 
     # PWA Debug Page (language-prefixed is fine for debug pages)

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -57,7 +57,6 @@ from .models import (
     EventConnection,
     CoachPushSubscription,
 )
-from .models.crush_connect import CrushConnectWaitlist
 from .forms import (
     CrushSignupForm,
     CrushProfileForm,
@@ -87,7 +86,6 @@ from .views_static import (  # noqa: F401
     terms_of_service,
     data_deletion_request,
     crush_coach,
-    crush_connect_teaser,
 )
 
 # Account & auth
@@ -245,17 +243,6 @@ def dashboard(request):
             or bool(profile.first_step_preference)
         )
 
-        # Crush Connect waitlist status
-        on_crush_connect_waitlist = False
-        crush_connect_position = None
-        crush_connect_total = CrushConnectWaitlist.objects.count()
-        try:
-            cc_entry = CrushConnectWaitlist.objects.get(user=request.user)
-            on_crush_connect_waitlist = True
-            crush_connect_position = cc_entry.waitlist_position
-        except CrushConnectWaitlist.DoesNotExist:
-            pass
-
         # Time-based greeting (use localtime for correct Luxembourg timezone)
         hour = timezone.localtime().hour
         name = profile.display_name
@@ -276,9 +263,6 @@ def dashboard(request):
             "connection_count": connection_count,
             "referral_url": referral_url,
             "has_crush_preferences": has_crush_preferences,
-            "on_crush_connect_waitlist": on_crush_connect_waitlist,
-            "crush_connect_position": crush_connect_position,
-            "crush_connect_total": crush_connect_total,
             "greeting": greeting,
             "apple_wallet_enabled": _is_apple_wallet_configured(),
         }

--- a/crush_lu/views_static.py
+++ b/crush_lu/views_static.py
@@ -1,8 +1,6 @@
 from django.shortcuts import render, redirect
 from django.utils import timezone
 from .models import MeetupEvent
-from .models.crush_connect import CrushConnectWaitlist
-from .models.events import EventRegistration
 
 
 def home(request):
@@ -50,32 +48,3 @@ def crush_coach(request):
     return render(request, "crush_lu/crush_coach.html")
 
 
-def crush_connect_teaser(request):
-    """Crush Connect teaser page with waitlist."""
-    context = {
-        "on_waitlist": False,
-        "waitlist_position": None,
-        "total_waitlist": CrushConnectWaitlist.objects.count(),
-        "is_eligible": False,
-        "profile_approved": False,
-        "has_attended_event": False,
-    }
-
-    if request.user.is_authenticated:
-        try:
-            entry = CrushConnectWaitlist.objects.get(user=request.user)
-            context["on_waitlist"] = True
-            context["waitlist_position"] = entry.waitlist_position
-            context["is_eligible"] = entry.is_eligible
-        except CrushConnectWaitlist.DoesNotExist:
-            pass
-
-        context["profile_approved"] = (
-            hasattr(request.user, "crushprofile")
-            and request.user.crushprofile.is_approved
-        )
-        context["has_attended_event"] = EventRegistration.objects.filter(
-            user=request.user, status="attended"
-        ).exists()
-
-    return render(request, "crush_lu/crush_connect.html", context)


### PR DESCRIPTION
## Summary
- **#329** Remove Crush Connect waitlist feature: views, URL routes, admin registration, model imports, API endpoints
- **#325, #326** Already resolved in prior commits (LuxID mockups, test pages)
- **#327** Invalid — finops serializers are actively used by `api_views.py`
- **#331, #332** SpeedDatingPair and PresentationRating model removal deferred — need FK dependency investigation before deletion

### Remaining cleanup (requires local environment):
- [ ] Delete `crush_lu/models/crush_connect.py`
- [ ] Delete `crush_lu/api_crush_connect.py`
- [ ] Delete `crush_lu/admin/crush_connect.py`
- [ ] Run `makemigrations` to create deletion migration
- [ ] Investigate and remove SpeedDatingPair (#331) and PresentationRating (#332)

## Test plan
- [ ] Run full test suite
- [ ] Verify `/crush-connect/` URL returns 404
- [ ] Verify dashboard loads without crush_connect context variables
- [ ] Verify admin panel loads without CrushConnectWaitlist

Closes #325, Closes #326, Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)