### PR TITLE
chore(deps): patch hono GHSA-458j-xx4x-4375 via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1585,9 +1585,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.1.18"
+  },
+  "overrides": {
+    "hono": "^4.12.14"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry pinning transitive `hono` to `^4.12.14`, patching Dependabot alert #23 (GHSA-458j-xx4x-4375 — JSX SSR attribute-name injection, CVSS 4.3).
- `hono` is pulled in only via `@upstash/context7-mcp` → `@modelcontextprotocol/sdk` (dev-only MCP tooling). The Django app doesn't do JSX SSR, so real-world exposure is nil — this is cleanup to keep the dashboard green.
- `npm audit` now reports 0 vulnerabilities.

## Test plan
- [x] `npm install` succeeds
- [x] `npm ls hono` shows `hono@4.12.14` at all locations
- [x] `npm audit` reports 0 vulnerabilities
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)