### PR TITLE
Fix LuxID profile updates during email account linking flow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
         language: [javascript-typescript, python]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1493,10 +1493,11 @@ def _luxid_phone_available(phone, profile):
         .exists()
     )
     if clash:
+        _masked = (phone[:3] + "***" + phone[-3:]) if phone and len(phone) > 6 else "***"
         logger.warning(
             "LuxID phone_number %s already owned by another CrushProfile; "
             "skipping phone prefill for user=%s",
-            phone,
+            _masked,
             getattr(profile.user, "email", profile.user_id),
         )
         return False

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1793,10 +1793,29 @@ def create_crush_profile_from_luxid(sender, instance, created, **kwargs):
             # Existing profile (email user connecting LuxID): the
             # pre_social_login handler is the primary path, but it can
             # miss this case when sociallogin.user.id is None at signal
-            # time. Ensure the phone is always populated here as a
-            # safety net so the "Verify with LuxID" fallback works
-            # regardless of allauth's internal association order.
+            # time. Mirror the same field-population logic here as a
+            # safety net so birthdate, gender, and phone are always
+            # populated regardless of allauth's internal association order.
             claims = _luxid_claims(instance.extra_data)
+            updated_fields = []
+
+            birthdate = claims.get("birthdate")
+            if birthdate and not profile.date_of_birth:
+                try:
+                    profile.date_of_birth = datetime.strptime(
+                        birthdate, "%Y-%m-%d"
+                    ).date()
+                    updated_fields.append("date_of_birth")
+                except (ValueError, TypeError):
+                    pass
+
+            gender = (claims.get("gender") or "").lower()
+            if gender and not profile.gender:
+                mapped = LUXID_GENDER_MAP.get(gender, "")
+                if mapped:
+                    profile.gender = mapped
+                    updated_fields.append("gender")
+
             phone = claims.get("phone_number")
             if (
                 phone
@@ -1807,13 +1826,16 @@ def create_crush_profile_from_luxid(sender, instance, created, **kwargs):
                 profile.phone_number = phone
                 profile.phone_verified = True
                 profile.phone_verified_at = timezone.now()
-                profile.save(
-                    update_fields=["phone_number", "phone_verified", "phone_verified_at"]
+                updated_fields.extend(
+                    ["phone_number", "phone_verified", "phone_verified_at"]
                 )
+
+            if updated_fields:
+                profile.save(update_fields=updated_fields)
                 logger.info(
-                    "Updated phone for existing CrushProfile via LuxID connect "
-                    "for user %s",
+                    "Updated existing CrushProfile via LuxID connect for user %s: %s",
                     instance.user.email,
+                    updated_fields,
                 )
 
         # Send welcome email for new OAuth signups

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1599,10 +1599,21 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                 )
             ]
 
-        # Update CrushProfile for existing users
-        if hasattr(sociallogin.user, "id") and sociallogin.user.id:
+        # Update CrushProfile for existing users.
+        # During the connect flow (email user linking LuxID for the first
+        # time), allauth has not yet associated sociallogin.user with
+        # request.user when pre_social_login fires, so sociallogin.user.id
+        # is None. Fall back to request.user so we can still update the
+        # existing profile in that case.
+        _sl_user = sociallogin.user
+        if not (hasattr(_sl_user, "id") and _sl_user.id):
+            _req_user = getattr(request, "user", None)
+            if _req_user is not None and getattr(_req_user, "is_authenticated", False):
+                _sl_user = _req_user
+
+        if hasattr(_sl_user, "id") and _sl_user.id:
             try:
-                profile = CrushProfile.objects.get(user=sociallogin.user)
+                profile = CrushProfile.objects.get(user=_sl_user)
                 updated_fields = []
 
                 # Map birthdate (OIDC format: YYYY-MM-DD)
@@ -1777,6 +1788,33 @@ def create_crush_profile_from_luxid(sender, instance, created, **kwargs):
                 f"Created CrushProfile for LuxID user {instance.user.email} "
                 f"with fields: {updated_fields}"
             )
