### PR TITLE
fix(pre-screening): make send_pre_screening_invites runnable from CLI

### DIFF
--- a/crush_lu/pre_screening_notifications.py
+++ b/crush_lu/pre_screening_notifications.py
@@ -68,10 +68,18 @@ def _pre_screening_url(request=None) -> str:
     ``i18n_patterns(..., prefix_default_language=True)``, so the unprefixed
     ``/pre-screening/`` would 404 in the browser. Callers typically wrap this
     in ``translation.override(lang)`` to match the user's preferred language.
+
+    The explicit ``urlconf`` argument makes the reverse work from both the
+    HTTP path (where ``DomainURLRoutingMiddleware`` has already pointed the
+    thread-local urlconf at ``urls_crush``) and the CLI path (where no
+    middleware has run, so ``reverse()`` would otherwise fall back to
+    ``settings.ROOT_URLCONF = "azureproject.urls"`` — the portal urlconf,
+    which does not export the ``crush_lu:`` namespace and raises
+    ``NoReverseMatch``).
     """
     from django.urls import reverse
 
-    path = reverse("crush_lu:pre_screening")
+    path = reverse("crush_lu:pre_screening", urlconf="azureproject.urls_crush")
     if request is not None:
         return request.build_absolute_uri(path)
     return f"https://{_default_email_host()}{path}"


### PR DESCRIPTION
## Summary
- `_pre_screening_url()` now passes `urlconf="azureproject.urls_crush"` explicitly to `reverse()`
- Unblocks running `manage.py send_pre_screening_invites` directly (dev shell, backfills, staging debugging)

## Why
Currently only works via the HTTP admin endpoint because `DomainURLRoutingMiddleware` threads the urlconf through `request.urlconf`. CLI invocations have no middleware, so `reverse("crush_lu:pre_screening")` falls back to `ROOT_URLCONF = "azureproject.urls"` (portal urlconf) which doesn't export the `crush_lu:` namespace — raises `NoReverseMatch`. Surfaced today while debugging on the staging slot.

## Why this doesn't break the HTTP path
An explicit `urlconf=` arg always wins over the thread-local fallback. In HTTP context the thread-local is already `urls_crush` anyway, so the two agree.

## Test plan
- [x] Reproduced `NoReverseMatch` on staging via `manage.py send_pre_screening_invites`
- [ ] After merge + deploy, re-run the same command on staging — expect it to render invites without error
- [x] HTTP path still works (manual function trigger + timer tick both green after this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)