### PR TITLE
fix(onboarding): keep country flag visible after phone verification

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -5455,6 +5455,11 @@ document.addEventListener("alpine:init", function () {
                 var verifiedAttr = this.$el.getAttribute("data-verified");
                 this.verified = verifiedAttr === "true";
 
+                // data-keep-iti="true" preserves the flag/dial-code display after
+                // verification. Use this on pages without a <form> (e.g. onboarding)
+                // where destroying the instance would leave a plain text field.
+                this.keepIti = this.$el.getAttribute("data-keep-iti") === "true";
+
                 this.phoneInputId =
                     this.$el.getAttribute("data-phone-input-id") || "id_phone_number";
 
@@ -5532,22 +5537,28 @@ document.addEventListener("alpine:init", function () {
                             // destroy the instance so it can't strip the dial code later
                             self.iti.setNumber(e.detail);
                         }
-                        // Set the raw input value to full E.164 number as a safety net
-                        phoneInput.value = e.detail;
                         phoneInput.readOnly = true;
-                        // Destroy intl-tel-input instance - phone is now verified and locked,
-                        // we don't want the library interfering with the value on form submit
-                        if (self.iti) {
-                            try {
-                                self.iti.destroy();
-                            } catch (err) {
-                                console.warn(
-                                    "intl-tel-input: Could not destroy after verification",
-                                    err,
-                                );
+                        if (self.keepIti && self.iti) {
+                            // No form submission on this page — keep the iti instance so
+                            // the country flag and dial code remain visible after verification.
+                            self.iti.setNumber(e.detail);
+                        } else {
+                            // Set the raw input value to full E.164 number as a safety net
+                            phoneInput.value = e.detail;
+                            // Destroy intl-tel-input instance - phone is now verified and locked,
+                            // we don't want the library stripping the dial code on form submit
+                            if (self.iti) {
+                                try {
+                                    self.iti.destroy();
+                                } catch (err) {
+                                    console.warn(
+                                        "intl-tel-input: Could not destroy after verification",
+                                        err,
+                                    );
+                                }
+                                self.iti = null;
+                                window.itiInstance = null;
                             }
-                            self.iti = null;
-                            window.itiInstance = null;
                         }
                     }
                 });

--- a/crush_lu/templates/crush_lu/onboarding/phone.html
+++ b/crush_lu/templates/crush_lu/onboarding/phone.html
@@ -29,7 +29,8 @@
              id="phone-verification-container"
              x-data="phoneVerificationComponent"
              data-verified="{% if profile.phone_verified %}true{% else %}false{% endif %}"
-             data-phone-input-id="onboarding_phone_input">
+             data-phone-input-id="onboarding_phone_input"
+             data-keep-iti="true">
 
       <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200">
         {% include "shared/icons/phone.html" with class="w-5 h-5" %}


### PR DESCRIPTION
## Summary

- After phone verification on `/onboarding/phone/`, the country flag and dial code selector disappeared — the input fell back to a plain text field showing the raw E.164 number (e.g. `+352621163882`) with no flag.
- The `create_profile` page correctly destroys the intl-tel-input instance after verification to prevent it from stripping the dial code on form submit. The onboarding page has no form submission, so this destruction is unnecessary and causes a visual regression.

## What changed

**`alpine-components.js`** — `phoneVerificationComponent` now reads a `data-keep-iti` attribute. When `true`, it calls `iti.setNumber()` and leaves the instance alive (flag stays visible). When absent/false, the old behaviour is preserved (iti destroyed, raw value written to input for safe form submission).

**`onboarding/phone.html`** — Added `data-keep-iti="true"` to the phone section. `create_profile.html` is unchanged.

## Test plan
- [ ] Verify phone number on `/onboarding/phone/` — flag and dial code should remain visible after verification, input should be read-only
- [ ] Verify `create_profile` phone verification still works — iti should be destroyed after verification, full E.164 number stored in the form input

https://claude.ai/code/session_01WJtLXECPukw96d1XP1Qbun

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJtLXECPukw96d1XP1Qbun)_