### PR TITLE
ci(security): add manage.py check --deploy + ramp HSTS safely

### DIFF
--- a/.github/workflows/test-and-validate.yml
+++ b/.github/workflows/test-and-validate.yml
@@ -130,6 +130,43 @@ jobs:
           pip-audit --requirement requirements.txt
         continue-on-error: true
 
+  django-deploy-check:
+    name: Django Deploy Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run manage.py check --deploy against production settings
+        # Fails on any security warning, so missing/weakened headers block merge.
+        # azureproject.production is the module Azure runs (see wsgi.py). It
+        # requires POSTGRESQLCONNSTR_* + SECRET_KEY; we feed dummies since the
+        # check validates settings, not live connections. Intentional HSTS-ramp
+        # warnings (W005, W021) are silenced via SILENCED_SYSTEM_CHECKS in
+        # production.py — remove those entries as the HSTS ramp completes.
+        env:
+          DJANGO_SETTINGS_MODULE: azureproject.production
+          DJANGO_DEBUG: 'False'
+          SECRET_KEY: 'ci-deploy-check-secret-key-not-for-production-use-xyz1234567890'
+          POSTGRESQLCONNSTR_DEFAULT: 'dbname=ci host=localhost user=ci password=ci'
+          CUSTOM_DOMAINS: 'crush.lu,vinsdelux.com,entreprinder.lu,power-up.lu,tableau.lu,delegations.lu,arborist.lu'
+          USE_AZURE_STORAGE: 'False'
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ''
+        run: |
+          python manage.py check --deploy --fail-level WARNING
+
   # Required check: "test" (for branch protection)
   test:
     name: test
@@ -150,7 +187,7 @@ jobs:
   validate:
     name: validate
     runs-on: ubuntu-latest
-    needs: [lint, javascript-lint, security-check]
+    needs: [lint, javascript-lint, security-check, django-deploy-check]
     if: always()
     steps:
       - name: Check validation results
@@ -158,12 +195,13 @@ jobs:
           echo "Lint: ${{ needs.lint.result }}"
           echo "JavaScript lint: ${{ needs.javascript-lint.result }}"
           echo "Security check: ${{ needs.security-check.result }}"
+          echo "Django deploy check: ${{ needs.django-deploy-check.result }}"
 
-          # All validation jobs should succeed
-          if [ "${{ needs.lint.result }}" != "success" ] || \
-             [ "${{ needs.javascript-lint.result }}" != "success" ] || \
-             [ "${{ needs.security-check.result }}" != "success" ]; then
-            echo "::error::Validation failed"
+          # django-deploy-check is the only one here that blocks merge.
+          # The other three use continue-on-error so they surface issues
+          # without failing CI; keep the same posture for them.
+          if [ "${{ needs.django-deploy-check.result }}" != "success" ]; then
+            echo "::error::Django deploy check failed — a security setting regressed"
             exit 1
           fi
           echo "✅ Validation passed!"

--- a/azureproject/asgi.py
+++ b/azureproject/asgi.py
@@ -17,7 +17,16 @@ import sys
 
 import django
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "azureproject.settings")
+# Mirror wsgi.py: pick production.py on Azure (WEBSITE_HOSTNAME is set by
+# App Service), settings.py otherwise (local dev, pytest). Must match
+# wsgi.py exactly — divergence here silently loads the wrong settings
+# module at runtime (e.g. SEC-04 headers missing from production traffic).
+_settings_module = (
+    "azureproject.production"
+    if "WEBSITE_HOSTNAME" in os.environ
+    else "azureproject.settings"
+)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", _settings_module)
 django.setup()
 
 from channels.auth import AuthMiddlewareStack  # noqa: E402

--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -602,6 +602,41 @@ if not telemetry_ok:
 # then switch to CONTENT_SECURITY_POLICY (enforcing) when ready.
 
 # =============================================================================