+
+        else:
+            # Existing profile (email user connecting LuxID): the
+            # pre_social_login handler is the primary path, but it can
+            # miss this case when sociallogin.user.id is None at signal
+            # time. Ensure the phone is always populated here as a
+            # safety net so the "Verify with LuxID" fallback works
+            # regardless of allauth's internal association order.
+            claims = _luxid_claims(instance.extra_data)
+            phone = claims.get("phone_number")
+            if (
+                phone
+                and _is_luxembourgish_phone(phone)
+                and phone != profile.phone_number
+                and _luxid_phone_available(phone, profile)
+            ):
+                profile.phone_number = phone
+                profile.phone_verified = True
+                profile.phone_verified_at = timezone.now()
+                profile.save(
+                    update_fields=["phone_number", "phone_verified", "phone_verified_at"]
+                )
+                logger.info(
+                    "Updated phone for existing CrushProfile via LuxID connect "
+                    "for user %s",
+                    instance.user.email,
+                )
 
         # Send welcome email for new OAuth signups
         if profile_created:

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1493,12 +1493,11 @@ def _luxid_phone_available(phone, profile):
         .exists()
     )
     if clash:
-        _masked = (phone[:3] + "***" + phone[-3:]) if phone and len(phone) > 6 else "***"
         logger.warning(
-            "LuxID phone_number %s already owned by another CrushProfile; "
-            "skipping phone prefill for user=%s",
-            _masked,
-            getattr(profile.user, "email", profile.user_id),
+            "LuxID phone_number clash detected; skipping phone prefill for "
+            "profile pk=%s user_id=%s",
+            profile.pk,
+            profile.user_id,
         )
         return False
     return True

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1603,10 +1603,19 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
         # During the connect flow (email user linking LuxID for the first
         # time), allauth has not yet associated sociallogin.user with
         # request.user when pre_social_login fires, so sociallogin.user.id
-        # is None. Fall back to request.user so we can still update the
-        # existing profile in that case.
+        # is None. Fall back to request.user ONLY when this is explicitly a
+        # connect process — never during a normal login, where falling back
+        # to request.user could write the new LuxID claims into the current
+        # session user's profile before they are logged out (cross-account
+        # data corruption).
         _sl_user = sociallogin.user
-        if not (hasattr(_sl_user, "id") and _sl_user.id):
+        _is_connect = (
+            getattr(sociallogin, "state", {}).get("process") == "connect"
+        )
+        if (
+            _is_connect
+            and not (hasattr(_sl_user, "id") and _sl_user.id)
+        ):
             _req_user = getattr(request, "user", None)
             if _req_user is not None and getattr(_req_user, "is_authenticated", False):
                 _sl_user = _req_user

--- a/crush_lu/templates/crush_lu/account_settings.html
+++ b/crush_lu/templates/crush_lu/account_settings.html
@@ -141,7 +141,7 @@
                     </a>
                     {% endif %}
                     {% if luxid_available and not luxid_connected %}
-                    <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                    <a href="{{ luxid_connect_url }}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
                         <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
                         LuxID
                     </a>
@@ -180,7 +180,7 @@
                     </a>
                     {% endif %}
                     {% if luxid_available %}
-                    <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                    <a href="{{ luxid_connect_url }}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
                         <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
                         LuxID
                     </a>

--- a/crush_lu/templates/crush_lu/account_settings.html
+++ b/crush_lu/templates/crush_lu/account_settings.html
@@ -83,7 +83,7 @@
                             {% elif social.provider == 'apple' %}
                             <svg class="w-6 h-6 mr-3 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                             <span class="font-semibold">Apple</span>
-                            {% elif social.provider == 'luxid' or social.provider == 'openid_connect' %}
+                            {% elif social.is_luxid %}
                             <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-6 h-6 mr-3 shrink-0 rounded" style="object-fit: contain;">
                             <span class="font-semibold">LuxID</span>
                             {% else %}

--- a/crush_lu/templates/crush_lu/account_settings.html
+++ b/crush_lu/templates/crush_lu/account_settings.html
@@ -1,5 +1,5 @@
 {% extends 'crush_lu/base.html' %}
-{% load socialaccount i18n %}
+{% load socialaccount i18n static %}
 
 {% block title %}{% trans "Account Settings - Crush.lu" %}{% endblock %}
 {% block mobile_page_title %}{% trans "Settings" %}{% endblock %}
@@ -83,6 +83,9 @@
                             {% elif social.provider == 'apple' %}
                             <svg class="w-6 h-6 mr-3 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                             <span class="font-semibold">Apple</span>
+                            {% elif social.provider == 'luxid' or social.provider == 'openid_connect' %}
+                            <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-6 h-6 mr-3 shrink-0 rounded" style="object-fit: contain;">
+                            <span class="font-semibold">LuxID</span>
                             {% else %}
                             {% include "shared/icons/link.html" with class="w-7 h-7" %}
                             <span class="font-semibold">{{ social.provider|title }}</span>
