### PR TITLE
fix(quiz-display): start HTTP polling fallback when WS state has no tables

### DIFF
--- a/crush_lu/static/crush_lu/js/quiz-display.js
+++ b/crush_lu/static/crush_lu/js/quiz-display.js
@@ -496,6 +496,13 @@ document.addEventListener("alpine:init", function () {
                     if (this.connected) this.stopPolling();
                 } else {
                     this.screen = "waiting";
+                    // If the WS state arrived without table data (e.g. server-side
+                    // exception in get_table_display_data), fall back to HTTP polling
+                    // so the table roster still loads rather than waiting until the
+                    // WebSocket drops and reconnects (which can take several minutes).
+                    if (!this.tables.length && !this._pollInterval) {
+                        this.startPolling();
+                    }
                 }
             },
 
@@ -581,6 +588,9 @@ document.addEventListener("alpine:init", function () {
                     this.stopCountdown();
                     // Show the table grid while paused between questions
                     this.screen = "waiting";
+                    if (!this.tables.length && !this._pollInterval) {
+                        this.startPolling();
+                    }
                 } else if (data.status === "round_complete") {
                     this.stopCountdown();
                     // Show leaderboard between rounds
@@ -712,6 +722,11 @@ document.addEventListener("alpine:init", function () {
                         self.confirmedCount =
                             data.confirmed_count || self.confirmedCount;
                         self.tables = data.tables || [];
+                        // Tables loaded via fallback poll — stop polling now that WS
+                        // is connected and the roster is visible on the waiting screen.
+                        if (self.tables.length > 0 && self.connected && self.screen === "waiting") {
+                            self.stopPolling();
+                        }
                         if (data.quiz_status) {
                             self.quizStatus = data.quiz_status;
                         }


### PR DESCRIPTION
## Summary

- When the WebSocket connects and sends `quiz.state` without table data (due to the `display_name=None` crash fixed in #391, or any future server-side exception), the waiting screen now immediately triggers HTTP polling to load the table roster rather than waiting up to several minutes for the WS to time out and reconnect.
- Paused quiz: `handleStatus` now also starts polling if tables aren't loaded yet, so coaches stepping through rounds don't see a stale empty screen.
- Polling stops itself once tables load successfully while the WS is still connected.

## Root cause

`handleQuizState` → waiting branch → `this.screen = "waiting"` was set but HTTP polling was never started. The WebSocket connection suppressed the initial polling timer (started within 1.5 s of page load), so if `tables` were absent from the WS state, they never loaded until the WS eventually dropped (typically several minutes later on an idle connection).

## Test plan

- [ ] Open the projector display page (`/de/quiz/<id>/display/`) while the quiz is in `waiting` status — tables should appear within a few seconds, not after several minutes
- [ ] Pause the quiz mid-round — display should switch back to the table grid immediately
- [ ] Resume the quiz — question countdown should pick up from the remaining time (not restart from full duration)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJmbjXrwVLWvTRnfeWG6UT)_