### PR TITLE
Refactor event registrations view to organize by status with pool stats

### DIFF
--- a/crush_lu/templates/crush_lu/coach_event_detail.html
+++ b/crush_lu/templates/crush_lu/coach_event_detail.html
@@ -184,147 +184,338 @@
     </a>
     <a href="?status=other" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg transition-colors {% if status_filter == 'other' %}bg-gray-600 text-white{% else %}bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700{% endif %}">
         {% trans "Other" %}
+        {% if other_count %}<span class="ml-1.5 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs rounded-full {% if status_filter == 'other' %}bg-white/20{% else %}bg-gray-100 dark:bg-gray-700{% endif %}">{{ other_count }}</span>{% endif %}
     </a>
 </div>
 
-<!-- Member Cards Grid -->
-{% if registrations %}
+<!-- ── Confirmed section ──────────────────────────────────────────────── -->
+{% if status_filter == 'all' or status_filter == 'confirmed' %}
+<div class="mb-8">
+    <div class="flex items-center gap-2 mb-3">
+        <span class="w-2.5 h-2.5 rounded-full bg-green-500 flex-shrink-0"></span>
+        <h3 class="text-sm font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
+            {% trans "Confirmed" %} <span class="text-green-600 dark:text-green-400 normal-case font-bold">({{ confirmed_count }})</span>
+        </h3>
+        {% if spots_remaining > 0 %}
+        <span class="text-xs text-gray-400 dark:text-gray-500">— {{ spots_remaining }} {% trans "spot(s) remaining" %}</span>
+        {% endif %}
+    </div>
+
+    {% if gender_pool_stats %}
+    <div class="flex flex-wrap gap-2 mb-4">
+        {% for pool in gender_pool_stats %}
+        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border
+            {% if pool.confirmed >= pool.limit %}bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-700 text-red-700 dark:text-red-300{% else %}bg-gray-50 dark:bg-gray-700/60 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300{% endif %}">
+            <span class="text-sm leading-none">{{ pool.symbol }}</span>
+            <span class="font-bold">{{ pool.confirmed }}/{{ pool.limit }}</span>
+            <span class="opacity-70">{{ pool.label }}</span>
+        </span>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if confirmed_registrations %}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        {% for reg in registrations %}
-            <a href="{% url 'crush_lu:coach_member_overview' reg.user.id %}" class="block bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 overflow-hidden hover:shadow-md dark:hover:shadow-gray-900/40 hover:ring-1 hover:ring-crush-purple/30 transition-all">
-                <div class="p-4">
-                    <div class="flex items-start gap-3">
-                        <!-- Avatar -->
-                        <div class="flex-shrink-0">
-                            {% with profile=reg.user.crushprofile %}
-                                {% if profile and profile.photo_1 %}
-                                    <img src="{% url 'crush_lu:serve_profile_photo' reg.user.id 'photo_1' %}"
-                                         alt=""
-                                         class="w-12 h-12 rounded-full object-cover"
-                                         loading="lazy">
-                                {% else %}
-                                    <div class="w-12 h-12 rounded-full bg-gradient-to-br from-crush-purple/20 to-crush-pink/20 dark:from-crush-purple/30 dark:to-crush-pink/30 flex items-center justify-center">
-                                        <span class="text-lg font-semibold text-crush-purple dark:text-crush-pink">{{ reg.user.first_name|first|upper }}</span>
-                                    </div>
-                                {% endif %}
-                            {% endwith %}
-                        </div>
-
-                        <!-- Info -->
-                        <div class="flex-1 min-w-0">
-                            <div class="flex items-center gap-1.5">
-                                <h4 class="font-semibold text-sm text-gray-900 dark:text-white truncate">
-                                    {% with profile=reg.user.crushprofile %}
-                                        {% if profile %}{{ profile.display_name }}{% else %}{{ reg.user.first_name|default:reg.user.username }}{% endif %}
-                                    {% endwith %}
-                                </h4>
-                                <!-- Gender icon -->
-                                {% with profile=reg.user.crushprofile %}
-                                    {% if profile.gender == 'F' %}
-                                        <span class="text-pink-500 text-xs" title="{% trans 'Female' %}">&#9792;</span>
-                                    {% elif profile.gender == 'M' %}
-                                        <span class="text-blue-500 text-xs" title="{% trans 'Male' %}">&#9794;</span>
-                                    {% elif profile.gender %}
-                                        <span class="text-purple-500 text-xs" title="{{ profile.get_gender_display }}">&#9898;</span>
-                                    {% endif %}
-                                {% endwith %}
-                            </div>
-
-                            <!-- Age -->
-                            {% with profile=reg.user.crushprofile %}
-                                {% if profile %}
-                                    <p class="text-xs text-gray-500 dark:text-gray-400">
-                                        {% if profile.show_exact_age and profile.age %}
-                                            {{ profile.age }} {% trans "years" %}
-                                        {% elif profile.age_range %}
-                                            {{ profile.age_range }}
-                                        {% endif %}
-                                    </p>
-                                {% endif %}
-                            {% endwith %}
-
-                            <!-- Verification Status -->
-                            {% with profile=reg.user.crushprofile %}
-                                {% if profile and profile.is_approved %}
-                                    <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded">
-                                        &#10003; {% trans "Verified" %}
-                                    </span>
-                                {% elif reg.latest_submission and reg.latest_submission.status == 'pending' %}
-                                    <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">
-                                        &#9679; {% trans "In Review" %}
-                                    </span>
-                                {% elif reg.latest_submission and reg.latest_submission.status == 'revision' %}
-                                    <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded">
-                                        &#8634; {% trans "Revision" %}
-                                    </span>
-                                {% elif reg.latest_submission and reg.latest_submission.status == 'recontact_coach' %}
-                                    <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 rounded">
-                                        &#9742; {% trans "Recontact" %}
-                                    </span>
-                                {% elif profile and not profile.is_approved %}
-                                    <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">
-                                        {% trans "Not Verified" %}
-                                    </span>
-                                {% endif %}
-                            {% endwith %}
-                        </div>
-
-                        <!-- Status Badge -->
-                        <div class="flex-shrink-0">
-                            {% if reg.status == 'confirmed' %}
-                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-full">{% trans "Confirmed" %}</span>
-                            {% elif reg.status == 'attended' %}
-                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full">{% trans "Attended" %}</span>
-                            {% elif reg.status == 'waitlist' %}
-                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded-full">{% trans "Waitlist" %}</span>
-                            {% elif reg.status == 'pending' %}
-                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">{% trans "Pending" %}</span>
-                            {% elif reg.status == 'no_show' %}
-                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-full">{% trans "No Show" %}</span>
+        {% for reg in confirmed_registrations %}
+        <a href="{% url 'crush_lu:coach_member_overview' reg.user.id %}" class="block bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 overflow-hidden hover:shadow-md dark:hover:shadow-gray-900/40 hover:ring-1 hover:ring-crush-purple/30 transition-all">
+            <div class="p-4">
+                <div class="flex items-start gap-3">
+                    <div class="flex-shrink-0">
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile and profile.photo_1 %}
+                                <img src="{% url 'crush_lu:serve_profile_photo' reg.user.id 'photo_1' %}" alt="" class="w-12 h-12 rounded-full object-cover" loading="lazy">
+                            {% else %}
+                                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-crush-purple/20 to-crush-pink/20 dark:from-crush-purple/30 dark:to-crush-pink/30 flex items-center justify-center">
+                                    <span class="text-lg font-semibold text-crush-purple dark:text-crush-pink">{{ reg.user.first_name|first|upper }}</span>
+                                </div>
                             {% endif %}
