### PR TITLE
fix(quiz-display): fix None display_name crash, pause screen, countdown timer

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -147,7 +147,10 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                         if table_data:
                             state.update(table_data)
                     except Exception:
-                        pass
+                        logger.exception(
+                            "Failed to get table display data for quiz %s",
+                            self.quiz_id,
+                        )
                     await self.send_json({"type": "quiz.state", "data": state})
                 return
 

--- a/crush_lu/static/crush_lu/js/quiz-display.js
+++ b/crush_lu/static/crush_lu/js/quiz-display.js
@@ -524,8 +524,8 @@ document.addEventListener("alpine:init", function () {
                     this.roundName = data.round_title;
                 }
 
-                // Start countdown
-                var time = data.time_remaining || data.time || 30;
+                // Start countdown — use nullish check so time_remaining=0 is respected
+                var time = (data.time_remaining != null) ? data.time_remaining : (data.time || 30);
                 this.countdownTotal = data.time || 30;
                 this.startCountdown(time);
 
@@ -552,7 +552,7 @@ document.addEventListener("alpine:init", function () {
                     });
                 }
 
-                var time = data.time_remaining || data.time || 30;
+                var time = (data.time_remaining != null) ? data.time_remaining : (data.time || 30);
                 this.countdownTotal = data.time || 30;
                 this.startCountdown(time);
 
@@ -579,6 +579,8 @@ document.addEventListener("alpine:init", function () {
                 } else if (data.status === "paused") {
                     this.quizStatus = "paused";
                     this.stopCountdown();
+                    // Show the table grid while paused between questions
+                    this.screen = "waiting";
                 } else if (data.status === "round_complete") {
                     this.stopCountdown();
                     // Show leaderboard between rounds

--- a/crush_lu/views_quiz.py
+++ b/crush_lu/views_quiz.py
@@ -34,10 +34,12 @@ _AVATAR_COLORS = [
 
 def _member_initials(name):
     """Extract up to 2 initials from a display name."""
+    if not name:
+        return "?"
     parts = name.split()
     if len(parts) >= 2:
         return (parts[0][0] + parts[-1][0]).upper()
-    return name[:2].upper() if name else "?"
+    return name[:2].upper()
 
 
 def _member_color(name):
@@ -69,7 +71,7 @@ def _get_table_members_json(quiz, round_number=0):
             ).select_related("user__crushprofile")
             for r in rotations:
                 profile = getattr(r.user, "crushprofile", None)
-                name = profile.display_name if profile else "Anonymous"
+                name = (profile.display_name if profile else None) or "Anonymous"
                 members.append(
                     {
                         "display_name": name,
@@ -82,7 +84,7 @@ def _get_table_members_json(quiz, round_number=0):
         else:
             for m in table.memberships.select_related("user__crushprofile"):
                 profile = getattr(m.user, "crushprofile", None)
-                name = profile.display_name if profile else "Anonymous"
+                name = (profile.display_name if profile else None) or "Anonymous"
                 members.append(
                     {
                         "display_name": name,
@@ -167,7 +169,7 @@ def quiz_live_view(request, event_id):
                 tablemates.append(
                     {
                         "display_name": (
-                            profile.display_name if profile else "Anonymous"
+                            (profile.display_name if profile else None) or "Anonymous"
                         ),
                         "role": r.role,
                     }
@@ -181,7 +183,7 @@ def quiz_live_view(request, event_id):
                 tablemates.append(
                     {
                         "display_name": (
-                            profile.display_name if profile else "Anonymous"
+                            (profile.display_name if profile else None) or "Anonymous"
                         ),
                         "role": "",
                     }
@@ -429,7 +431,7 @@ def quiz_table_display_data(request, event_id):
     for entry in top_individuals:
         try:
             profile = CrushProfile.objects.get(user_id=entry["user_id"])
-            name = profile.display_name
+            name = profile.display_name or "Anonymous"
             has_photo = bool(getattr(profile, "photo_1", None))
             photo_url = (
                 f"/api/quiz/photo/{entry['user_id']}/" if has_photo else None


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three runtime bugs on the quiz projector display page (`/de/quiz/11/display/` etc.) reported after PR #390 was merged:

- **"Quiz starts soon…" shown on paused quiz even when tables are assigned** — a `None` `display_name` on any participant's `CrushProfile` caused `_member_initials(None)` to crash with `AttributeError`. This exception was silently swallowed in the WS consumer, so `tables` was never added to the `quiz.state` message and the display fell back to the empty-tables screen.
- **Paused quiz keeps showing the frozen question screen** (for displays already connected when the coach pauses) — `handleStatus` stopped the countdown but never transitioned to `screen = "waiting"`, so the table-grid view never appeared.
- **Countdown restarts from full time when reconnecting after timer expired** — `data.time_remaining || data.time || 30` treated `0` as falsy, causing the timer to restart from the full round duration instead of showing 0.

## Changes

### `crush_lu/views_quiz.py`
- `_member_initials`: guard against `None` name at the top of the function (before `name.split()`)
- `_get_table_members_json` (×2 branches) + `quiz_live_view` tablemates + `quiz_table_display_data` individual scores: use `(profile.display_name if profile else None) or "Anonymous"` / `profile.display_name or "Anonymous"` so a null `display_name` never reaches the helper functions

### `crush_lu/consumers.py`
- Replace silent `pass` on `get_table_display_data` exception with `logger.exception(...)` so future failures are visible in server logs

### `crush_lu/static/crush_lu/js/quiz-display.js`
- `handleStatus` "paused" branch: add `this.screen = "waiting"` to show the table-grid attendee view when the coach pauses between questions
- `handleQuestion` + `showQuestion`: use `(data.time_remaining != null) ? data.time_remaining : (data.time || 30)` so a `time_remaining` of `0` is respected instead of falling through to the full round time

## Test plan

- [ ] Open `/de/quiz/11/display/` while quiz is paused — table grid with member avatars should show
- [ ] While display is connected and coach pauses the quiz — screen should transition to table grid
- [ ] Open display page after question timer has expired — countdown should show `0s`, not restart
- [ ] Participant with `display_name = None` in their profile does not crash the WS state delivery

https://claude.ai/code/session_01RJmbjXrwVLWvTRnfeWG6UT
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJmbjXrwVLWvTRnfeWG6UT)_