### PR TITLE
fix: LuxID login redirects to signup when email matches existing account

### DIFF
--- a/azureproject/adapters.py
+++ b/azureproject/adapters.py
@@ -348,10 +348,17 @@ class MultiDomainAccountAdapter(DefaultAccountAdapter):
         subject = render_to_string(f'{template_prefix}_subject.txt', ctx)
         subject = ' '.join(subject.splitlines()).strip()  # Remove newlines
 
-        # Try HTML first, fallback to plain text
+        # Try HTML first, fallback to plain text.
+        # Guard against templates that render empty/whitespace for the current
+        # domain (e.g. email_confirmation_message.html gates its content on
+        # 'crush.lu' in request.get_host and produces no output for other hosts).
+        # Passing an empty string as html_message would send a blank HTML part,
+        # so treat whitespace-only output the same as a missing template.
         try:
-            html_message = render_to_string(f'{template_prefix}_message.html', ctx)
-        except:
+            html_message = render_to_string(f'{template_prefix}_message.html', ctx) or None
+            if html_message and not html_message.strip():
+                html_message = None
+        except Exception:
             html_message = None
 
         message = render_to_string(f'{template_prefix}_message.txt', ctx)

--- a/crush_lu/providers/luxid/provider.py
+++ b/crush_lu/providers/luxid/provider.py
@@ -67,5 +67,18 @@ class LuxIDProvider(OpenIDConnectProvider):
         # Override to use "luxid_callback" instead of "openid_connect_callback"
         return reverse(f"{self.id}_callback")
 
+    def extract_email_addresses(self, data):
+        addresses = super().extract_email_addresses(data)
+        # LuxID is POST Luxembourg's government-grade CIAM and the authoritative
+        # trust anchor for the email it releases. allauth's OIDC base class
+        # defaults email_verified to False when the claim is absent, which
+        # prevents _lookup_by_email() from matching the email to an existing
+        # account and forces the user to the /accounts/3rdparty/signup/ page
+        # instead of auto-connecting. Force verified=True so that
+        # SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT works correctly.
+        for addr in addresses:
+            addr.verified = True
+        return addresses
+
 
 provider_classes = [LuxIDProvider]

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -16,7 +16,11 @@ from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django.utils import timezone
 from allauth.socialaccount.models import SocialAccount
-from allauth.socialaccount.signals import pre_social_login, social_account_updated
+from allauth.socialaccount.signals import (
+    pre_social_login,
+    social_account_added,
+    social_account_updated,
+)
 
 from azureproject.domains import DOMAINS as _PLATFORM_DOMAINS
 