-                        </div>
+                        {% endwith %}
                     </div>
-
-                    <!-- Extra Info -->
-                    <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 space-y-1.5">
-                        <!-- Registration date -->
-                        <p class="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">
-                            {% include "shared/icons/clock.html" with class="w-3 h-3" %}
-                            {% trans "Registered" %}: {{ reg.registered_at|date:"M j, g:i A" }}
-                        </p>
-
-                        <!-- Dietary restrictions (food events only) -->
-                        {% if event.has_food_component and reg.dietary_restrictions %}
-                            <p class="text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
-                                <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
-                                {{ reg.dietary_restrictions }}
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-1.5">
+                            <h4 class="font-semibold text-sm text-gray-900 dark:text-white truncate">
+                                {% with profile=reg.user.crushprofile %}{% if profile %}{{ profile.display_name }}{% else %}{{ reg.user.first_name|default:reg.user.username }}{% endif %}{% endwith %}
+                            </h4>
+                            {% with profile=reg.user.crushprofile %}
+                                {% if profile.gender == 'F' %}<span class="text-pink-500 text-xs" title="{% trans 'Female' %}">&#9792;</span>
+                                {% elif profile.gender == 'M' %}<span class="text-blue-500 text-xs" title="{% trans 'Male' %}">&#9794;</span>
+                                {% elif profile.gender %}<span class="text-purple-500 text-xs" title="{{ profile.get_gender_display }}">&#9898;</span>{% endif %}
+                            {% endwith %}
+                        </div>
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile %}
+                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                {% if profile.show_exact_age and profile.age %}{{ profile.age }} {% trans "years" %}{% elif profile.age_range %}{{ profile.age_range }}{% endif %}
                             </p>
