### PR TITLE
fix(booking): route confirmation email through send_domain_email + audit log

### DIFF
--- a/azureproject/email_utils.py
+++ b/azureproject/email_utils.py
@@ -115,7 +115,8 @@ def _is_test_environment():
 
 
 def send_domain_email(subject, message, recipient_list, request=None, domain=None,
-                     html_message=None, from_email=None, cc=None, fail_silently=False):
+                     html_message=None, from_email=None, cc=None, fail_silently=False,
+                     attachments=None):
     """
     Send email using domain-specific configuration (Graph API, SMTP, or Console in DEBUG).
 
@@ -131,6 +132,8 @@ def send_domain_email(subject, message, recipient_list, request=None, domain=Non
         from_email: Override from email (optional)
         cc: List of CC email addresses (optional)
         fail_silently: Whether to suppress exceptions (default: False)
+        attachments: Optional iterable of (filename, content, mimetype) tuples
+            to attach to the message (e.g. a calendar .ics file).
 
     Returns:
         int: Number of successfully sent emails
@@ -227,6 +230,11 @@ def send_domain_email(subject, message, recipient_list, request=None, domain=Non
     # Set content type to HTML if html_message provided
     if html_message:
         email.content_subtype = 'html'
+
+    # Attach any extra files (e.g. .ics calendar invites)
+    if attachments:
+        for filename, content, mimetype in attachments:
+            email.attach(filename, content, mimetype)
 
     # Send email
     return email.send(fail_silently=fail_silently)

--- a/crush_lu/views_booking.py
+++ b/crush_lu/views_booking.py
@@ -12,7 +12,6 @@ token guessing.
 from datetime import datetime
 from uuid import UUID
 
-from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.http import Http404
@@ -142,6 +141,15 @@ def confirm_booking(request, booking_token):
     except ProfileSubmission.DoesNotExist:
         raise Http404("Invalid booking token")
 
+    submission.log_system_action(
+        "booking_confirmed",
+        actor=f"user:{submission.profile.user_id}",
+        slot_id=slot.id,
+        coach_id=slot.coach_id,
+        start_at=slot.start_at.isoformat(),
+    )
+    submission.save(update_fields=["system_actions"])
+
     _send_confirmation_email(submission, slot, request)
 
     messages.success(request, _("Your screening call is booked. Check your email for the calendar invite."))
@@ -183,8 +191,9 @@ def _send_confirmation_email(submission, slot, request):
     """
     import logging
 
-    from django.core.mail import EmailMultiAlternatives
     from django.template.loader import render_to_string
+
+    from azureproject.email_utils import send_domain_email
 
     from .services.ics_helper import generate_screening_ics
 
@@ -214,19 +223,21 @@ def _send_confirmation_email(submission, slot, request):
         body_txt = render_to_string("crush_lu/emails/screening_confirmed.txt", context)
         body_html = render_to_string("crush_lu/emails/screening_confirmed.html", context)
 
-        msg = EmailMultiAlternatives(
+        send_domain_email(
             subject=str(_("Your Crush.lu screening call is booked")),
-            body=body_txt,
-            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", None),
-            to=[user_email],
+            message=body_txt,
+            recipient_list=[user_email],
+            request=request,
+            html_message=body_html,
+            fail_silently=True,
+            attachments=[
+                (
+                    "screening-call.ics",
+                    generate_screening_ics(submission, slot, booking_url),
+                    "text/calendar; method=REQUEST",
+                ),
+            ],
         )
-        msg.attach_alternative(body_html, "text/html")
-        msg.attach(
-            "screening-call.ics",
-            generate_screening_ics(submission, slot, booking_url),
-            "text/calendar; method=REQUEST",
-        )
-        msg.send(fail_silently=True)
         logger.info(
             "hybrid_coach.booking_confirmed",
             extra={


### PR DESCRIPTION
## Summary

Two staging-discovered bugs in the hybrid-coach self-booking flow:

1. **Booking confirmation email was silently dropped.** \`_send_confirmation_email\` used \`EmailMultiAlternatives.send(fail_silently=True)\` directly, bypassing the \`send_domain_email()\` helper that has the \`STAGING_MODE\` console-backend branch. On staging the email vanished into Graph API with no log trace. Fix: extend \`send_domain_email\` with \`attachments=\` (for the .ics file) and route through it.

2. **\`booking_confirmed\` audit log was missing.** Cancel path writes \`booking_cancelled\` to \`system_actions\`; confirm path wrote nothing. Symmetric fix added after \`claim_for_submission\` succeeds.

## Staging evidence

- Confirmed twice (12:03:12 UTC, 12:03:32 UTC) + cancelled once (12:03:18 UTC) → slot #2 booked, slot #1 cancelled ✓
- \`system_actions\` contained only \`fallback_offered\` + \`booking_cancelled\` — **no confirm entries**
- No \`screening_confirmed\` email visible in \`az webapp log tail\` for either confirm

## Not in this PR (follow-ups flagged)

- **Email body i18n** — German-preferring users still see English body text. Templates already wrap every user-visible string in \`{% trans %}\`; the gap is missing msgid translations in \`crush_lu/locale/de/django.po\` and \`fr/django.po\`. Running \`makemessages\` reformats 11k+ lines across 11 \`.po\` files; that hygiene + translation pass deserves its own PR.
- **\`review_call_date\`** — investigated (writers at \`views_coach.py:778\` + \`admin/profiles.py:1457\`, readers in coach-dashboard templates). It's the "call completed" timestamp set by coach, not a scheduled-at timestamp. Null after booking is correct. No change needed.
- **Pre-existing smart-quote damage** in DE .po (\`“ ”\` used as syntax quotes in ~40 lines, causes \`msgmerge\` fatal errors). Tiny independent fix; bundle with the i18n PR.

## Test plan

- [x] Agent B verified diff locally; code changes compile + import cleanly.
- [ ] Deploy to staging slot → re-run the self-booking flow → expect \`screening_confirmed\` email to appear in \`az webapp log tail\` with the .ics attachment inline-visible.
- [ ] Verify \`system_actions\` now contains \`booking_confirmed\` entry after \`confirm_booking\` with \`slot_id\`, \`coach_id\`, \`start_at\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)