@@ -1874,6 +1878,61 @@ def create_crush_profile_from_luxid(sender, instance, created, **kwargs):
         logger.error(
             f"Error in LuxID SocialAccount post_save handler: {str(e)}",
             exc_info=True,
+        )
+
+
+# =============================================================================
+# EMAIL VERIFICATION — SOCIAL ACCOUNT CONNECT
+# =============================================================================
+
+
+@receiver(social_account_added)
+def verify_email_on_social_account_connect(sender, request, sociallogin, **kwargs):
+    """
+    Mark a user's EmailAddress as verified when they connect a social account
+    that authenticates the same email.
+
+    When a user signs up via email/password under ACCOUNT_EMAIL_VERIFICATION="optional"
+    their EmailAddress is created with verified=False. If they later connect a social
+    account (Google, Facebook, etc.) that authenticates the same email, allauth creates
+    the SocialAccount but does NOT retroactively set EmailAddress.verified=True.
+    This handler closes that gap so the user is not blocked if verification becomes
+    mandatory, and so SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT works correctly
+    on future logins.
+    """
+    from allauth.account.models import EmailAddress
+
+    user = sociallogin.user
+    if not (user and getattr(user, "pk", None)):
+        return
+
+    # Collect authenticated emails from this social login
+    social_emails = {
+        addr.email.lower()
+        for addr in sociallogin.email_addresses
+        if addr.email
+    }
+    # Fall back to extra_data if email_addresses is empty
+    if not social_emails:
+        raw = sociallogin.account.extra_data.get("email", "")
+        if raw:
+            social_emails.add(raw.lower())
+
+    if not social_emails:
+        return
+
+    updated = EmailAddress.objects.filter(
+        user=user,
+        verified=False,
+        email__in=social_emails,
+    ).update(verified=True)
+
+    if updated:
+        logger.info(
+            "Verified %d EmailAddress record(s) for user %s after connecting %s",
+            updated,
+            user.pk,
+            sociallogin.account.provider,
         )
 
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1906,17 +1906,16 @@ def verify_email_on_social_account_connect(sender, request, sociallogin, **kwarg
     if not (user and getattr(user, "pk", None)):
         return
 
-    # Collect authenticated emails from this social login
+    # Only collect emails that allauth itself considers provider-verified.
+    # cleanup_email_addresses() sets addr.verified=True based on the provider's
+    # VERIFIED_EMAIL setting or the email_verified claim in the OAuth response.
+    # Skipping unverified entries prevents a generic OIDC provider (without
+    # email_verified) from promoting an unconfirmed address to verified status.
     social_emails = {
         addr.email.lower()
         for addr in sociallogin.email_addresses
-        if addr.email
+        if addr.email and addr.verified
     }
-    # Fall back to extra_data if email_addresses is empty
-    if not social_emails:
-        raw = sociallogin.account.extra_data.get("email", "")
-        if raw:
-            social_emails.add(raw.lower())
 
     if not social_emails:
         return

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1578,26 +1578,30 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
         except Exception:
             pass
 
-        # Belt-and-braces: if allauth's OIDC extractor didn't populate
-        # sociallogin.email_addresses but we do see an `email` claim in the
-        # flattened OIDC payload, push it in so SocialSignupForm prefills
-        # correctly and allauth's auto-signup path can proceed.
+        # NOTE: sociallogin.lookup() (which drives email-based auto-connect)
+        # runs BEFORE pre_social_login fires, so changes to email_addresses
+        # here do NOT affect the auto-connect decision. The authoritative fix
+        # for auto-connect is LuxIDProvider.extract_email_addresses() which
+        # forces verified=True before lookup() runs.
         #
-        # LuxID is POST Luxembourg's government-grade CIAM — the provider
-        # itself is the trust anchor, so any email in the token is already
-        # verified on their side even when they don't release the
-        # `email_verified` claim. Hardcode verified=True to skip Crush.lu's
-        # own email-verification flow for LuxID users.
-        if not sociallogin.email_addresses and _claims.get("email"):
+        # This block is kept as a belt-and-braces for the SocialSignupForm
+        # pre-fill path (new-user signup) and as a guard against unexpected
+        # allauth internals that may read email_addresses after this signal.
+        if _claims.get("email"):
             from allauth.account.models import EmailAddress as _EmailAddress
 
-            sociallogin.email_addresses = [
-                _EmailAddress(
-                    email=_claims["email"],
-                    verified=True,
-                    primary=True,
-                )
-            ]
+            if sociallogin.email_addresses:
+                # Ensure any existing addresses are marked verified.
+                for _addr in sociallogin.email_addresses:
+                    _addr.verified = True
+            else:
+                sociallogin.email_addresses = [
+                    _EmailAddress(
+                        email=_claims["email"],
+                        verified=True,
+                        primary=True,
+                    )
+                ]
 
         # Update CrushProfile for existing users.
         # During the connect flow (email user linking LuxID for the first

--- a/crush_lu/templates/account/email/email_confirmation_message.html
+++ b/crush_lu/templates/account/email/email_confirmation_message.html
@@ -1,9 +1,9 @@
-{% load i18n account %}{% autoescape off %}{% user_display user as user_display %}<!DOCTYPE html>
+{% load i18n account %}{% autoescape off %}{% user_display user as user_display %}{% if request and 'crush.lu' in request.get_host %}<!DOCTYPE html>
 <html lang="{% get_current_language %}">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{% blocktrans %}Confirm your email - Crush.lu{% endblocktrans %}</title>
+<title>{% blocktrans with site_name=current_site.name %}Confirm your email - {{ site_name }}{% endblocktrans %}</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
   <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f3f4f6;padding:40px 16px;">
@@ -14,7 +14,7 @@
           <!-- Logo -->
           <tr>
             <td align="center" style="padding-bottom:24px;">
-              <span style="font-size:28px;font-weight:800;color:#7c3aed;letter-spacing:-0.5px;">Crush.lu</span>
+              <span style="font-size:28px;font-weight:800;color:#7c3aed;letter-spacing:-0.5px;">{{ current_site.name }}</span>
             </td>
           </tr>
 
@@ -37,7 +37,7 @@
                 {% blocktrans %}Confirm your email address{% endblocktrans %}
               </h1>
               <p style="margin:0 0 24px;font-size:15px;color:#6b7280;text-align:center;line-height:1.6;">
-                {% blocktrans %}Hi {{ user_display }}, click the button below to verify your email address and access your Crush.lu account.{% endblocktrans %}
+                {% blocktrans with site_name=current_site.name %}Hi {{ user_display }}, click the button below to verify your email address and access your {{ site_name }} account.{% endblocktrans %}
               </p>
 
               <!-- CTA Button -->
@@ -63,7 +63,7 @@
               <hr style="border:none;border-top:1px solid #f3f4f6;margin:0 0 20px;">
 
               <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;">
-                {% blocktrans %}If you did not create a Crush.lu account, you can safely ignore this email.{% endblocktrans %}
+                {% blocktrans with site_name=current_site.name %}If you did not create a {{ site_name }} account, you can safely ignore this email.{% endblocktrans %}
               </p>
 
             </td>
@@ -73,7 +73,7 @@
           <tr>
             <td align="center" style="padding-top:24px;">
               <p style="margin:0;font-size:12px;color:#9ca3af;">
-                © Crush.lu · {% blocktrans %}Sent from noreply@crush.lu{% endblocktrans %}
+                © {{ current_site.name }} · noreply@crush.lu
               </p>
             </td>
           </tr>
@@ -84,4 +84,4 @@
   </table>
 </body>
 </html>
-{% endautoescape %}
+{% endif %}{% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_message.html
+++ b/crush_lu/templates/account/email/email_confirmation_message.html
@@ -1,0 +1,87 @@
+{% load i18n account %}{% autoescape off %}{% user_display user as user_display %}<!DOCTYPE html>
+<html lang="{% get_current_language %}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% blocktrans %}Confirm your email - Crush.lu{% endblocktrans %}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f3f4f6;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;">
+
+          <!-- Logo -->
+          <tr>
+            <td align="center" style="padding-bottom:24px;">
+              <span style="font-size:28px;font-weight:800;color:#7c3aed;letter-spacing:-0.5px;">Crush.lu</span>
+            </td>
+          </tr>
+
+          <!-- Card -->
+          <tr>
+            <td style="background-color:#ffffff;border-radius:16px;padding:40px 36px;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+
+              <!-- Icon -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding-bottom:24px;">
+                    <div style="width:56px;height:56px;background-color:#ede9fe;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;">
+                      <span style="font-size:28px;">✉️</span>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+
+              <h1 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#111827;text-align:center;">
+                {% blocktrans %}Confirm your email address{% endblocktrans %}
+              </h1>
+              <p style="margin:0 0 24px;font-size:15px;color:#6b7280;text-align:center;line-height:1.6;">
+                {% blocktrans %}Hi {{ user_display }}, click the button below to verify your email address and access your Crush.lu account.{% endblocktrans %}
+              </p>
+
+              <!-- CTA Button -->
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="padding-bottom:28px;">
+                    <a href="{{ activate_url }}"
+                       style="display:inline-block;background-color:#7c3aed;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:14px 32px;border-radius:10px;">
+                      {% blocktrans %}Confirm Email Address{% endblocktrans %}
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Fallback link -->
+              <p style="margin:0 0 8px;font-size:12px;color:#9ca3af;text-align:center;">
+                {% blocktrans %}If the button doesn't work, copy and paste this link into your browser:{% endblocktrans %}
+              </p>
+              <p style="margin:0 0 24px;font-size:12px;color:#7c3aed;text-align:center;word-break:break-all;">
+                <a href="{{ activate_url }}" style="color:#7c3aed;">{{ activate_url }}</a>
+              </p>
+
+              <hr style="border:none;border-top:1px solid #f3f4f6;margin:0 0 20px;">
+
+              <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;">
+                {% blocktrans %}If you did not create a Crush.lu account, you can safely ignore this email.{% endblocktrans %}
+              </p>
+
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding-top:24px;">
+              <p style="margin:0;font-size:12px;color:#9ca3af;">
+                © Crush.lu · {% blocktrans %}Sent from noreply@crush.lu{% endblocktrans %}
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+{% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_message.txt
+++ b/crush_lu/templates/account/email/email_confirmation_message.txt
@@ -1,10 +1,10 @@
-{% load i18n account %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name="Crush.lu" %}Hi {{ user_display }},{% endblocktrans %}
+{% load i18n account %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name=current_site.name %}Hi {{ user_display }},{% endblocktrans %}
 
-{% blocktrans with site_name="Crush.lu" %}Please confirm your email address for your Crush.lu account by clicking the link below:{% endblocktrans %}
+{% blocktrans with site_name=current_site.name %}Please confirm your email address for your {{ site_name }} account by clicking the link below:{% endblocktrans %}
 
 {{ activate_url }}
 
 {% blocktrans %}If you did not request this, you can safely ignore this email.{% endblocktrans %}
 
-{% blocktrans with site_name="Crush.lu" %}— The Crush.lu team{% endblocktrans %}
+{% blocktrans with site_name=current_site.name %}— The {{ site_name }} team{% endblocktrans %}
 {% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_message.txt
+++ b/crush_lu/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,10 @@
+{% load i18n account %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name="Crush.lu" %}Hi {{ user_display }},{% endblocktrans %}
+
+{% blocktrans with site_name="Crush.lu" %}Please confirm your email address for your Crush.lu account by clicking the link below:{% endblocktrans %}
+
+{{ activate_url }}
+
+{% blocktrans %}If you did not request this, you can safely ignore this email.{% endblocktrans %}
+
+{% blocktrans with site_name="Crush.lu" %}— The Crush.lu team{% endblocktrans %}
+{% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_signup_message.html
+++ b/crush_lu/templates/account/email/email_confirmation_signup_message.html
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.html" %}

--- a/crush_lu/templates/account/email/email_confirmation_signup_message.txt
+++ b/crush_lu/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.txt" %}

--- a/crush_lu/templates/account/email/email_confirmation_signup_subject.txt
+++ b/crush_lu/templates/account/email/email_confirmation_signup_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% autoescape off %}{% blocktrans %}Welcome to Crush.lu — please confirm your email{% endblocktrans %}{% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_signup_subject.txt
+++ b/crush_lu/templates/account/email/email_confirmation_signup_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Welcome to Crush.lu — please confirm your email{% endblocktrans %}{% endautoescape %}
+{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}Welcome to {{ site_name }} — please confirm your email{% endblocktrans %}{% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_subject.txt
+++ b/crush_lu/templates/account/email/email_confirmation_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% autoescape off %}{% blocktrans %}Confirm your email address on Crush.lu{% endblocktrans %}{% endautoescape %}

--- a/crush_lu/templates/account/email/email_confirmation_subject.txt
+++ b/crush_lu/templates/account/email/email_confirmation_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Confirm your email address on Crush.lu{% endblocktrans %}{% endautoescape %}
+{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name %}Confirm your email address on {{ site_name }}{% endblocktrans %}{% endautoescape %}

--- a/crush_lu/templates/account/email_confirm.html
+++ b/crush_lu/templates/account/email_confirm.html
@@ -2,7 +2,7 @@
 {% if 'entreprinder' in request.get_host %}
 {# Entreprinder has its own Bootstrap-based branded layout #}
 {% include "account/email_confirm_entreprinder.html" %}
-{% elif 'crush.lu' in request.get_host or 'localhost' in request.get_host or '127.0.0.1' in request.get_host %}
+{% elif 'crush.lu' in request.get_host or request.get_host == 'localhost' or request.get_host == 'crush.localhost' or '127.0.0.1' in request.get_host %}
 {# Crush.lu and local dev — full branded template using crush_lu/base.html #}
 {% include "account/email_confirm_crush.html" %}
 {% else %}

--- a/crush_lu/templates/account/email_confirm.html
+++ b/crush_lu/templates/account/email_confirm.html
@@ -1,9 +1,12 @@
 {# Domain-aware email confirmation template router #}
 {% if 'entreprinder' in request.get_host %}
+{# Entreprinder has its own Bootstrap-based branded layout #}
 {% include "account/email_confirm_entreprinder.html" %}
-{% else %}
-{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
-{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html + relative URLs only — #}
-{# no crush_lu: namespace references so it is safe on all domain URLConfs. #}
+{% elif 'crush.lu' in request.get_host or 'localhost' in request.get_host or '127.0.0.1' in request.get_host %}
+{# Crush.lu and local dev — full branded template using crush_lu/base.html #}
 {% include "account/email_confirm_crush.html" %}
+{% else %}
+{# Other domains (powerup.lu, arborist.lu, delegations.lu, portal, etc.) — #}
+{# self-contained neutral page with no app namespace dependencies. #}
+{% include "account/email_confirm_neutral.html" %}
 {% endif %}

--- a/crush_lu/templates/account/email_confirm.html
+++ b/crush_lu/templates/account/email_confirm.html
@@ -1,0 +1,5 @@
+{% if 'entreprinder' in request.get_host %}
+{% include "account/email_confirm_entreprinder.html" %}
+{% else %}
+{% include "account/email_confirm_crush.html" %}
+{% endif %}

--- a/crush_lu/templates/account/email_confirm.html
+++ b/crush_lu/templates/account/email_confirm.html
@@ -1,5 +1,9 @@
+{# Domain-aware email confirmation template router #}
 {% if 'entreprinder' in request.get_host %}
 {% include "account/email_confirm_entreprinder.html" %}
 {% else %}
+{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
+{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html + relative URLs only — #}
+{# no crush_lu: namespace references so it is safe on all domain URLConfs. #}
 {% include "account/email_confirm_crush.html" %}
 {% endif %}

--- a/crush_lu/templates/account/email_confirm_crush.html
+++ b/crush_lu/templates/account/email_confirm_crush.html
@@ -1,0 +1,78 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+{% load account %}
+
+{% block title %}{% trans "Confirm Email Address - Crush.lu" %}{% endblock %}
+{% block meta_robots %}noindex, nofollow{% endblock %}
+
+{% block content %}
+<div class="min-h-[60vh] flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg dark:shadow-gray-900/20 p-8 text-center">
+
+            {% if confirmation %}
+                {% user_display confirmation.email_address.user as user_display %}
+
+                {% if can_confirm %}
+                    <div class="w-16 h-16 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+                        {% include "shared/icons/envelope.html" with class="w-8 h-8 text-purple-600 dark:text-purple-400" %}
+                    </div>
+
+                    <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                        {% trans "Confirm Your Email" %}
+                    </h1>
+                    <p class="text-gray-500 dark:text-gray-400 mb-6">
+                        {% blocktrans with email=confirmation.email_address.email %}
+                            Please confirm that <strong>{{ email }}</strong> is your email address for Crush.lu.
+                        {% endblocktrans %}
+                    </p>
+
+                    <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+                        {% csrf_token %}
+                        {{ redirect_field }}
+                        <button type="submit" class="btn-crush-primary w-full py-3 text-base font-semibold">
+                            {% trans "Confirm Email Address" %}
+                        </button>
+                    </form>
+
+                {% else %}
+                    <div class="w-16 h-16 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+                        {% include "shared/icons/x-circle.html" with class="w-8 h-8 text-red-500 dark:text-red-400" %}
+                    </div>
+
+                    <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                        {% trans "Unable to Confirm" %}
+                    </h1>
+                    <p class="text-gray-500 dark:text-gray-400">
+                        {% blocktrans with email=confirmation.email_address.email %}
+                            Unable to confirm {{ email }} because it is already confirmed by a different account.
+                        {% endblocktrans %}
+                    </p>
+                {% endif %}
+
+            {% else %}
+                <div class="w-16 h-16 bg-yellow-100 dark:bg-yellow-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+                    {% include "shared/icons/exclamation-triangle.html" with class="w-8 h-8 text-yellow-500 dark:text-yellow-400" %}
+                </div>
+
+                <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                    {% trans "Link Expired" %}
+                </h1>
+                <p class="text-gray-500 dark:text-gray-400 mb-6">
+                    {% trans "This email confirmation link has expired or is invalid." %}
+                </p>
+                <a href="{% url 'account_email' %}" class="btn-crush-primary inline-block py-3 px-6">
+                    {% trans "Request a New Link" %}
+                </a>
+            {% endif %}
+
+            <div class="mt-6 pt-6 border-t border-gray-100 dark:border-gray-700">
+                <a href="{% url 'crush_lu:index' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400">
+                    ← {% trans "Back to Crush.lu" %}
+                </a>
+            </div>
+
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/account/email_confirm_crush.html
+++ b/crush_lu/templates/account/email_confirm_crush.html
@@ -67,7 +67,7 @@
             {% endif %}
 
             <div class="mt-6 pt-6 border-t border-gray-100 dark:border-gray-700">
-                <a href="{% url 'crush_lu:index' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400">
+                <a href="/" class="text-sm text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400">
                     ← {% trans "Back to Crush.lu" %}
                 </a>
             </div>

--- a/crush_lu/templates/account/email_confirm_neutral.html
+++ b/crush_lu/templates/account/email_confirm_neutral.html
@@ -1,0 +1,32 @@
+{% load i18n %}{% load account %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:"en" }}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% trans "Confirm Email Address" %}</title>
+<style>body{margin:0;padding:40px 16px;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827}.card{max-width:480px;margin:0 auto;background:#fff;border-radius:12px;padding:40px;box-shadow:0 1px 4px rgba(0,0,0,.08)}h1{margin:0 0 12px;font-size:22px;font-weight:700}p{margin:0 0 20px;color:#6b7280;line-height:1.6}.btn{display:inline-block;background:#4f46e5;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;border:none;cursor:pointer;font-size:15px}.link{color:#4f46e5}</style>
+</head>
+<body>
+<div class="card">
+  {% if confirmation %}
+    {% user_display confirmation.email_address.user as user_display %}
+    {% if can_confirm %}
+      <h1>{% trans "Confirm Email Address" %}</h1>
+      <p>{% blocktrans with email=confirmation.email_address.email %}Please confirm that <a class="link" href="mailto:{{ email }}">{{ email }}</a> is your email address for user {{ user_display }}.{% endblocktrans %}</p>
+      <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+        {% csrf_token %}
+        {{ redirect_field }}
+        <button type="submit" class="btn">{% trans "Confirm" %}</button>
+      </form>
+    {% else %}
+      <h1>{% trans "Unable to Confirm" %}</h1>
+      <p>{% blocktrans with email=confirmation.email_address.email %}Unable to confirm {{ email }} because it is already confirmed by a different account.{% endblocktrans %}</p>
+    {% endif %}
+  {% else %}
+    <h1>{% trans "Link Expired" %}</h1>
+    <p>{% blocktrans %}This email confirmation link has expired or is invalid.{% endblocktrans %}</p>
+    <a class="btn" href="{% url 'account_email' %}">{% trans "Request a New Link" %}</a>
+  {% endif %}
+</div>
+</body>
+</html>

--- a/crush_lu/templates/account/verification_sent.html
+++ b/crush_lu/templates/account/verification_sent.html
@@ -1,0 +1,5 @@
+{% if 'entreprinder' in request.get_host %}
+{% include "account/verification_sent_entreprinder.html" %}
+{% else %}
+{% include "account/verification_sent_crush.html" %}
+{% endif %}

--- a/crush_lu/templates/account/verification_sent.html
+++ b/crush_lu/templates/account/verification_sent.html
@@ -1,9 +1,12 @@
 {# Domain-aware verification sent template router #}
 {% if 'entreprinder' in request.get_host %}
+{# Entreprinder has its own Bootstrap-based branded layout #}
 {% include "account/verification_sent_entreprinder.html" %}
-{% else %}
-{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
-{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html + relative URLs only — #}
-{# no crush_lu: namespace references so it is safe on all domain URLConfs. #}
+{% elif 'crush.lu' in request.get_host or 'localhost' in request.get_host or '127.0.0.1' in request.get_host %}
+{# Crush.lu and local dev — full branded template using crush_lu/base.html #}
 {% include "account/verification_sent_crush.html" %}
+{% else %}
+{# Other domains (powerup.lu, arborist.lu, delegations.lu, portal, etc.) — #}
+{# self-contained neutral page with no app namespace dependencies. #}
+{% include "account/verification_sent_neutral.html" %}
 {% endif %}

--- a/crush_lu/templates/account/verification_sent.html
+++ b/crush_lu/templates/account/verification_sent.html
@@ -1,5 +1,9 @@
+{# Domain-aware verification sent template router #}
 {% if 'entreprinder' in request.get_host %}
 {% include "account/verification_sent_entreprinder.html" %}
 {% else %}
+{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
+{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html + relative URLs only — #}
+{# no crush_lu: namespace references so it is safe on all domain URLConfs. #}
 {% include "account/verification_sent_crush.html" %}
 {% endif %}

--- a/crush_lu/templates/account/verification_sent.html
+++ b/crush_lu/templates/account/verification_sent.html
@@ -2,7 +2,7 @@
 {% if 'entreprinder' in request.get_host %}
 {# Entreprinder has its own Bootstrap-based branded layout #}
 {% include "account/verification_sent_entreprinder.html" %}
-{% elif 'crush.lu' in request.get_host or 'localhost' in request.get_host or '127.0.0.1' in request.get_host %}
+{% elif 'crush.lu' in request.get_host or request.get_host == 'localhost' or request.get_host == 'crush.localhost' or '127.0.0.1' in request.get_host %}
 {# Crush.lu and local dev — full branded template using crush_lu/base.html #}
 {% include "account/verification_sent_crush.html" %}
 {% else %}

--- a/crush_lu/templates/account/verification_sent_crush.html
+++ b/crush_lu/templates/account/verification_sent_crush.html
@@ -1,0 +1,43 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Verify Your Email - Crush.lu" %}{% endblock %}
+{% block meta_robots %}noindex, nofollow{% endblock %}
+
+{% block content %}
+<div class="min-h-[60vh] flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg dark:shadow-gray-900/20 p-8 text-center">
+
+            <div class="w-16 h-16 bg-purple-100 dark:bg-purple-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+                {% include "shared/icons/envelope.html" with class="w-8 h-8 text-purple-600 dark:text-purple-400" %}
+            </div>
+
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                {% trans "Check Your Inbox" %}
+            </h1>
+            <p class="text-gray-500 dark:text-gray-400 mb-4">
+                {% blocktrans %}
+                    We've sent a verification link to your email address.
+                    Click the link in the email to confirm your account.
+                {% endblocktrans %}
+            </p>
+            <p class="text-sm text-gray-400 dark:text-gray-500 mb-6">
+                {% blocktrans %}
+                    If you don't see it in your inbox, check your spam folder.
+                    The email is sent from <strong>noreply@crush.lu</strong>.
+                {% endblocktrans %}
+            </p>
+
+            <a href="{% url 'account_email' %}" class="inline-block w-full py-3 px-6 text-sm font-medium border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors mb-3">
+                {% trans "Resend Verification Email" %}
+            </a>
+
+            <a href="{% url 'crush_lu:index' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400">
+                ← {% trans "Back to Crush.lu" %}
+            </a>
+
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/account/verification_sent_crush.html
+++ b/crush_lu/templates/account/verification_sent_crush.html
@@ -33,7 +33,7 @@
                 {% trans "Resend Verification Email" %}
             </a>
 
-            <a href="{% url 'crush_lu:index' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400">
+            <a href="/" class="text-sm text-gray-500 dark:text-gray-400 hover:text-purple-600 dark:hover:text-purple-400">
                 ← {% trans "Back to Crush.lu" %}
             </a>
 

--- a/crush_lu/templates/account/verification_sent_neutral.html
+++ b/crush_lu/templates/account/verification_sent_neutral.html
@@ -1,0 +1,15 @@
+{% load i18n %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:"en" }}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% trans "Verify Your Email Address" %}</title>
+<style>body{margin:0;padding:40px 16px;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827}.card{max-width:480px;margin:0 auto;background:#fff;border-radius:12px;padding:40px;box-shadow:0 1px 4px rgba(0,0,0,.08)}h1{margin:0 0 12px;font-size:22px;font-weight:700}p{margin:0 0 20px;color:#6b7280;line-height:1.6}</style>
+</head>
+<body>
+<div class="card">
+  <h1>{% trans "Verify Your Email Address" %}</h1>
+  <p>{% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process. If you do not see the verification email in your main inbox, check your spam folder. Please contact us if you do not receive the verification email within a few minutes.{% endblocktrans %}</p>
+</div>
+</body>
+</html>

--- a/crush_lu/templates/account/verified_email_required.html
+++ b/crush_lu/templates/account/verified_email_required.html
@@ -1,5 +1,9 @@
+{# Domain-aware verified email required template router #}
 {% if 'entreprinder' in request.get_host %}
 {% include "account/verified_email_required_entreprinder.html" %}
 {% else %}
+{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
+{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html + relative URLs only — #}
+{# no crush_lu: namespace references so it is safe on all domain URLConfs. #}
 {% include "account/verified_email_required_crush.html" %}
 {% endif %}

--- a/crush_lu/templates/account/verified_email_required.html
+++ b/crush_lu/templates/account/verified_email_required.html
@@ -1,0 +1,5 @@
+{% if 'entreprinder' in request.get_host %}
+{% include "account/verified_email_required_entreprinder.html" %}
+{% else %}
+{% include "account/verified_email_required_crush.html" %}
+{% endif %}

--- a/crush_lu/templates/account/verified_email_required.html
+++ b/crush_lu/templates/account/verified_email_required.html
@@ -1,9 +1,12 @@
 {# Domain-aware verified email required template router #}
 {% if 'entreprinder' in request.get_host %}
+{# Entreprinder has its own Bootstrap-based branded layout #}
 {% include "account/verified_email_required_entreprinder.html" %}
-{% else %}
-{# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}
-{# localhost, 127.0.0.1, and any unknown hosts. Uses crush_lu/base.html + relative URLs only — #}
-{# no crush_lu: namespace references so it is safe on all domain URLConfs. #}
+{% elif 'crush.lu' in request.get_host or 'localhost' in request.get_host or '127.0.0.1' in request.get_host %}
+{# Crush.lu and local dev — full branded template using crush_lu/base.html #}
 {% include "account/verified_email_required_crush.html" %}
+{% else %}
+{# Other domains (powerup.lu, arborist.lu, delegations.lu, portal, etc.) — #}
+{# self-contained neutral page with no app namespace dependencies. #}
+{% include "account/verified_email_required_neutral.html" %}
 {% endif %}

--- a/crush_lu/templates/account/verified_email_required.html
+++ b/crush_lu/templates/account/verified_email_required.html
@@ -2,7 +2,7 @@
 {% if 'entreprinder' in request.get_host %}
 {# Entreprinder has its own Bootstrap-based branded layout #}
 {% include "account/verified_email_required_entreprinder.html" %}
-{% elif 'crush.lu' in request.get_host or 'localhost' in request.get_host or '127.0.0.1' in request.get_host %}
+{% elif 'crush.lu' in request.get_host or request.get_host == 'localhost' or request.get_host == 'crush.localhost' or '127.0.0.1' in request.get_host %}
 {# Crush.lu and local dev — full branded template using crush_lu/base.html #}
 {% include "account/verified_email_required_crush.html" %}
 {% else %}

--- a/crush_lu/templates/account/verified_email_required_crush.html
+++ b/crush_lu/templates/account/verified_email_required_crush.html
@@ -1,0 +1,43 @@
+{% extends 'crush_lu/base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans "Email Verification Required - Crush.lu" %}{% endblock %}
+{% block meta_robots %}noindex, nofollow{% endblock %}
+
+{% block content %}
+<div class="min-h-[60vh] flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-md">
+        <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg dark:shadow-gray-900/20 p-8 text-center">
+
+            <div class="w-16 h-16 bg-yellow-100 dark:bg-yellow-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+                {% include "shared/icons/envelope.html" with class="w-8 h-8 text-yellow-500 dark:text-yellow-400" %}
+            </div>
+
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+                {% trans "Verify Your Email" %}
+            </h1>
+            <p class="text-gray-500 dark:text-gray-400 mb-4">
+                {% blocktrans %}
+                    Before you can continue, we need to verify your email address.
+                    Please check your inbox for a verification link from Crush.lu.
+                {% endblocktrans %}
+            </p>
+            <p class="text-sm text-gray-400 dark:text-gray-500 mb-6">
+                {% blocktrans %}
+                    Don't see the email? Check your spam folder or request a new link below.
+                    The email is sent from <strong>noreply@crush.lu</strong>.
+                {% endblocktrans %}
+            </p>
+
+            <a href="{% url 'account_email' %}" class="btn-crush-primary inline-block w-full py-3 mb-3">
+                {% trans "Manage Email & Resend Link" %}
+            </a>
+
+            <a href="{% url 'account_logout' %}" class="inline-block w-full py-3 px-6 text-sm font-medium border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors">
+                {% trans "Log Out" %}
+            </a>
+
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crush_lu/templates/account/verified_email_required_neutral.html
+++ b/crush_lu/templates/account/verified_email_required_neutral.html
@@ -1,0 +1,17 @@
+{% load i18n %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:"en" }}">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{% trans "Verify Your Email Address" %}</title>
+<style>body{margin:0;padding:40px 16px;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111827}.card{max-width:480px;margin:0 auto;background:#fff;border-radius:12px;padding:40px;box-shadow:0 1px 4px rgba(0,0,0,.08)}h1{margin:0 0 12px;font-size:22px;font-weight:700}p{margin:0 0 20px;color:#6b7280;line-height:1.6}.btn{display:inline-block;background:#4f46e5;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600}.link{color:#4f46e5}</style>
+</head>
+<body>
+<div class="card">
+  <h1>{% trans "Verify Your Email Address" %}</h1>
+  <p>{% blocktrans %}This part of the site requires us to verify that you are who you claim to be. For this purpose, we require that you verify ownership of your email address.{% endblocktrans %}</p>
+  {% url 'account_email' as email_url %}
+  <p>{% blocktrans %}We have sent an email to you for verification. Please click on the link inside that email. If you do not see the verification email in your main inbox, check your spam folder. Otherwise <a class="link" href="{{ email_url }}">request a new verification email</a>.{% endblocktrans %}</p>
+</div>
+</body>
+</html>

--- a/entreprinder/templates/account/email_confirm_entreprinder.html
+++ b/entreprinder/templates/account/email_confirm_entreprinder.html
@@ -1,0 +1,36 @@
+{% extends "account/base_account.html" %}
+{% load i18n %}
+{% load account %}
+
+{% block head_title %}{% trans "Confirm E-mail Address" %}{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-6 mx-auto">
+    <h1 class="mb-4">{% trans "Confirm E-mail Address" %}</h1>
+
+    {% if confirmation %}
+
+    {% user_display confirmation.email_address.user as user_display %}
+
+    {% if can_confirm %}
+    <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+
+    <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+    {% csrf_token %}
+        <button class="btn btn-primary" type="submit">{% trans 'Confirm' %}</button>
+    </form>
+    {% else %}
+    <p>{% blocktrans with confirmation.email_address.email as email %}Unable to confirm {{ email }} because it is already confirmed by a different account.{% endblocktrans %}</p>
+    {% endif %}
+
+    {% else %}
+
+    {% url 'account_email' as email_url %}
+
+    <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/entreprinder/templates/account/verification_sent_entreprinder.html
+++ b/entreprinder/templates/account/verification_sent_entreprinder.html
@@ -1,0 +1,13 @@
+{% extends "account/base_account.html" %}
+{% load i18n %}
+
+{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-6 mx-auto">
+    <h1 class="mb-4">{% trans "Verify Your E-mail Address" %}</h1>
+    <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. If you do not see the verification e-mail in your main inbox, check your spam folder. Please contact us if you do not receive the verification e-mail within a few minutes.{% endblocktrans %}</p>
+  </div>
+</div>
+{% endblock %}

--- a/entreprinder/templates/account/verified_email_required_entreprinder.html
+++ b/entreprinder/templates/account/verified_email_required_entreprinder.html
@@ -1,0 +1,15 @@
+{% extends "account/base_account.html" %}
+{% load i18n %}
+
+{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-6 mx-auto">
+    <h1 class="mb-4">{% trans "Verify Your E-mail Address" %}</h1>
+    <p>{% blocktrans %}This part of the site requires us to verify that you are who you claim to be. For this purpose, we require that you verify ownership of your e-mail address.{% endblocktrans %}</p>
+    {% url 'account_email' as email_url %}
+    <p>{% blocktrans %}We have sent an e-mail to you for verification. Please click on the link inside that email. If you do not see the verification e-mail in your main inbox, check your spam folder. Otherwise <a href="{{ email_url }}">request a new verification e-mail</a>.{% endblocktrans %}</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
$(cat <<'EOF'
## Problem

When a user already has an account (created via email/password or another social provider like Microsoft) and tries to sign in with LuxID using the same email address, they are redirected to `/accounts/3rdparty/signup/` instead of being automatically connected to their existing account.

## Root cause

allauth's email-based auto-connect flow (`SOCIALACCOUNT_EMAIL_AUTHENTICATION = True` + `SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True`) works as follows:

1. `sociallogin.lookup()` runs — filters `sociallogin.email_addresses` by `verified=True`, then queries the DB for a matching user
2. `adapter.pre_social_login()` and the `pre_social_login` signal fire (after lookup)

The critical issue: allauth's generic OIDC `extract_email_addresses()` defaults `email_verified` to `False` when the claim is absent from the token:

```python
# allauth/socialaccount/providers/openid_connect/provider.py
EmailAddress(email=email, verified=data.get("email_verified", False), ...)
```

LuxID (POST Luxembourg's CIAM) does not always include the `email_verified` claim. With `verified=False`, `_lookup_by_email()` skips the DB query entirely — no match is found — and the user lands on the signup page.

The existing `pre_social_login` signal handler that patches `email_addresses` fires **after** `lookup()` so it cannot influence the auto-connect decision.

## Fix

### `crush_lu/providers/luxid/provider.py`
Override `extract_email_addresses` in `LuxIDProvider` to force `verified=True`. LuxID is a government-grade eID (POST Luxembourg CIAM) and is the authoritative trust anchor for any email it releases — verification is implicit at the IdP level regardless of whether the `email_verified` OIDC claim is present.

This runs during OAuth callback processing, **before** `sociallogin.lookup()`, so the email is correctly marked verified when the auto-connect check runs.

### `crush_lu/signals.py`
Update the belt-and-braces block in the `pre_social_login` handler to:
- Patch `verified=True` on **existing** entries (not just inject when empty), covering any edge case where allauth's internals set up email_addresses before the signal
- Add a clear comment explaining that this block cannot affect auto-connect (lookup already ran) and is retained for signup form pre-fill only

## Test plan

- [ ] User has existing email/password account → signs in with LuxID (same email) → lands on account settings, LuxID now connected (no signup redirect)
- [ ] User has existing Microsoft social account → signs in with LuxID (same email) → same result
- [ ] New user signs in with LuxID for the first time → normal signup flow unaffected
- [ ] User already has LuxID connected → normal login, no duplicate connection

https://claude.ai/code/session_01FYjpsYtEF9MFRAT25L35PK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYjpsYtEF9MFRAT25L35PK)_