### PR TITLE
perf: fix N+1 queries in voting results, event filtering, and company lookup

### DIFF
--- a/crush_lu/api_views.py
+++ b/crush_lu/api_views.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
+from django.db.models import Count, Q
 from django.utils import timezone
 
 from .models import (
@@ -240,30 +241,35 @@ def voting_results_api(request, event_id):
             'error': 'No voting session found'
         }, status=404)
 
-    # Get all global activity options with vote counts for this event
-    results = []
-    for option in GlobalActivityOption.objects.filter(is_active=True).order_by('activity_type', 'sort_order'):
-        vote_count = EventActivityVote.objects.filter(
-            event=event, selected_option=option
-        ).count()
+    # Get all options with vote counts in a single query (avoids N+1)
+    options = GlobalActivityOption.objects.filter(
+        is_active=True
+    ).annotate(
+        vote_count=Count(
+            'eventactivityvote',
+            filter=Q(eventactivityvote__event=event)
+        )
+    ).order_by('activity_type', 'sort_order')
 
+    winner_ids = {
+        voting_session.winning_presentation_style_id,
+        voting_session.winning_speed_dating_twist_id,
+    }
+
+    results = []
+    for option in options:
         percentage = 0
         if voting_session.total_votes > 0:
-            percentage = (vote_count / voting_session.total_votes) * 100
-
-        is_winner = (
-            option == voting_session.winning_presentation_style
-            or option == voting_session.winning_speed_dating_twist
-        )
+            percentage = (option.vote_count / voting_session.total_votes) * 100
 
         results.append({
             'id': option.id,
             'display_name': option.display_name,
             'activity_type': option.activity_type,
             'activity_variant': option.activity_variant,
-            'vote_count': vote_count,
+            'vote_count': option.vote_count,
             'percentage': round(percentage, 1),
-            'is_winner': is_winner,
+            'is_winner': option.id in winner_ids,
         })
 
     return JsonResponse({

--- a/crush_lu/views_events.py
+++ b/crush_lu/views_events.py
@@ -112,21 +112,33 @@ def _promote_from_waitlist(event, cancelled_user=None):
 
 def _filter_private_events(events, user):
     """Filter out private invitation events unless user is invited."""
-    visible = []
-    for event in events:
-        if event.is_private_invitation:
-            if user.is_authenticated and (
-                event.invited_users.filter(id=user.id).exists()
-                or EventInvitation.objects.filter(
-                    event=event,
-                    created_user=user,
-                    approval_status="approved",
-                ).exists()
-            ):
-                visible.append(event)
-        else:
-            visible.append(event)
-    return visible
+    if not user.is_authenticated:
+        return [e for e in events if not e.is_private_invitation]
+
+    # Batch-fetch invitation data to avoid N+1 queries
+    private_events = [e for e in events if e.is_private_invitation]
+    if private_events:
+        private_ids = [e.id for e in private_events]
+        invited_event_ids = set(
+            MeetupEvent.objects.filter(
+                id__in=private_ids, invited_users=user
+            ).values_list('id', flat=True)
+        )
+        approved_event_ids = set(
+            EventInvitation.objects.filter(
+                event_id__in=private_ids,
+                created_user=user,
+                approval_status="approved",
+            ).values_list('event_id', flat=True)
+        )
+        allowed_ids = invited_event_ids | approved_event_ids
+    else:
+        allowed_ids = set()
+
+    return [
+        e for e in events
+        if not e.is_private_invitation or e.id in allowed_ids
+    ]
 
 
 def event_list(request):

--- a/delegations/views.py
+++ b/delegations/views.py
@@ -51,10 +51,10 @@ def _get_or_create_profile(user):
                 ).first()
             # Then email domain
             if not company:
-                for c in Company.objects.filter(is_active=True):
-                    if c.email_domains and email_domain in [d.lower() for d in c.email_domains]:
-                        company = c
-                        break
+                company = Company.objects.filter(
+                    is_active=True,
+                    email_domains__icontains=email_domain
+                ).first()
 
     # Determine status
     management_keywords = ['ceo', 'cto', 'cfo', 'director', 'owner', 'founder', 'president', 'chief']


### PR DESCRIPTION
## Summary
- **#268** Replace per-option COUNT loop in voting_results_api with single annotated query using `Count` + `Q` filter
- **#283** Batch-fetch invitation data in `_filter_private_events` instead of per-event N+1 queries
- **#284** Replace unbounded Company iteration with `__icontains` filter for email domain lookup

### Already resolved:
- **#267** Vote status logic fixed in PR #346
- **#285** Already uses batch prefetch with `select_related` and dict lookups
- **#286** Uses `values_list()` efficiently — Python matrix building, not N+1
- **#289** Like/Dislike models deleted in prior commit

> **Note:** This PR touches `crush_lu/api_views.py` which is also modified by PR #346. Rebase after PR #346 merges.

## Test plan
- [ ] Verify voting results API returns correct vote counts
- [ ] Verify private invitation events are correctly filtered for invited/non-invited users
- [ ] Verify delegations company lookup works with email domain matching
- [ ] Use `assertNumQueries` or Django Debug Toolbar to confirm N+1 is eliminated

Closes #268, Closes #283, Closes #284, Closes #285, Closes #286, Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)