### PR TITLE
fix(quiz-display): keep polling on waiting screen so check-ins appear live

### DIFF
--- a/crush_lu/static/crush_lu/js/quiz-display.js
+++ b/crush_lu/static/crush_lu/js/quiz-display.js
@@ -496,11 +496,10 @@ document.addEventListener("alpine:init", function () {
                     if (this.connected) this.stopPolling();
                 } else {
                     this.screen = "waiting";
-                    // If the WS state arrived without table data (e.g. server-side
-                    // exception in get_table_display_data), fall back to HTTP polling
-                    // so the table roster still loads rather than waiting until the
-                    // WebSocket drops and reconnects (which can take several minutes).
-                    if (!this.tables.length && !this._pollInterval) {
+                    // Always poll on the waiting screen so new check-ins appear
+                    // within 5 s without a page refresh. Polling stops automatically
+                    // when a question arrives (handleQuestion calls stopPolling).
+                    if (!this._pollInterval) {
                         this.startPolling();
                     }
                 }
@@ -588,7 +587,7 @@ document.addEventListener("alpine:init", function () {
                     this.stopCountdown();
                     // Show the table grid while paused between questions
                     this.screen = "waiting";
-                    if (!this.tables.length && !this._pollInterval) {
+                    if (!this._pollInterval) {
                         this.startPolling();
                     }
                 } else if (data.status === "round_complete") {
@@ -722,11 +721,6 @@ document.addEventListener("alpine:init", function () {
                         self.confirmedCount =
                             data.confirmed_count || self.confirmedCount;
                         self.tables = data.tables || [];
-                        // Tables loaded via fallback poll — stop polling now that WS
-                        // is connected and the roster is visible on the waiting screen.
-                        if (self.tables.length > 0 && self.connected && self.screen === "waiting") {
-                            self.stopPolling();
-                        }
                         if (data.quiz_status) {
                             self.quizStatus = data.quiz_status;
                         }


### PR DESCRIPTION
## Problem

When someone checked in during the pre-quiz waiting phase, they didn't appear on the projector display — a manual page refresh was required.

## Root cause

Polling was stopped as soon as the table roster loaded (either from the WebSocket state or via HTTP fallback). After that, no mechanism updated the display when attendance changed.

## Fix

Keep the 5-second HTTP poll running for the entire duration of the waiting/paused screen. Polling is already stopped by `handleQuestion` when the quiz goes active, so this has no impact during active play.

## Test plan

- [ ] Open the projector display at `/de/quiz/<id>/display/` before quiz starts
- [ ] Check in an attendee — they should appear on the table grid within ~5 seconds without refreshing
- [ ] Start the quiz — polling stops and questions display normally via WebSocket

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJmbjXrwVLWvTRnfeWG6UT)_