-                        {% endif %}
-
-                        <!-- Plus-one guest -->
-                        {% if event.allow_plus_ones and reg.bringing_guest %}
-                            <p class="text-xs text-purple-600 dark:text-purple-400 flex items-center gap-1">
-                                {% include "shared/icons/user-plus.html" with class="w-3 h-3" %}
-                                +1: {{ reg.guest_name|default:_("Guest") }}
-                            </p>
+                            {% endif %}
+                        {% endwith %}
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile and profile.is_approved %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded">&#10003; {% trans "Verified" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'pending' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">&#9679; {% trans "In Review" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'revision' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded">&#8634; {% trans "Revision" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'recontact_coach' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 rounded">&#9742; {% trans "Recontact" %}</span>
+                            {% elif profile and not profile.is_approved %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">{% trans "Not Verified" %}</span>
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                    <div class="flex-shrink-0">
+                        {% if reg.status == 'attended' %}
+                            <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full">{% trans "Attended" %}</span>
+                        {% else %}
+                            <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-full">{% trans "Confirmed" %}</span>
                         {% endif %}
                     </div>
                 </div>
-            </a>
+                <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 space-y-1.5">
+                    <p class="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">
+                        {% include "shared/icons/clock.html" with class="w-3 h-3" %}
+                        {% trans "Registered" %}: {{ reg.registered_at|date:"M j, g:i A" }}
+                    </p>
+                    {% if event.has_food_component and reg.dietary_restrictions %}
+                    <p class="text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
+                        <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
+                        {{ reg.dietary_restrictions }}
+                    </p>
+                    {% endif %}
+                    {% if event.allow_plus_ones and reg.bringing_guest %}
+                    <p class="text-xs text-purple-600 dark:text-purple-400 flex items-center gap-1">
+                        {% include "shared/icons/user-plus.html" with class="w-3 h-3" %}
+                        +1: {{ reg.guest_name|default:_("Guest") }}
+                    </p>
+                    {% endif %}
+                </div>
+            </div>
+        </a>
         {% endfor %}
     </div>
-{% else %}
+    {% elif status_filter == 'confirmed' %}
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-8 text-center">
-        <div class="text-gray-400 dark:text-gray-500 mb-2">
-            {% include "shared/icons/users.html" with class="w-10 h-10 mx-auto" %}
-        </div>
-        <p class="text-gray-500 dark:text-gray-400">
-            {% if status_filter != 'all' %}
-                {% trans "No registrations match this filter." %}
-            {% else %}
-                {% trans "No one has registered for this event yet." %}
-            {% endif %}
-        </p>
+        <p class="text-gray-500 dark:text-gray-400 text-sm">{% trans "No confirmed registrations yet." %}</p>
     </div>
+    {% endif %}
+</div>
 {% endif %}
+
+<!-- ── Waitlist section ───────────────────────────────────────────────── -->
+{% if status_filter == 'all' or status_filter == 'waitlist' %}
+<div class="mb-8">
+    <div class="flex items-center gap-2 mb-3">
+        <span class="w-2.5 h-2.5 rounded-full bg-amber-500 flex-shrink-0"></span>
+        <h3 class="text-sm font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
+            {% trans "Waitlist" %} <span class="text-amber-600 dark:text-amber-400 normal-case font-bold">({{ waitlist_count }})</span>
+        </h3>
+    </div>
+
+    {% if gender_pool_stats %}
+    <div class="flex flex-wrap gap-2 mb-4">
+        {% for pool in gender_pool_stats %}
+        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-700 text-amber-700 dark:text-amber-300">
+            <span class="text-sm leading-none">{{ pool.symbol }}</span>
+            <span class="font-bold">{{ pool.waitlist }}</span>
+            <span class="opacity-70">{% trans "waiting" %}</span>
+        </span>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if waitlist_registrations %}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {% for reg in waitlist_registrations %}
+        <a href="{% url 'crush_lu:coach_member_overview' reg.user.id %}" class="block bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 overflow-hidden hover:shadow-md dark:hover:shadow-gray-900/40 hover:ring-1 hover:ring-amber-400/40 transition-all">
+            <div class="p-4">
+                <div class="flex items-start gap-3">
+                    <div class="flex-shrink-0">
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile and profile.photo_1 %}
+                                <img src="{% url 'crush_lu:serve_profile_photo' reg.user.id 'photo_1' %}" alt="" class="w-12 h-12 rounded-full object-cover" loading="lazy">
+                            {% else %}
+                                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-crush-purple/20 to-crush-pink/20 dark:from-crush-purple/30 dark:to-crush-pink/30 flex items-center justify-center">
+                                    <span class="text-lg font-semibold text-crush-purple dark:text-crush-pink">{{ reg.user.first_name|first|upper }}</span>
+                                </div>
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-1.5">
+                            <h4 class="font-semibold text-sm text-gray-900 dark:text-white truncate">
+                                {% with profile=reg.user.crushprofile %}{% if profile %}{{ profile.display_name }}{% else %}{{ reg.user.first_name|default:reg.user.username }}{% endif %}{% endwith %}
+                            </h4>
+                            {% with profile=reg.user.crushprofile %}
+                                {% if profile.gender == 'F' %}<span class="text-pink-500 text-xs" title="{% trans 'Female' %}">&#9792;</span>
+                                {% elif profile.gender == 'M' %}<span class="text-blue-500 text-xs" title="{% trans 'Male' %}">&#9794;</span>
+                                {% elif profile.gender %}<span class="text-purple-500 text-xs" title="{{ profile.get_gender_display }}">&#9898;</span>{% endif %}
+                            {% endwith %}
+                        </div>
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile %}
+                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                {% if profile.show_exact_age and profile.age %}{{ profile.age }} {% trans "years" %}{% elif profile.age_range %}{{ profile.age_range }}{% endif %}
+                            </p>
+                            {% endif %}
+                        {% endwith %}
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile and profile.is_approved %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded">&#10003; {% trans "Verified" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'pending' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">&#9679; {% trans "In Review" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'revision' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded">&#8634; {% trans "Revision" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'recontact_coach' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 rounded">&#9742; {% trans "Recontact" %}</span>
+                            {% elif profile and not profile.is_approved %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">{% trans "Not Verified" %}</span>
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                    <!-- Position badge replaces the plain "Waitlist" status label -->
+                    <div class="flex-shrink-0 flex flex-col items-end gap-1">
+                        <span class="inline-flex items-center justify-center min-w-[2rem] h-8 px-2 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-sm font-bold tabular-nums" title="{% trans 'Queue position' %}">#{{ reg.waitlist_position }}</span>
+                        {% if event.gender_limits_active and reg.waitlist_position_in_pool %}
+                        <span class="text-[10px] font-medium text-gray-400 dark:text-gray-500 tabular-nums">
+                            {% if reg.waitlist_pool == 'm' %}♂{% elif reg.waitlist_pool == 'f' %}♀{% elif reg.waitlist_pool == 'nb' %}⚬{% endif %}
+                            #{{ reg.waitlist_position_in_pool }}
+                        </span>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 space-y-1.5">
+                    <p class="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">
+                        {% include "shared/icons/clock.html" with class="w-3 h-3" %}
+                        {% trans "Joined waitlist" %}: {{ reg.registered_at|date:"M j, g:i A" }}
+                    </p>
+                    {% if event.has_food_component and reg.dietary_restrictions %}
+                    <p class="text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
+                        <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
+                        {{ reg.dietary_restrictions }}
+                    </p>
+                    {% endif %}
+                    {% if event.allow_plus_ones and reg.bringing_guest %}
+                    <p class="text-xs text-purple-600 dark:text-purple-400 flex items-center gap-1">
+                        {% include "shared/icons/user-plus.html" with class="w-3 h-3" %}
+                        +1: {{ reg.guest_name|default:_("Guest") }}
+                    </p>
+                    {% endif %}
+                </div>
+            </div>
+        </a>
+        {% endfor %}
+    </div>
+    {% elif status_filter == 'waitlist' %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-8 text-center">
+        <p class="text-gray-500 dark:text-gray-400 text-sm">{% trans "Nobody on the waitlist." %}</p>
+    </div>
+    {% endif %}
+</div>
+{% endif %}
+
+<!-- ── Other section (pending / no-show) ─────────────────────────────── -->
+{% if status_filter == 'all' or status_filter == 'other' %}
+{% if other_registrations %}
+<div class="mb-8">
+    <div class="flex items-center gap-2 mb-3">
+        <span class="w-2.5 h-2.5 rounded-full bg-gray-400 flex-shrink-0"></span>
+        <h3 class="text-sm font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">
+            {% trans "Other" %} <span class="text-gray-500 dark:text-gray-400 normal-case font-bold">({{ other_count }})</span>
+        </h3>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {% for reg in other_registrations %}
+        <a href="{% url 'crush_lu:coach_member_overview' reg.user.id %}" class="block bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 overflow-hidden hover:shadow-md dark:hover:shadow-gray-900/40 hover:ring-1 hover:ring-crush-purple/30 transition-all">
+            <div class="p-4">
+                <div class="flex items-start gap-3">
+                    <div class="flex-shrink-0">
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile and profile.photo_1 %}
+                                <img src="{% url 'crush_lu:serve_profile_photo' reg.user.id 'photo_1' %}" alt="" class="w-12 h-12 rounded-full object-cover" loading="lazy">
+                            {% else %}
+                                <div class="w-12 h-12 rounded-full bg-gradient-to-br from-crush-purple/20 to-crush-pink/20 dark:from-crush-purple/30 dark:to-crush-pink/30 flex items-center justify-center">
+                                    <span class="text-lg font-semibold text-crush-purple dark:text-crush-pink">{{ reg.user.first_name|first|upper }}</span>
+                                </div>
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-1.5">
+                            <h4 class="font-semibold text-sm text-gray-900 dark:text-white truncate">
+                                {% with profile=reg.user.crushprofile %}{% if profile %}{{ profile.display_name }}{% else %}{{ reg.user.first_name|default:reg.user.username }}{% endif %}{% endwith %}
+                            </h4>
+                            {% with profile=reg.user.crushprofile %}
+                                {% if profile.gender == 'F' %}<span class="text-pink-500 text-xs" title="{% trans 'Female' %}">&#9792;</span>
+                                {% elif profile.gender == 'M' %}<span class="text-blue-500 text-xs" title="{% trans 'Male' %}">&#9794;</span>
+                                {% elif profile.gender %}<span class="text-purple-500 text-xs" title="{{ profile.get_gender_display }}">&#9898;</span>{% endif %}
+                            {% endwith %}
+                        </div>
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile %}
+                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                {% if profile.show_exact_age and profile.age %}{{ profile.age }} {% trans "years" %}{% elif profile.age_range %}{{ profile.age_range }}{% endif %}
+                            </p>
+                            {% endif %}
+                        {% endwith %}
+                        {% with profile=reg.user.crushprofile %}
+                            {% if profile and profile.is_approved %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded">&#10003; {% trans "Verified" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'pending' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">&#9679; {% trans "In Review" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'revision' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded">&#8634; {% trans "Revision" %}</span>
+                            {% elif reg.latest_submission and reg.latest_submission.status == 'recontact_coach' %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 rounded">&#9742; {% trans "Recontact" %}</span>
+                            {% elif profile and not profile.is_approved %}
+                                <span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded">{% trans "Not Verified" %}</span>
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                    <div class="flex-shrink-0">
+                        {% if reg.status == 'pending' %}
+                            <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">{% trans "Pending" %}</span>
+                        {% elif reg.status == 'no_show' %}
+                            <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-full">{% trans "No Show" %}</span>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 space-y-1.5">
+                    <p class="text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">
+                        {% include "shared/icons/clock.html" with class="w-3 h-3" %}
+                        {% trans "Registered" %}: {{ reg.registered_at|date:"M j, g:i A" }}
+                    </p>
+                    {% if event.has_food_component and reg.dietary_restrictions %}
+                    <p class="text-xs text-orange-600 dark:text-orange-400 flex items-center gap-1">
+                        <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"></path></svg>
+                        {{ reg.dietary_restrictions }}
+                    </p>
+                    {% endif %}
+                    {% if event.allow_plus_ones and reg.bringing_guest %}
+                    <p class="text-xs text-purple-600 dark:text-purple-400 flex items-center gap-1">
+                        {% include "shared/icons/user-plus.html" with class="w-3 h-3" %}
+                        +1: {{ reg.guest_name|default:_("Guest") }}
+                    </p>
+                    {% endif %}
+                </div>
+            </div>
+        </a>
+        {% endfor %}
+    </div>
+</div>
+{% elif status_filter == 'other' %}
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-8 text-center">
+    <p class="text-gray-500 dark:text-gray-400 text-sm">{% trans "No registrations in this category." %}</p>
+</div>
+{% endif %}
+{% endif %}
+
+{% if total_registrations == 0 %}
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-8 text-center">
+    <div class="text-gray-400 dark:text-gray-500 mb-2">
+        {% include "shared/icons/users.html" with class="w-10 h-10 mx-auto" %}
+    </div>
+    <p class="text-gray-500 dark:text-gray-400">{% trans "No one has registered for this event yet." %}</p>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -1755,9 +1755,12 @@ def coach_event_detail(request, event_id):
         if event.gender_limits_active:
             gender = getattr(getattr(reg.user, "crushprofile", None), "gender", None)
             pool = event.get_gender_pool(gender) if gender else None
-            pool_counters[pool] = pool_counters.get(pool, 0) + 1
             reg.waitlist_pool = pool
-            reg.waitlist_position_in_pool = pool_counters[pool]
+            if pool:
+                pool_counters[pool] = pool_counters.get(pool, 0) + 1
+                reg.waitlist_position_in_pool = pool_counters[pool]
+            else:
+                reg.waitlist_position_in_pool = None
         else:
             reg.waitlist_pool = None
             reg.waitlist_position_in_pool = None

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -1783,6 +1783,8 @@ def coach_event_detail(request, event_id):
 
     # Status filter — controls which section(s) the template renders
     status_filter = request.GET.get("status", "all")
+    if status_filter not in ("all", "confirmed", "waitlist", "other"):
+        status_filter = "all"
 
     # Batch-query latest ProfileSubmission per registered user
     user_ids = [r.user_id for r in all_regs]

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -1735,30 +1735,57 @@ def coach_event_detail(request, event_id):
     """Detailed view of event registrations for coaches"""
     event = get_object_or_404(MeetupEvent, id=event_id)
 
-    registrations = (
+    all_regs = list(
         EventRegistration.objects.filter(event=event)
         .exclude(status="cancelled")
         .select_related("user__crushprofile")
         .order_by("registered_at")
     )
 
-    # Status filter
+    # Split by status group (order preserved = FIFO within each group)
+    all_confirmed = [r for r in all_regs if r.status in ("confirmed", "attended")]
+    all_waitlisted = [r for r in all_regs if r.status == "waitlist"]
+    all_other = [r for r in all_regs if r.status in ("pending", "no_show")]
+
+    # Annotate each waitlisted registration with its global queue position and
+    # per-gender-pool position so the coach can see who is next in line.
+    pool_counters = {}
+    for i, reg in enumerate(all_waitlisted, start=1):
+        reg.waitlist_position = i
+        if event.gender_limits_active:
+            gender = getattr(getattr(reg.user, "crushprofile", None), "gender", None)
+            pool = event.get_gender_pool(gender) if gender else None
+            pool_counters[pool] = pool_counters.get(pool, 0) + 1
+            reg.waitlist_pool = pool
+            reg.waitlist_position_in_pool = pool_counters[pool]
+        else:
+            reg.waitlist_pool = None
+            reg.waitlist_position_in_pool = None
+
+    # Gender pool stats — one entry per active pool, shown as summary pills
+    gender_pool_stats = None
+    if event.gender_limits_active:
+        pool_confirmed_counts = {}
+        for r in all_confirmed:
+            gender = getattr(getattr(r.user, "crushprofile", None), "gender", None)
+            pool = event.get_gender_pool(gender) if gender else None
+            if pool:
+                pool_confirmed_counts[pool] = pool_confirmed_counts.get(pool, 0) + 1
+        pool_waitlist_counts = {p: c for p, c in pool_counters.items() if p}
+        gender_pool_stats = [
+            entry for entry in [
+                {"key": "m",  "symbol": "♂", "label": _("Male"),       "confirmed": pool_confirmed_counts.get("m",  0), "waitlist": pool_waitlist_counts.get("m",  0), "limit": event.max_participants_m},
+                {"key": "f",  "symbol": "♀", "label": _("Female"),     "confirmed": pool_confirmed_counts.get("f",  0), "waitlist": pool_waitlist_counts.get("f",  0), "limit": event.max_participants_f},
+                {"key": "nb", "symbol": "⚬", "label": _("Non-binary"), "confirmed": pool_confirmed_counts.get("nb", 0), "waitlist": pool_waitlist_counts.get("nb", 0), "limit": event.max_participants_nb},
+            ]
+            if entry["limit"]
+        ]
+
+    # Status filter — controls which section(s) the template renders
     status_filter = request.GET.get("status", "all")
-    if status_filter == "confirmed":
-        filtered_registrations = [
-            r for r in registrations if r.status in ("confirmed", "attended")
-        ]
-    elif status_filter == "waitlist":
-        filtered_registrations = [r for r in registrations if r.status == "waitlist"]
-    elif status_filter == "other":
-        filtered_registrations = [
-            r for r in registrations if r.status in ("pending", "no_show")
-        ]
-    else:
-        filtered_registrations = list(registrations)
 
     # Batch-query latest ProfileSubmission per registered user
-    user_ids = [r.user_id for r in registrations]
+    user_ids = [r.user_id for r in all_regs]
     latest_submissions = {}
     if user_ids:
         for sub in (
@@ -1769,15 +1796,12 @@ def coach_event_detail(request, event_id):
             if sub.profile.user_id not in latest_submissions:
                 latest_submissions[sub.profile.user_id] = sub
 
-    # Attach latest submission to each registration for template use
-    for reg in filtered_registrations:
+    for reg in all_confirmed + all_waitlisted + all_other:
         reg.latest_submission = latest_submissions.get(reg.user_id)
 
-    # Count stats
-    confirmed_count = sum(
-        1 for r in registrations if r.status in ("confirmed", "attended")
-    )
-    waitlist_count = sum(1 for r in registrations if r.status == "waitlist")
+    confirmed_count = len(all_confirmed)
+    waitlist_count = len(all_waitlisted)
+    other_count = len(all_other)
     spots_remaining = max(0, event.max_participants - confirmed_count)
 
     # Post-event activity: connections and sparks
@@ -1795,18 +1819,21 @@ def coach_event_detail(request, event_id):
         status__in=[CrushSpark.Status.PENDING_REVIEW, CrushSpark.Status.REQUESTED]
     ).count()
 
-    # Check if this event has a quiz
     has_quiz = hasattr(event, "quiz")
 
     context = {
         "coach": request.coach,
         "event": event,
-        "registrations": filtered_registrations,
+        "confirmed_registrations": all_confirmed,
+        "waitlist_registrations": all_waitlisted,
+        "other_registrations": all_other,
         "confirmed_count": confirmed_count,
         "waitlist_count": waitlist_count,
+        "other_count": other_count,
         "spots_remaining": spots_remaining,
-        "total_registrations": len(registrations),
+        "total_registrations": confirmed_count + waitlist_count + other_count,
         "status_filter": status_filter,
+        "gender_pool_stats": gender_pool_stats,
         "connection_count": connection_count,
         "mutual_connections": mutual_connections,
         "spark_count": spark_count,


### PR DESCRIPTION
## Purpose
Reorganize the coach event detail view to display registrations grouped by status (confirmed, waitlist, other) with enhanced visual hierarchy and gender pool statistics. This improves the coach's ability to manage event capacity and see queue positions at a glance.

Key improvements:
* Registrations are now organized into three distinct sections (confirmed, waitlist, other) instead of a flat list
* Waitlist registrations now display their queue position (#1, #2, etc.) and per-gender-pool position when gender limits are active
* Gender pool statistics are displayed as summary pills showing confirmed/waitlist counts per pool
* Status filter buttons now show registration counts for each category
* Improved visual distinction between sections with color-coded indicators

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Navigate to a coach event detail page
* Verify registrations are grouped into confirmed, waitlist, and other sections
* Check that waitlist registrations display queue positions (#1, #2, etc.)
* If the event has gender limits enabled, verify pool statistics appear and per-pool positions are shown
* Click status filter buttons to verify they show correct counts and filter appropriately
* Verify the "spots remaining" indicator displays correctly in the confirmed section

## What to Check
Verify that the following are valid:
* Registrations are correctly categorized by status (confirmed/attended, waitlist, pending/no_show)
* Waitlist queue positions are sequential and accurate
* Gender pool statistics display only for active pools
* Per-pool waitlist positions are calculated correctly when gender limits are enabled
* Status filter buttons display accurate counts
* Empty state messages appear when no registrations exist in a filtered category
* All existing registration card information (verification status, dietary restrictions, plus-ones) is preserved

## Other Information
The view now pre-computes all registration groupings and queue positions in the backend, reducing template complexity and improving performance. The template uses conditional rendering to show only relevant sections based on the active status filter.

https://claude.ai/code/session_01XJSH73tHwtaNmxWoHWGGaR