@@ -110,7 +113,7 @@
                 {% endif %}
 
                 <!-- Available Providers to Connect -->
-                {% if google_available and not google_connected or facebook_available and not facebook_connected or microsoft_available and not microsoft_connected or apple_available and not apple_connected %}
+                {% if google_available and not google_connected or facebook_available and not facebook_connected or microsoft_available and not microsoft_connected or apple_available and not apple_connected or luxid_available and not luxid_connected %}
                 <h6 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">{% trans "Connect More Accounts" %}</h6>
                 <div class="flex flex-wrap gap-2">
                     {% if google_available and not google_connected %}
@@ -137,6 +140,12 @@
                         Apple
                     </a>
                     {% endif %}
+                    {% if luxid_available and not luxid_connected %}
+                    <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                        <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
+                        LuxID
+                    </a>
+                    {% endif %}
                 </div>
                 {% endif %}
 
@@ -144,7 +153,7 @@
                 <p class="text-gray-500 dark:text-gray-400 dark:text-gray-500 mb-4">
                     {% trans "You don't have any social accounts connected yet." %}
                 </p>
-                {% if google_available or facebook_available or microsoft_available or apple_available %}
+                {% if google_available or facebook_available or microsoft_available or apple_available or luxid_available %}
                 <div class="flex flex-wrap gap-2">
                     {% if google_available %}
                     <a href="{% provider_login_url 'google' process='connect' %}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
@@ -168,6 +177,12 @@
                     <a href="{% provider_login_url 'apple' process='connect' %}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
                         <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                         Apple
+                    </a>
+                    {% endif %}
+                    {% if luxid_available %}
+                    <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                        <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
+                        LuxID
                     </a>
                     {% endif %}
                 </div>

--- a/crush_lu/templates/crush_lu/partials/edit_account_settings.html
+++ b/crush_lu/templates/crush_lu/partials/edit_account_settings.html
@@ -74,7 +74,7 @@
                         {% elif social.provider == 'apple' %}
                         <svg class="w-6 h-6 mr-3 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                         <span class="font-semibold">Apple</span>
-                        {% elif social.provider == 'luxid' or social.provider == 'openid_connect' %}
+                        {% elif social.is_luxid %}
                         <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-6 h-6 mr-3 shrink-0 rounded" style="object-fit: contain;">
                         <span class="font-semibold">LuxID</span>
                         {% else %}

--- a/crush_lu/templates/crush_lu/partials/edit_account_settings.html
+++ b/crush_lu/templates/crush_lu/partials/edit_account_settings.html
@@ -132,7 +132,7 @@
                 </a>
                 {% endif %}
                 {% if luxid_available and not luxid_connected %}
-                <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                <a href="{{ luxid_connect_url }}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
                     <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
                     LuxID
                 </a>
@@ -171,7 +171,7 @@
                 </a>
                 {% endif %}
                 {% if luxid_available %}
-                <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                <a href="{{ luxid_connect_url }}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
                     <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
                     LuxID
                 </a>

--- a/crush_lu/templates/crush_lu/partials/edit_account_settings.html
+++ b/crush_lu/templates/crush_lu/partials/edit_account_settings.html
@@ -1,4 +1,4 @@
-{% load socialaccount i18n %}
+{% load socialaccount i18n static %}
 
 <div class="max-w-3xl mx-auto">
     <!-- Account Info Card -->
@@ -74,6 +74,9 @@
                         {% elif social.provider == 'apple' %}
                         <svg class="w-6 h-6 mr-3 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                         <span class="font-semibold">Apple</span>
+                        {% elif social.provider == 'luxid' or social.provider == 'openid_connect' %}
+                        <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-6 h-6 mr-3 shrink-0 rounded" style="object-fit: contain;">
+                        <span class="font-semibold">LuxID</span>
                         {% else %}
                         {% include "shared/icons/link.html" with class="w-7 h-7" %}
                         <span class="font-semibold">{{ social.provider|title }}</span>
@@ -101,7 +104,7 @@
             {% endif %}
 
             <!-- Available Providers to Connect -->
-            {% if google_available and not google_connected or facebook_available and not facebook_connected or microsoft_available and not microsoft_connected or apple_available and not apple_connected %}
+            {% if google_available and not google_connected or facebook_available and not facebook_connected or microsoft_available and not microsoft_connected or apple_available and not apple_connected or luxid_available and not luxid_connected %}
             <h6 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">{% trans "Connect More Accounts" %}</h6>
             <div class="flex flex-wrap gap-2">
                 {% if google_available and not google_connected %}
