### PR TITLE
perf(signals): remove eager storage init from user signup (#292)

### DIFF
--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -35,7 +35,6 @@ from .models import (
     CrushSpark,
 )
 from .models.journey import JourneyProgress
-from .storage import initialize_user_storage
 from .utils.i18n import is_valid_language
 
 logger = logging.getLogger(__name__)
@@ -149,37 +148,6 @@ def trigger_wallet_pass_updates(profile):
     """
     _trigger_apple_pass_refresh(profile)
     _trigger_google_wallet_object_update(profile)
-
-
-@receiver(post_save, sender=User)
-def create_user_storage_folder(sender, instance, created, **kwargs):
-    """
-    Create user storage folder structure when a new user is created.
-
-    This initializes the user's private storage folder in Azure Blob Storage
-    (or local filesystem in development) with a marker file.
-
-    Structure created:
-        users/{user_id}/.user_created
-
-    Note: This signal fires for all User creations across all domains.
-    The storage is Crush.lu-specific (crush-profiles-private container),
-    so it only affects Crush.lu photo storage.
-    """
-    if not created:
-        return
-
-    try:
-        success = initialize_user_storage(instance.id)
-        if success:
-            logger.info(
-                f"Created storage folder for new user {instance.id} ({instance.email})"
-            )
-        else:
-            logger.warning(f"Failed to create storage folder for user {instance.id}")
-    except Exception as e:
-        # Don't fail user creation if storage initialization fails
-        logger.error(f"Error creating storage folder for user {instance.id}: {str(e)}")
 
 
 @receiver(post_save, sender=User)

--- a/crush_lu/storage.py
+++ b/crush_lu/storage.py
@@ -19,17 +19,17 @@ Environment Variables:
                                    Example for staging: 'crush-lu-private-staging'
 
 User Storage Structure:
-    users/{user_id}/.user_created    # Marker file
     users/{user_id}/photos/          # Profile photos
     users/{user_id}/exports/         # GDPR exports
+
+Storage folders are created implicitly on first upload — Azure Blob
+has no real folders, so there is no up-front initialization step.
 """
 
 import os
 import logging
 from datetime import datetime, timedelta, timezone
 from django.conf import settings
-from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 
 logger = logging.getLogger(__name__)
 
@@ -227,88 +227,6 @@ class CrushProfilePhotoStorage(PrivateAzureStorage):
 
         # Reconstruct path
         return os.path.join(dir_name, unique_filename)
-
-
-def initialize_user_storage(user_id):
-    """
-    Create user storage folder structure with a marker file.
-
-    This function creates the folder structure for a user in Azure Blob Storage
-    (Azurite in development, Azure in production) or local filesystem as fallback.
-    Azure Blob Storage doesn't have true folders, but creating a file at a path
-    implicitly creates the "folder" structure.
-
-    Structure created:
-        users/{user_id}/.user_created    # Empty marker file
-
-    The photos/ and exports/ subfolders are created implicitly when files
-    are uploaded to them.
-
-    Args:
-        user_id: The Django User ID
-
-    Returns:
-        bool: True if successful, False otherwise
-    """
-    marker_path = f"users/{user_id}/.user_created"
-
-    try:
-        # Check storage mode: Azurite, Production Azure, or Local filesystem
-        if is_azurite_mode() or os.getenv('AZURE_ACCOUNT_NAME'):
-            # Use CrushProfilePhotoStorage for both Azurite and production Azure
-            storage = CrushProfilePhotoStorage()
-
-            # Check if marker already exists
-            if storage.exists(marker_path):
-                logger.debug(f"User storage already initialized for user {user_id}")
-                return True
-
-            # Create empty marker file
-            storage.save(marker_path, ContentFile(b''))
-            mode = "Azurite" if is_azurite_mode() else "Azure"
-            logger.info(f"Initialized {mode} storage for user {user_id}")
-        else:
-            # Fallback: Use default storage (local filesystem)
-            if default_storage.exists(marker_path):
-                logger.debug(f"User storage already initialized for user {user_id}")
-                return True
-
-            # Ensure directory exists for local filesystem
-            full_path = os.path.join(settings.MEDIA_ROOT, f"users/{user_id}")
-            os.makedirs(full_path, exist_ok=True)
-
-            # Create empty marker file
-            default_storage.save(marker_path, ContentFile(b''))
-            logger.info(f"Initialized local storage for user {user_id}")
-
-        return True
-
-    except Exception as e:
-        logger.error(f"Failed to initialize storage for user {user_id}: {str(e)}")
-        return False
-
-
-def user_storage_exists(user_id):
-    """
-    Check if user storage folder has been initialized.
-
-    Args:
-        user_id: The Django User ID
-
-    Returns:
-        bool: True if user storage exists, False otherwise
-    """
-    marker_path = f"users/{user_id}/.user_created"
-
-    try:
-        if is_azurite_mode() or os.getenv('AZURE_ACCOUNT_NAME'):
-            storage = CrushProfilePhotoStorage()
-            return storage.exists(marker_path)
-        else:
-            return default_storage.exists(marker_path)
-    except Exception as e:
-        logger.error(f"Error checking storage for user {user_id}: {str(e)}")
-        return False
 
 
 def delete_user_storage(user_id):


### PR DESCRIPTION
## Summary

- Remove `create_user_storage_folder` signal — it sat in the request path on every User save to write an empty marker blob to Azure.
- Remove `initialize_user_storage` (only caller was the signal) and `user_storage_exists` (no callers anywhere).
- Drop now-unused `ContentFile` and `default_storage` imports; update module docstring.

Net: −114 lines, no user-visible change.

Closes #292.

## Why

The marker file `users/{id}/.user_created` was write-only. Nothing read it: `delete_user_storage` and `list_user_storage_folders` enumerate by the `users/{id}/` prefix, and photo uploads create blob paths implicitly. So every signup paid an Azure round-trip for nothing — and an Azure hiccup could slow or fail registration.

## Test plan

- [x] `grep -r initialize_user_storage|user_storage_exists|\.user_created` across the repo — only hits were the ones I removed.
- [x] `pytest crush_lu/tests/test_account_deletion.py crush_lu/tests/test_models.py crush_lu/tests/test_api.py` — 60 tests pass, including the ones that create users and then delete them (so `delete_user_storage` is exercised without the marker).
- [ ] Prod: on first deploy, existing users' `.user_created` markers remain in `crush-lu-private` harmlessly. Optional one-time cleanup script could delete them; not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)