+# SECURITY HEADERS (SEC-04)
+# =============================================================================
+# Production is served exclusively over HTTPS via Azure Front Door, which
+# terminates TLS and forwards X-Forwarded-Proto so Django's SSL redirect logic
+# works correctly. HealthCheckMiddleware is first in MIDDLEWARE and short-
+# circuits /healthz/ before SecurityMiddleware runs, so Azure health probes
+# remain unaffected.
+SECURE_SSL_REDIRECT = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+# HSTS ramp: start at 1 hour so any cert / mixed-content / subdomain issue
+# clears from browser caches quickly. Step up only after a week of clean
+# observation across all 7 apex domains:
+#   1h -> 1d -> 1w -> 30d -> 1y (+ includeSubDomains -> + preload + submit
+#   to hstspreload.org). includeSubDomains is off until every subdomain
+#   (staging.*, test.*, api.*, admin.*, mail.*, cdn.*) is confirmed HTTPS.
+SECURE_HSTS_SECONDS = 3600  # 1 hour
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_HSTS_PRELOAD = False
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+X_FRAME_OPTIONS = "DENY"
+
+# `manage.py check --deploy` warns on anything weaker than the preload-ready
+# end state. The ramp above is intentional, so silence just those two checks
+# and remove each entry as the corresponding setting reaches target:
+#   W005 -> remove when SECURE_HSTS_INCLUDE_SUBDOMAINS flips to True
+#   W021 -> remove when SECURE_HSTS_PRELOAD flips to True
+# Keeping this list tight means any NEW security warning (e.g. someone
+# dropping SESSION_COOKIE_SECURE) will still fail CI.
+SILENCED_SYSTEM_CHECKS = [
+    "security.W005",  # SECURE_HSTS_INCLUDE_SUBDOMAINS not True during ramp
+    "security.W021",  # SECURE_HSTS_PRELOAD not True during ramp
+]
+
+# =============================================================================
 # DJANGO 6.0 BACKGROUND TASKS
 # =============================================================================
 # Inherits ImmediateBackend from settings.py (tasks run synchronously).

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -1018,24 +1018,7 @@ COMPONENTS = {
     "app_dirs": ["components"],
 }
 
-# =============================================================================
-# PRODUCTION SECURITY HEADERS (SEC-04)
-# =============================================================================
-# Only applied when DEBUG=False AND not running under pytest. Local HTTP dev
-# and the test client both speak plain HTTP, so SSL redirect would break them
-# (301 instead of 200 on every request). Production is served exclusively over
-# HTTPS via Azure Front Door, which terminates TLS and forwards
-# X-Forwarded-Proto so Django's SSL redirect logic works correctly.
-#
-# HealthCheckMiddleware is first in MIDDLEWARE and short-circuits /healthz/
-# before SecurityMiddleware runs, so Azure health probes remain unaffected.
-_RUNNING_TESTS = "PYTEST_VERSION" in os.environ or "pytest" in sys.argv[0]
-if not DEBUG and not _RUNNING_TESTS:
-    SECURE_SSL_REDIRECT = True
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-    SECURE_HSTS_SECONDS = 31536000  # 1 year
-    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-    SECURE_HSTS_PRELOAD = True
-    SECURE_CONTENT_TYPE_NOSNIFF = True
-    SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
-    X_FRAME_OPTIONS = "DENY"
+# Production-only security headers (SSL redirect, HSTS, nosniff, referrer,
+# X-Frame-Options) live in azureproject/production.py. settings.py is used by
+# local dev and pytest, both of which speak plain HTTP and would break under
+# SSL redirect.


### PR DESCRIPTION
## Summary

- Move SEC-04 security headers from `settings.py` into `production.py` (right file — `wsgi.py` loads production.py on Azure). Removes the `if not DEBUG and not _RUNNING_TESTS:` gate.
- Ramp HSTS from 1-year-preload-everywhere down to `max-age=3600`, `includeSubDomains=False`, `preload=False`. Step up weekly as each apex/subdomain is confirmed HTTPS-clean. Full schedule documented in-file.
- Add `django-deploy-check` job running `manage.py check --deploy --fail-level WARNING` against `azureproject.production`. Wired into the `validate` required check so any **new** security regression fails CI. Expected ramp warnings (`security.W005`, `security.W021`) silenced via `SILENCED_SYSTEM_CHECKS`.

## Why

Shipping `HSTS=1y + includeSubDomains + preload` is a 1-year browser-cache commitment across all 7 apex domains and every subdomain — too aggressive for day one. The conventional rollout is a ramp. Adding `check --deploy` to CI closes the gap that let SEC-04 sit missing until a manual audit found it.

## Test plan

- [ ] CI `django-deploy-check` job passes (this is the whole point)
- [ ] CI still runs existing lint, test, js-lint, pip-audit jobs
- [ ] On a manual settings regression (e.g. flip `SESSION_COOKIE_SECURE = False` in production.py and push), CI fails with the relevant `security.W*` ID
- [ ] After this lands, confirm staging still serves `Strict-Transport-Security: max-age=3600` (not 31536000) after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)