@@ -128,6 +131,12 @@
                     Apple
                 </a>
                 {% endif %}
+                {% if luxid_available and not luxid_connected %}
+                <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                    <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
+                    LuxID
+                </a>
+                {% endif %}
             </div>
             {% endif %}
 
@@ -135,7 +144,7 @@
             <p class="text-gray-500 dark:text-gray-400 mb-4">
                 {% trans "You don't have any social accounts connected yet." %}
             </p>
-            {% if google_available or facebook_available or microsoft_available or apple_available %}
+            {% if google_available or facebook_available or microsoft_available or apple_available or luxid_available %}
             <div class="flex flex-wrap gap-2">
                 {% if google_available %}
                 <a href="{% provider_login_url 'google' process='connect' %}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
@@ -159,6 +168,12 @@
                 <a href="{% provider_login_url 'apple' process='connect' %}" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
                     <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="currentColor"><path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/></svg>
                     Apple
+                </a>
+                {% endif %}
+                {% if luxid_available %}
+                <a href="{% url 'luxid_login' %}?process=connect" class="border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 px-4 py-2 rounded-lg transition-colors flex items-center">
+                    <img src="{% static 'crush_lu/images/Logo-LuxID_small.webp' %}" alt="LuxID" class="w-5 h-5 mr-2 rounded" style="object-fit: contain;">
+                    LuxID
                 </a>
                 {% endif %}
             </div>

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1033,7 +1033,7 @@ def _edit_sub_account_settings(request, profile):
         available_providers = set()
 
     oidc_app = None
