### PR TITLE
feat(screening): pre-screening questionnaire end-to-end

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -369,6 +369,10 @@ WALLET_GOOGLE_PRIVATE_KEY_PATH = os.getenv("WALLET_GOOGLE_PRIVATE_KEY_PATH", "")
 WALLET_GOOGLE_KEY_ID = os.getenv("WALLET_GOOGLE_KEY_ID", "")
 WALLET_GOOGLE_EVENT_TICKET_ENABLED = _env_bool("WALLET_GOOGLE_EVENT_TICKET_ENABLED", default=True)
 
+# Pre-screening questionnaire (Crush.lu). Off by default; enable in production
+# after all Phases have shipped and the Coach-facing rollout is ready.
+PRE_SCREENING_ENABLED = _env_bool("PRE_SCREENING_ENABLED", default=False)
+
 # Event Check-In Configuration
 EVENT_CHECKIN_WINDOW_HOURS = int(os.getenv("EVENT_CHECKIN_WINDOW_HOURS", "12"))
 

--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -252,6 +252,7 @@ urlpatterns = base_patterns + api_patterns + [
     # Dedicated Crush.lu Admin Panel (Coach Panel)
     # Note: Dashboard must come BEFORE admin site to avoid path matching issues
     path('crush-admin/dashboard/', admin_views.crush_admin_dashboard, name='crush_admin_dashboard'),
+    path('crush-admin/pre-screening/export.csv', admin_views.export_pre_screening_csv, name='crush_admin_pre_screening_csv'),
     path('crush-admin/api/signup-trend/', signup_trend_api, name='crush_admin_signup_trend'),
     path('crush-admin/api/verification-trend/', verification_trend_api, name='crush_admin_verification_trend'),
     path('crush-admin/api/cumulative-growth/', cumulative_growth_api, name='crush_admin_cumulative_growth'),

--- a/crush_lu/admin_views.py
+++ b/crush_lu/admin_views.py
@@ -28,6 +28,69 @@ from .models import (
 )
 
 
+def export_pre_screening_csv(request):
+    """CSV export of per-question answer distributions (Phase 6).
+
+    Each row is (section_id, question_id, answer_value, count). Useful for
+    spotting concept-misalignment clusters and free-text themes.
+    """
+    import csv
+    from collections import Counter
+    from django.conf import settings
+    from django.contrib.admin.views.decorators import staff_member_required  # noqa
+    from django.http import HttpResponse, HttpResponseForbidden
+
+    if not request.user.is_authenticated or not request.user.is_staff:
+        return HttpResponseForbidden("Staff only.")
+    if not getattr(settings, "PRE_SCREENING_ENABLED", False):
+        return HttpResponseForbidden("Feature disabled.")
+
+    from .pre_screening_schema import PRE_SCREENING_SCHEMA
+
+    submitted = ProfileSubmission.objects.filter(
+        pre_screening_submitted_at__isnull=False
+    ).values_list("pre_screening_responses", flat=True)
+
+    distribution: Counter = Counter()
+    text_lengths: list[int] = []
+    for responses in submitted:
+        for section in PRE_SCREENING_SCHEMA["sections"]:
+            for question in section["questions"]:
+                qid = question["id"]
+                val = (responses or {}).get(qid)
+                if val in (None, "", []):
+                    continue
+                if question["type"] == "multi_select":
+                    for v in val:
+                        distribution[(section["id"], qid, v)] += 1
+                elif question["type"] == "text":
+                    if isinstance(val, str):
+                        text_lengths.append(len(val))
+                else:
+                    distribution[(section["id"], qid, str(val))] += 1
+
+    resp = HttpResponse(content_type="text/csv")
+    resp["Content-Disposition"] = (
+        'attachment; filename="pre_screening_answer_distribution.csv"'
+    )
+    writer = csv.writer(resp)
+    writer.writerow(["section", "question", "answer", "count"])
+    for (section_id, qid, val), n in sorted(
+        distribution.items(), key=lambda kv: (kv[0][0], kv[0][1], -kv[1])
+    ):
+        writer.writerow([section_id, qid, val, n])
+    # Trailer rows with summary stats on free-text answers.
+    if text_lengths:
+        avg_len = sum(text_lengths) / len(text_lengths)
+        writer.writerow([])
+        writer.writerow(["# free-text answer stats"])
+        writer.writerow(["count", len(text_lengths)])
+        writer.writerow(["avg_length_chars", round(avg_len, 1)])
+        writer.writerow(["max_length_chars", max(text_lengths)])
+        writer.writerow(["min_length_chars", min(text_lengths)])
+    return resp
+
+
 def _get_date_range(request):
     """
     Parse date range from request GET parameter.
@@ -700,6 +763,80 @@ def crush_admin_dashboard(request):
     # PREPARE CONTEXT
     # ============================================================================
 
+    # ------------------------------------------------------------------
+    # Pre-screening analytics (Phase 6). Disabled when feature flag is off.
+    # ------------------------------------------------------------------
+    pre_screening_metrics: dict = {}
+    try:
+        from django.conf import settings as _settings
+
+        if getattr(_settings, "PRE_SCREENING_ENABLED", False):
+            pending_qs = ProfileSubmission.objects.filter(status="pending")
+            pending_count = pending_qs.count()
+            pending_submitted = pending_qs.filter(
+                pre_screening_submitted_at__isnull=False
+            ).count()
+            completion_rate = _safe_pct(pending_submitted, pending_count)
+
+            submitted_qs = ProfileSubmission.objects.filter(
+                pre_screening_submitted_at__isnull=False
+            )
+            avg_score = submitted_qs.aggregate(
+                avg=Avg("pre_screening_readiness_score")
+            )["avg"]
+
+            # Flag distribution (flatten JSONField list across rows)
+            flag_counts: dict[str, int] = {}
+            for flags in submitted_qs.values_list("pre_screening_flags", flat=True):
+                for flag in flags or []:
+                    flag_counts[flag] = flag_counts.get(flag, 0) + 1
+
+            # Simple score histogram (0-10 inclusive)
+            score_histogram = {str(i): 0 for i in range(11)}
+            for score in submitted_qs.values_list(
+                "pre_screening_readiness_score", flat=True
+            ):
+                if score is not None and 0 <= score <= 10:
+                    score_histogram[str(score)] += 1
+
+            # Event no-show rate for users who submitted pre-screening.
+            # Kept deliberately simple — a richer breakdown with a control
+            # group belongs in a dedicated analytics report.
+            ps_noshow = 0
+            ps_total = 0
+            try:
+                profile_ids = list(
+                    CrushProfile.objects
+                    .filter(user__profilesubmission__pre_screening_submitted_at__isnull=False)
+                    .values_list("id", flat=True)
+                )
+                if profile_ids:
+                    reg_rollup = (
+                        EventRegistration.objects.filter(profile_id__in=profile_ids)
+                        .values("status")
+                        .annotate(n=Count("id"))
+                    )
+                    for row in reg_rollup:
+                        ps_total += row["n"]
+                        if row["status"] == "no_show":
+                            ps_noshow += row["n"]
+            except Exception as sub_exc:
+                logger.warning("no-show rollup failed: %s", sub_exc)
+            noshow_with = _safe_pct(ps_noshow, ps_total)
+
+            pre_screening_metrics = {
+                "pending_count": pending_count,
+                "pending_submitted": pending_submitted,
+                "completion_rate": completion_rate,
+                "avg_score": round(avg_score, 1) if avg_score is not None else None,
+                "flag_counts": dict(sorted(flag_counts.items(), key=lambda kv: -kv[1])),
+                "score_histogram": score_histogram,
+                "noshow_rate_submitted_users": noshow_with,
+                "submitted_registrations_total": ps_total,
+            }
+    except Exception as exc:  # Never break the dashboard on metrics issues.
+        logger.warning("pre_screening metrics unavailable: %s", exc)
+
     context = {
         # Date filter info
         'date_range': date_range,
@@ -831,6 +968,9 @@ def crush_admin_dashboard(request):
         # Page metadata
         'title': 'Crush.lu Analytics Dashboard',
         'site_header': '💕 Crush.lu Administration',
+
+        # Pre-screening analytics (Phase 6)
+        'pre_screening_metrics': pre_screening_metrics,
     }
 
     return render(request, 'admin/crush_lu/dashboard.html', context)

--- a/crush_lu/management/commands/send_pre_screening_invites.py
+++ b/crush_lu/management/commands/send_pre_screening_invites.py
@@ -1,0 +1,99 @@
+"""Trigger pre-screening invite / reminder / push flows.
+
+Intended to be called on a short cron (e.g. every 10 minutes) by an Azure
+Function timer — the same pattern as the existing crush-contact-sync
+function. The command is idempotent: per-submission cache keys dedupe so a
+single submission will receive at most one invite, one reminder, and one push.
+
+Windows applied to each submission:
+- 1h since submit: invite email (no pre-screening yet)
+- 4h since submit: user push notification
+- 24h since submit: reminder email (one-shot, not periodic)
+
+All three are skipped if the user already submitted the pre-screening.
+"""
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from crush_lu.pre_screening_notifications import (
+    candidates_for_invite,
+    candidates_for_push,
+    candidates_for_reminder,
+    send_pre_screening_invite_email,
+    send_pre_screening_user_push,
+)
+
+
+class Command(BaseCommand):
+    help = "Send pre-screening invites, reminders, and push nudges for pending submissions."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be sent without sending.",
+        )
+        parser.add_argument(
+            "--only",
+            choices=["invite", "reminder", "push"],
+            help="Run only one of the three flows.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=500,
+            help="Per-flow upper bound on submissions processed.",
+        )
+
+    def handle(self, *args, **options):
+        if not getattr(settings, "PRE_SCREENING_ENABLED", False):
+            self.stdout.write(
+                self.style.WARNING(
+                    "PRE_SCREENING_ENABLED is off; nothing to send."
+                )
+            )
+            return
+
+        dry = options["dry_run"]
+        only = options.get("only")
+        limit = options["limit"]
+
+        totals = {"invite": 0, "reminder": 0, "push": 0}
+        skipped = {"invite": 0, "reminder": 0, "push": 0}
+
+        if only in (None, "invite"):
+            for sub in candidates_for_invite()[:limit]:
+                if dry:
+                    totals["invite"] += 1
+                    continue
+                if send_pre_screening_invite_email(sub, reminder=False):
+                    totals["invite"] += 1
+                else:
+                    skipped["invite"] += 1
+
+        if only in (None, "reminder"):
+            for sub in candidates_for_reminder()[:limit]:
+                if dry:
+                    totals["reminder"] += 1
+                    continue
+                if send_pre_screening_invite_email(sub, reminder=True):
+                    totals["reminder"] += 1
+                else:
+                    skipped["reminder"] += 1
+
+        if only in (None, "push"):
+            for sub in candidates_for_push()[:limit]:
+                if dry:
+                    totals["push"] += 1
+                    continue
+                if send_pre_screening_user_push(sub):
+                    totals["push"] += 1
+                else:
+                    skipped["push"] += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"pre_screening flows {'(dry run) ' if dry else ''}"
+                f"sent={totals} skipped={skipped}"
+            )
+        )

--- a/crush_lu/migrations/0125_add_pre_screening_fields.py
+++ b/crush_lu/migrations/0125_add_pre_screening_fields.py
@@ -1,0 +1,56 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crush_lu", "0124_add_event_registration_user_status_index"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="profilesubmission",
+            name="pre_screening_responses",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                help_text="User-submitted answers to pre-screening questionnaire",
+            ),
+        ),
+        migrations.AddField(
+            model_name="profilesubmission",
+            name="pre_screening_submitted_at",
+            field=models.DateTimeField(
+                blank=True,
+                db_index=True,
+                help_text="When the user finalized their pre-screening answers",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="profilesubmission",
+            name="pre_screening_version",
+            field=models.PositiveIntegerField(
+                default=0,
+                help_text="Schema version the user answered (0 = not offered yet)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="profilesubmission",
+            name="pre_screening_readiness_score",
+            field=models.IntegerField(
+                blank=True,
+                help_text="Rule-based 0–10 readiness score, null if no pre-screening",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="profilesubmission",
+            name="pre_screening_flags",
+            field=models.JSONField(
+                blank=True,
+                default=list,
+                help_text="Flag identifiers surfaced to the Coach for attention",
+            ),
+        ),
+    ]

--- a/crush_lu/migrations/0126_add_pre_screening_sms_templates.py
+++ b/crush_lu/migrations/0126_add_pre_screening_sms_templates.py
@@ -1,0 +1,56 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crush_lu", "0125_add_pre_screening_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="crushsiteconfig",
+            name="pre_screening_reminder_sms_en",
+            field=models.CharField(
+                blank=True,
+                default=(
+                    "Hi {first_name}, {coach_name} from Crush.lu here. Before we talk, "
+                    "please answer a few quick questions at {link}. It takes 3 minutes "
+                    "and helps me help you. Thanks!"
+                ),
+                help_text="Placeholders: {first_name}, {coach_name}, {link}",
+                max_length=320,
+                verbose_name="Pre-screening reminder SMS (English)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="crushsiteconfig",
+            name="pre_screening_reminder_sms_de",
+            field=models.CharField(
+                blank=True,
+                default=(
+                    "Hallo {first_name}, hier ist {coach_name} von Crush.lu. Vor "
+                    "unserem Gespraech beantworte bitte ein paar kurze Fragen unter "
+                    "{link}. Es dauert 3 Minuten und hilft mir, dir zu helfen. Danke!"
+                ),
+                help_text="Placeholders: {first_name}, {coach_name}, {link}",
+                max_length=320,
+                verbose_name="Pre-screening reminder SMS (German)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="crushsiteconfig",
+            name="pre_screening_reminder_sms_fr",
+            field=models.CharField(
+                blank=True,
+                default=(
+                    "Bonjour {first_name}, c'est {coach_name} de Crush.lu. Avant notre "
+                    "appel, merci de repondre a quelques questions rapides sur {link}. "
+                    "3 minutes et ca m'aide a t'aider. Merci !"
+                ),
+                help_text="Placeholders: {first_name}, {coach_name}, {link}",
+                max_length=320,
+                verbose_name="Pre-screening reminder SMS (French)",
+            ),
+        ),
+    ]

--- a/crush_lu/migrations/0127_add_screening_call_mode.py
+++ b/crush_lu/migrations/0127_add_screening_call_mode.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crush_lu", "0126_add_pre_screening_sms_templates"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="profilesubmission",
+            name="screening_call_mode",
+            field=models.CharField(
+                choices=[
+                    ("legacy", "Legacy 5-section"),
+                    ("calibration", "Calibration 3-section"),
+                ],
+                default="legacy",
+                help_text="Which call-checklist shape applies to this submission",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -788,6 +788,15 @@ class ProfileSubmission(models.Model):
         blank=True,
         help_text=_("Structured checklist data from screening call")
     )
+    screening_call_mode = models.CharField(
+        max_length=20,
+        choices=[
+            ('legacy', _('Legacy 5-section')),
+            ('calibration', _('Calibration 3-section')),
+        ],
+        default='legacy',
+        help_text=_("Which call-checklist shape applies to this submission"),
+    )
 
     # Pre-screening questionnaire (user-submitted, optional, fills in before call)
     pre_screening_responses = models.JSONField(

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -789,6 +789,33 @@ class ProfileSubmission(models.Model):
         help_text=_("Structured checklist data from screening call")
     )
 
+    # Pre-screening questionnaire (user-submitted, optional, fills in before call)
+    pre_screening_responses = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=_("User-submitted answers to pre-screening questionnaire"),
+    )
+    pre_screening_submitted_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text=_("When the user finalized their pre-screening answers"),
+    )
+    pre_screening_version = models.PositiveIntegerField(
+        default=0,
+        help_text=_("Schema version the user answered (0 = not offered yet)"),
+    )
+    pre_screening_readiness_score = models.IntegerField(
+        null=True,
+        blank=True,
+        help_text=_("Rule-based 0–10 readiness score, null if no pre-screening"),
+    )
+    pre_screening_flags = models.JSONField(
+        default=list,
+        blank=True,
+        help_text=_("Flag identifiers surfaced to the Coach for attention"),
+    )
+
     # Candidate-to-coach note (write-once, submitted during review wait)
     candidate_note = models.TextField(
         blank=True,

--- a/crush_lu/models/site_config.py
+++ b/crush_lu/models/site_config.py
@@ -99,6 +99,29 @@ class CrushSiteConfig(models.Model):
         help_text=_("Placeholders: {first_name}, {coach_name}, {event_title}, {event_date}, {event_url}"),
     )
 
+    # SMS templates for pre-screening reminders (coach -> candidate, while profile pending)
+    pre_screening_reminder_sms_en = models.CharField(
+        max_length=320,
+        blank=True,
+        default="Hi {first_name}, {coach_name} from Crush.lu here. Before we talk, please answer a few quick questions at {link}. It takes 3 minutes and helps me help you. Thanks!",
+        verbose_name=_("Pre-screening reminder SMS (English)"),
+        help_text=_("Placeholders: {first_name}, {coach_name}, {link}"),
+    )
+    pre_screening_reminder_sms_de = models.CharField(
+        max_length=320,
+        blank=True,
+        default="Hallo {first_name}, hier ist {coach_name} von Crush.lu. Vor unserem Gespraech beantworte bitte ein paar kurze Fragen unter {link}. Es dauert 3 Minuten und hilft mir, dir zu helfen. Danke!",
+        verbose_name=_("Pre-screening reminder SMS (German)"),
+        help_text=_("Placeholders: {first_name}, {coach_name}, {link}"),
+    )
+    pre_screening_reminder_sms_fr = models.CharField(
+        max_length=320,
+        blank=True,
+        default="Bonjour {first_name}, c'est {coach_name} de Crush.lu. Avant notre appel, merci de repondre a quelques questions rapides sur {link}. 3 minutes et ca m'aide a t'aider. Merci !",
+        verbose_name=_("Pre-screening reminder SMS (French)"),
+        help_text=_("Placeholders: {first_name}, {coach_name}, {link}"),
+    )
+
     # Status banner
     banner_enabled = models.BooleanField(
         default=False,

--- a/crush_lu/pre_screening_notifications.py
+++ b/crush_lu/pre_screening_notifications.py
@@ -1,0 +1,228 @@
+"""Email + push helpers for the pre-screening questionnaire (Phase 5).
+
+These functions are callable directly (e.g. from a management command driven
+by an Azure Function timer trigger — see ``azure-functions/contact-sync`` for
+the sibling pattern) and from the tasks in ``crush_lu.tasks``.
+
+Scheduling is deliberately NOT wired in this module: the repo has no Celery
+beat. The intended deployment pattern is a dedicated Azure Function timer
+that POSTs to an admin endpoint or invokes the
+``send_pre_screening_invites`` management command on a cron schedule.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.template.loader import render_to_string
+from django.utils import timezone
+from django.utils.html import strip_tags
+from django.utils.translation import gettext as _
+from django.utils.translation import override
+
+from .email_helpers import (
+    can_send_email,
+    get_email_context_with_unsubscribe,
+    send_domain_email,
+)
+from .models import ProfileSubmission
+from .utils.i18n import get_user_preferred_language
+
+logger = logging.getLogger(__name__)
+
+
+# Cache keys used to deduplicate at-most-once sends.
+_INVITE_SENT_KEY = "pre_screening_invite_sent:{submission_id}"
+_REMINDER_SENT_KEY = "pre_screening_reminder_sent:{submission_id}"
+_PUSH_SENT_KEY = "pre_screening_push_sent:{submission_id}"
+
+
+def _already_sent(cache_key: str) -> bool:
+    return bool(cache.get(cache_key))
+
+
+def _mark_sent(cache_key: str, ttl_seconds: int = 60 * 60 * 24 * 30) -> None:
+    cache.set(cache_key, 1, ttl_seconds)
+
+
+def _pre_screening_url(request=None) -> str:
+    """Build the absolute URL for the pre-screening form."""
+    path = "/pre-screening/"
+    if request is not None:
+        return request.build_absolute_uri(path)
+    return "https://crush.lu" + path
+
+
+class _FakeRequest:
+    """Minimal request stand-in used when the sender has no HTTP context
+    (management command / background task). Mirrors the ``FakeRequest``
+    pattern in ``crush_lu.tasks``.
+    """
+    def __init__(self, host="crush.lu", secure=True):
+        self._host = host
+        self._secure = secure
+        self.META = {"HTTP_HOST": host, "SERVER_PORT": "443" if secure else "80"}
+
+    def get_host(self):
+        return self._host
+
+    def is_secure(self):
+        return self._secure
+
+    def get_port(self):
+        return "443" if self._secure else "80"
+
+    def build_absolute_uri(self, path):
+        proto = "https" if self._secure else "http"
+        return f"{proto}://{self._host}{path}"
+
+
+def send_pre_screening_invite_email(submission: ProfileSubmission,
+                                    *, reminder: bool = False,
+                                    request=None) -> bool:
+    """Send the invite (or reminder) email for a single submission.
+
+    Returns True on send, False on skip (already submitted, unsubscribed, etc.).
+    Idempotent via cache keys — safe to invoke from retries.
+    """
+    if submission.pre_screening_submitted_at is not None:
+        return False
+    if submission.status != "pending":
+        return False
+    user = submission.profile.user
+    if not can_send_email(user, "profile_updates"):
+        return False
+
+    cache_key = (_REMINDER_SENT_KEY if reminder else _INVITE_SENT_KEY).format(
+        submission_id=submission.id
+    )
+    if _already_sent(cache_key):
+        return False
+
+    # All downstream email helpers expect a request-like object for URL
+    # generation; supply a stand-in when we're called from a cron context.
+    if request is None:
+        request = _FakeRequest()
+
+    lang = get_user_preferred_language(user=user, request=request, default="en")
+    context = get_email_context_with_unsubscribe(
+        user,
+        request,
+        reminder=reminder,
+        pre_screening_url=_pre_screening_url(request),
+    )
+    # `get_email_context_with_unsubscribe` may already set `user`; only seed
+    # if absent.
+    context.setdefault("user", user)
+
+    with override(lang):
+        subject = (
+            _("Your Coach is getting ready — 3 minutes, 13 questions")
+            if reminder
+            else _("Help your Coach prepare — 3 minutes, 13 questions")
+        )
+        html_message = render_to_string(
+            "crush_lu/emails/pre_screening_invite.html", context
+        )
+        plain_message = render_to_string(
+            "crush_lu/emails/pre_screening_invite.txt", context
+        ) or strip_tags(html_message)
+
+    sent = send_domain_email(
+        subject=subject,
+        message=plain_message,
+        html_message=html_message,
+        recipient_list=[user.email],
+        request=request,
+        fail_silently=False,
+    )
+    if sent:
+        _mark_sent(cache_key)
+        logger.info(
+            "pre_screening.invite_sent",
+            extra={"submission_id": submission.id, "reminder": reminder},
+        )
+    return bool(sent)
+
+
+def send_pre_screening_user_push(submission: ProfileSubmission) -> bool:
+    """Push notification nudging the user to open the pre-screening form."""
+    if submission.pre_screening_submitted_at is not None:
+        return False
+    if submission.status != "pending":
+        return False
+
+    cache_key = _PUSH_SENT_KEY.format(submission_id=submission.id)
+    if _already_sent(cache_key):
+        return False
+
+    try:
+        from . import push_notifications
+
+        user = submission.profile.user
+        lang = get_user_preferred_language(user=user, default="en")
+        with override(lang):
+            title = str(_("Meet your Coach better"))
+            body = str(_("Answer 13 quick questions before your call"))
+        url = "/pre-screening/"
+        result = push_notifications.send_push_notification(
+            user=user, title=title, body=body, url=url,
+            tag=f"pre-screening-invite-{submission.id}",
+        )
+        success = bool((result or {}).get("success"))
+        if success:
+            _mark_sent(cache_key)
+            logger.info(
+                "pre_screening.user_push_sent",
+                extra={"submission_id": submission.id},
+            )
+        return success
+    except Exception as exc:
+        logger.exception(
+            "pre_screening.user_push_failed",
+            extra={"submission_id": submission.id, "error": str(exc)},
+        )
+        return False
+
+
+def candidates_for_invite(now=None) -> list[ProfileSubmission]:
+    """Submissions that have been pending for >= 1h with no pre-screening yet."""
+    now = now or timezone.now()
+    cutoff = now - timedelta(hours=1)
+    return list(
+        ProfileSubmission.objects.filter(
+            status="pending",
+            pre_screening_submitted_at__isnull=True,
+            submitted_at__lte=cutoff,
+        )
+        .select_related("profile__user")
+    )
+
+
+def candidates_for_reminder(now=None) -> list[ProfileSubmission]:
+    """Submissions >= 24h old with still no pre-screening — send one reminder."""
+    now = now or timezone.now()
+    cutoff = now - timedelta(hours=24)
+    return list(
+        ProfileSubmission.objects.filter(
+            status="pending",
+            pre_screening_submitted_at__isnull=True,
+            submitted_at__lte=cutoff,
+        )
+        .select_related("profile__user")
+    )
+
+
+def candidates_for_push(now=None) -> list[ProfileSubmission]:
+    """Submissions >= 4h old with no pre-screening — one push attempt."""
+    now = now or timezone.now()
+    cutoff = now - timedelta(hours=4)
+    return list(
+        ProfileSubmission.objects.filter(
+            status="pending",
+            pre_screening_submitted_at__isnull=True,
+            submitted_at__lte=cutoff,
+        )
+        .select_related("profile__user")
+    )

--- a/crush_lu/pre_screening_schema.py
+++ b/crush_lu/pre_screening_schema.py
@@ -1,0 +1,485 @@
+"""
+Canonical schema for the Crush.lu pre-screening questionnaire.
+
+This module is the single source of truth for the pre-screening questions,
+their allowed answers, the validator, and the rule-based Readiness Score.
+
+Design notes:
+- All user-facing labels use `gettext_lazy` so they resolve per-request.
+- The schema is versioned; bump ``PRE_SCREENING_SCHEMA["version"]`` when
+  making a breaking change to questions or choices. Existing responses keep
+  their original version number for display/migration.
+- The scorer is deterministic. No LLM, no heuristics beyond the rules below.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+PRE_SCREENING_SCHEMA: dict[str, Any] = {
+    "version": 1,
+    "sections": [
+        # ------------------------------------------------------------------
+        # Section A — Logistics
+        # ------------------------------------------------------------------
+        {
+            "id": "logistics",
+            "title": _("Quick logistics"),
+            "questions": [
+                {
+                    "id": "residence",
+                    "type": "single_select",
+                    "required": True,
+                    "label": _("Where do you live?"),
+                    "choices": [
+                        {"value": "lu_city", "label": _("Luxembourg – Luxembourg City")},
+                        {"value": "lu_esch", "label": _("Luxembourg – Esch-sur-Alzette")},
+                        {"value": "lu_other", "label": _("Luxembourg – other canton")},
+                        {"value": "fr_border", "label": _("France (border region)")},
+                        {"value": "de_border", "label": _("Germany (border region)")},
+                        {"value": "be_border", "label": _("Belgium (border region)")},
+                        {"value": "other", "label": _("Other")},
+                    ],
+                },
+                {
+                    "id": "languages",
+                    "type": "multi_select",
+                    "required": True,
+                    "min_choices": 1,
+                    "label": _("Which languages can you comfortably speak at a social event?"),
+                    "choices": [
+                        {"value": "en", "label": _("English")},
+                        {"value": "fr", "label": _("French")},
+                        {"value": "de", "label": _("German")},
+                        {"value": "lu", "label": _("Luxembourgish")},
+                        {"value": "other", "label": _("Other")},
+                    ],
+                },
+                {
+                    "id": "age_confirm",
+                    "type": "yes_no",
+                    "required": True,
+                    "label": _("Are you 18 or older and legally able to date?"),
+                },
+                {
+                    "id": "source",
+                    "type": "single_select",
+                    "required": True,
+                    "label": _("How did you hear about Crush.lu?"),
+                    "choices": [
+                        {"value": "friend", "label": _("A friend or family member")},
+                        {"value": "social", "label": _("Social media (Instagram, Facebook, TikTok)")},
+                        {"value": "search", "label": _("Google or other search engine")},
+                        {"value": "news", "label": _("RTL, Luxemburger Wort, or other news")},
+                        {"value": "event", "label": _("At an event")},
+                        {"value": "ai", "label": _("ChatGPT or another AI assistant")},
+                        {"value": "other", "label": _("Somewhere else")},
+                    ],
+                },
+            ],
+        },
+        # ------------------------------------------------------------------
+        # Section B — Concept
+        # ------------------------------------------------------------------
+        {
+            "id": "concept",
+            "title": _("Understanding Crush.lu"),
+            "questions": [
+                {
+                    "id": "what_is_crush",
+                    "type": "single_select",
+                    "required": True,
+                    "label": _("What is Crush.lu to you?"),
+                    "choices": [
+                        {"value": "events", "label": _("A way to meet people in real life through events")},
+                        {"value": "tinder", "label": _("An online dating app like Tinder or Bumble")},
+                        {"value": "matchmaking", "label": _("A matchmaking service that finds dates for me")},
+                        {"value": "unsure", "label": _("I'm still figuring it out")},
+                    ],
+                },
+                {
+                    "id": "event_frequency",
+                    "type": "single_select",
+                    "required": True,
+                    "label": _(
+                        "Our events are small (15–25 people) and in person. How often would you realistically attend?"
+                    ),
+                    "choices": [
+                        {"value": "weekly", "label": _("Once a week if there's a good one")},
+                        {"value": "monthly", "label": _("Once or twice a month")},
+                        {"value": "few_per_year", "label": _("A few times a year")},
+                        {"value": "online_only", "label": _("I mostly want online dating, events not so much")},
+                    ],
+                },
+                {
+                    "id": "relationship_goal",
+                    "type": "single_select",
+                    "required": True,
+                    "label": _("Which of these sounds most like what you want?"),
+                    "choices": [
+                        {"value": "many_people", "label": _("Meet many people quickly, figure it out from there")},
+                        {"value": "meaningful", "label": _("A few meaningful encounters over several months")},
+                        {"value": "friendship_first", "label": _("Friendship first, see if something develops")},
+                        {"value": "committed", "label": _("A committed relationship as soon as possible")},
+                    ],
+                },
+                {
+                    "id": "coach_attitude",
+                    "type": "single_select",
+                    "required": True,
+                    "label": _(
+                        "Our Crush Coaches review every profile and help introduce people. "
+                        "How do you feel about that?"
+                    ),
+                    "choices": [
+                        {"value": "loves", "label": _("Love it — human help makes this feel safer")},
+                        {"value": "fine", "label": _("Fine with it as long as I stay in control")},
+                        {"value": "curious", "label": _("Curious but unsure what the Coach actually does")},
+                        {"value": "no_intermediary", "label": _("Would prefer no intermediary")},
+                    ],
+                },
+                {
+                    "id": "looking_forward_to",
+                    "type": "multi_select",
+                    "required": True,
+                    "min_choices": 1,
+                    "max_choices": 3,
+                    "label": _("What are you most looking forward to? (pick up to 3)"),
+                    "choices": [
+                        {"value": "events", "label": _("Meeting new people at events")},
+                        {"value": "discovery", "label": _("Discovering who's nearby in my canton")},
+                        {"value": "coach_match", "label": _("Being matched one-on-one by a Coach")},
+                        {"value": "offline_quickly", "label": _("Taking things offline quickly")},
+                        {"value": "organized_dates", "label": _("Having someone organize dates for me")},
+                        {"value": "exploring", "label": _("Just exploring, no pressure")},
+                    ],
+                },
+            ],
+        },
+        # ------------------------------------------------------------------
+        # Section C — Own Words
+        # ------------------------------------------------------------------
+        {
+            "id": "own_words",
+            "title": _("In your own words"),
+            "questions": [
+                {
+                    "id": "hoping_to_meet",
+                    "type": "text",
+                    "required": True,
+                    "max_length": 200,
+                    "label": _("In one sentence, what kind of person are you hoping to meet?"),
+                    "placeholder": _("Someone curious, who likes walking and asking questions…"),
+                },
+                {
+                    "id": "note_to_coach",
+                    "type": "text",
+                    "required": False,
+                    "max_length": 300,
+                    "label": _("Is there anything you'd like your Coach to know before the call? (optional)"),
+                    "placeholder": _("I'm a bit shy at first — hope that's okay."),
+                },
+            ],
+        },
+        # ------------------------------------------------------------------
+        # Section D — Consents
+        # ------------------------------------------------------------------
+        {
+            "id": "consents",
+            "title": _("Before we continue"),
+            "questions": [
+                {
+                    "id": "consent_events",
+                    "type": "checkbox",
+                    "required": True,
+                    "label": _(
+                        "I understand events are the core of Crush.lu and I intend to attend at least one."
+                    ),
+                },
+                {
+                    "id": "consent_coach",
+                    "type": "checkbox",
+                    "required": True,
+                    "label": _(
+                        "I understand profiles are reviewed by a human Coach who may contact me by phone or SMS."
+                    ),
+                },
+                {
+                    "id": "consent_no_show",
+                    "type": "checkbox",
+                    "required": True,
+                    "label": _(
+                        "I understand that repeatedly not showing up at events affects my membership standing."
+                    ),
+                },
+                {
+                    "id": "consent_terms",
+                    "type": "checkbox",
+                    "required": True,
+                    # NOTE: Template renders the bracketed phrases as links to the
+                    # Code of Conduct and Privacy Policy pages.
+                    "label": _(
+                        "I accept the [Code of Conduct] and [Privacy Policy]."
+                    ),
+                },
+            ],
+        },
+    ],
+}
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def iter_questions(schema: dict[str, Any] | None = None):
+    """Yield (section, question) tuples across the entire schema."""
+    schema = schema or PRE_SCREENING_SCHEMA
+    for section in schema["sections"]:
+        for question in section["questions"]:
+            yield section, question
+
+
+def get_question(question_id: str, schema: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    for _section, question in iter_questions(schema):
+        if question["id"] == question_id:
+            return question
+    return None
+
+
+def get_section(section_id: str, schema: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    schema = schema or PRE_SCREENING_SCHEMA
+    for section in schema["sections"]:
+        if section["id"] == section_id:
+            return section
+    return None
+
+
+def _allowed_values(question: dict[str, Any]) -> set[str]:
+    return {c["value"] for c in question.get("choices", [])}
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+def validate_pre_screening_responses(
+    responses: dict[str, Any],
+    version: int | None = None,
+    *,
+    partial: bool = False,
+    section_id: str | None = None,
+) -> None:
+    """Validate user-submitted pre-screening responses.
+
+    Args:
+        responses: flat mapping of question_id -> answer.
+        version: schema version the responses claim to answer. Must match the
+            current schema version (or None, meaning current).
+        partial: if True, skip "required field missing" errors. Used for
+            per-section HTMX saves.
+        section_id: if set, only validate questions inside this section.
+
+    Raises:
+        ValidationError: with ``code`` set to one of the error codes below.
+
+    Error codes:
+        - invalid_version
+        - unknown_question
+        - required_missing
+        - invalid_choice
+        - min_choices_not_met
+        - max_choices_exceeded
+        - text_too_long
+        - invalid_type
+    """
+    if not isinstance(responses, dict):
+        raise ValidationError(_("Responses must be an object."), code="invalid_type")
+
+    if version is not None and version != PRE_SCREENING_SCHEMA["version"]:
+        raise ValidationError(
+            _("Pre-screening schema version mismatch."),
+            code="invalid_version",
+        )
+
+    errors: dict[str, list[ValidationError]] = {}
+
+    allowed_qids = {q["id"] for _s, q in iter_questions()}
+    for qid in responses:
+        if qid not in allowed_qids:
+            errors.setdefault(qid, []).append(
+                ValidationError(_("Unknown question."), code="unknown_question")
+            )
+
+    for section, question in iter_questions():
+        if section_id is not None and section["id"] != section_id:
+            continue
+
+        qid = question["id"]
+        qtype = question["type"]
+        required = question.get("required", False)
+        value = responses.get(qid, None)
+        present = qid in responses and value not in (None, "", [])
+
+        if not present:
+            if required and not partial:
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("This question is required."), code="required_missing")
+                )
+            continue
+
+        if qtype == "single_select":
+            if value not in _allowed_values(question):
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Invalid choice."), code="invalid_choice")
+                )
+        elif qtype == "multi_select":
+            if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Must be a list of choices."), code="invalid_type")
+                )
+                continue
+            allowed = _allowed_values(question)
+            if any(v not in allowed for v in value):
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Invalid choice."), code="invalid_choice")
+                )
+            min_choices = question.get("min_choices")
+            max_choices = question.get("max_choices")
+            if min_choices is not None and len(value) < min_choices:
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Pick at least %(n)d."), code="min_choices_not_met",
+                                    params={"n": min_choices})
+                )
+            if max_choices is not None and len(value) > max_choices:
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Pick at most %(n)d."), code="max_choices_exceeded",
+                                    params={"n": max_choices})
+                )
+        elif qtype == "text":
+            if not isinstance(value, str):
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Must be text."), code="invalid_type")
+                )
+                continue
+            max_length = question.get("max_length")
+            if max_length is not None and len(value) > max_length:
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Too long."), code="text_too_long")
+                )
+        elif qtype == "checkbox":
+            if value is not True:
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Must be checked."), code="required_missing")
+                )
+        elif qtype == "yes_no":
+            if value not in (True, False, "yes", "no"):
+                errors.setdefault(qid, []).append(
+                    ValidationError(_("Must be yes or no."), code="invalid_choice")
+                )
+        else:
+            errors.setdefault(qid, []).append(
+                ValidationError(_("Unknown question type."), code="invalid_type")
+            )
+
+    if errors:
+        raise ValidationError(errors)
+
+
+# --------------------------------------------------------------------------
+# Scoring
+# --------------------------------------------------------------------------
+
+def _is_low_effort(text: str) -> bool:
+    """Detect obviously throwaway free-text answers."""
+    if not isinstance(text, str):
+        return True
+    stripped = text.strip()
+    if len(stripped) < 20:
+        return True
+    # Single character repeated (e.g., "aaaaaaaa")
+    if len(set(stripped.lower().replace(" ", ""))) <= 2:
+        return True
+    return False
+
+
+def compute_readiness_score(responses: dict[str, Any]) -> tuple[int, list[str]]:
+    """Compute a 0–10 readiness score plus a list of flag identifiers.
+
+    The score is a rule-based heuristic meant to help the Coach prioritise,
+    never to auto-decide.
+
+    Returns:
+        (score, flags) where ``score`` is clipped to [0, 10] and ``flags`` is
+        a sorted list of stable string identifiers (see FLAG_DESCRIPTIONS).
+    """
+    score = 0
+
+    what_is_crush = responses.get("what_is_crush")
+    event_frequency = responses.get("event_frequency")
+    coach_attitude = responses.get("coach_attitude")
+    hoping_to_meet = responses.get("hoping_to_meet") or ""
+    looking_forward_to = responses.get("looking_forward_to") or []
+
+    # Positive signals
+    if what_is_crush in ("events", "unsure"):
+        score += 2
+    if event_frequency in ("weekly", "monthly"):
+        score += 2
+    if coach_attitude in ("loves", "fine"):
+        score += 1
+    if isinstance(hoping_to_meet, str):
+        score += min(3, len(hoping_to_meet) // 50)
+    if isinstance(looking_forward_to, list) and "events" in looking_forward_to:
+        score += 1
+
+    # Negative signals
+    if coach_attitude == "no_intermediary":
+        score -= 3
+    if event_frequency == "online_only":
+        score -= 2
+
+    score = max(0, min(10, score))
+
+    flags: list[str] = []
+    if what_is_crush == "tinder":
+        flags.append("concept_misalignment")
+    if event_frequency == "online_only":
+        flags.append("events_disinterest")
+    if coach_attitude == "no_intermediary":
+        flags.append("coach_reluctance")
+    if _is_low_effort(hoping_to_meet):
+        flags.append("low_effort_text")
+
+    return score, sorted(flags)
+
+
+# Human-readable explanations shown to the Coach as flag tooltips.
+FLAG_DESCRIPTIONS: dict[str, Any] = {
+    "concept_misalignment": _(
+        "User thinks Crush.lu is a swipe app — expect to clarify during call."
+    ),
+    "events_disinterest": _(
+        "User prefers online-only dating. Discuss whether in-person events fit."
+    ),
+    "coach_reluctance": _(
+        "User would prefer no intermediary. Explain the Coach's role gently."
+    ),
+    "low_effort_text": _(
+        "Free-text answer is very short or repetitive — ask them to elaborate."
+    ),
+}
+
+
+def readiness_score_label(score: int | None) -> str:
+    """Bucket a score into one of 'high' / 'medium' / 'low' / 'pending'."""
+    if score is None:
+        return "pending"
+    if score >= 8:
+        return "high"
+    if score >= 5:
+        return "medium"
+    return "low"

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -9968,6 +9968,83 @@ document.addEventListener("alpine:init", function () {
         };
     });
 
+    // Screening Call Calibration Component (Phase 4)
+    // 3-section, minimal-state flow for Coaches who have the pre-screening data.
+    // Section 2 auto-populates a suggested script from the user's what_is_crush answer.
+    Alpine.data("screeningCallCalibration", function () {
+        return {
+            warmIntroComplete: false,
+            conceptCalibrationComplete: false,
+            conceptNotes: "",
+            discretionNotes: "",
+            conceptAnswer: "",
+            init() {
+                // Pre-populate from prior checklist_data if the Coach saved partial state.
+                const initialEl = this.$root.querySelector("[data-checklist-initial]");
+                if (initialEl && initialEl.dataset.checklistInitial) {
+                    try {
+                        const prior = JSON.parse(initialEl.dataset.checklistInitial);
+                        this.warmIntroComplete = !!prior.warm_intro_complete;
+                        this.conceptCalibrationComplete = !!prior.concept_calibration_complete;
+                        this.conceptNotes = prior.concept_notes || "";
+                        this.discretionNotes = prior.discretion_notes || "";
+                    } catch (e) {
+                        // Malformed JSON — ignore, start empty.
+                    }
+                }
+                const conceptEl = this.$root.querySelector("[data-concept-answer]");
+                if (conceptEl) {
+                    this.conceptAnswer = conceptEl.dataset.conceptAnswer || "";
+                }
+            },
+            get completedCount() {
+                let n = 0;
+                if (this.warmIntroComplete) n++;
+                if (this.conceptCalibrationComplete) n++;
+                return n;
+            },
+            get progressWidth() {
+                return "width: " + (this.completedCount / 2 * 100) + "%";
+            },
+            get submitDisabled() {
+                return !(this.warmIntroComplete && this.conceptCalibrationComplete);
+            },
+            get submitButtonClass() {
+                return this.submitDisabled
+                    ? "bg-gray-300 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed"
+                    : "bg-crush-purple text-white hover:bg-purple-700";
+            },
+            get conceptScript() {
+                // Auto-populate a gentle calibration script based on the user's
+                // pre-screening answer. Strings are English-first; the Coach adapts live.
+                switch (this.conceptAnswer) {
+                    case "tinder":
+                        return "I saw you described Crush.lu as similar to Tinder. Let me share how we're different — we're events-first, and our Coaches introduce people one-on-one. Does that change how you'd like to use the platform?";
+                    case "matchmaking":
+                        return "You described us as a matchmaking service. We do introduce people, but events are where the magic happens — tell me, how open are you to attending an in-person event in the next month?";
+                    case "unsure":
+                        return "You mentioned you're still figuring it out — that's perfect, most of our members start there. Let me walk you through how a typical first month looks at Crush.lu, and you can tell me what resonates.";
+                    case "events":
+                        return "You described us well — events-first is exactly right. Tell me, which event format sounds most exciting to you, and what would make the perfect first event for you?";
+                    default:
+                        return "Let me explain how Crush.lu works in one minute, then I'll ask you how that lands. We're events-first, Coach-supported, and the online piece is opt-in.";
+                }
+            },
+            get checklistDataJson() {
+                // Flat keys compatible with the JSONField — legacy and calibration
+                // coexist inside the same column.
+                return JSON.stringify({
+                    mode: "calibration",
+                    warm_intro_complete: this.warmIntroComplete,
+                    concept_calibration_complete: this.conceptCalibrationComplete,
+                    concept_notes: this.conceptNotes,
+                    discretion_notes: this.discretionNotes,
+                    concept_answer: this.conceptAnswer,
+                });
+            },
+        };
+    });
+
     // Screening Call Guideline Component for Coach Review
     // 7-step accordion with checklist items and notes
     Alpine.data("screeningCallGuideline", function () {

--- a/crush_lu/tasks.py
+++ b/crush_lu/tasks.py
@@ -174,3 +174,52 @@ def send_coach_push_notification_task(coach_user_id, title, body, url=None):
         logger.error(
             f"[TASK] Failed to send push to coach {coach_user_id}: {e}"
         )
+
+
+# --------------------------------------------------------------------------
+# Pre-screening questionnaire tasks (Phase 5)
+# --------------------------------------------------------------------------
+
+@task(priority=5)
+def send_pre_screening_invite_task(submission_id, host, is_secure=True, reminder=False):
+    """Send the pre-screening invite or reminder email for one submission."""
+    from .models import ProfileSubmission
+    from .pre_screening_notifications import send_pre_screening_invite_email
+
+    try:
+        submission = ProfileSubmission.objects.select_related(
+            "profile__user"
+        ).get(pk=submission_id)
+    except ProfileSubmission.DoesNotExist:
+        logger.warning(
+            f"[TASK] ProfileSubmission {submission_id} not found for pre-screening invite"
+        )
+        return
+    request = _build_fake_request(host, is_secure)
+    try:
+        send_pre_screening_invite_email(submission, reminder=reminder, request=request)
+    except Exception as e:
+        logger.error(
+            f"[TASK] Failed to send pre-screening {'reminder' if reminder else 'invite'} "
+            f"for submission {submission_id}: {e}"
+        )
+
+
+@task(priority=7)
+def send_pre_screening_user_push_task(submission_id):
+    """Push nudge to the user to fill in pre-screening."""
+    from .models import ProfileSubmission
+    from .pre_screening_notifications import send_pre_screening_user_push
+
+    try:
+        submission = ProfileSubmission.objects.select_related(
+            "profile__user"
+        ).get(pk=submission_id)
+    except ProfileSubmission.DoesNotExist:
+        return
+    try:
+        send_pre_screening_user_push(submission)
+    except Exception as e:
+        logger.error(
+            f"[TASK] Failed to send pre-screening user push for {submission_id}: {e}"
+        )

--- a/crush_lu/templates/admin/crush_lu/dashboard.html
+++ b/crush_lu/templates/admin/crush_lu/dashboard.html
@@ -79,6 +79,58 @@
     </div>
 
         <div class="tab-panel" :class="overviewTabClass" x-show="isOverview">
+        {# Pre-screening analytics (Phase 6) — shown only when feature flag is on #}
+        {% if pre_screening_metrics %}
+        <div class="metric-card" style="background: linear-gradient(135deg, #fef3c7, #fce7f3); padding: 20px; border-radius: 12px; margin-bottom: 20px;">
+            <h3 style="margin: 0 0 12px 0; color: #111;">📋 {% trans "Pre-Screening Analytics" %}</h3>
+            <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px;">
+                <div>
+                    <div style="font-size: 12px; color: #555; text-transform: uppercase;">{% trans "Completion rate" %}</div>
+                    <div style="font-size: 24px; font-weight: 700;">{{ pre_screening_metrics.completion_rate }}%</div>
+                    <div style="font-size: 11px; color: #666;">{{ pre_screening_metrics.pending_submitted }} / {{ pre_screening_metrics.pending_count }} {% trans "of pending" %}</div>
+                </div>
+                <div>
+                    <div style="font-size: 12px; color: #555; text-transform: uppercase;">{% trans "Avg readiness" %}</div>
+                    <div style="font-size: 24px; font-weight: 700;">{{ pre_screening_metrics.avg_score|default:"—" }}{% if pre_screening_metrics.avg_score %}<span style="font-size: 14px;">/10</span>{% endif %}</div>
+                </div>
+                <div>
+                    <div style="font-size: 12px; color: #555; text-transform: uppercase;">{% trans "No-show rate" %}</div>
+                    <div style="font-size: 24px; font-weight: 700;">{{ pre_screening_metrics.noshow_rate_submitted_users }}%</div>
+                    <div style="font-size: 11px; color: #666;">{% trans "for users who answered" %}</div>
+                </div>
+                <div>
+                    <div style="font-size: 12px; color: #555; text-transform: uppercase;">{% trans "Top flags this week" %}</div>
+                    <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px;">
+                        {% for flag, count in pre_screening_metrics.flag_counts.items|slice:":3" %}
+                        <span style="font-size: 11px; padding: 2px 6px; background: rgba(0,0,0,0.08); border-radius: 10px;">{{ flag }} · {{ count }}</span>
+                        {% empty %}
+                        <span style="font-size: 11px; color: #666;">{% trans "no flags" %}</span>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            {% if pre_screening_metrics.score_histogram %}
+            <div style="margin-top: 16px;">
+                <div style="font-size: 12px; color: #555; text-transform: uppercase; margin-bottom: 6px;">{% trans "Readiness score distribution" %}</div>
+                <div style="display: flex; gap: 2px; align-items: flex-end; height: 48px;">
+                    {% for score, count in pre_screening_metrics.score_histogram.items %}
+                    <div style="flex: 1; background: #9B59B6; min-height: 2px; height: {% widthratio count 1 8 %}%; max-height: 48px;" title="{{ score }}: {{ count }}"></div>
+                    {% endfor %}
+                </div>
+                <div style="display: flex; justify-content: space-between; font-size: 10px; color: #666; margin-top: 2px;">
+                    <span>0</span><span>5</span><span>10</span>
+                </div>
+            </div>
+            {% endif %}
+            <div style="margin-top: 12px;">
+                <a href="{% url 'crush_admin_pre_screening_csv' %}"
+                   style="font-size: 12px; color: #7c3aed; text-decoration: underline;">
+                   {% trans "Download per-question CSV" %} ↓
+                </a>
+            </div>
+        </div>
+        {% endif %}
+
         {# Key Metrics #}
         <div class="metric-grid">
             <a href="{% url 'crush_admin:crush_lu_crushprofile_changelist' %}" class="metric-card purple">

--- a/crush_lu/templates/crush_lu/_pending_submission_card.html
+++ b/crush_lu/templates/crush_lu/_pending_submission_card.html
@@ -1,4 +1,4 @@
-{% load i18n crush_media %}
+{% load i18n crush_media pre_screening_tags %}
 {# Reusable card for pending profile submissions on coach dashboard #}
 {# Expected context: submission (ProfileSubmission object with is_urgent, is_warning attributes) #}
 
@@ -56,6 +56,24 @@
                     <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded-full" title="{% trans 'SMS sent' %}">
                         💬 {{ submission.sms_attempt_count }}
                     </span>
+                {% endif %}
+                {% if pre_screening_enabled %}
+                    {% if submission.pre_screening_submitted_at %}
+                        {% with ps_label=submission.pre_screening_readiness_score|prescreening_score_label %}
+                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full
+                                     {% if ps_label == 'high' %}bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300
+                                     {% elif ps_label == 'medium' %}bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300
+                                     {% else %}bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300{% endif %}"
+                              title="{% trans 'Pre-screening readiness' %}">
+                            📋 {{ submission.pre_screening_readiness_score }}/10
+                        </span>
+                        {% endwith %}
+                    {% else %}
+                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full"
+                              title="{% trans 'Pre-screening not yet submitted' %}">
+                            📋 —
+                        </span>
+                    {% endif %}
                 {% endif %}
             </p>
 

--- a/crush_lu/templates/crush_lu/_pre_screening_display.html
+++ b/crush_lu/templates/crush_lu/_pre_screening_display.html
@@ -1,0 +1,140 @@
+{% load i18n pre_screening_tags %}
+{# Coach-facing display of a user's pre-screening answers. Always visible on
+   coach_review_profile.html; three states: submitted / not submitted / flag off. #}
+{% prescreening_schema as ps_schema %}
+
+{% if not pre_screening_enabled %}
+  {# feature flag off — render nothing at all #}
+{% elif submission.pre_screening_submitted_at %}
+  {% with score=submission.pre_screening_readiness_score flags=submission.pre_screening_flags|default:'' score_label=submission.pre_screening_readiness_score|prescreening_score_label %}
+  <section class="mb-6 rounded-xl border border-blue-200 dark:border-blue-800/50 bg-blue-50 dark:bg-blue-900/20 overflow-hidden">
+    <header class="px-5 py-4 flex items-start gap-3">
+      <div class="w-9 h-9 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center flex-shrink-0 mt-0.5">
+        {% include "shared/icons/chat-bubble-left-right.html" with class="w-5 h-5 text-blue-700 dark:text-blue-300" %}
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center flex-wrap gap-2 mb-1">
+          <p class="text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-wide mb-0">
+            {% trans "Pre-Screening Answers" %}
+          </p>
+          <span class="normal-case font-normal text-xs text-blue-600/80 dark:text-blue-400/80">
+            &middot; {{ submission.pre_screening_submitted_at|timesince }} {% trans "ago" %}
+          </span>
+        </div>
+        <div class="flex items-center flex-wrap gap-2 mt-1">
+          <span class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-bold
+                       {% if score_label == 'high' %}bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200
+                       {% elif score_label == 'medium' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200
+                       {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200{% endif %}">
+            {% trans "Readiness" %} {{ score }}/10
+          </span>
+          {% for f in flags %}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+                  title="{{ f|prescreening_flag_description }}">
+              ⚑ {{ f }}
+            </span>
+          {% endfor %}
+        </div>
+      </div>
+    </header>
+
+    <div class="border-t border-blue-100 dark:border-blue-800/30">
+      {% for section in ps_schema.sections %}
+        {% if section.id != 'consents' %}
+        <details class="group border-b border-blue-100/60 dark:border-blue-800/30 last:border-0" {% if forloop.first %}open{% endif %}>
+          <summary class="px-5 py-3 cursor-pointer text-sm font-semibold text-blue-800 dark:text-blue-200 flex items-center justify-between hover:bg-blue-100/40 dark:hover:bg-blue-900/30">
+            <span>{{ section.title }}</span>
+            <span class="text-xs text-blue-600/70 dark:text-blue-400/70 group-open:hidden">{% trans "show" %}</span>
+            <span class="text-xs text-blue-600/70 dark:text-blue-400/70 hidden group-open:inline">{% trans "hide" %}</span>
+          </summary>
+          <dl class="px-5 py-3 space-y-3 bg-white/40 dark:bg-slate-900/10">
+            {% for q in section.questions %}
+              {% with answer=submission.pre_screening_responses|get_item:q.id %}
+              <div>
+                <dt class="text-xs font-semibold text-gray-600 dark:text-gray-400 mb-1">{{ q.label }}</dt>
+                <dd class="text-sm text-gray-900 dark:text-gray-100 mb-0">
+                  {% if q.type == 'text' %}
+                    {% if answer %}
+                      <blockquote class="border-l-2 border-blue-300 dark:border-blue-700 pl-3 italic">{{ answer }}</blockquote>
+                    {% else %}
+                      <span class="text-gray-400 dark:text-gray-500 italic">{% trans "— not answered —" %}</span>
+                    {% endif %}
+                  {% elif q.type == 'multi_select' %}
+                    {% if answer %}
+                      <span class="flex flex-wrap gap-1.5">
+                        {% for v in answer %}
+                          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200">
+                            {{ q|prescreening_choice_label:v }}
+                          </span>
+                        {% endfor %}
+                      </span>
+                    {% else %}
+                      <span class="text-gray-400 dark:text-gray-500 italic">{% trans "— not answered —" %}</span>
+                    {% endif %}
+                  {% elif q.type == 'yes_no' %}
+                    {% if answer == True or answer == 'yes' %}<span class="font-semibold text-green-700 dark:text-green-300">{% trans "Yes" %}</span>
+                    {% elif answer == False or answer == 'no' %}<span class="font-semibold text-red-700 dark:text-red-300">{% trans "No" %}</span>
+                    {% else %}<span class="text-gray-400 italic">{% trans "— not answered —" %}</span>{% endif %}
+                  {% else %}
+                    {{ q|prescreening_choice_label:answer }}
+                  {% endif %}
+                </dd>
+              </div>
+              {% endwith %}
+            {% endfor %}
+          </dl>
+        </details>
+        {% endif %}
+      {% endfor %}
+      {# Consents: compact checklist #}
+      {% for section in ps_schema.sections %}{% if section.id == 'consents' %}
+      <details class="group border-t border-blue-100/60 dark:border-blue-800/30">
+        <summary class="px-5 py-3 cursor-pointer text-sm font-semibold text-blue-800 dark:text-blue-200 flex items-center justify-between hover:bg-blue-100/40 dark:hover:bg-blue-900/30">
+          <span>{% trans "Consents" %}</span>
+          <span class="text-xs text-green-700 dark:text-green-300">✓ {% trans "all accepted" %}</span>
+        </summary>
+        <ul class="px-5 py-3 space-y-1.5 bg-white/40 dark:bg-slate-900/10">
+          {% for q in section.questions %}
+            <li class="flex items-start gap-2 text-xs text-gray-700 dark:text-gray-300">
+              <span class="text-green-600 dark:text-green-400">✓</span>
+              <span>{{ q.label }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      </details>
+      {% endif %}{% endfor %}
+    </div>
+  </section>
+  {% endwith %}
+{% else %}
+  <section class="mb-6 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-800/50 px-5 py-4">
+    <div class="flex items-start gap-3">
+      <div class="w-9 h-9 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+        {% include "shared/icons/chat-bubble-left.html" with class="w-5 h-5 text-gray-500 dark:text-gray-400" %}
+      </div>
+      <div class="flex-1 min-w-0">
+        <p class="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">
+          {% trans "Pre-screening not yet submitted" %}
+        </p>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+          {% trans "You can send a quick SMS reminder asking them to fill it out before you call." %}
+        </p>
+        {% if can_send_prescreening_sms %}
+          <button type="button"
+                  hx-post="{% url 'crush_lu:coach_send_pre_screening_reminder' submission.id %}"
+                  hx-target="#prescreening-sms-result"
+                  hx-swap="innerHTML"
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-crush-purple text-white hover:bg-purple-700 transition-colors">
+            {% include "shared/icons/paper-airplane.html" with class="w-3.5 h-3.5" %}
+            {% trans "Send SMS reminder" %}
+          </button>
+        {% else %}
+          <p class="text-xs italic text-gray-400 dark:text-gray-500">
+            {% trans "Candidate has no verified phone number — cannot send SMS." %}
+          </p>
+        {% endif %}
+        <div id="prescreening-sms-result" class="mt-2"></div>
+      </div>
+    </div>
+  </section>
+{% endif %}

--- a/crush_lu/templates/crush_lu/_screening_tab.html
+++ b/crush_lu/templates/crush_lu/_screening_tab.html
@@ -1,5 +1,9 @@
 {% load i18n %}
 
+{% if submission.screening_call_mode == 'calibration' %}
+  {% include "crush_lu/_screening_tab_calibration.html" %}
+{% else %}
+
 <div id="screening-call-section-content">
     {% if submission.review_call_completed %}
         {# Completed state - show summary #}
@@ -232,3 +236,19 @@
         </div>
     {% endif %}
 </div>
+{% if submission.pre_screening_submitted_at and not submission.review_call_completed %}
+  <div class="mt-3 text-center">
+    <form method="post"
+          hx-post="{% url 'crush_lu:coach_set_screening_mode' submission.id %}"
+          hx-target="#screening-call-section-content"
+          hx-swap="outerHTML">
+      {% csrf_token %}
+      <input type="hidden" name="mode" value="calibration">
+      <button type="submit"
+              class="text-xs font-semibold text-crush-purple hover:underline">
+        {% trans "Switch to short calibration call (3-section)" %}
+      </button>
+    </form>
+  </div>
+{% endif %}
+{% endif %}

--- a/crush_lu/templates/crush_lu/_screening_tab_calibration.html
+++ b/crush_lu/templates/crush_lu/_screening_tab_calibration.html
@@ -1,0 +1,175 @@
+{% load i18n %}
+{# Calibration call checklist — 3 sections for Coaches when the user
+   submitted pre-screening. The existing 5-section flow is in
+   _screening_tab.html. #}
+
+<div id="screening-call-section-content">
+  {% if submission.review_call_completed %}
+    {# ───── Completed state ───── #}
+    <div class="bg-green-50 dark:bg-green-900/30 border-2 border-green-500 dark:border-green-700 rounded-xl p-6 mb-6">
+      <div class="flex items-center justify-between flex-wrap gap-2 mb-4">
+        <div class="flex items-center gap-3">
+          {% include "shared/icons/check-circle.html" with class="w-8 h-8 text-green-600 dark:text-green-400" %}
+          <h3 class="text-xl font-bold text-green-900 dark:text-green-300 mb-0">{% trans "Calibration Call Completed" %}</h3>
+        </div>
+        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-200 rounded-full">
+          {% trans "Mode: Calibration (3-section)" %}
+        </span>
+      </div>
+      <p class="text-sm text-green-800 dark:text-green-300 mb-0">
+        <strong>{% trans "Completed:" %}</strong> {{ submission.review_call_date|date:"M d, Y g:i A" }}
+      </p>
+      {% if submission.review_call_notes %}
+        <div class="mt-4 bg-white dark:bg-gray-800 rounded-lg p-4 border border-green-200 dark:border-green-700">
+          <p class="text-sm mb-0">
+            <strong class="text-gray-900 dark:text-gray-100">{% trans "Final Notes:" %}</strong><br>
+            <span class="text-gray-700 dark:text-gray-200">{{ submission.review_call_notes }}</span>
+          </p>
+        </div>
+      {% endif %}
+    </div>
+    <div class="text-center">
+      <p class="text-gray-600 dark:text-gray-300">{% trans "You can now proceed to the Decision tab to complete the review." %}</p>
+    </div>
+    {% include 'crush_lu/_review_guidelines.html' %}
+  {% else %}
+    {# ───── Interactive 3-section calibration checklist ───── #}
+    <div class="bg-blue-50 dark:bg-blue-900/30 border-2 border-blue-400 dark:border-blue-600 rounded-xl p-6 mb-6">
+      <div class="flex items-center gap-3 flex-wrap">
+        {% include "shared/icons/sparkles.html" with class="w-8 h-8 text-blue-600 dark:text-blue-400" %}
+        <div class="flex-1">
+          <h3 class="text-xl font-bold text-blue-900 dark:text-blue-200 mb-0">{% trans "Short Calibration Call" %}</h3>
+          <p class="text-sm text-blue-800 dark:text-blue-200 mt-1 mb-0">
+            {% trans "Candidate answered the pre-screening questionnaire — focus on calibration, not logistics." %}
+          </p>
+        </div>
+        <form method="post"
+              hx-post="{% url 'crush_lu:coach_set_screening_mode' submission.id %}"
+              hx-target="#screening-call-section-content"
+              hx-swap="innerHTML"
+              class="m-0">
+          {% csrf_token %}
+          <input type="hidden" name="mode" value="legacy">
+          <button type="submit"
+                  class="text-xs font-semibold px-3 py-1.5 rounded-lg bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-slate-700">
+            {% trans "Switch to legacy 5-section" %}
+          </button>
+        </form>
+      </div>
+    </div>
+
+    <div x-data="screeningCallCalibration">
+      <div data-checklist-initial='{{ submission.review_call_checklist|default:"{}" | escapejs }}' class="hidden"></div>
+      <div data-concept-answer="{{ submission.pre_screening_responses.what_is_crush|default:'' }}" class="hidden"></div>
+
+      {# Contact info #}
+      <div class="mb-6 bg-gradient-to-r from-purple-50 to-pink-50 dark:from-purple-900/30 dark:to-pink-900/30 border border-purple-200 dark:border-purple-700 rounded-xl p-5">
+        <p class="text-sm flex items-center gap-2 mb-3">
+          {% include "shared/icons/phone.html" with class="w-5 h-5 text-purple-600 dark:text-purple-400" %}
+          <strong class="text-gray-900 dark:text-gray-100">{% trans "Phone:" %}</strong>
+          <span class="text-lg font-mono text-gray-900 dark:text-gray-100">{{ profile.phone_number }}</span>
+        </p>
+        <p class="text-sm flex items-center gap-2 mb-0">
+          {% include "shared/icons/user.html" with class="w-5 h-5 text-purple-600 dark:text-purple-400" %}
+          <strong class="text-gray-900 dark:text-gray-100">{% trans "Name:" %}</strong>
+          <span class="text-gray-900 dark:text-gray-100">{{ profile.user.first_name }} {{ profile.user.last_name }}</span>
+        </p>
+      </div>
+
+      {# Progress #}
+      <div class="mb-6 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5">
+        <div class="flex justify-between items-center text-sm text-gray-600 dark:text-gray-300 mb-2">
+          <span class="font-semibold">{% trans "Progress" %}</span>
+          <span class="font-bold text-purple-600 dark:text-purple-400"><span x-text="completedCount"></span>/2 {% trans "required complete" %}</span>
+        </div>
+        <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3">
+          <div class="bg-gradient-to-r from-purple-500 to-pink-500 h-3 rounded-full transition-all duration-300" x-bind:style="progressWidth"></div>
+        </div>
+      </div>
+
+      {# Section 1: Warm Intro & Identity #}
+      <details class="mb-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 overflow-hidden" open>
+        <summary class="px-5 py-4 cursor-pointer flex items-center gap-3 hover:bg-gray-50 dark:hover:bg-slate-700">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 text-sm font-bold">1</span>
+          <span class="font-semibold text-gray-900 dark:text-white">{% trans "Warm Intro & Identity Check" %}</span>
+          <span class="ml-auto text-xs text-green-700 dark:text-green-300" x-show="warmIntroComplete">✓</span>
+        </summary>
+        <div class="px-5 pb-5 space-y-3 border-t border-gray-100 dark:border-gray-700">
+          <p class="text-sm text-gray-600 dark:text-gray-300 mt-3">
+            {% trans "Greet them by name, confirm you're speaking to the right person, and set a warm tone for the call." %}
+          </p>
+          <label class="flex items-start gap-2 p-3 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700">
+            <input type="checkbox" class="mt-1 rounded text-crush-purple focus:ring-crush-purple" x-model="warmIntroComplete">
+            <span class="text-sm text-gray-900 dark:text-gray-100">{% trans "Introduced myself, confirmed identity, set a warm tone." %}</span>
+          </label>
+        </div>
+      </details>
+
+      {# Section 2: Concept Calibration (auto-populated script) #}
+      <details class="mb-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 overflow-hidden" open>
+        <summary class="px-5 py-4 cursor-pointer flex items-center gap-3 hover:bg-gray-50 dark:hover:bg-slate-700">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300 text-sm font-bold">2</span>
+          <span class="font-semibold text-gray-900 dark:text-white">{% trans "Concept Calibration" %}</span>
+          <span class="ml-auto text-xs text-green-700 dark:text-green-300" x-show="conceptCalibrationComplete">✓</span>
+        </summary>
+        <div class="px-5 pb-5 space-y-3 border-t border-gray-100 dark:border-gray-700">
+          <div class="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/50">
+            <p class="text-xs font-semibold text-amber-800 dark:text-amber-200 uppercase tracking-wide mb-1">{% trans "Suggested script" %}</p>
+            <p class="text-sm text-amber-900 dark:text-amber-100 mb-0" x-text="conceptScript"></p>
+          </div>
+          <label class="flex items-start gap-2 p-3 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700">
+            <input type="checkbox" class="mt-1 rounded text-crush-purple focus:ring-crush-purple" x-model="conceptCalibrationComplete">
+            <span class="text-sm text-gray-900 dark:text-gray-100">{% trans "Calibrated their expectations, confirmed they understand events-first + Coach-supported." %}</span>
+          </label>
+          <textarea name="conceptNotes"
+                    x-model="conceptNotes"
+                    rows="3"
+                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-700 text-sm text-gray-900 dark:text-white p-3 resize-none focus:ring-2 focus:ring-crush-purple focus:border-crush-purple"
+                    placeholder="{% trans 'What did they say? Any concerns or enthusiasm to note?' %}"></textarea>
+        </div>
+      </details>
+
+      {# Section 3: Optional discretion follow-up #}
+      <details class="mb-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 overflow-hidden">
+        <summary class="px-5 py-4 cursor-pointer flex items-center gap-3 hover:bg-gray-50 dark:hover:bg-slate-700">
+          <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 text-sm font-bold">3</span>
+          <span class="font-semibold text-gray-900 dark:text-white">{% trans "Coach's Discretion Follow-Up" %} <span class="text-xs text-gray-500 dark:text-gray-400">({% trans "optional" %})</span></span>
+        </summary>
+        <div class="px-5 pb-5 space-y-3 border-t border-gray-100 dark:border-gray-700">
+          <p class="text-sm text-gray-600 dark:text-gray-300 mt-3">
+            {% trans "Anything surprising in their answers? Something you want to dig into beyond the script?" %}
+          </p>
+          <textarea name="discretionNotes"
+                    x-model="discretionNotes"
+                    rows="3"
+                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-700 text-sm text-gray-900 dark:text-white p-3 resize-none focus:ring-2 focus:ring-crush-purple focus:border-crush-purple"
+                    placeholder="{% trans 'Open-ended notes — anything the next Coach or reviewer should know.' %}"></textarea>
+        </div>
+      </details>
+
+      {# Submit form #}
+      <form method="post"
+            hx-post="{% url 'crush_lu:coach_mark_review_call_complete' submission.id %}"
+            hx-target="#screening-call-section"
+            hx-swap="outerHTML"
+            class="mt-6 space-y-3">
+        {% csrf_token %}
+        <input type="hidden" name="checklist_data" x-bind:value="checklistDataJson">
+        <label class="block text-sm font-semibold text-gray-900 dark:text-white">{% trans "Final call notes" %}</label>
+        <textarea name="call_notes"
+                  rows="3"
+                  class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-700 text-sm text-gray-900 dark:text-white p-3 resize-none focus:ring-2 focus:ring-crush-purple focus:border-crush-purple"
+                  placeholder="{% trans 'Anything else to record about the call?' %}"></textarea>
+        <button type="submit"
+                x-bind:disabled="submitDisabled"
+                x-bind:class="submitButtonClass"
+                class="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-lg text-sm font-semibold transition-colors">
+          {% include "shared/icons/check-circle.html" with class="w-4 h-4" %}
+          {% trans "Mark Calibration Call Complete" %}
+        </button>
+      </form>
+    </div>
+
+    {% include 'crush_lu/_review_guidelines.html' %}
+  {% endif %}
+</div>

--- a/crush_lu/templates/crush_lu/coach_review_profile.html
+++ b/crush_lu/templates/crush_lu/coach_review_profile.html
@@ -244,6 +244,9 @@
         </div>
     </div>
 
+    {# ── Pre-Screening answers (Phase 3 — always visible when feature flag on) ── #}
+    {% include "crush_lu/_pre_screening_display.html" %}
+
     {# ── Candidate Note (if submitted during review wait) ── #}
     {% if submission.candidate_note %}
     <div class="mb-6 rounded-xl border border-blue-200 dark:border-blue-800/50 bg-blue-50 dark:bg-blue-900/20 overflow-hidden">

--- a/crush_lu/templates/crush_lu/emails/pre_screening_invite.html
+++ b/crush_lu/templates/crush_lu/emails/pre_screening_invite.html
@@ -1,0 +1,36 @@
+{% extends "crush_lu/emails/base_email.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Help your Coach prepare — 3 minutes, 13 questions" %}{% endblock %}
+{% block header_title %}{% trans "Help your Coach prepare" %}{% endblock %}
+
+{% block content %}
+<h2>{% blocktrans with name=user.first_name %}Hi {{ name }},{% endblocktrans %}</h2>
+
+{% if reminder %}
+  <p>{% trans "A quick nudge — your Coach is getting ready to call you about your profile." %}</p>
+  <p>{% trans "Before they do, please take 3 minutes to answer a few questions. It makes the call much smoother and means we can focus on you, not paperwork." %}</p>
+{% else %}
+  <p>{% trans "Thank you for submitting your profile! While your Coach gets ready to reach out, we have a small favour to ask." %}</p>
+  <p>{% trans "Could you answer 13 quick questions about yourself and what you're looking for? It takes about 3 minutes and really helps your Coach prepare for the call." %}</p>
+{% endif %}
+
+<p style="text-align: center; margin: 30px 0;">
+  <a class="button" href="{{ pre_screening_url }}">
+    {% trans "Answer the pre-screening questions" %}
+  </a>
+</p>
+
+<div class="info-box">
+  <p style="margin: 0;"><strong>{% trans "Why we ask:" %}</strong></p>
+  <ul style="margin: 10px 0 0 0;">
+    <li>{% trans "Your Coach won't waste time on basics during the call" %}</li>
+    <li>{% trans "We calibrate what Crush.lu actually is — events, not swiping" %}</li>
+    <li>{% trans "You stay in control of what you share" %}</li>
+  </ul>
+</div>
+
+<p style="font-size: 14px; color: #888;">
+  {% trans "It's entirely optional — if you'd rather just wait for the call, that's fine too." %}
+</p>
+{% endblock %}

--- a/crush_lu/templates/crush_lu/emails/pre_screening_invite.txt
+++ b/crush_lu/templates/crush_lu/emails/pre_screening_invite.txt
@@ -1,0 +1,18 @@
+{% load i18n %}{% blocktrans with name=user.first_name %}Hi {{ name }},{% endblocktrans %}
+
+{% if reminder %}{% trans "A quick nudge — your Coach is getting ready to call you about your profile." %}
+
+{% trans "Before they do, please take 3 minutes to answer a few questions. It makes the call much smoother and means we can focus on you, not paperwork." %}{% else %}{% trans "Thank you for submitting your profile! While your Coach gets ready to reach out, we have a small favour to ask." %}
+
+{% trans "Could you answer 13 quick questions about yourself and what you're looking for? It takes about 3 minutes and really helps your Coach prepare for the call." %}{% endif %}
+
+{% trans "Link:" %} {{ pre_screening_url }}
+
+{% trans "Why we ask:" %}
+- {% trans "Your Coach won't waste time on basics during the call" %}
+- {% trans "We calibrate what Crush.lu actually is — events, not swiping" %}
+- {% trans "You stay in control of what you share" %}
+
+{% trans "It's entirely optional — if you'd rather just wait for the call, that's fine too." %}
+
+— {% trans "The Crush.lu team" %}

--- a/crush_lu/templates/crush_lu/pre_screening.html
+++ b/crush_lu/templates/crush_lu/pre_screening.html
@@ -1,0 +1,44 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n pre_screening_tags %}
+
+{% block title %}{% trans "Pre-Screening – Crush.lu" %}{% endblock %}
+{% block meta_description %}{% trans "Answer a few quick questions so your Crush Coach can prepare for your review call." %}{% endblock %}
+
+{% block content %}
+<div class="flex justify-center py-6 md:py-8">
+  <div class="w-full max-w-2xl px-4">
+    {# ── Gradient header ── #}
+    <div class="text-center mb-6">
+      <div class="inline-flex w-14 h-14 rounded-full bg-gradient-to-br from-crush-purple to-crush-pink items-center justify-center mb-3 shadow-lg">
+        {% include "shared/icons/chat-bubble-left.html" with class="w-7 h-7 text-white" %}
+      </div>
+      <h1 class="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2">
+        {% trans "Help your Coach prepare" %}
+      </h1>
+      <p class="text-sm text-gray-600 dark:text-gray-300 max-w-md mx-auto">
+        {% trans "A few quick questions about you and what you're looking for. Your Coach will see your answers before the call so you don't have to cover the basics twice." %}
+      </p>
+    </div>
+
+    {# ── Progress indicator ── #}
+    {% include "crush_lu/pre_screening/_progress.html" with oob=False %}
+
+    {# ── Sections ── #}
+    <div class="space-y-4">
+      {% for section_ctx in sections_context %}
+        {% include "crush_lu/pre_screening/_section.html" with section=section_ctx.section section_number=section_ctx.number section_complete=section_ctx.complete section_flash=section_ctx.flash responses=responses errors=section_ctx.errors %}
+      {% endfor %}
+    </div>
+
+    {# ── Finalize ── #}
+    {% include "crush_lu/pre_screening/_finalize.html" with oob=False %}
+
+    <div class="text-center mt-6">
+      <a href="{% url 'crush_lu:profile_submitted' %}"
+         class="text-xs text-gray-500 dark:text-gray-400 hover:underline">
+        {% trans "Back to review status" %}
+      </a>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/crush_lu/pre_screening/_finalize.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_finalize.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+<form id="prescreening-finalize"
+      {% if oob %}hx-swap-oob="outerHTML:#prescreening-finalize"{% endif %}
+      method="post"
+      action="{% url 'crush_lu:pre_screening_finalize' %}"
+      class="mt-6">
+  {% csrf_token %}
+  <button type="submit"
+          {% if not can_finalize %}disabled{% endif %}
+          class="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-lg text-sm font-semibold transition-colors
+                 {% if can_finalize %}bg-crush-purple text-white hover:bg-purple-700
+                 {% else %}bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed{% endif %}">
+    {% include "shared/icons/paper-airplane.html" with class="w-4 h-4" %}
+    {% if already_submitted %}
+      {% trans "Update answers for Coach" %}
+    {% else %}
+      {% trans "Submit to Coach" %}
+    {% endif %}
+  </button>
+  {% if not can_finalize %}
+    <p class="text-xs text-center text-gray-500 dark:text-gray-400 mt-2">
+      {% trans "Complete all required questions to submit." %}
+    </p>
+  {% endif %}
+</form>

--- a/crush_lu/templates/crush_lu/pre_screening/_progress.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_progress.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+<div id="prescreening-progress"
+     {% if oob %}hx-swap-oob="outerHTML:#prescreening-progress"{% endif %}
+     class="mb-5 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 shadow-sm px-5 py-3">
+  <div class="flex items-center justify-between text-sm">
+    <span class="font-semibold text-gray-900 dark:text-white">
+      {% blocktrans with done=completed_section_count total=total_section_count %}{{ done }} of {{ total }} sections complete{% endblocktrans %}
+    </span>
+    <span class="text-xs text-gray-500 dark:text-gray-400">
+      {% if already_submitted %}
+        {% trans "Submitted — you can still edit until the call" %}
+      {% else %}
+        {% trans "Estimated 3 minutes" %}
+      {% endif %}
+    </span>
+  </div>
+  <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 mt-2 overflow-hidden">
+    <div class="bg-gradient-to-r from-crush-purple to-crush-pink h-full rounded-full transition-all duration-500"
+         style="width: {{ progress_percent }}%"></div>
+  </div>
+</div>

--- a/crush_lu/templates/crush_lu/pre_screening/_q_checkbox.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_q_checkbox.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+<div class="flex items-start gap-3 p-3 rounded-lg border
+            {% if errors %}border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-900/10
+            {% elif value %}border-green-300 dark:border-green-800 bg-green-50/50 dark:bg-green-900/10
+            {% else %}border-gray-200 dark:border-gray-700{% endif %}">
+  <input type="checkbox"
+         id="q-{{ q.id }}"
+         name="{{ q.id }}"
+         value="1"
+         class="mt-1 rounded text-crush-purple focus:ring-crush-purple"
+         {% if value %}checked{% endif %}
+         {% if q.required %}required{% endif %}
+         {% if errors %}aria-invalid="true" aria-describedby="err-{{ q.id }}"{% endif %}>
+  <label for="q-{{ q.id }}" class="text-sm text-gray-900 dark:text-gray-100 flex-1 cursor-pointer">
+    {# Render the label with [Code of Conduct] and [Privacy Policy] expanded into links. #}
+    {% if q.id == "consent_terms" %}
+      {% url 'crush_lu:terms_of_service' as terms_url %}
+      {% url 'crush_lu:privacy_policy' as privacy_url %}
+      {% blocktrans with terms_url=terms_url privacy_url=privacy_url %}I accept the <a href="{{ terms_url }}" target="_blank" class="text-crush-purple underline">Code of Conduct</a> and <a href="{{ privacy_url }}" target="_blank" class="text-crush-purple underline">Privacy Policy</a>.{% endblocktrans %}
+    {% else %}
+      {{ q.label }}
+    {% endif %}
+    {% if q.required %} <span class="text-red-500" aria-hidden="true">*</span>{% endif %}
+  </label>
+</div>
+{% if errors %}
+  <p id="err-{{ q.id }}" class="text-xs text-red-600 dark:text-red-400 mt-1" role="alert" aria-live="polite">
+    {% trans "This is required." %}
+  </p>
+{% endif %}

--- a/crush_lu/templates/crush_lu/pre_screening/_q_multi_select.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_q_multi_select.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+<fieldset class="space-y-2">
+  <legend class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
+    {{ q.label }}{% if q.required %} <span class="text-red-500" aria-hidden="true">*</span>{% endif %}
+  </legend>
+  <div class="grid gap-2" role="group" {% if errors %}aria-describedby="err-{{ q.id }}"{% endif %}>
+    {% for c in q.choices %}
+      <label class="flex items-start gap-3 p-3 min-h-[44px] rounded-lg border cursor-pointer transition-colors
+                    {% if c.value in value %}border-crush-purple bg-purple-50 dark:bg-purple-900/20{% else %}border-gray-200 dark:border-gray-700 hover:border-crush-purple/50 hover:bg-gray-50 dark:hover:bg-slate-800{% endif %}">
+        <input type="checkbox"
+               name="{{ q.id }}"
+               value="{{ c.value }}"
+               class="mt-0.5 rounded text-crush-purple focus:ring-crush-purple"
+               {% if c.value in value %}checked{% endif %}>
+        <span class="text-sm text-gray-900 dark:text-gray-100">{{ c.label }}</span>
+      </label>
+    {% endfor %}
+  </div>
+  {% if q.max_choices %}
+    <p class="text-xs text-gray-500 dark:text-gray-400">
+      {% blocktrans with n=q.max_choices %}Pick up to {{ n }}.{% endblocktrans %}
+    </p>
+  {% endif %}
+  {% if errors %}
+    <p id="err-{{ q.id }}" class="text-xs text-red-600 dark:text-red-400 mt-1" role="alert" aria-live="polite">
+      {% trans "Please adjust your selection." %}
+    </p>
+  {% endif %}
+</fieldset>

--- a/crush_lu/templates/crush_lu/pre_screening/_q_single_select.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_q_single_select.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+<fieldset class="space-y-2">
+  <legend class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
+    {{ q.label }}{% if q.required %} <span class="text-red-500" aria-hidden="true">*</span>{% endif %}
+  </legend>
+  <div class="grid gap-2" role="radiogroup" aria-labelledby="label-{{ q.id }}" {% if errors %}aria-invalid="true" aria-describedby="err-{{ q.id }}"{% endif %}>
+    {% for c in q.choices %}
+      <label class="flex items-start gap-3 p-3 min-h-[44px] rounded-lg border cursor-pointer transition-colors
+                    {% if value == c.value %}border-crush-purple bg-purple-50 dark:bg-purple-900/20{% else %}border-gray-200 dark:border-gray-700 hover:border-crush-purple/50 hover:bg-gray-50 dark:hover:bg-slate-800{% endif %}">
+        <input type="radio"
+               name="{{ q.id }}"
+               value="{{ c.value }}"
+               class="mt-0.5 text-crush-purple focus:ring-crush-purple"
+               {% if value == c.value %}checked{% endif %}
+               {% if q.required %}required{% endif %}>
+        <span class="text-sm text-gray-900 dark:text-gray-100">{{ c.label }}</span>
+      </label>
+    {% endfor %}
+  </div>
+  {% if errors %}
+    <p id="err-{{ q.id }}" class="text-xs text-red-600 dark:text-red-400 mt-1" role="alert" aria-live="polite">
+      {% trans "Please choose one option." %}
+    </p>
+  {% endif %}
+</fieldset>

--- a/crush_lu/templates/crush_lu/pre_screening/_q_text.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_q_text.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+<div class="space-y-2">
+  <label for="q-{{ q.id }}" class="block text-sm font-semibold text-gray-900 dark:text-white">
+    {{ q.label }}{% if q.required %} <span class="text-red-500" aria-hidden="true">*</span>{% endif %}
+  </label>
+  <textarea id="q-{{ q.id }}"
+            name="{{ q.id }}"
+            rows="3"
+            maxlength="{{ q.max_length|default:500 }}"
+            {% if q.required %}required{% endif %}
+            {% if errors %}aria-invalid="true" aria-describedby="err-{{ q.id }}"{% endif %}
+            placeholder="{{ q.placeholder|default:'' }}"
+            class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-700 text-sm text-gray-900 dark:text-white p-3 resize-none focus:ring-2 focus:ring-crush-purple focus:border-crush-purple">{{ value|default:'' }}</textarea>
+  <p class="text-xs text-gray-500 dark:text-gray-400">
+    {% if q.max_length %}{% blocktrans with n=q.max_length %}Up to {{ n }} characters.{% endblocktrans %}{% endif %}
+  </p>
+  {% if errors %}
+    <p id="err-{{ q.id }}" class="text-xs text-red-600 dark:text-red-400" role="alert" aria-live="polite">
+      {% trans "Please check this answer." %}
+    </p>
+  {% endif %}
+</div>

--- a/crush_lu/templates/crush_lu/pre_screening/_q_yes_no.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_q_yes_no.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<fieldset class="space-y-2">
+  <legend class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
+    {{ q.label }}{% if q.required %} <span class="text-red-500" aria-hidden="true">*</span>{% endif %}
+  </legend>
+  <div class="grid grid-cols-2 gap-2" role="radiogroup" {% if errors %}aria-describedby="err-{{ q.id }}"{% endif %}>
+    <label class="flex items-center justify-center gap-2 p-3 min-h-[44px] rounded-lg border cursor-pointer transition-colors
+                  {% if value == True or value == 'yes' %}border-crush-purple bg-purple-50 dark:bg-purple-900/20{% else %}border-gray-200 dark:border-gray-700 hover:border-crush-purple/50{% endif %}">
+      <input type="radio" name="{{ q.id }}" value="yes" class="sr-only"
+             {% if value == True or value == 'yes' %}checked{% endif %}
+             {% if q.required %}required{% endif %}>
+      <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">{% trans "Yes" %}</span>
+    </label>
+    <label class="flex items-center justify-center gap-2 p-3 min-h-[44px] rounded-lg border cursor-pointer transition-colors
+                  {% if value == False or value == 'no' %}border-crush-purple bg-purple-50 dark:bg-purple-900/20{% else %}border-gray-200 dark:border-gray-700 hover:border-crush-purple/50{% endif %}">
+      <input type="radio" name="{{ q.id }}" value="no" class="sr-only"
+             {% if value == False or value == 'no' %}checked{% endif %}>
+      <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">{% trans "No" %}</span>
+    </label>
+  </div>
+  {% if errors %}
+    <p id="err-{{ q.id }}" class="text-xs text-red-600 dark:text-red-400 mt-1" role="alert" aria-live="polite">
+      {% trans "Please choose yes or no." %}
+    </p>
+  {% endif %}
+</fieldset>

--- a/crush_lu/templates/crush_lu/pre_screening/_section.html
+++ b/crush_lu/templates/crush_lu/pre_screening/_section.html
@@ -1,0 +1,51 @@
+{% load i18n pre_screening_tags %}
+<section id="prescreening-section-{{ section.id }}"
+         class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 shadow-sm overflow-hidden">
+  <header class="px-5 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+    <div class="flex items-center gap-2">
+      <span class="inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold
+                   {% if section_complete %}bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300
+                   {% else %}bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300{% endif %}">
+        {% if section_complete %}✓{% else %}{{ section_number }}{% endif %}
+      </span>
+      <h3 class="text-base font-bold text-gray-900 dark:text-white mb-0">{{ section.title }}</h3>
+    </div>
+    {% if section_complete %}
+      <span class="text-xs font-semibold text-green-700 dark:text-green-300">{% trans "Saved" %}</span>
+    {% endif %}
+  </header>
+
+  <form method="post"
+        hx-post="{% url 'crush_lu:pre_screening_save_section' section.id %}"
+        hx-target="#prescreening-section-{{ section.id }}"
+        hx-swap="outerHTML"
+        hx-indicator="#indicator-{{ section.id }}"
+        class="px-5 py-4 space-y-5">
+    {% csrf_token %}
+    {% for question in section.questions %}
+      {% render_prescreening_question question responses errors %}
+    {% endfor %}
+
+    <div class="flex items-center justify-between gap-3 pt-2">
+      <span id="indicator-{{ section.id }}" class="htmx-indicator text-xs text-gray-500 dark:text-gray-400">
+        {% trans "Saving…" %}
+      </span>
+      <button type="submit"
+              class="inline-flex items-center justify-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold bg-crush-purple text-white hover:bg-purple-700 transition-colors">
+        {% trans "Save this section" %}
+      </button>
+    </div>
+
+    {% if section_flash %}
+      <div class="text-xs text-green-700 dark:text-green-300 mt-2" role="status" aria-live="polite">
+        {{ section_flash }}
+      </div>
+    {% endif %}
+  </form>
+</section>
+
+{# HTMX out-of-band swaps: refresh progress + finalize state after a section save. #}
+{% if oob_updates %}
+  {% include "crush_lu/pre_screening/_progress.html" with oob=True %}
+  {% include "crush_lu/pre_screening/_finalize.html" with oob=True %}
+{% endif %}

--- a/crush_lu/templates/crush_lu/privacy_policy.html
+++ b/crush_lu/templates/crush_lu/privacy_policy.html
@@ -110,6 +110,7 @@
                     <li>{% trans "Screening call records: whether a call occurred, date, notes, and a structured checklist" %}</li>
                     <li>{% trans "Call attempt logs: date, result (success, no answer, voicemail, wrong number, user busy, scheduled callback), and notes" %}</li>
                     <li>{% trans "Coach session records: session type (onboarding, feedback, guidance, follow-up), notes, and scheduling information" %}</li>
+                    <li>{% trans "Pre-screening questionnaire responses: your self-reported answers to a short optional questionnaire that prepares your Coach for the review call (logistics, expectations, own-words text answers, and explicit consents). A rule-based Readiness Score and attention flags are computed from these answers to help your Coach prioritise — they are advisory only and never used to auto-decide on your profile." %}</li>
                 </ul>
 
                 <h5>{% trans "3.5 Event Data" %}</h5>

--- a/crush_lu/templates/crush_lu/profile_submitted.html
+++ b/crush_lu/templates/crush_lu/profile_submitted.html
@@ -245,6 +245,46 @@
                     {# ── Section 5: Proactive Actions ── #}
                     <div class="space-y-3 mb-6 text-left">
 
+                        {# 5-pre: Pre-screening questionnaire CTA #}
+                        {% if pre_screening_visible %}
+                          {% if pre_screening_submitted %}
+                            <a href="{% url 'crush_lu:pre_screening' %}"
+                               class="block rounded-xl border border-green-200 dark:border-green-800/50 bg-green-50 dark:bg-green-900/20 shadow-sm px-5 py-3.5 hover:bg-green-100/70 dark:hover:bg-green-900/30 transition-colors">
+                              <div class="flex items-center gap-3">
+                                <div class="w-9 h-9 rounded-full bg-green-100 dark:bg-green-900/40 flex items-center justify-center flex-shrink-0">
+                                  {% include "shared/icons/check-circle.html" with class="w-5 h-5 text-green-700 dark:text-green-300" %}
+                                </div>
+                                <div class="flex-1">
+                                  <p class="text-sm font-semibold text-green-800 dark:text-green-200 mb-0">
+                                    {% trans "Pre-screening submitted ✓" %}
+                                  </p>
+                                  <p class="text-xs text-green-700/80 dark:text-green-300/80 mb-0">
+                                    {% trans "Your Coach has your answers. Tap to view or edit until the call." %}
+                                  </p>
+                                </div>
+                              </div>
+                            </a>
+                          {% else %}
+                            <a href="{% url 'crush_lu:pre_screening' %}"
+                               class="block rounded-xl border-2 border-crush-purple/30 dark:border-purple-500/40 bg-gradient-to-br from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20 shadow-sm px-5 py-4 hover:shadow-md transition-shadow">
+                              <div class="flex items-center gap-3">
+                                <div class="w-10 h-10 rounded-full bg-gradient-to-br from-crush-purple to-crush-pink flex items-center justify-center flex-shrink-0">
+                                  {% include "shared/icons/chat-bubble-left.html" with class="w-5 h-5 text-white" %}
+                                </div>
+                                <div class="flex-1">
+                                  <p class="text-sm font-bold text-gray-900 dark:text-white mb-0.5">
+                                    {% trans "Help your Coach prepare" %}
+                                  </p>
+                                  <p class="text-xs text-gray-600 dark:text-gray-300 mb-0">
+                                    {% trans "Answer a few quick questions (3 min) so the call is about you, not paperwork." %}
+                                  </p>
+                                </div>
+                                {% include "shared/icons/arrow-right.html" with class="w-4 h-4 text-crush-purple dark:text-purple-300 flex-shrink-0" %}
+                              </div>
+                            </a>
+                          {% endif %}
+                        {% endif %}
+
                         {# 5a: Add a note for your coach #}
                         <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 shadow-sm overflow-hidden">
                             {# Header row — toggles form or shows sent confirmation #}

--- a/crush_lu/templatetags/pre_screening_tags.py
+++ b/crush_lu/templatetags/pre_screening_tags.py
@@ -100,3 +100,14 @@ def prescreening_score_label(score: int | None):
 @register.simple_tag
 def prescreening_schema():
     return PRE_SCREENING_SCHEMA
+
+
+@register.filter
+def get_item(mapping, key):
+    """Index a dict by key inside a template. Returns '' if missing."""
+    if not mapping:
+        return ""
+    try:
+        return mapping.get(key, "")
+    except AttributeError:
+        return ""

--- a/crush_lu/templatetags/pre_screening_tags.py
+++ b/crush_lu/templatetags/pre_screening_tags.py
@@ -1,0 +1,102 @@
+"""Template tags for rendering pre-screening questionnaire inputs."""
+from __future__ import annotations
+
+from typing import Any
+
+from django import template
+from django.template.loader import render_to_string
+
+from crush_lu.pre_screening_schema import (
+    FLAG_DESCRIPTIONS,
+    PRE_SCREENING_SCHEMA,
+    get_question,
+    get_section,
+    readiness_score_label,
+)
+
+register = template.Library()
+
+
+_INPUT_TEMPLATES: dict[str, str] = {
+    "single_select": "crush_lu/pre_screening/_q_single_select.html",
+    "multi_select": "crush_lu/pre_screening/_q_multi_select.html",
+    "text": "crush_lu/pre_screening/_q_text.html",
+    "checkbox": "crush_lu/pre_screening/_q_checkbox.html",
+    "yes_no": "crush_lu/pre_screening/_q_yes_no.html",
+}
+
+
+@register.simple_tag(takes_context=True)
+def render_prescreening_question(context, question: dict, responses: dict,
+                                 errors: dict | None = None):
+    """Render a single pre-screening question with its current response.
+
+    Args:
+        question: one of the question dicts from PRE_SCREENING_SCHEMA.
+        responses: user's current responses (flat dict of question_id -> value).
+        errors: optional dict of question_id -> list of error codes.
+
+    Usage:
+        {% render_prescreening_question question responses errors %}
+    """
+    template_path = _INPUT_TEMPLATES.get(question["type"])
+    if template_path is None:
+        return ""
+
+    value = responses.get(question["id"])
+    qid = question["id"]
+    ctx = {
+        "q": question,
+        "value": value,
+        "errors": (errors or {}).get(qid, []),
+        "request": context.get("request"),
+        "csp_nonce": context.get("csp_nonce", ""),
+    }
+    # Normalize multi_select defaults so templates can iterate safely.
+    if question["type"] == "multi_select" and not isinstance(value, list):
+        ctx["value"] = []
+    return render_to_string(template_path, ctx)
+
+
+@register.filter
+def prescreening_choice_label(question: dict, value: Any):
+    """Resolve a stored choice value back to its human label."""
+    if question is None or value in (None, ""):
+        return ""
+    if question["type"] == "multi_select" and isinstance(value, list):
+        labels = []
+        by_value = {c["value"]: c["label"] for c in question.get("choices", [])}
+        for v in value:
+            labels.append(str(by_value.get(v, v)))
+        return ", ".join(labels)
+    for choice in question.get("choices", []):
+        if choice["value"] == value:
+            return choice["label"]
+    return value
+
+
+@register.filter
+def prescreening_question(question_id: str):
+    """Look up a question dict by id for use in display templates."""
+    return get_question(question_id)
+
+
+@register.filter
+def prescreening_section(section_id: str):
+    return get_section(section_id)
+
+
+@register.filter
+def prescreening_flag_description(flag: str):
+    return FLAG_DESCRIPTIONS.get(flag, flag)
+
+
+@register.filter
+def prescreening_score_label(score: int | None):
+    """Return 'high' / 'medium' / 'low' / 'pending' for a numeric score."""
+    return readiness_score_label(score)
+
+
+@register.simple_tag
+def prescreening_schema():
+    return PRE_SCREENING_SCHEMA

--- a/crush_lu/tests/test_pre_screening_analytics.py
+++ b/crush_lu/tests/test_pre_screening_analytics.py
@@ -1,0 +1,158 @@
+"""Tests for Phase 6 — pre-screening analytics dashboard + CSV export."""
+from __future__ import annotations
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from crush_lu.models import CrushCoach, CrushProfile, ProfileSubmission
+from crush_lu.models.profiles import UserDataConsent
+
+User = get_user_model()
+
+
+def _make_profile(username: str, phone_suffix: str) -> CrushProfile:
+    user = User.objects.create_user(
+        username=username, email=username, password="pw", first_name="Test"
+    )
+    UserDataConsent.objects.filter(user=user).update(crushlu_consent_given=True)
+    return CrushProfile.objects.create(
+        user=user,
+        date_of_birth=date(1995, 1, 1),
+        gender="F",
+        location="Luxembourg City",
+        bio="bio",
+        phone_number=f"+35266{phone_suffix}",
+        event_languages=["en"],
+        is_approved=False,
+    )
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class DashboardAnalyticsTests(TestCase):
+    def setUp(self):
+        self.coach_user = User.objects.create_superuser(
+            username="super@example.com",
+            email="super@example.com",
+            password="pw",
+            first_name="Super",
+        )
+        UserDataConsent.objects.filter(user=self.coach_user).update(
+            crushlu_consent_given=True
+        )
+        self.coach = CrushCoach.objects.create(
+            user=self.coach_user, bio="b", is_active=True, max_active_reviews=10
+        )
+
+        # 3 submitted + 1 pending, varied scores/flags
+        self.p1 = _make_profile("a@example.com", "1234501")
+        self.s1 = ProfileSubmission.objects.create(
+            profile=self.p1, coach=self.coach, status="pending",
+            pre_screening_submitted_at=timezone.now(),
+            pre_screening_version=1,
+            pre_screening_readiness_score=9,
+            pre_screening_flags=[],
+            pre_screening_responses={
+                "residence": "lu_city", "languages": ["en"], "age_confirm": True,
+                "source": "friend", "what_is_crush": "events",
+                "event_frequency": "monthly", "relationship_goal": "meaningful",
+                "coach_attitude": "loves", "looking_forward_to": ["events"],
+                "hoping_to_meet": "Someone who loves walks and asks good questions.",
+                "consent_events": True, "consent_coach": True,
+                "consent_no_show": True, "consent_terms": True,
+            },
+        )
+        self.p2 = _make_profile("b@example.com", "1234502")
+        self.s2 = ProfileSubmission.objects.create(
+            profile=self.p2, coach=self.coach, status="pending",
+            pre_screening_submitted_at=timezone.now(),
+            pre_screening_version=1,
+            pre_screening_readiness_score=3,
+            pre_screening_flags=["concept_misalignment", "low_effort_text"],
+            pre_screening_responses={
+                "residence": "fr_border", "languages": ["fr"], "age_confirm": True,
+                "source": "social", "what_is_crush": "tinder",
+                "event_frequency": "few_per_year", "relationship_goal": "many_people",
+                "coach_attitude": "curious", "looking_forward_to": ["exploring"],
+                "hoping_to_meet": "idk",
+                "consent_events": True, "consent_coach": True,
+                "consent_no_show": True, "consent_terms": True,
+            },
+        )
+        self.p3 = _make_profile("c@example.com", "1234503")
+        self.s3 = ProfileSubmission.objects.create(
+            profile=self.p3, coach=self.coach, status="pending",
+            pre_screening_submitted_at=timezone.now(),
+            pre_screening_version=1,
+            pre_screening_readiness_score=6,
+            pre_screening_flags=["concept_misalignment"],
+            pre_screening_responses={"what_is_crush": "tinder"},
+        )
+        self.p4 = _make_profile("d@example.com", "1234504")
+        self.s4 = ProfileSubmission.objects.create(
+            profile=self.p4, coach=self.coach, status="pending"
+        )
+
+        self.client.login(username="super@example.com", password="pw")
+
+    def test_dashboard_renders_prescreening_section(self):
+        resp = self.client.get(reverse("crush_admin_dashboard"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Pre-Screening Analytics")
+        self.assertContains(resp, "Completion rate")
+        self.assertContains(resp, "75.0%")  # 3 of 4 pending submitted
+        self.assertContains(resp, "concept_misalignment")
+
+    def test_csv_export_returns_rows(self):
+        resp = self.client.get(reverse("crush_admin_pre_screening_csv"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/csv", resp["Content-Type"])
+        body = resp.content.decode()
+        # Header row
+        self.assertIn("section,question,answer,count", body)
+        # what_is_crush=tinder appears twice (s2 + s3)
+        self.assertIn("concept,what_is_crush,tinder,2", body)
+        # Free-text stats trailer
+        self.assertIn("free-text answer stats", body)
+
+    def test_csv_export_requires_staff(self):
+        self.client.logout()
+        regular = _make_profile("regular@example.com", "1234599")
+        self.client.login(username="regular@example.com", password="pw")
+        resp = self.client.get(reverse("crush_admin_pre_screening_csv"))
+        self.assertEqual(resp.status_code, 403)
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=False,
+)
+class DashboardFeatureFlagOffTests(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            username="admin2@example.com",
+            email="admin2@example.com",
+            password="pw",
+        )
+        UserDataConsent.objects.filter(user=self.admin).update(
+            crushlu_consent_given=True
+        )
+        CrushCoach.objects.create(
+            user=self.admin, bio="b", is_active=True, max_active_reviews=10
+        )
+        self.client.login(username="admin2@example.com", password="pw")
+
+    def test_dashboard_hides_prescreening_when_flag_off(self):
+        resp = self.client.get(reverse("crush_admin_dashboard"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Pre-Screening Analytics")
+
+    def test_csv_export_blocked_when_flag_off(self):
+        resp = self.client.get(reverse("crush_admin_pre_screening_csv"))
+        self.assertEqual(resp.status_code, 403)

--- a/crush_lu/tests/test_pre_screening_calibration.py
+++ b/crush_lu/tests/test_pre_screening_calibration.py
@@ -1,0 +1,207 @@
+"""Tests for Phase 4 — calibration (3-section) screening call checklist."""
+from __future__ import annotations
+
+import json
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from crush_lu.models import CrushCoach, CrushProfile, ProfileSubmission
+from crush_lu.models.profiles import UserDataConsent
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class CalibrationModeTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.coach_user = User.objects.create_user(
+            username="coach_calib@example.com",
+            email="coach_calib@example.com",
+            password="pw",
+            first_name="Coach",
+        )
+        UserDataConsent.objects.filter(user=self.coach_user).update(
+            crushlu_consent_given=True
+        )
+        self.coach = CrushCoach.objects.create(
+            user=self.coach_user, bio="b", is_active=True, max_active_reviews=10
+        )
+        self.user = User.objects.create_user(
+            username="ucalib@example.com",
+            email="ucalib@example.com",
+            password="pw",
+            first_name="User",
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="bio",
+            phone_number="+352661234568",
+            phone_verified=True,
+            event_languages=["en"],
+            is_approved=False,
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, coach=self.coach, status="pending"
+        )
+
+    # --------- Auto-set on finalize ---------
+
+    def test_finalize_sets_calibration_mode(self):
+        self.client.login(username="ucalib@example.com", password="pw")
+        self.submission.pre_screening_responses = {
+            "residence": "lu_city",
+            "languages": ["en"],
+            "age_confirm": True,
+            "source": "friend",
+            "what_is_crush": "events",
+            "event_frequency": "monthly",
+            "relationship_goal": "meaningful",
+            "coach_attitude": "loves",
+            "looking_forward_to": ["events"],
+            "hoping_to_meet": "Someone curious who asks great questions.",
+            "consent_events": True,
+            "consent_coach": True,
+            "consent_no_show": True,
+            "consent_terms": True,
+        }
+        self.submission.save()
+        self.assertEqual(self.submission.screening_call_mode, "legacy")
+        self.client.post(reverse("crush_lu:pre_screening_finalize"))
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.screening_call_mode, "calibration")
+
+    # --------- Tab branching ---------
+
+    def test_review_page_renders_calibration_tab_when_mode_set(self):
+        self.submission.screening_call_mode = "calibration"
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.pre_screening_responses = {"what_is_crush": "tinder"}
+        self.submission.save()
+        self.client.login(username="coach_calib@example.com", password="pw")
+        resp = self.client.get(
+            reverse("crush_lu:coach_review_profile", args=[self.submission.id])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Short Calibration Call")
+        self.assertContains(resp, "screeningCallCalibration")
+        self.assertContains(resp, 'data-concept-answer="tinder"')
+        # Legacy 5-section component must not also be rendered on the tab.
+        self.assertNotContains(resp, "screeningCallGuideline")
+
+    def test_review_page_renders_legacy_tab_when_mode_legacy(self):
+        self.submission.screening_call_mode = "legacy"
+        self.submission.save()
+        self.client.login(username="coach_calib@example.com", password="pw")
+        resp = self.client.get(
+            reverse("crush_lu:coach_review_profile", args=[self.submission.id])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "screeningCallGuideline")
+        self.assertNotContains(resp, "screeningCallCalibration")
+
+    # --------- Mode toggle ---------
+
+    def test_coach_can_switch_to_calibration_when_prescreening_submitted(self):
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.screening_call_mode = "legacy"
+        self.submission.save()
+        self.client.login(username="coach_calib@example.com", password="pw")
+        resp = self.client.post(
+            reverse(
+                "crush_lu:coach_set_screening_mode", args=[self.submission.id]
+            ),
+            {"mode": "calibration"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.screening_call_mode, "calibration")
+
+    def test_coach_can_revert_to_legacy(self):
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.screening_call_mode = "calibration"
+        self.submission.save()
+        self.client.login(username="coach_calib@example.com", password="pw")
+        resp = self.client.post(
+            reverse(
+                "crush_lu:coach_set_screening_mode", args=[self.submission.id]
+            ),
+            {"mode": "legacy"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.screening_call_mode, "legacy")
+
+    def test_cannot_set_calibration_without_prescreening(self):
+        self.client.login(username="coach_calib@example.com", password="pw")
+        resp = self.client.post(
+            reverse(
+                "crush_lu:coach_set_screening_mode", args=[self.submission.id]
+            ),
+            {"mode": "calibration"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.screening_call_mode, "legacy")
+
+    def test_cannot_change_mode_after_call_completed(self):
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.review_call_completed = True
+        self.submission.save()
+        self.client.login(username="coach_calib@example.com", password="pw")
+        resp = self.client.post(
+            reverse(
+                "crush_lu:coach_set_screening_mode", args=[self.submission.id]
+            ),
+            {"mode": "calibration"},
+        )
+        self.assertEqual(resp.status_code, 410)
+
+    # --------- Completion flow accepts calibration shape ---------
+
+    def test_complete_call_accepts_calibration_checklist_shape(self):
+        self.submission.screening_call_mode = "calibration"
+        self.submission.save()
+        self.client.login(username="coach_calib@example.com", password="pw")
+        calibration_data = {
+            "mode": "calibration",
+            "warm_intro_complete": True,
+            "concept_calibration_complete": True,
+            "concept_notes": "They were open to events.",
+            "discretion_notes": "Friendly and responsive.",
+            "concept_answer": "tinder",
+        }
+        resp = self.client.post(
+            reverse(
+                "crush_lu:coach_mark_review_call_complete",
+                args=[self.submission.id],
+            ),
+            {
+                "call_notes": "Good call, calibration done.",
+                "checklist_data": json.dumps(calibration_data),
+            },
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.submission.refresh_from_db()
+        self.assertTrue(self.submission.review_call_completed)
+        self.assertEqual(
+            self.submission.review_call_checklist["mode"], "calibration"
+        )
+        self.assertTrue(
+            self.submission.review_call_checklist["warm_intro_complete"]
+        )

--- a/crush_lu/tests/test_pre_screening_coach.py
+++ b/crush_lu/tests/test_pre_screening_coach.py
@@ -1,0 +1,283 @@
+"""Integration tests for the Coach-facing pre-screening display (Phase 3)."""
+from __future__ import annotations
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from crush_lu.models import CallAttempt, CrushCoach, CrushProfile, ProfileSubmission
+from crush_lu.models.profiles import UserDataConsent
+
+User = get_user_model()
+
+
+def _complete_responses() -> dict:
+    return {
+        "residence": "lu_city",
+        "languages": ["en", "fr"],
+        "age_confirm": True,
+        "source": "friend",
+        "what_is_crush": "events",
+        "event_frequency": "monthly",
+        "relationship_goal": "meaningful",
+        "coach_attitude": "loves",
+        "looking_forward_to": ["events", "discovery"],
+        "hoping_to_meet": "Someone thoughtful, curious, and kind.",
+        "note_to_coach": "",
+        "consent_events": True,
+        "consent_coach": True,
+        "consent_no_show": True,
+        "consent_terms": True,
+    }
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class CoachPreScreeningDisplayTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.coach_user = User.objects.create_user(
+            username="coach3@example.com",
+            email="coach3@example.com",
+            password="pw",
+            first_name="Coach",
+        )
+        UserDataConsent.objects.filter(user=self.coach_user).update(
+            crushlu_consent_given=True
+        )
+        self.coach = CrushCoach.objects.create(
+            user=self.coach_user, bio="b", is_active=True, max_active_reviews=10
+        )
+        self.user = User.objects.create_user(
+            username="u3@example.com",
+            email="u3@example.com",
+            password="pw",
+            first_name="Tester",
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="bio",
+            phone_number="+352661234567",
+            phone_verified=True,
+            event_languages=["en"],
+            is_approved=False,
+            preferred_language="en",
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, coach=self.coach, status="pending"
+        )
+        self.client.login(username="coach3@example.com", password="pw")
+
+    # -------- Display when submitted --------
+
+    def test_review_page_shows_pre_screening_when_submitted(self):
+        self.submission.pre_screening_responses = _complete_responses()
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.pre_screening_version = 1
+        self.submission.pre_screening_readiness_score = 9
+        self.submission.pre_screening_flags = []
+        self.submission.save()
+        resp = self.client.get(
+            reverse("crush_lu:coach_review_profile", args=[self.submission.id])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Pre-Screening Answers")
+        self.assertContains(resp, "Readiness")
+        self.assertContains(resp, "9/10")
+        # Choice labels should be resolved, not raw values
+        self.assertContains(resp, "A way to meet people in real life through events")
+        # Free-text answer renders
+        self.assertContains(resp, "Someone thoughtful, curious, and kind.")
+
+    def test_review_page_shows_not_submitted_state(self):
+        resp = self.client.get(
+            reverse("crush_lu:coach_review_profile", args=[self.submission.id])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Pre-screening not yet submitted")
+        self.assertContains(resp, "Send SMS reminder")
+
+    def test_flag_chips_render_with_tooltip(self):
+        self.submission.pre_screening_responses = _complete_responses()
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.pre_screening_flags = ["concept_misalignment", "low_effort_text"]
+        self.submission.pre_screening_readiness_score = 4
+        self.submission.save()
+        resp = self.client.get(
+            reverse("crush_lu:coach_review_profile", args=[self.submission.id])
+        )
+        self.assertContains(resp, "concept_misalignment")
+        self.assertContains(resp, "low_effort_text")
+        # Tooltip text from FLAG_DESCRIPTIONS
+        self.assertContains(resp, "User thinks Crush.lu is a swipe app")
+
+    # -------- SMS reminder endpoint --------
+
+    def test_send_sms_reminder_creates_call_attempt(self):
+        url = reverse(
+            "crush_lu:coach_send_pre_screening_reminder",
+            args=[self.submission.id],
+        )
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+        attempts = CallAttempt.objects.filter(submission=self.submission)
+        self.assertEqual(attempts.count(), 1)
+        self.assertEqual(attempts.first().result, "sms_sent")
+        body = resp.content.decode()
+        self.assertIn("sms:+352661234567", body)
+        self.assertIn("Crush.lu", body)
+
+    def test_send_sms_reminder_rejects_unverified_phone(self):
+        # CrushProfile.save() preserves phone_verified once True; bypass via QuerySet.update().
+        CrushProfile.objects.filter(pk=self.profile.pk).update(phone_verified=False)
+        url = reverse(
+            "crush_lu:coach_send_pre_screening_reminder",
+            args=[self.submission.id],
+        )
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            CallAttempt.objects.filter(submission=self.submission).count(), 0
+        )
+
+    def test_send_sms_reminder_uses_user_preferred_language(self):
+        self.profile.preferred_language = "fr"
+        self.profile.save()
+        url = reverse(
+            "crush_lu:coach_send_pre_screening_reminder",
+            args=[self.submission.id],
+        )
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        # French template phrase: "Bonjour"
+        self.assertIn("Bonjour", body)
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=False,
+)
+class CoachDisplayFeatureFlagOffTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.coach_user = User.objects.create_user(
+            username="coach4@example.com", email="coach4@example.com", password="pw"
+        )
+        UserDataConsent.objects.filter(user=self.coach_user).update(
+            crushlu_consent_given=True
+        )
+        self.coach = CrushCoach.objects.create(
+            user=self.coach_user, bio="b", is_active=True, max_active_reviews=10
+        )
+        self.user = User.objects.create_user(
+            username="u4@example.com", email="u4@example.com", password="pw"
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="bio",
+            phone_number="+352661234567",
+            phone_verified=True,
+            event_languages=["en"],
+            is_approved=False,
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, coach=self.coach, status="pending"
+        )
+        self.client.login(username="coach4@example.com", password="pw")
+
+    def test_display_hidden_when_flag_off(self):
+        resp = self.client.get(
+            reverse("crush_lu:coach_review_profile", args=[self.submission.id])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Pre-Screening Answers")
+        self.assertNotContains(resp, "Pre-screening not yet submitted")
+
+    def test_sms_reminder_blocked_when_flag_off(self):
+        url = reverse(
+            "crush_lu:coach_send_pre_screening_reminder",
+            args=[self.submission.id],
+        )
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 410)
+        self.assertEqual(
+            CallAttempt.objects.filter(submission=self.submission).count(), 0
+        )
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class CoachQueueBadgeTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.coach_user = User.objects.create_user(
+            username="coach5@example.com", email="coach5@example.com", password="pw"
+        )
+        UserDataConsent.objects.filter(user=self.coach_user).update(
+            crushlu_consent_given=True
+        )
+        self.coach = CrushCoach.objects.create(
+            user=self.coach_user, bio="b", is_active=True, max_active_reviews=10
+        )
+
+    _phone_counter = 0
+
+    def _make_submission(self, username: str, *, submitted: bool, score: int = 0):
+        CoachQueueBadgeTests._phone_counter += 1
+        phone = f"+35266{CoachQueueBadgeTests._phone_counter:07d}"
+        user = User.objects.create_user(
+            username=username, email=username, password="pw", first_name=username
+        )
+        UserDataConsent.objects.filter(user=user).update(crushlu_consent_given=True)
+        profile = CrushProfile.objects.create(
+            user=user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="bio",
+            phone_number=phone,
+            event_languages=["en"],
+            is_approved=False,
+        )
+        sub = ProfileSubmission.objects.create(
+            profile=profile, coach=self.coach, status="pending"
+        )
+        if submitted:
+            sub.pre_screening_submitted_at = timezone.now()
+            sub.pre_screening_readiness_score = score
+            sub.pre_screening_version = 1
+            sub.save()
+        return sub
+
+    def test_queue_shows_badge_states(self):
+        self._make_submission("alice@example.com", submitted=True, score=9)
+        self._make_submission("bob@example.com", submitted=False)
+        self.client.login(username="coach5@example.com", password="pw")
+        resp = self.client.get(reverse("crush_lu:coach_profiles"))
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        # Submitted user: numeric score badge
+        self.assertIn("9/10", body)
+        # Pending user: dash placeholder
+        self.assertIn("📋 —", body)

--- a/crush_lu/tests/test_pre_screening_notifications.py
+++ b/crush_lu/tests/test_pre_screening_notifications.py
@@ -1,0 +1,255 @@
+"""Tests for Phase 5 — email + push invite/reminder/push flows."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from io import StringIO
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.core.cache import cache
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from crush_lu.models import CrushCoach, CrushProfile, ProfileSubmission
+from crush_lu.models.profiles import UserDataConsent
+from crush_lu.pre_screening_notifications import (
+    candidates_for_invite,
+    candidates_for_reminder,
+    send_pre_screening_invite_email,
+    send_pre_screening_user_push,
+)
+
+User = get_user_model()
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+)
+class PreScreeningInviteEmailTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        mail.outbox = []
+        self.user = User.objects.create_user(
+            username="p5@example.com",
+            email="p5@example.com",
+            password="pw",
+            first_name="Alex",
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="b",
+            phone_number="+352661234569",
+            event_languages=["en"],
+            is_approved=False,
+            preferred_language="en",
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, status="pending"
+        )
+
+    def test_invite_email_sent_once(self):
+        self.assertTrue(send_pre_screening_invite_email(self.submission))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("3 minutes", mail.outbox[0].subject)
+        # Idempotent — second call is a no-op thanks to cache dedup.
+        self.assertFalse(send_pre_screening_invite_email(self.submission))
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_invite_skipped_when_pre_screening_already_submitted(self):
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.save()
+        self.assertFalse(send_pre_screening_invite_email(self.submission))
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_invite_skipped_when_submission_no_longer_pending(self):
+        self.submission.status = "approved"
+        self.submission.save()
+        self.assertFalse(send_pre_screening_invite_email(self.submission))
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_reminder_email_is_separate_from_invite(self):
+        self.assertTrue(send_pre_screening_invite_email(self.submission, reminder=False))
+        self.assertTrue(send_pre_screening_invite_email(self.submission, reminder=True))
+        self.assertEqual(len(mail.outbox), 2)
+        subjects = {m.subject for m in mail.outbox}
+        self.assertEqual(len(subjects), 2)  # two distinct subjects
+
+    def test_third_reminder_never_fires(self):
+        send_pre_screening_invite_email(self.submission, reminder=True)
+        self.assertEqual(len(mail.outbox), 1)
+        # Second reminder is idempotent-no-op
+        self.assertFalse(send_pre_screening_invite_email(self.submission, reminder=True))
+        self.assertEqual(len(mail.outbox), 1)
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class PreScreeningCandidateQueryTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(
+            username="p5b@example.com",
+            email="p5b@example.com",
+            password="pw",
+            first_name="Alex",
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="b",
+            phone_number="+352661234570",
+            event_languages=["en"],
+            is_approved=False,
+        )
+
+    def _make_submission(self, *, hours_ago: float, submitted: bool = False,
+                        status: str = "pending") -> ProfileSubmission:
+        sub = ProfileSubmission.objects.create(
+            profile=self.profile, status=status
+        )
+        ProfileSubmission.objects.filter(pk=sub.pk).update(
+            submitted_at=timezone.now() - timedelta(hours=hours_ago)
+        )
+        sub.refresh_from_db()
+        if submitted:
+            sub.pre_screening_submitted_at = timezone.now()
+            sub.save(update_fields=["pre_screening_submitted_at"])
+        return sub
+
+    def test_invite_candidate_requires_one_hour_age(self):
+        fresh = self._make_submission(hours_ago=0.5)
+        aged = self._make_submission(hours_ago=2)
+        ids = [s.id for s in candidates_for_invite()]
+        self.assertIn(aged.id, ids)
+        self.assertNotIn(fresh.id, ids)
+
+    def test_reminder_candidate_requires_twenty_four_hours(self):
+        # Override existing submissions so only the ones we want remain eligible.
+        day_old = self._make_submission(hours_ago=25)
+        half_day = self._make_submission(hours_ago=12)
+        ids = [s.id for s in candidates_for_reminder()]
+        self.assertIn(day_old.id, ids)
+        self.assertNotIn(half_day.id, ids)
+
+    def test_candidate_queries_exclude_already_submitted(self):
+        done = self._make_submission(hours_ago=2, submitted=True)
+        pending = self._make_submission(hours_ago=2)
+        invite_ids = [s.id for s in candidates_for_invite()]
+        self.assertIn(pending.id, invite_ids)
+        self.assertNotIn(done.id, invite_ids)
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+)
+class PreScreeningCommandTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        mail.outbox = []
+        self.user = User.objects.create_user(
+            username="cmd@example.com", email="cmd@example.com", password="pw",
+            first_name="Sam",
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="b",
+            phone_number="+352661234571",
+            event_languages=["en"],
+            is_approved=False,
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, status="pending"
+        )
+        ProfileSubmission.objects.filter(pk=self.submission.pk).update(
+            submitted_at=timezone.now() - timedelta(hours=2)
+        )
+
+    def test_command_sends_invite(self):
+        out = StringIO()
+        call_command("send_pre_screening_invites", "--only=invite", stdout=out)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("sent=", out.getvalue())
+
+    def test_command_dry_run_sends_nothing(self):
+        call_command("send_pre_screening_invites", "--dry-run")
+        self.assertEqual(len(mail.outbox), 0)
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=False,
+)
+class PreScreeningCommandFlagOffTests(TestCase):
+    def test_command_bails_when_flag_off(self):
+        out = StringIO()
+        call_command("send_pre_screening_invites", stdout=out)
+        self.assertIn("PRE_SCREENING_ENABLED is off", out.getvalue())
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class PreScreeningPushTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(
+            username="push@example.com", email="push@example.com", password="pw"
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg City",
+            bio="b",
+            phone_number="+352661234572",
+            event_languages=["en"],
+            is_approved=False,
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, status="pending"
+        )
+
+    @patch("crush_lu.push_notifications.send_push_notification")
+    def test_push_sends_once(self, mock_send):
+        mock_send.return_value = {"success": 1, "failed": 0}
+        self.assertTrue(send_pre_screening_user_push(self.submission))
+        self.assertEqual(mock_send.call_count, 1)
+        # Second call dedupes via cache.
+        self.assertFalse(send_pre_screening_user_push(self.submission))
+        self.assertEqual(mock_send.call_count, 1)
+
+    @patch("crush_lu.push_notifications.send_push_notification")
+    def test_push_skipped_after_submission(self, mock_send):
+        self.submission.pre_screening_submitted_at = timezone.now()
+        self.submission.save()
+        self.assertFalse(send_pre_screening_user_push(self.submission))
+        mock_send.assert_not_called()

