### PR TITLE
fix(wallet): disable gzip on Apple Wallet pass responses

### DIFF
--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -285,7 +285,7 @@
             <div class="flex flex-col sm:flex-row gap-3 flex-wrap">
                 {# Apple Wallet #}
                 {% if apple_wallet_enabled %}
-                <a href="{% url 'wallet_apple_pass' %}" class="inline-block p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                <a href="{% url 'wallet_apple_pass' %}" target="_blank" rel="noopener" class="inline-block p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
                     <img src="{% static 'crush_lu/img/wallet/apple_wallet_badge.svg' %}" alt="{% trans 'Add to Apple Wallet' %}" class="h-12 w-auto">
                 </a>
                 {% else %}

--- a/crush_lu/templates/crush_lu/event_ticket.html
+++ b/crush_lu/templates/crush_lu/event_ticket.html
@@ -91,7 +91,7 @@
             <div class="px-6 pb-6 text-center space-y-3">
                 {% if apple_wallet_enabled %}
                 <div>
-                    <a href="{{ apple_wallet_url }}" class="inline-block p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                    <a href="{{ apple_wallet_url }}" target="_blank" rel="noopener" class="inline-block p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
                         <img src="{% static 'crush_lu/img/wallet/apple_wallet_badge.svg' %}" alt="{% trans 'Add to Apple Wallet' %}" class="h-12 w-auto">
                     </a>
                 </div>

--- a/crush_lu/tests/test_apple_wallet.py
+++ b/crush_lu/tests/test_apple_wallet.py
@@ -273,6 +273,8 @@ class TestAppleWalletPassView:
         assert response.status_code == 200
         assert response["Content-Type"] == "application/vnd.apple.pkpass"
         assert "crushlu.pkpass" in response["Content-Disposition"]
+        # pkpass must not be gzipped — iOS Wallet rejects compressed passes
+        assert response.get("Content-Encoding") == "identity"
 
     def test_requires_authentication(self):
         from django.test import Client
@@ -314,6 +316,8 @@ class TestAppleEventTicketView:
 
         assert response.status_code == 200
         assert response["Content-Type"] == "application/vnd.apple.pkpass"
+        # pkpass must not be gzipped — iOS Wallet rejects compressed passes
+        assert response.get("Content-Encoding") == "identity"
 
     def test_rejects_other_users_registration(self, event_with_registrations, db):
         from django.contrib.auth.models import User

--- a/crush_lu/views_wallet.py
+++ b/crush_lu/views_wallet.py
@@ -73,6 +73,8 @@ def apple_wallet_pass(request):
         pkpass_data = build_apple_pass(profile, request=request)
         response = HttpResponse(pkpass_data, content_type="application/vnd.apple.pkpass")
         response["Content-Disposition"] = "attachment; filename=crushlu.pkpass"
+        # pkpass is already a ZIP; gzipping breaks iOS Wallet validation.
+        response["Content-Encoding"] = "identity"
         return response
     except ImproperlyConfigured as e:
         logger.error("Apple Wallet configuration error: %s", e)
@@ -213,6 +215,8 @@ def apple_event_ticket_pass(request, registration_id):
         response["Content-Disposition"] = (
             f'attachment; filename=crush-event-{registration.event_id}.pkpass'
         )
+        # pkpass is already a ZIP; gzipping breaks iOS Wallet validation.
+        response["Content-Encoding"] = "identity"
         return response
     except ImproperlyConfigured as e:
         logger.error("Apple Wallet event ticket config error: %s", e)


### PR DESCRIPTION
## Summary
- iOS Safari shows **"Safari cannot download this file"** when users tap *Add to Apple Wallet*. Production response headers confirm `content-encoding: gzip` on `application/vnd.apple.pkpass` — Django's `GZipMiddleware` was double-compressing an already-ZIP-bundled pkpass, and iOS Safari fails to hand the result to Wallet.
- Fix: set `Content-Encoding: identity` on both pass views. `GZipMiddleware.process_response` skips any response with an existing `Content-Encoding` header, so this opts out cleanly without touching global middleware config.
- Bonus: added `target="_blank" rel="noopener"` to the wallet anchor tags so users who installed Crush.lu as a home-screen PWA get the download routed to Safari proper (standalone PWA WKWebView can't download `.pkpass` either — latent bug that would've surfaced next).
- Added regression assertions (`Content-Encoding == "identity"`) on the existing view tests so gzip can't silently creep back in.

## Test plan
- [x] `pytest crush_lu/tests/test_apple_wallet.py` — all 20 tests pass with new assertions
- [ ] Production smoke test post-deploy: on iPhone Safari, log into crush.lu, tap **Add to Apple Wallet** from the dashboard — Wallet should open with pass preview
- [ ] Same test from home-screen PWA launch (confirms `target="_blank"` branch)
- [ ] Event ticket flow: open a confirmed event ticket, tap **Add to Apple Wallet** — Wallet should open
- [ ] DevTools → Network → verify response now has `content-encoding: identity` (or absent), not `gzip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)