-    if "openid_connect" in available_providers and "luxid" not in available_providers:
+    if "openid_connect" in available_providers:
         try:
             oidc_app = SocialApp.objects.filter(
                 provider="openid_connect", provider_id="luxid", sites=current_site
@@ -1052,6 +1052,16 @@ def _edit_sub_account_settings(request, profile):
         except Exception:
             pass
     luxid_connected = "luxid" in connected_providers or _luxid_oidc_connected
+
+    # Annotate is_luxid on each account so templates can brand correctly without
+    # treating every openid_connect account as LuxID.
+    _luxid_oidc_app_pk = oidc_app.pk if oidc_app is not None else None
+    for account in crush_social_accounts:
+        account.is_luxid = account.provider == "luxid" or (
+            account.provider == "openid_connect"
+            and _luxid_oidc_app_pk is not None
+            and getattr(account, "app_id", None) == _luxid_oidc_app_pk
+        )
 
     context = {
         "profile": profile,

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1041,6 +1041,18 @@ def _edit_sub_account_settings(request, profile):
         except Exception:
             pass
 
+    # Scope the openid_connect connected check to the LuxID-specific OIDC app so
+    # that accounts from other OIDC IdPs on the same site are not misclassified.
+    _luxid_oidc_connected = False
+    if oidc_app is not None and "openid_connect" in connected_providers:
+        try:
+            _luxid_oidc_connected = request.user.socialaccount_set.filter(
+                provider="openid_connect", app=oidc_app
+            ).exists()
+        except Exception:
+            pass
+    luxid_connected = "luxid" in connected_providers or _luxid_oidc_connected
+
     context = {
         "profile": profile,
         "section": "account",
@@ -1048,7 +1060,7 @@ def _edit_sub_account_settings(request, profile):
         "facebook_connected": "facebook" in connected_providers,
         "microsoft_connected": "microsoft" in connected_providers,
         "apple_connected": "apple" in connected_providers,
-        "luxid_connected": bool({"luxid", "openid_connect"} & connected_providers),
+        "luxid_connected": luxid_connected,
         "google_available": "google" in available_providers,
         "facebook_available": "facebook" in available_providers,
         "microsoft_available": "microsoft" in available_providers,

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1032,6 +1032,15 @@ def _edit_sub_account_settings(request, profile):
     except Exception:
         available_providers = set()
 
+    oidc_app = None
+    if "openid_connect" in available_providers and "luxid" not in available_providers:
+        try:
+            oidc_app = SocialApp.objects.filter(
+                provider="openid_connect", sites=current_site
+            ).first()
+        except Exception:
+            pass
+
     context = {
         "profile": profile,
         "section": "account",
@@ -1045,7 +1054,7 @@ def _edit_sub_account_settings(request, profile):
         "microsoft_available": "microsoft" in available_providers,
         "apple_available": "apple" in available_providers,
         "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
-        "luxid_connect_url": _luxid_connect_url(available_providers),
+        "luxid_connect_url": _luxid_connect_url(available_providers, oidc_app=oidc_app),
         "crush_social_accounts": crush_social_accounts,
         "social_photos": social_photos,
         "is_apple_relay_user": bool(

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1041,27 +1041,27 @@ def _edit_sub_account_settings(request, profile):
         except Exception:
             pass
 
-    # Scope the openid_connect connected check to the LuxID-specific OIDC app so
-    # that accounts from other OIDC IdPs on the same site are not misclassified.
-    _luxid_oidc_connected = False
+    # Scope the openid_connect connected check to the LuxID-specific OIDC app.
+    # SocialAccount has no app FK in allauth 65.x; route through SocialToken which does.
+    _luxid_oidc_acct_ids: set = set()
     if oidc_app is not None and "openid_connect" in connected_providers:
         try:
-            _luxid_oidc_connected = request.user.socialaccount_set.filter(
-                provider="openid_connect", app=oidc_app
-            ).exists()
+            from allauth.socialaccount.models import SocialToken
+            _luxid_oidc_acct_ids = set(
+                SocialToken.objects.filter(
+                    account__user=request.user,
+                    account__provider="openid_connect",
+                    app=oidc_app,
+                ).values_list("account_id", flat=True)
+            )
         except Exception:
             pass
-    luxid_connected = "luxid" in connected_providers or _luxid_oidc_connected
+    luxid_connected = "luxid" in connected_providers or bool(_luxid_oidc_acct_ids)
 
     # Annotate is_luxid on each account so templates can brand correctly without
     # treating every openid_connect account as LuxID.
-    _luxid_oidc_app_pk = oidc_app.pk if oidc_app is not None else None
     for account in crush_social_accounts:
-        account.is_luxid = account.provider == "luxid" or (
-            account.provider == "openid_connect"
-            and _luxid_oidc_app_pk is not None
-            and getattr(account, "app_id", None) == _luxid_oidc_app_pk
-        )
+        account.is_luxid = account.provider == "luxid" or account.pk in _luxid_oidc_acct_ids
 
     context = {
         "profile": profile,

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -991,7 +991,7 @@ def _edit_sub_account_settings(request, profile):
     from django.contrib.sites.models import Site
     from .social_photos import get_all_social_photos
 
-    CRUSH_SOCIAL_PROVIDERS = ["google", "facebook", "microsoft", "apple"]
+    CRUSH_SOCIAL_PROVIDERS = ["google", "facebook", "microsoft", "apple", "luxid", "openid_connect"]
 
     connected_providers = set(
         request.user.socialaccount_set.values_list("provider", flat=True)
@@ -1009,6 +1009,13 @@ def _edit_sub_account_settings(request, profile):
                 or account.extra_data.get("email")
                 or ""
             )
+        elif account.provider in ("luxid", "openid_connect"):
+            _claims = (
+                account.extra_data.get("userinfo")
+                or account.extra_data.get("id_token")
+                or account.extra_data
+            )
+            account.display_email = _claims.get("email", "") if isinstance(_claims, dict) else ""
         else:
             account.display_email = account.extra_data.get("email", "")
 
@@ -1031,10 +1038,12 @@ def _edit_sub_account_settings(request, profile):
         "facebook_connected": "facebook" in connected_providers,
         "microsoft_connected": "microsoft" in connected_providers,
         "apple_connected": "apple" in connected_providers,
+        "luxid_connected": bool({"luxid", "openid_connect"} & connected_providers),
         "google_available": "google" in available_providers,
         "facebook_available": "facebook" in available_providers,
         "microsoft_available": "microsoft" in available_providers,
         "apple_available": "apple" in available_providers,
+        "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
         "crush_social_accounts": crush_social_accounts,
         "social_photos": social_photos,
         "is_apple_relay_user": bool(

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -109,6 +109,7 @@ from .views_account import (  # noqa: F401
     signup,
     export_user_data,
     apple_relay_link_prompt,
+    _luxid_connect_url,
 )
 
 # Events
@@ -1044,6 +1045,7 @@ def _edit_sub_account_settings(request, profile):
         "microsoft_available": "microsoft" in available_providers,
         "apple_available": "apple" in available_providers,
         "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
+        "luxid_connect_url": _luxid_connect_url(available_providers),
         "crush_social_accounts": crush_social_accounts,
         "social_photos": social_photos,
         "is_apple_relay_user": bool(

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1036,7 +1036,7 @@ def _edit_sub_account_settings(request, profile):
     if "openid_connect" in available_providers and "luxid" not in available_providers:
         try:
             oidc_app = SocialApp.objects.filter(
-                provider="openid_connect", sites=current_site
+                provider="openid_connect", provider_id="luxid", sites=current_site
             ).first()
         except Exception:
             pass
@@ -1053,7 +1053,7 @@ def _edit_sub_account_settings(request, profile):
         "facebook_available": "facebook" in available_providers,
         "microsoft_available": "microsoft" in available_providers,
         "apple_available": "apple" in available_providers,
-        "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
+        "luxid_available": "luxid" in available_providers or oidc_app is not None,
         "luxid_connect_url": _luxid_connect_url(available_providers, oidc_app=oidc_app),
         "crush_social_accounts": crush_social_accounts,
         "social_photos": social_photos,

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -439,7 +439,9 @@ def account_settings(request):
 
     # Crush.lu only supports these social providers
     # (LinkedIn is PowerUP-only, not shown in Crush.lu account settings)
-    CRUSH_SOCIAL_PROVIDERS = ["google", "facebook", "microsoft", "apple"]
+    # LuxID can be stored as "luxid" (custom provider) or "openid_connect"
+    # (generic OIDC fallback), so both spellings are included.
+    CRUSH_SOCIAL_PROVIDERS = ["google", "facebook", "microsoft", "apple", "luxid", "openid_connect"]
 
     # Get connected social providers for this user (filtered to Crush.lu providers)
     connected_providers = set(
@@ -451,8 +453,9 @@ def account_settings(request):
         provider__in=CRUSH_SOCIAL_PROVIDERS
     )
 
-    # Annotate each social account with a resolved display email
-    # Microsoft stores email in 'mail' or 'userPrincipalName', not 'email'
+    # Annotate each social account with a resolved display email.
+    # Microsoft stores email in 'mail' or 'userPrincipalName', not 'email'.
+    # LuxID wraps claims inside {"userinfo": {...}} or {"id_token": {...}}.
     for account in crush_social_accounts:
         if account.provider == "microsoft":
             account.display_email = (
@@ -461,6 +464,13 @@ def account_settings(request):
                 or account.extra_data.get("email")
                 or ""
             )
+        elif account.provider in ("luxid", "openid_connect"):
+            _claims = (
+                account.extra_data.get("userinfo")
+                or account.extra_data.get("id_token")
+                or account.extra_data
+            )
+            account.display_email = _claims.get("email", "") if isinstance(_claims, dict) else ""
         else:
             account.display_email = account.extra_data.get("email", "")
 
@@ -489,10 +499,12 @@ def account_settings(request):
             "facebook_connected": "facebook" in connected_providers,
             "microsoft_connected": "microsoft" in connected_providers,
             "apple_connected": "apple" in connected_providers,
+            "luxid_connected": bool({"luxid", "openid_connect"} & connected_providers),
             "google_available": "google" in available_providers,
             "facebook_available": "facebook" in available_providers,
             "microsoft_available": "microsoft" in available_providers,
             "apple_available": "apple" in available_providers,
+            "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
             "crush_social_accounts": crush_social_accounts,  # Filtered list for display
             "social_photos": social_photos,  # Social photos for import
             # Apple "Hide My Email" relay detection

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -526,6 +526,18 @@ def account_settings(request):
         except Exception:
             pass
 
+    # Scope the openid_connect connected check to the LuxID-specific OIDC app so
+    # that accounts from other OIDC IdPs on the same site are not misclassified.
+    _luxid_oidc_connected = False
+    if oidc_app is not None and "openid_connect" in connected_providers:
+        try:
+            _luxid_oidc_connected = request.user.socialaccount_set.filter(
+                provider="openid_connect", app=oidc_app
+            ).exists()
+        except Exception:
+            pass
+    luxid_connected = "luxid" in connected_providers or _luxid_oidc_connected
+
     return render(
         request,
         "crush_lu/account_settings.html",
@@ -535,7 +547,7 @@ def account_settings(request):
             "facebook_connected": "facebook" in connected_providers,
             "microsoft_connected": "microsoft" in connected_providers,
             "apple_connected": "apple" in connected_providers,
-            "luxid_connected": bool({"luxid", "openid_connect"} & connected_providers),
+            "luxid_connected": luxid_connected,
             "google_available": "google" in available_providers,
             "facebook_available": "facebook" in available_providers,
             "microsoft_available": "microsoft" in available_providers,

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -358,6 +358,27 @@ def data_deletion_status(request):
     )
 
 
+def _luxid_connect_url(available_providers):
+    """Return the correct OAuth connect URL for LuxID given available providers.
+
+    Prefers the custom 'luxid' provider (fixed URL, no path kwargs). Falls back
+    to allauth's generic openid_connect URL when the SocialApp is configured
+    with provider='openid_connect' instead, so the connect button never points
+    at a missing SocialApp.
+    """
+    if "luxid" in available_providers:
+        try:
+            return reverse("luxid_login") + "?process=connect"
+        except Exception:
+            pass
+    if "openid_connect" in available_providers:
+        try:
+            return reverse("openid_connect_login") + "?process=connect"
+        except Exception:
+            pass
+    return None
+
+
 @crush_login_required
 def account_settings(request):
     """
@@ -505,6 +526,7 @@ def account_settings(request):
             "microsoft_available": "microsoft" in available_providers,
             "apple_available": "apple" in available_providers,
             "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
+            "luxid_connect_url": _luxid_connect_url(available_providers),
             "crush_social_accounts": crush_social_accounts,  # Filtered list for display
             "social_photos": social_photos,  # Social photos for import
             # Apple "Hide My Email" relay detection

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -526,27 +526,27 @@ def account_settings(request):
         except Exception:
             pass
 
-    # Scope the openid_connect connected check to the LuxID-specific OIDC app so
-    # that accounts from other OIDC IdPs on the same site are not misclassified.
-    _luxid_oidc_connected = False
+    # Scope the openid_connect connected check to the LuxID-specific OIDC app.
+    # SocialAccount has no app FK in allauth 65.x; route through SocialToken which does.
+    _luxid_oidc_acct_ids: set = set()
     if oidc_app is not None and "openid_connect" in connected_providers:
         try:
-            _luxid_oidc_connected = request.user.socialaccount_set.filter(
-                provider="openid_connect", app=oidc_app
-            ).exists()
+            from allauth.socialaccount.models import SocialToken
+            _luxid_oidc_acct_ids = set(
+                SocialToken.objects.filter(
+                    account__user=request.user,
+                    account__provider="openid_connect",
+                    app=oidc_app,
+                ).values_list("account_id", flat=True)
+            )
         except Exception:
             pass
-    luxid_connected = "luxid" in connected_providers or _luxid_oidc_connected
+    luxid_connected = "luxid" in connected_providers or bool(_luxid_oidc_acct_ids)
 
     # Annotate is_luxid on each account so templates can brand correctly without
     # treating every openid_connect account as LuxID.
-    _luxid_oidc_app_pk = oidc_app.pk if oidc_app is not None else None
     for account in crush_social_accounts:
-        account.is_luxid = account.provider == "luxid" or (
-            account.provider == "openid_connect"
-            and _luxid_oidc_app_pk is not None
-            and getattr(account, "app_id", None) == _luxid_oidc_app_pk
-        )
+        account.is_luxid = account.provider == "luxid" or account.pk in _luxid_oidc_acct_ids
 
     return render(
         request,

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -521,7 +521,7 @@ def account_settings(request):
     if "openid_connect" in available_providers and "luxid" not in available_providers:
         try:
             oidc_app = SocialApp.objects.filter(
-                provider="openid_connect", sites=current_site
+                provider="openid_connect", provider_id="luxid", sites=current_site
             ).first()
         except Exception:
             pass
@@ -540,7 +540,7 @@ def account_settings(request):
             "facebook_available": "facebook" in available_providers,
             "microsoft_available": "microsoft" in available_providers,
             "apple_available": "apple" in available_providers,
-            "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
+            "luxid_available": "luxid" in available_providers or oidc_app is not None,
             "luxid_connect_url": _luxid_connect_url(available_providers, oidc_app=oidc_app),
             "crush_social_accounts": crush_social_accounts,  # Filtered list for display
             "social_photos": social_photos,  # Social photos for import

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -518,7 +518,7 @@ def account_settings(request):
         available_providers = set()
 
     oidc_app = None
-    if "openid_connect" in available_providers and "luxid" not in available_providers:
+    if "openid_connect" in available_providers:
         try:
             oidc_app = SocialApp.objects.filter(
                 provider="openid_connect", provider_id="luxid", sites=current_site
@@ -537,6 +537,16 @@ def account_settings(request):
         except Exception:
             pass
     luxid_connected = "luxid" in connected_providers or _luxid_oidc_connected
+
+    # Annotate is_luxid on each account so templates can brand correctly without
+    # treating every openid_connect account as LuxID.
+    _luxid_oidc_app_pk = oidc_app.pk if oidc_app is not None else None
+    for account in crush_social_accounts:
+        account.is_luxid = account.provider == "luxid" or (
+            account.provider == "openid_connect"
+            and _luxid_oidc_app_pk is not None
+            and getattr(account, "app_id", None) == _luxid_oidc_app_pk
+        )
 
     return render(
         request,

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -358,22 +358,28 @@ def data_deletion_status(request):
     )
 
 
-def _luxid_connect_url(available_providers):
+def _luxid_connect_url(available_providers, oidc_app=None):
     """Return the correct OAuth connect URL for LuxID given available providers.
 
     Prefers the custom 'luxid' provider (fixed URL, no path kwargs). Falls back
     to allauth's generic openid_connect URL when the SocialApp is configured
-    with provider='openid_connect' instead, so the connect button never points
-    at a missing SocialApp.
+    with provider='openid_connect' instead. In that case the openid_connect URL
+    requires a provider_id path kwarg (allauth 0.61+), so the caller must pass
+    the SocialApp object as oidc_app to supply it.
     """
     if "luxid" in available_providers:
         try:
             return reverse("luxid_login") + "?process=connect"
         except Exception:
             pass
-    if "openid_connect" in available_providers:
+    if "openid_connect" in available_providers and oidc_app is not None:
         try:
-            return reverse("openid_connect_login") + "?process=connect"
+            pid = getattr(oidc_app, "provider_id", None) or getattr(oidc_app, "slug", None)
+            if pid:
+                return (
+                    reverse("openid_connect_login", kwargs={"provider_id": pid})
+                    + "?process=connect"
+                )
         except Exception:
             pass
     return None
@@ -511,6 +517,15 @@ def account_settings(request):
         logger.warning("Failed to fetch available social providers", exc_info=True)
         available_providers = set()
 
+    oidc_app = None
+    if "openid_connect" in available_providers and "luxid" not in available_providers:
+        try:
+            oidc_app = SocialApp.objects.filter(
+                provider="openid_connect", sites=current_site
+            ).first()
+        except Exception:
+            pass
+
     return render(
         request,
         "crush_lu/account_settings.html",
@@ -526,7 +541,7 @@ def account_settings(request):
             "microsoft_available": "microsoft" in available_providers,
             "apple_available": "apple" in available_providers,
             "luxid_available": bool({"luxid", "openid_connect"} & available_providers),
-            "luxid_connect_url": _luxid_connect_url(available_providers),
+            "luxid_connect_url": _luxid_connect_url(available_providers, oidc_app=oidc_app),
             "crush_social_accounts": crush_social_accounts,  # Filtered list for display
             "social_photos": social_photos,  # Social photos for import
             # Apple "Hide My Email" relay detection


### PR DESCRIPTION
## Purpose
* Fix a bug where LuxID profile data (birthdate, gender, phone) was not being populated when an existing email user connects LuxID for the first time
* During the `pre_social_login` signal, `sociallogin.user.id` is `None` during the connect flow because allauth hasn't yet associated the social login with the request user, causing the profile update to be skipped
* Add a fallback to use `request.user` when `sociallogin.user.id` is unavailable, and add a safety net in the `post_save` signal handler to ensure profile fields are always populated
* Add LuxID support to the account settings UI to display connected LuxID accounts and allow users to connect LuxID

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Verify that an existing email user can connect LuxID via account settings
* Confirm that after connecting LuxID, the user's profile is updated with birthdate, gender, and phone number from LuxID claims
* Verify that the LuxID provider displays correctly in the connected accounts list with the LuxID logo
* Test both the initial connection flow and subsequent logins with the connected LuxID account

## What to Check
Verify that the following are valid:
* LuxID appears in the "Connect More Accounts" section when available and not yet connected
* Connected LuxID accounts display with the LuxID logo in the account settings
* Profile data (birthdate, gender, phone) is populated from LuxID claims during the connect flow
* The code handles both "luxid" and "openid_connect" provider names (fallback naming)
* Existing tests continue to pass

## Other Information
The changes handle the allauth signal timing issue where `sociallogin.user` is not yet associated with `request.user` during the connect flow. The fix uses a two-pronged approach:
1. In `update_crush_profile_from_luxid`: Fall back to `request.user` when `sociallogin.user.id` is None
2. In `create_crush_profile_from_luxid`: Add a safety net in the post_save handler to populate fields if they weren't set during pre_social_login

This ensures profile data is always populated regardless of allauth's internal association order.

https://claude.ai/code/session_01FYjpsYtEF9MFRAT25L35PK