--- a/crush_lu/tests/test_pre_screening_schema.py
+++ b/crush_lu/tests/test_pre_screening_schema.py
@@ -1,0 +1,373 @@
+"""Unit tests for the pre-screening schema validator and scorer."""
+from __future__ import annotations
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from crush_lu.pre_screening_schema import (
+    FLAG_DESCRIPTIONS,
+    PRE_SCREENING_SCHEMA,
+    compute_readiness_score,
+    get_question,
+    get_section,
+    iter_questions,
+    readiness_score_label,
+    validate_pre_screening_responses,
+)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+def _valid_responses(**overrides) -> dict:
+    """A complete, valid response set. Override keys to test edge cases."""
+    base = {
+        "residence": "lu_city",
+        "languages": ["en", "fr"],
+        "age_confirm": True,
+        "source": "friend",
+        "what_is_crush": "events",
+        "event_frequency": "monthly",
+        "relationship_goal": "meaningful",
+        "coach_attitude": "loves",
+        "looking_forward_to": ["events", "discovery"],
+        "hoping_to_meet": "Someone curious who likes long walks and honest conversation.",
+        "note_to_coach": "",
+        "consent_events": True,
+        "consent_coach": True,
+        "consent_no_show": True,
+        "consent_terms": True,
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------
+# Schema shape
+# --------------------------------------------------------------------------
+
+def test_schema_has_version():
+    assert PRE_SCREENING_SCHEMA["version"] >= 1
+
+
+def test_schema_has_all_four_sections():
+    section_ids = [s["id"] for s in PRE_SCREENING_SCHEMA["sections"]]
+    assert section_ids == ["logistics", "concept", "own_words", "consents"]
+
+
+def test_schema_question_counts_match_appendix_a():
+    counts = {s["id"]: len(s["questions"]) for s in PRE_SCREENING_SCHEMA["sections"]}
+    assert counts == {
+        "logistics": 4,
+        "concept": 5,
+        "own_words": 2,
+        "consents": 4,
+    }
+
+
+def test_get_question_and_section():
+    assert get_question("what_is_crush")["type"] == "single_select"
+    assert get_section("concept")["id"] == "concept"
+    assert get_question("nope") is None
+
+
+# --------------------------------------------------------------------------
+# Validator — happy paths
+# --------------------------------------------------------------------------
+
+def test_valid_response_passes():
+    validate_pre_screening_responses(_valid_responses(), version=1)
+
+
+def test_valid_response_with_optional_note():
+    validate_pre_screening_responses(
+        _valid_responses(note_to_coach="I'm a bit shy."), version=1
+    )
+
+
+def test_valid_response_without_version():
+    validate_pre_screening_responses(_valid_responses(), version=None)
+
+
+# --------------------------------------------------------------------------
+# Validator — error codes
+# --------------------------------------------------------------------------
+
+def _error_codes(exc: ValidationError, qid: str) -> list[str]:
+    messages = exc.message_dict if hasattr(exc, "message_dict") else {}
+    return [getattr(e, "code", None) for e in (messages.get(qid) or [])]
+
+
+def test_invalid_version_raises():
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(_valid_responses(), version=999)
+    assert excinfo.value.error_list[0].code == "invalid_version"
+
+
+def test_required_missing():
+    resp = _valid_responses()
+    resp.pop("residence")
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "required_missing" in [
+        e.code for e in excinfo.value.error_dict.get("residence", [])
+    ]
+
+
+def test_invalid_choice_single_select():
+    resp = _valid_responses(residence="atlantis")
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "invalid_choice" in [
+        e.code for e in excinfo.value.error_dict.get("residence", [])
+    ]
+
+
+def test_invalid_choice_multi_select():
+    resp = _valid_responses(languages=["en", "klingon"])
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "invalid_choice" in [
+        e.code for e in excinfo.value.error_dict.get("languages", [])
+    ]
+
+
+def test_min_choices_languages_empty():
+    resp = _valid_responses(languages=[])
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    # Empty list is treated as "not present" -> required_missing
+    assert "required_missing" in [
+        e.code for e in excinfo.value.error_dict.get("languages", [])
+    ]
+
+
+def test_min_choices_not_met_for_looking_forward_to_never_triggers_for_empty():
+    # Empty list short-circuits to required_missing, which is correct.
+    resp = _valid_responses(looking_forward_to=[])
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    codes = [e.code for e in excinfo.value.error_dict.get("looking_forward_to", [])]
+    assert "required_missing" in codes
+
+
+def test_max_choices_exceeded():
+    resp = _valid_responses(
+        looking_forward_to=["events", "discovery", "coach_match", "offline_quickly"]
+    )
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "max_choices_exceeded" in [
+        e.code for e in excinfo.value.error_dict.get("looking_forward_to", [])
+    ]
+
+
+def test_text_too_long():
+    resp = _valid_responses(hoping_to_meet="x" * 201)
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "text_too_long" in [
+        e.code for e in excinfo.value.error_dict.get("hoping_to_meet", [])
+    ]
+
+
+def test_checkbox_unchecked_fails():
+    resp = _valid_responses(consent_events=False)
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "required_missing" in [
+        e.code for e in excinfo.value.error_dict.get("consent_events", [])
+    ]
+
+
+def test_unknown_question_rejected():
+    resp = _valid_responses(bogus_question="yes")
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "unknown_question" in [
+        e.code for e in excinfo.value.error_dict.get("bogus_question", [])
+    ]
+
+
+def test_multi_select_wrong_type():
+    resp = _valid_responses(languages="en")
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses(resp, version=1)
+    assert "invalid_type" in [
+        e.code for e in excinfo.value.error_dict.get("languages", [])
+    ]
+
+
+# --------------------------------------------------------------------------
+# Validator — partial / section-scoped saves
+# --------------------------------------------------------------------------
+
+def test_partial_mode_skips_required_missing():
+    # Only logistics answered; concept/own_words/consents missing.
+    resp = {
+        "residence": "lu_city",
+        "languages": ["en"],
+        "age_confirm": True,
+        "source": "friend",
+    }
+    # partial=True must not raise for unanswered required questions.
+    validate_pre_screening_responses(resp, version=1, partial=True)
+
+
+def test_section_scoped_validation():
+    # Only validate logistics — missing concept answers is fine.
+    resp = {
+        "residence": "lu_city",
+        "languages": ["en"],
+        "age_confirm": True,
+        "source": "friend",
+    }
+    validate_pre_screening_responses(resp, version=1, section_id="logistics")
+
+
+def test_section_scoped_still_catches_bad_choice():
+    resp = {"residence": "atlantis"}
+    with pytest.raises(ValidationError):
+        validate_pre_screening_responses(
+            resp, version=1, partial=True, section_id="logistics"
+        )
+
+
+def test_non_dict_response_rejected():
+    with pytest.raises(ValidationError) as excinfo:
+        validate_pre_screening_responses([], version=1)  # type: ignore[arg-type]
+    assert excinfo.value.error_list[0].code == "invalid_type"
+
+
+# --------------------------------------------------------------------------
+# Scorer
+# --------------------------------------------------------------------------
+
+def test_scorer_returns_tuple_and_clips_to_range():
+    for resp in [
+        _valid_responses(),
+        _valid_responses(coach_attitude="no_intermediary", event_frequency="online_only"),
+        _valid_responses(what_is_crush="tinder", event_frequency="online_only",
+                         coach_attitude="no_intermediary", hoping_to_meet="x"),
+    ]:
+        score, flags = compute_readiness_score(resp)
+        assert 0 <= score <= 10
+        assert isinstance(flags, list)
+
+
+def test_high_readiness_profile():
+    resp = _valid_responses(
+        what_is_crush="events",
+        event_frequency="weekly",
+        coach_attitude="loves",
+        hoping_to_meet=(
+            "Someone thoughtful and curious who loves walking and good conversation, "
+            "maybe a bit introverted but warm, who values depth over small talk."
+        ),
+        looking_forward_to=["events", "discovery"],
+    )
+    score, flags = compute_readiness_score(resp)
+    assert score >= 8
+    assert flags == []
+
+
+def test_low_readiness_triggers_all_flags():
+    resp = _valid_responses(
+        what_is_crush="tinder",
+        event_frequency="online_only",
+        coach_attitude="no_intermediary",
+        hoping_to_meet="idk",
+    )
+    score, flags = compute_readiness_score(resp)
+    assert score <= 2
+    assert "concept_misalignment" in flags
+    assert "events_disinterest" in flags
+    assert "coach_reluctance" in flags
+    assert "low_effort_text" in flags
+
+
+def test_low_effort_detects_repeated_chars():
+    resp = _valid_responses(hoping_to_meet="aaaaaaaaaaaaaaaaaaaaaa")
+    _score, flags = compute_readiness_score(resp)
+    assert "low_effort_text" in flags
+
+
+def test_low_effort_detects_short_text():
+    resp = _valid_responses(hoping_to_meet="anyone")
+    _score, flags = compute_readiness_score(resp)
+    assert "low_effort_text" in flags
+
+
+def test_optional_note_to_coach_never_flags():
+    resp = _valid_responses(note_to_coach="")
+    _score, flags = compute_readiness_score(resp)
+    assert "no_note_to_coach" not in flags
+
+
+def test_tinder_answer_flags_without_rejecting():
+    """Per product principle: no single answer auto-rejects."""
+    resp = _valid_responses(what_is_crush="tinder")
+    score, flags = compute_readiness_score(resp)
+    assert "concept_misalignment" in flags
+    assert score >= 0  # not forced to rock bottom
+
+
+def test_unsure_about_concept_is_positive():
+    # "events" and "unsure" both get the +2 concept-alignment bump; their
+    # scores must match when everything else is equal.
+    resp_events = _valid_responses(what_is_crush="events")
+    resp_unsure = _valid_responses(what_is_crush="unsure")
+    s_events, _ = compute_readiness_score(resp_events)
+    s_unsure, _ = compute_readiness_score(resp_unsure)
+    assert s_events == s_unsure
+    # And they should be clearly above the "low" threshold.
+    assert s_events >= 5
+
+
+def test_diverse_inputs_always_in_range():
+    import random
+    rng = random.Random(42)
+    what_choices = ["events", "tinder", "matchmaking", "unsure"]
+    freq_choices = ["weekly", "monthly", "few_per_year", "online_only"]
+    attitudes = ["loves", "fine", "curious", "no_intermediary"]
+    for _ in range(20):
+        resp = _valid_responses(
+            what_is_crush=rng.choice(what_choices),
+            event_frequency=rng.choice(freq_choices),
+            coach_attitude=rng.choice(attitudes),
+            hoping_to_meet="x" * rng.randint(0, 200),
+            looking_forward_to=rng.sample(
+                ["events", "discovery", "coach_match"], rng.randint(1, 3)
+            ),
+        )
+        score, _flags = compute_readiness_score(resp)
+        assert 0 <= score <= 10
+
+
+# --------------------------------------------------------------------------
+# Score label bucketing
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("score,label", [
+    (None, "pending"),
+    (0, "low"),
+    (4, "low"),
+    (5, "medium"),
+    (7, "medium"),
+    (8, "high"),
+    (10, "high"),
+])
+def test_readiness_score_label(score, label):
+    assert readiness_score_label(score) == label
+
+
+# --------------------------------------------------------------------------
+# Flag descriptions exist for every flag the scorer can emit
+# --------------------------------------------------------------------------
+
+def test_every_flag_has_a_description():
+    # Enumerate all flag codes the scorer can emit by running it across the
+    # canonical worst-case input. Add more here if new flags are introduced.
+    known = {"concept_misalignment", "events_disinterest", "coach_reluctance", "low_effort_text"}
+    assert set(FLAG_DESCRIPTIONS.keys()) == known

--- a/crush_lu/tests/test_pre_screening_views.py
+++ b/crush_lu/tests/test_pre_screening_views.py
@@ -1,0 +1,271 @@
+"""Integration tests for the pre-screening questionnaire views."""
+from __future__ import annotations
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from crush_lu.models import CrushCoach, CrushProfile, ProfileSubmission
+from crush_lu.models.profiles import UserDataConsent
+from crush_lu.pre_screening_schema import PRE_SCREENING_SCHEMA
+
+User = get_user_model()
+
+
+def _valid_final_responses() -> dict:
+    return {
+        "residence": "lu_city",
+        "languages": ["en", "fr"],
+        "age_confirm": True,
+        "source": "friend",
+        "what_is_crush": "events",
+        "event_frequency": "monthly",
+        "relationship_goal": "meaningful",
+        "coach_attitude": "loves",
+        "looking_forward_to": ["events", "discovery"],
+        "hoping_to_meet": "Someone curious who likes walking and honest conversation and good coffee.",
+        "note_to_coach": "",
+        "consent_events": True,
+        "consent_coach": True,
+        "consent_no_show": True,
+        "consent_terms": True,
+    }
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=True,
+)
+class PreScreeningFormTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.coach_user = User.objects.create_user(
+            username="coach@example.com",
+            email="coach@example.com",
+            password="coachpw",
+            first_name="Coach",
+        )
+        UserDataConsent.objects.filter(user=self.coach_user).update(
+            crushlu_consent_given=True
+        )
+        self.coach = CrushCoach.objects.create(
+            user=self.coach_user, bio="Bio", is_active=True, max_active_reviews=5
+        )
+        self.user = User.objects.create_user(
+            username="u@example.com",
+            email="u@example.com",
+            password="userpw",
+            first_name="User",
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="M",
+            location="Luxembourg City",
+            bio="Test bio",
+            phone_number="+352661234567",
+            event_languages=["en"],
+            is_approved=False,
+        )
+        self.submission = ProfileSubmission.objects.create(
+            profile=self.profile, coach=self.coach, status="pending"
+        )
+        self.client.login(username="u@example.com", password="userpw")
+
+    # --------------- GET form ---------------
+
+    def test_get_renders_form(self):
+        resp = self.client.get(reverse("crush_lu:pre_screening"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Help your Coach prepare")
+        self.assertContains(resp, "Quick logistics")
+        self.assertContains(resp, "0 of 4 sections complete")
+        self.assertContains(resp, 'id="prescreening-progress"')
+        self.assertContains(resp, 'id="prescreening-finalize"')
+
+    def test_redirect_when_no_submission(self):
+        self.submission.delete()
+        self.profile.delete()
+        resp = self.client.get(reverse("crush_lu:pre_screening"))
+        self.assertEqual(resp.status_code, 302)
+
+    def test_redirect_when_already_approved(self):
+        self.submission.status = "approved"
+        self.submission.save()
+        resp = self.client.get(reverse("crush_lu:pre_screening"))
+        self.assertRedirects(
+            resp, reverse("crush_lu:profile_submitted"), fetch_redirect_response=False
+        )
+
+    def test_redirect_when_call_completed(self):
+        self.submission.review_call_completed = True
+        self.submission.save()
+        resp = self.client.get(reverse("crush_lu:pre_screening"))
+        self.assertRedirects(
+            resp, reverse("crush_lu:profile_submitted"), fetch_redirect_response=False
+        )
+
+    # --------------- HTMX per-section save ---------------
+
+    def test_save_section_persists_valid_answers(self):
+        url = reverse("crush_lu:pre_screening_save_section", args=["logistics"])
+        resp = self.client.post(url, {
+            "residence": "lu_city",
+            "languages": ["en", "fr"],
+            "age_confirm": "yes",
+            "source": "friend",
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.pre_screening_responses["residence"], "lu_city")
+        self.assertEqual(
+            sorted(self.submission.pre_screening_responses["languages"]),
+            ["en", "fr"],
+        )
+        self.assertIs(self.submission.pre_screening_responses["age_confirm"], True)
+        # Partial save must NOT set finalize timestamp
+        self.assertIsNone(self.submission.pre_screening_submitted_at)
+
+    def test_save_section_returns_oob_progress_and_finalize(self):
+        url = reverse("crush_lu:pre_screening_save_section", args=["logistics"])
+        resp = self.client.post(url, {
+            "residence": "lu_city",
+            "languages": ["en"],
+            "age_confirm": "yes",
+            "source": "friend",
+        })
+        body = resp.content.decode()
+        self.assertIn('hx-swap-oob="outerHTML:#prescreening-progress"', body)
+        self.assertIn('hx-swap-oob="outerHTML:#prescreening-finalize"', body)
+        self.assertIn("1 of 4 sections complete", body)
+
+    def test_all_four_sections_save_independently(self):
+        section_payloads = {
+            "logistics": {
+                "residence": "lu_city",
+                "languages": ["en"],
+                "age_confirm": "yes",
+                "source": "friend",
+            },
+            "concept": {
+                "what_is_crush": "events",
+                "event_frequency": "monthly",
+                "relationship_goal": "meaningful",
+                "coach_attitude": "loves",
+                "looking_forward_to": ["events"],
+            },
+            "own_words": {
+                "hoping_to_meet": "Someone curious who likes walking and honest talk.",
+            },
+            "consents": {
+                "consent_events": "1",
+                "consent_coach": "1",
+                "consent_no_show": "1",
+                "consent_terms": "1",
+            },
+        }
+        for section_id, payload in section_payloads.items():
+            url = reverse(
+                "crush_lu:pre_screening_save_section", args=[section_id]
+            )
+            resp = self.client.post(url, payload)
+            self.assertEqual(resp.status_code, 200, f"{section_id} save failed")
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.pre_screening_responses["residence"], "lu_city")
+        self.assertEqual(
+            self.submission.pre_screening_responses["what_is_crush"], "events"
+        )
+        self.assertTrue(self.submission.pre_screening_responses["consent_terms"])
+        # Finalize is now possible.
+        final = self.client.post(reverse("crush_lu:pre_screening_finalize"))
+        self.assertEqual(final.status_code, 302)
+        self.submission.refresh_from_db()
+        self.assertIsNotNone(self.submission.pre_screening_submitted_at)
+
+    def test_save_section_unknown_id_404s(self):
+        url = reverse(
+            "crush_lu:pre_screening_save_section", args=["not-a-section"]
+        )
+        resp = self.client.post(url, {"residence": "lu_city"})
+        self.assertEqual(resp.status_code, 404)
+
+    def test_save_section_clears_prior_answers_in_same_section(self):
+        self.submission.pre_screening_responses = {"source": "friend"}
+        self.submission.save(update_fields=["pre_screening_responses"])
+        url = reverse("crush_lu:pre_screening_save_section", args=["logistics"])
+        self.client.post(url, {
+            "residence": "lu_esch",
+            "languages": ["de"],
+            "age_confirm": "yes",
+            "source": "social",
+        })
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.pre_screening_responses["source"], "social")
+
+    # --------------- Finalize ---------------
+
+    def test_finalize_requires_full_valid_set(self):
+        self.submission.pre_screening_responses = {"residence": "lu_city"}
+        self.submission.save(update_fields=["pre_screening_responses"])
+        resp = self.client.post(reverse("crush_lu:pre_screening_finalize"))
+        self.assertEqual(resp.status_code, 302)
+        self.submission.refresh_from_db()
+        self.assertIsNone(self.submission.pre_screening_submitted_at)
+
+    def test_finalize_persists_score_and_flags(self):
+        self.submission.pre_screening_responses = _valid_final_responses()
+        self.submission.save(update_fields=["pre_screening_responses"])
+        resp = self.client.post(reverse("crush_lu:pre_screening_finalize"))
+        self.assertRedirects(
+            resp,
+            reverse("crush_lu:profile_submitted"),
+            fetch_redirect_response=False,
+        )
+        self.submission.refresh_from_db()
+        self.assertIsNotNone(self.submission.pre_screening_submitted_at)
+        self.assertEqual(
+            self.submission.pre_screening_version,
+            PRE_SCREENING_SCHEMA["version"],
+        )
+        self.assertIsNotNone(self.submission.pre_screening_readiness_score)
+        self.assertIsInstance(self.submission.pre_screening_flags, list)
+
+
+@override_settings(
+    ROOT_URLCONF="azureproject.urls_crush",
+    PRE_SCREENING_ENABLED=False,
+)
+class PreScreeningFeatureFlagTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="u2@example.com", email="u2@example.com", password="pw"
+        )
+        UserDataConsent.objects.filter(user=self.user).update(
+            crushlu_consent_given=True
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1990, 1, 1),
+            gender="M",
+            location="Luxembourg City",
+            bio="x",
+            phone_number="+352661234567",
+            event_languages=["en"],
+            is_approved=False,
+        )
+        ProfileSubmission.objects.create(profile=self.profile, status="pending")
+        self.client.login(username="u2@example.com", password="pw")
+
+    def test_flag_off_redirects_away(self):
+        resp = self.client.get(reverse("crush_lu:pre_screening"))
+        self.assertRedirects(
+            resp,
+            reverse("crush_lu:profile_submitted"),
+            fetch_redirect_response=False,
+        )

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -266,6 +266,7 @@ urlpatterns = [
     path('coach/review/<int:submission_id>/call-attempt/', views.coach_log_failed_call, name='coach_log_failed_call'),
     path('coach/review/<int:submission_id>/sms-sent/', views.coach_log_sms_sent, name='coach_log_sms_sent'),
     path('coach/review/<int:submission_id>/pre-screening-reminder/', views.coach_send_pre_screening_reminder, name='coach_send_pre_screening_reminder'),
+    path('coach/review/<int:submission_id>/screening-mode/', views.coach_set_screening_mode, name='coach_set_screening_mode'),
     path('coach/sessions/', views.coach_sessions, name='coach_sessions'),
     path('coach/verifications/', views.coach_verification_history, name='coach_verification_history'),
     path('coach/team-stats/', views.coach_team_stats, name='coach_team_stats'),

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -7,6 +7,7 @@ from django.http import HttpResponse
 from allauth.account.views import LoginView, LogoutView
 from allauth.account.forms import LoginForm
 from . import views
+from . import views_pre_screening
 from .forms import CrushSignupForm
 from .throttling import LoginRateThrottle
 import logging
@@ -141,6 +142,15 @@ urlpatterns = [
     path('create-profile/', views.create_profile, name='create_profile'),
     path('profile-submitted/', views.profile_submitted, name='profile_submitted'),
     path('profile/rejected/', views.profile_rejected, name='profile_rejected'),
+
+    # Pre-screening questionnaire (feature-flagged via PRE_SCREENING_ENABLED)
+    path('pre-screening/', views_pre_screening.pre_screening_form, name='pre_screening'),
+    path('pre-screening/section/<slug:section_id>/',
+         views_pre_screening.pre_screening_save_section,
+         name='pre_screening_save_section'),
+    path('pre-screening/finalize/',
+         views_pre_screening.pre_screening_finalize,
+         name='pre_screening_finalize'),
 
     # Profile step-by-step saving APIs - MOVED to urls_crush.py (language-neutral)
     # These APIs are called from alpine-components.js with hardcoded paths:

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -265,6 +265,7 @@ urlpatterns = [
     path('coach/review/<int:submission_id>/call-complete/', views.coach_mark_review_call_complete, name='coach_mark_review_call_complete'),
     path('coach/review/<int:submission_id>/call-attempt/', views.coach_log_failed_call, name='coach_log_failed_call'),
     path('coach/review/<int:submission_id>/sms-sent/', views.coach_log_sms_sent, name='coach_log_sms_sent'),
+    path('coach/review/<int:submission_id>/pre-screening-reminder/', views.coach_send_pre_screening_reminder, name='coach_send_pre_screening_reminder'),
     path('coach/sessions/', views.coach_sessions, name='coach_sessions'),
     path('coach/verifications/', views.coach_verification_history, name='coach_verification_history'),
     path('coach/team-stats/', views.coach_team_stats, name='coach_team_stats'),

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -141,6 +141,7 @@ from .views_coach import (  # noqa: F401
     coach_log_failed_call,
     coach_log_sms_sent,
     coach_review_profile,
+    coach_send_pre_screening_reminder,
     coach_preview_email,
     coach_sessions,
     coach_edit_profile,

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1800,6 +1800,16 @@ def profile_submitted(request):
         .first()
     )
 
+    from django.conf import settings as _settings
+
+    pre_screening_enabled = getattr(_settings, "PRE_SCREENING_ENABLED", False)
+    pre_screening_submitted = submission.pre_screening_submitted_at is not None
+    pre_screening_visible = (
+        pre_screening_enabled
+        and submission.status == "pending"
+        and not submission.review_call_completed
+    )
+
     context = {
         "submission": submission,
         "coach_contact_phone": coach_contact_phone,
@@ -1813,6 +1823,8 @@ def profile_submitted(request):
         "progress_percent": progress_percent,
         "next_event": next_event,
         "has_candidate_note": bool(submission.candidate_note),
+        "pre_screening_visible": pre_screening_visible,
+        "pre_screening_submitted": pre_screening_submitted,
     }
     return render(request, "crush_lu/profile_submitted.html", context)
 

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -142,6 +142,7 @@ from .views_coach import (  # noqa: F401
     coach_log_sms_sent,
     coach_review_profile,
     coach_send_pre_screening_reminder,
+    coach_set_screening_mode,
     coach_preview_email,
     coach_sessions,
     coach_edit_profile,

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -549,6 +549,8 @@ def coach_profiles(request):
         profile.upcoming_events = incomplete_upcoming_regs.get(profile.user_id, [])
         profile.past_event_count = incomplete_past_counts.get(profile.user_id, 0)
 
+    from django.conf import settings as _settings
+
     context = {
         "coach": coach,
         "pending_submissions": pending_submissions,
@@ -558,6 +560,7 @@ def coach_profiles(request):
         "recontact_submissions": recontact_submissions,
         "revision_profiles": revision_profiles,
         "all_incomplete": all_incomplete,
+        "pre_screening_enabled": getattr(_settings, "PRE_SCREENING_ENABLED", False),
     }
     return render(request, "crush_lu/coach_profiles.html", context)
 
@@ -947,14 +950,91 @@ def coach_review_profile(request, submission_id):
         sms_body = template.format(first_name=first_name, coach_name=coach_name)
         sms_template_encoded = quote(sms_body, safe="")
 
+    from django.conf import settings as _settings
+
+    pre_screening_enabled = getattr(_settings, "PRE_SCREENING_ENABLED", False)
+    can_send_prescreening_sms = bool(
+        profile.phone_number and profile.phone_verified
+    )
+
     context = {
         "submission": submission,
         "profile": profile,
         "form": form,
         "social_account": social_account,
         "sms_template_encoded": sms_template_encoded,
+        "pre_screening_enabled": pre_screening_enabled,
+        "can_send_prescreening_sms": can_send_prescreening_sms,
     }
     return render(request, "crush_lu/coach_review_profile.html", context)
+
+
+@coach_required
+@require_http_methods(["POST"])
+def coach_send_pre_screening_reminder(request, submission_id):
+    """HTMX: log that the Coach opened an SMS reminder for pre-screening.
+
+    Returns a small HTML fragment containing the tel: SMS link the Coach's
+    device can open, and records a CallAttempt so the outreach is auditable.
+    """
+    from django.conf import settings as _settings
+    from urllib.parse import quote
+    from .models import CallAttempt
+    from .models.site_config import CrushSiteConfig
+
+    if not getattr(_settings, "PRE_SCREENING_ENABLED", False):
+        return HttpResponse(status=410)
+
+    coach = request.coach
+    submission = get_object_or_404(
+        ProfileSubmission.objects.select_related("profile__user"),
+        id=submission_id,
+        coach=coach,
+    )
+    profile = submission.profile
+
+    if not (profile.phone_number and profile.phone_verified):
+        return HttpResponse(
+            '<p class="text-xs text-red-600 dark:text-red-400">'
+            + str(_("No verified phone number on file."))
+            + "</p>",
+            status=400,
+        )
+
+    config = CrushSiteConfig.get_config()
+    lang = getattr(profile, "preferred_language", "en") or "en"
+    template_field = f"pre_screening_reminder_sms_{lang}"
+    template = (
+        getattr(config, template_field, config.pre_screening_reminder_sms_en)
+        or config.pre_screening_reminder_sms_en
+    )
+    coach_name = coach.user.first_name or "Your coach"
+    first_name = profile.user.first_name or ""
+    link = request.build_absolute_uri("/pre-screening/")
+    sms_body = template.format(
+        first_name=first_name, coach_name=coach_name, link=link
+    )
+    sms_href = f"sms:{profile.phone_number}?&body={quote(sms_body)}"
+
+    CallAttempt.objects.create(
+        submission=submission,
+        profile=profile,
+        result="sms_sent",
+        coach=coach,
+        notes=_("Pre-screening reminder SMS drafted"),
+    )
+
+    html = (
+        '<a href="' + sms_href + '" '
+        'class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold '
+        'bg-green-600 text-white hover:bg-green-700">'
+        + str(_("Open SMS app →"))
+        + "</a>"
+        '<p class="text-xs text-gray-500 dark:text-gray-400 mt-1">'
+        + str(_("Attempt logged."))
+        + "</p>"
+    )
+    return HttpResponse(html)
 
 
 @coach_required

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -971,6 +971,58 @@ def coach_review_profile(request, submission_id):
 
 @coach_required
 @require_http_methods(["POST"])
+def coach_set_screening_mode(request, submission_id):
+    """Let a Coach switch between legacy (5-section) and calibration (3-section).
+
+    Called from both tab templates. Re-renders the tab via HTMX so the coach
+    can toggle mid-flow without losing the page.
+    """
+    coach = request.coach
+    submission = get_object_or_404(
+        ProfileSubmission.objects.select_related("profile__user"),
+        id=submission_id,
+        coach=coach,
+    )
+    if submission.review_call_completed:
+        return HttpResponse(status=410)
+    mode = request.POST.get("mode")
+    if mode not in ("legacy", "calibration"):
+        return HttpResponse(status=400)
+    # Legacy-only path: only allow calibration if pre-screening was submitted.
+    if mode == "calibration" and not submission.pre_screening_submitted_at:
+        return HttpResponse(status=400)
+    submission.screening_call_mode = mode
+    submission.save(update_fields=["screening_call_mode"])
+
+    # Re-render the tab in place.
+    from urllib.parse import quote
+    from .models.site_config import CrushSiteConfig
+
+    profile = submission.profile
+    sms_template_encoded = ""
+    if profile.phone_number and profile.phone_verified:
+        config = CrushSiteConfig.get_config()
+        lang = getattr(profile, "preferred_language", "en") or "en"
+        template_field = f"sms_template_{lang}"
+        template = (
+            getattr(config, template_field, config.sms_template_en)
+            or config.sms_template_en
+        )
+        coach_name = coach.user.first_name or "Your coach"
+        first_name = profile.user.first_name or ""
+        sms_body = template.format(first_name=first_name, coach_name=coach_name)
+        sms_template_encoded = quote(sms_body, safe="")
+
+    context = {
+        "submission": submission,
+        "profile": profile,
+        "sms_template_encoded": sms_template_encoded,
+    }
+    return render(request, "crush_lu/_screening_tab.html", context)
+
+
+@coach_required
+@require_http_methods(["POST"])
 def coach_send_pre_screening_reminder(request, submission_id):
     """HTMX: log that the Coach opened an SMS reminder for pre-screening.
 

--- a/crush_lu/views_pre_screening.py
+++ b/crush_lu/views_pre_screening.py
@@ -372,12 +372,18 @@ def pre_screening_finalize(request):
     submission.pre_screening_version = PRE_SCREENING_SCHEMA["version"]
     submission.pre_screening_readiness_score = score
     submission.pre_screening_flags = flags
+    # Completing pre-screening automatically opts the Coach into the shorter
+    # 3-section calibration call. Coaches can manually revert to legacy via
+    # the screening tab if they prefer the full 5-section flow.
+    if submission.screening_call_mode == "legacy":
+        submission.screening_call_mode = "calibration"
     submission.save(update_fields=[
         "pre_screening_responses",
         "pre_screening_submitted_at",
         "pre_screening_version",
         "pre_screening_readiness_score",
         "pre_screening_flags",
+        "screening_call_mode",
     ])
 
     logger.info(

--- a/crush_lu/views_pre_screening.py
+++ b/crush_lu/views_pre_screening.py
@@ -1,0 +1,400 @@
+"""Views for the pre-screening questionnaire (Phase 2).
+
+User-facing form that fills in logistics, concept alignment, free-text, and
+consents after a profile has been submitted but before the Coach reviews it.
+All write endpoints are ratelimited. Everything is gated by
+``settings.PRE_SCREENING_ENABLED``.
+"""
+from __future__ import annotations
+
+import logging
+
+from django.conf import settings
+from django.contrib import messages
+from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.http import Http404, HttpResponse
+from django.shortcuts import redirect, render
+from django.utils import timezone
+from django.utils.translation import gettext as _
+from django.views.decorators.http import require_http_methods
+
+from .decorators import crush_login_required, ratelimit
+from .models import CrushProfile, ProfileSubmission
+from .pre_screening_schema import (
+    PRE_SCREENING_SCHEMA,
+    compute_readiness_score,
+    get_section,
+    iter_questions,
+    validate_pre_screening_responses,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def _get_active_submission(user) -> ProfileSubmission | None:
+    """Return the user's latest pending ProfileSubmission, or None."""
+    try:
+        profile = CrushProfile.objects.get(user=user)
+    except CrushProfile.DoesNotExist:
+        return None
+    return (
+        ProfileSubmission.objects.filter(profile=profile)
+        .order_by("-submitted_at")
+        .first()
+    )
+
+
+def _can_edit(submission: ProfileSubmission | None) -> bool:
+    if submission is None:
+        return False
+    if submission.status != "pending":
+        return False
+    if submission.review_call_completed:
+        return False
+    return True
+
+
+def _coerce_form_value(question: dict, post_data) -> object:
+    """Translate a raw POST field into its schema-native value."""
+    qid = question["id"]
+    qtype = question["type"]
+    if qtype == "single_select":
+        return post_data.get(qid) or None
+    if qtype == "multi_select":
+        return post_data.getlist(qid) or None
+    if qtype == "text":
+        return (post_data.get(qid) or "").strip()
+    if qtype == "checkbox":
+        return bool(post_data.get(qid))
+    if qtype == "yes_no":
+        raw = post_data.get(qid)
+        if raw == "yes":
+            return True
+        if raw == "no":
+            return False
+        return None
+    return None
+
+
+def _parse_section_from_post(section_id: str, post_data) -> dict:
+    section = get_section(section_id)
+    if section is None:
+        raise Http404("Unknown section")
+    parsed = {}
+    for question in section["questions"]:
+        value = _coerce_form_value(question, post_data)
+        # Drop empties so they don't trip the validator's "unknown question"
+        # check when the user saves a section with nothing filled in.
+        if value in (None, "", []):
+            continue
+        parsed[question["id"]] = value
+    return parsed
+
+
+def _section_is_complete(section: dict, responses: dict) -> bool:
+    """A section is complete iff every required question in it is answered."""
+    for question in section["questions"]:
+        if not question.get("required"):
+            continue
+        qid = question["id"]
+        value = responses.get(qid)
+        if value in (None, "", []):
+            return False
+        if question["type"] == "checkbox" and value is not True:
+            return False
+    return True
+
+
+def _is_complete(responses: dict) -> bool:
+    try:
+        validate_pre_screening_responses(
+            responses, version=PRE_SCREENING_SCHEMA["version"]
+        )
+    except ValidationError:
+        return False
+    return True
+
+
+def _build_sections_context(responses: dict, errors_by_qid: dict | None = None,
+                            flash_section_id: str | None = None) -> list[dict]:
+    errors_by_qid = errors_by_qid or {}
+    output = []
+    for idx, section in enumerate(PRE_SCREENING_SCHEMA["sections"], start=1):
+        section_errors = {
+            q["id"]: errors_by_qid[q["id"]]
+            for q in section["questions"]
+            if q["id"] in errors_by_qid
+        }
+        output.append({
+            "section": section,
+            "number": idx,
+            "complete": _section_is_complete(section, responses),
+            "errors": section_errors,
+            "flash": _("Saved.") if flash_section_id == section["id"] else "",
+        })
+    return output
+
+
+def _errors_by_qid(exc: ValidationError) -> dict:
+    if hasattr(exc, "error_dict"):
+        return {qid: list(errs) for qid, errs in exc.error_dict.items()}
+    return {}
+
+
+def _should_notify_coach(submission: ProfileSubmission, *, edit: bool) -> bool:
+    """Rate-limit coach push notifications for edits to max 1 per hour."""
+    if not submission.coach or not edit:
+        return True  # first-submit: always notify
+    cache_key = f"pre_screening_edit_notify:{submission.id}"
+    if cache.get(cache_key):
+        return False
+    cache.set(cache_key, 1, 3600)  # 1 hour throttle
+    return True
+
+
+def _notify_coach(submission: ProfileSubmission, *, edit: bool) -> None:
+    if not submission.coach:
+        return
+    if not _should_notify_coach(submission, edit=edit):
+        return
+    try:
+        from .coach_notifications import notify_coach_system_alert
+
+        display_name = (
+            submission.profile.display_name
+            or submission.profile.user.first_name
+            or submission.profile.user.username
+        )
+        score = submission.pre_screening_readiness_score
+        flags = submission.pre_screening_flags or []
+        flag_summary = f" ({', '.join(flags)})" if flags else ""
+        if edit:
+            title = str(_("%(name)s updated their answers") % {"name": display_name})
+            body = str(_("New readiness: %(score)s/10") % {"score": score})
+        else:
+            title = str(
+                _("%(name)s completed pre-screening") % {"name": display_name}
+            )
+            body = str(
+                _("Readiness: %(score)s/10%(flags)s")
+                % {"score": score, "flags": flag_summary}
+            )
+        notify_coach_system_alert(
+            coach=submission.coach,
+            title=title,
+            message=body,
+            url=f"/coach/review/{submission.id}/",
+        )
+    except Exception:
+        logger.warning(
+            "Failed to send pre-screening coach notification",
+            extra={"submission_id": submission.id},
+        )
+
+
+def _gate_or_redirect(request):
+    """Return a redirect response if the feature flag is off, else None."""
+    if not getattr(settings, "PRE_SCREENING_ENABLED", False):
+        messages.info(request, _("Pre-screening is not available yet."))
+        return redirect("crush_lu:profile_submitted")
+    return None
+
+
+# --------------------------------------------------------------------------
+# Views
+# --------------------------------------------------------------------------
+
+@crush_login_required
+def pre_screening_form(request):
+    """Main form page. GET renders, POST on this URL is not expected."""
+    gate = _gate_or_redirect(request)
+    if gate is not None:
+        return gate
+
+    submission = _get_active_submission(request.user)
+    if submission is None:
+        messages.error(request, _("No profile submission found."))
+        return redirect("crush_lu:create_profile")
+
+    if not _can_edit(submission):
+        if submission.review_call_completed:
+            messages.info(
+                request,
+                _("Your Coach has already completed your screening call."),
+            )
+        else:
+            messages.info(
+                request,
+                _("Pre-screening is no longer available for this submission."),
+            )
+        return redirect("crush_lu:profile_submitted")
+
+    responses = dict(submission.pre_screening_responses or {})
+    sections_context = _build_sections_context(responses)
+    completed_count = sum(1 for s in sections_context if s["complete"])
+    total = len(sections_context)
+    progress_percent = int((completed_count / total) * 100) if total else 0
+
+    context = {
+        "submission": submission,
+        "responses": responses,
+        "sections_context": sections_context,
+        "completed_section_count": completed_count,
+        "total_section_count": total,
+        "progress_percent": progress_percent,
+        "can_finalize": _is_complete(responses),
+        "already_submitted": submission.pre_screening_submitted_at is not None,
+    }
+    return render(request, "crush_lu/pre_screening.html", context)
+
+
+@crush_login_required
+@ratelimit(key="user", rate="30/h", method="POST", block=True)
+@require_http_methods(["POST"])
+def pre_screening_save_section(request, section_id: str):
+    """HTMX endpoint: save one section's answers (partial / non-final)."""
+    gate = _gate_or_redirect(request)
+    if gate is not None:
+        return gate
+
+    section = get_section(section_id)
+    if section is None:
+        raise Http404("Unknown section")
+
+    submission = _get_active_submission(request.user)
+    if submission is None or not _can_edit(submission):
+        return HttpResponse(status=410)
+
+    try:
+        parsed = _parse_section_from_post(section_id, request.POST)
+    except Http404:
+        raise
+
+    responses = dict(submission.pre_screening_responses or {})
+    # Remove any prior answers inside this section so users can un-select.
+    for q in section["questions"]:
+        responses.pop(q["id"], None)
+    responses.update(parsed)
+
+    errors_by_qid: dict = {}
+    try:
+        validate_pre_screening_responses(
+            responses,
+            version=None,
+            partial=True,
+            section_id=section_id,
+        )
+    except ValidationError as exc:
+        errors_by_qid = _errors_by_qid(exc)
+
+    submission.pre_screening_responses = responses
+    submission.save(update_fields=["pre_screening_responses"])
+
+    section_complete = _section_is_complete(section, responses) and not errors_by_qid
+    section_number = next(
+        (i + 1 for i, s in enumerate(PRE_SCREENING_SCHEMA["sections"])
+         if s["id"] == section_id),
+        1,
+    )
+
+    logger.info(
+        "pre_screening.section_saved",
+        extra={
+            "submission_id": submission.id,
+            "section_id": section_id,
+            "has_errors": bool(errors_by_qid),
+        },
+    )
+
+    # Stats for the out-of-band progress + finalize refresh.
+    sections_context = _build_sections_context(responses)
+    completed_count = sum(1 for s in sections_context if s["complete"])
+    total = len(sections_context)
+
+    context = {
+        "section": section,
+        "section_number": section_number,
+        "section_complete": section_complete,
+        "responses": responses,
+        "errors": errors_by_qid,
+        "section_flash": _("Saved.") if not errors_by_qid else "",
+        # Out-of-band swaps keep the page's progress indicator and finalize
+        # button in sync without a full-page reload.
+        "oob_updates": True,
+        "completed_section_count": completed_count,
+        "total_section_count": total,
+        "progress_percent": int((completed_count / total) * 100) if total else 0,
+        "can_finalize": _is_complete(responses),
+        "already_submitted": submission.pre_screening_submitted_at is not None,
+    }
+    return render(request, "crush_lu/pre_screening/_section.html", context)
+
+
+@crush_login_required
+@ratelimit(key="user", rate="10/h", method="POST", block=True)
+@require_http_methods(["POST"])
+def pre_screening_finalize(request):
+    """Final submit: validate everything, compute score, notify Coach."""
+    gate = _gate_or_redirect(request)
+    if gate is not None:
+        return gate
+
+    submission = _get_active_submission(request.user)
+    if submission is None or not _can_edit(submission):
+        messages.error(request, _("Cannot finalize pre-screening."))
+        return redirect("crush_lu:profile_submitted")
+
+    # Parse every section from POST (top-level finalize form has its own
+    # inputs, but we mostly rely on what's already saved by per-section HTMX).
+    responses = dict(submission.pre_screening_responses or {})
+
+    is_edit = submission.pre_screening_submitted_at is not None
+
+    try:
+        validate_pre_screening_responses(
+            responses, version=PRE_SCREENING_SCHEMA["version"]
+        )
+    except ValidationError:
+        messages.error(
+            request,
+            _("Please complete every required question before submitting."),
+        )
+        return redirect("crush_lu:pre_screening")
+
+    score, flags = compute_readiness_score(responses)
+    submission.pre_screening_responses = responses
+    submission.pre_screening_submitted_at = timezone.now()
+    submission.pre_screening_version = PRE_SCREENING_SCHEMA["version"]
+    submission.pre_screening_readiness_score = score
+    submission.pre_screening_flags = flags
+    submission.save(update_fields=[
+        "pre_screening_responses",
+        "pre_screening_submitted_at",
+        "pre_screening_version",
+        "pre_screening_readiness_score",
+        "pre_screening_flags",
+    ])
+
+    logger.info(
+        "pre_screening.finalized",
+        extra={
+            "submission_id": submission.id,
+            "score": score,
+            "flags": flags,
+            "version": PRE_SCREENING_SCHEMA["version"],
+            "edit": is_edit,
+        },
+    )
+
+    _notify_coach(submission, edit=is_edit)
+
+    messages.success(
+        request,
+        _("Your pre-screening answers have been sent to your Coach. Thank you!"),
+    )
+    return redirect("crush_lu:profile_submitted")


### PR DESCRIPTION
## Summary
- Adds a complete pre-screening questionnaire flow for Crush.lu: data model, user-facing form, coach-facing display, calibration mode for shorter calls, invite/reminder notifications, and an analytics dashboard.
- 6 commits, ~4,279 lines across 43 files, with test coverage for schema, views, coach flow, calibration, notifications, and analytics.

## Commits
- a23df78 feat(screening): data model for pre-screening questionnaire
- 8a978fa feat(screening): user-facing pre-screening questionnaire
- b1e327e feat(screening): coach-facing pre-screening display
- 64c1b54 feat(screening): calibration mode for shorter screening calls
- 63e4a07 feat(screening): invite and reminder flows for pre-screening
- 28e6e51 feat(screening): pre-screening analytics dashboard

## Test plan
- [ ] CI green (pytest suite, including new pre-screening tests)
- [ ] Manually walk a test user through the questionnaire end-to-end
- [ ] Verify coach view renders all answer types correctly
- [ ] Trigger an invite + reminder and confirm email delivery
- [ ] Open analytics dashboard and confirm metrics render
- [ ] Smoke-check calibration mode shortens the call flow as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)