### PR TITLE
Fix LuxID OIDC claims extraction to merge id_token and userinfo

### DIFF
--- a/azureproject/adapters.py
+++ b/azureproject/adapters.py
@@ -263,10 +263,19 @@ class MultiDomainSocialAccountAdapter(DefaultSocialAccountAdapter):
         # uses OIDC for LuxID, so both spellings are treated as LuxID.
         elif sociallogin.account.provider in ('luxid', 'openid_connect'):
             extra_data = sociallogin.account.extra_data
-            user.first_name = extra_data.get('given_name', '') or data.get('first_name', '') or ''
-            user.last_name = extra_data.get('family_name', '') or data.get('last_name', '') or ''
-            if extra_data.get('email'):
-                user.email = extra_data['email']
+            # allauth 65.x stores OIDC token response nested:
+            # {"userinfo": {...}, "id_token": {...}}.  _pick_data() prefers
+            # userinfo entirely, dropping id_token claims when userinfo is
+            # present.  Merge both so email/name are found regardless of
+            # which endpoint LuxID releases them through.
+            _id_token = extra_data.get("id_token") or {}
+            _userinfo = extra_data.get("userinfo") or {}
+            _claims = {**_id_token, **_userinfo} or extra_data  # userinfo wins
+            user.first_name = _claims.get('given_name', '') or data.get('first_name', '') or ''
+            user.last_name = _claims.get('family_name', '') or data.get('last_name', '') or ''
+            email = _claims.get('email') or data.get('email', '')
+            if email:
+                user.email = email
         else:
             # Other providers (LinkedIn, etc.)
             user.first_name = data.get('first_name', '') or ''

--- a/crush_lu/providers/luxid/provider.py
+++ b/crush_lu/providers/luxid/provider.py
@@ -68,13 +68,19 @@ class LuxIDProvider(OpenIDConnectProvider):
         return reverse(f"{self.id}_callback")
 
     def extract_email_addresses(self, data):
-        addresses = super().extract_email_addresses(data)
+        # allauth 65.x's _pick_data() prefers ``userinfo`` over ``id_token``
+        # and ignores id_token entirely when userinfo is present.  If LuxID
+        # releases ``email`` only in the id_token (not in the userinfo
+        # endpoint response) the address list would be empty.  Merge both
+        # sources first; _pick_data falls through to return ``data`` as-is
+        # when the merged dict contains neither "userinfo" nor "id_token" key.
+        id_token = data.get("id_token") or {}
+        userinfo = data.get("userinfo") or {}
+        merged = {**id_token, **userinfo}  # userinfo wins for overlapping keys
+        flat_data = merged if merged else data
+        addresses = super().extract_email_addresses(flat_data)
         # LuxID is POST Luxembourg's government-grade CIAM and the authoritative
-        # trust anchor for the email it releases. allauth's OIDC base class
-        # defaults email_verified to False when the claim is absent, which
-        # prevents _lookup_by_email() from matching the email to an existing
-        # account and forces the user to the /accounts/3rdparty/signup/ page
-        # instead of auto-connecting. Force verified=True so that
+        # trust anchor for the email it releases.  Force verified=True so that
         # SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT works correctly.
         for addr in addresses:
             addr.verified = True

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1649,14 +1649,22 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                     "[LUXID] Phone-based lookup: connecting LuxID to existing user pk=%s",
                     _existing_user.pk,
                 )
-                sociallogin.user = _existing_user
-                # This is now a connect, not a new signup.  Clear the signup
-                # thread-local flags set earlier in this handler so downstream
-                # post_save handlers (create_user_data_consent, welcome-email
-                # in create_crush_profile_from_luxid) don't incorrectly treat
-                # the existing account as a brand-new OAuth registration.
+                # Clear signup thread-local flags BEFORE calling connect() so
+                # the post_save signal fired by connect().save() sees clean
+                # state.  Downstream handlers (create_user_data_consent and
+                # the welcome-email branch in create_crush_profile_from_luxid)
+                # check these flags and must not treat an existing account as
+                # a brand-new registration.
                 _thread_local.oauth_signup_request = None
                 _thread_local.oauth_consent_data = None
+                # Persist the SocialAccount and token now rather than relying
+                # on allauth's _login() path to do it.  _login() only saves
+                # the SocialAccount when _did_authenticate_by_email is set
+                # (the email auto-connect flag); our phone branch never sets
+                # that flag, so without an explicit connect() call the LuxID
+                # social account would be logged in but never stored, causing
+                # the same phone lookup to repeat on every subsequent login.
+                sociallogin.connect(request, _existing_user)
             except CrushProfile.DoesNotExist:
                 logger.debug("[LUXID] Phone-based lookup: no existing user for this phone")
             except CrushProfile.MultipleObjectsReturned:

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1459,16 +1459,22 @@ LUXID_GENDER_MAP = {
 
 
 def _luxid_claims(extra_data):
-    """Flatten allauth's OIDC envelope to a single claims dict.
+    """Return a merged claims dict from allauth's nested OIDC envelope.
 
-    Allauth's OpenID Connect provider stores the raw response as
-    ``{"id_token": {...}, "userinfo": {...}}``. Prefer userinfo (matches
-    allauth's own ``_pick_data``) and fall back to id_token, so claims
-    like ``birthdate`` / ``phone_number`` are readable at one level.
+    Allauth 65.x stores the raw token response as
+    ``{"id_token": {...}, "userinfo": {...}}``.  Its internal ``_pick_data()``
+    prefers ``userinfo`` and ignores ``id_token`` entirely when ``userinfo``
+    is present, so claims released only in the id_token (e.g. ``email``)
+    are silently dropped.  We merge both sources — id_token first, userinfo
+    on top — so userinfo wins for overlapping keys while id_token-only
+    claims remain accessible.
     """
     if not isinstance(extra_data, dict):
         return {}
-    return extra_data.get("userinfo") or extra_data.get("id_token") or extra_data
+    id_token = extra_data.get("id_token") or {}
+    userinfo = extra_data.get("userinfo") or {}
+    merged = {**id_token, **userinfo}  # userinfo wins for overlapping keys
+    return merged if merged else extra_data
 
 
 def _is_luxembourgish_phone(phone):
@@ -1566,20 +1572,23 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
     try:
         extra_data = sociallogin.account.extra_data
 
-        # Allauth's OpenID Connect provider stores the raw response envelope
-        # {"id_token": {...}, "userinfo": {...}} in SocialAccount.extra_data,
-        # so claims like `email` live one level down, not at the top. Flatten
-        # here (prefer userinfo per allauth's _pick_data) before inspecting.
-        _claims = extra_data.get("userinfo") or extra_data.get("id_token") or {}
+        # Allauth 65.x stores the raw OIDC response as
+        # {"id_token": {...}, "userinfo": {...}} in SocialAccount.extra_data.
+        # _pick_data() (used internally by allauth) prefers userinfo and drops
+        # id_token entirely when userinfo is present.  Use _luxid_claims() to
+        # merge both so we capture email/phone whether LuxID releases them via
+        # userinfo or only embeds them in the id_token.
+        _claims = _luxid_claims(extra_data)
 
-        # Lightweight diagnostic — POST Luxembourg's CIAM is now releasing
-        # the `email` claim (essential) on the `crush` UAT client, so we no
-        # longer need the expansive ERROR-level probe. Keep a single INFO
-        # line so we can still confirm the envelope shape at a glance.
+        # Diagnostic: log which source has the email claim to aid debugging.
         try:
+            _dbg_userinfo = extra_data.get("userinfo") or {}
+            _dbg_id_token = extra_data.get("id_token") or {}
             logger.info(
-                "[LUXID] envelope_keys=%s userinfo_has_email=%s",
+                "[LUXID] envelope_keys=%s userinfo_has_email=%s id_token_has_email=%s merged_has_email=%s",
                 sorted(extra_data.keys()),
+                bool(_dbg_userinfo.get("email")),
+                bool(_dbg_id_token.get("email")),
                 bool(_claims.get("email")),
             )
         except Exception:
@@ -1609,6 +1618,49 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                         primary=True,
                     )
                 ]
+
+            # Safety net: ensure user.email is populated for the SocialSignupForm.
+            # populate_user() runs earlier but may miss the email if allauth's
+            # _pick_data() discards the id_token when userinfo is present yet
+            # the userinfo endpoint omits the email claim.
+            if not getattr(sociallogin.user, "email", None):
+                sociallogin.user.email = _claims["email"]
+                logger.info("[LUXID] Safety net: set user.email from OIDC claims")
+
+        # Phone-based existing-user lookup.
+        # allauth's email auto-connect runs via sociallogin.lookup() BEFORE
+        # this signal fires.  For users who registered with a different email
+        # (or no email) but whose LuxID-verified phone matches a Crush.lu
+        # account, we do a secondary lookup here and redirect the new social
+        # login to their existing account by setting sociallogin.user.
+        # allauth 65.x derives is_existing from bool(sociallogin.user.pk), so
+        # once we point sociallogin.user at an existing DB user, allauth's
+        # _authenticate() will call _login() (not process_signup()), saving
+        # the new SocialAccount link and logging the user in seamlessly.
+        _phone = _claims.get("phone_number")
+        if _phone and _is_luxembourgish_phone(_phone) and not sociallogin.is_existing:
+            try:
+                _existing_profile = CrushProfile.objects.select_related("user").get(
+                    phone_number=_phone,
+                    phone_verified=True,
+                )
+                _existing_user = _existing_profile.user
+                logger.info(
+                    "[LUXID] Phone-based lookup: connecting LuxID to existing user %s",
+                    _existing_user.email,
+                )
+                sociallogin.user = _existing_user
+            except CrushProfile.DoesNotExist:
+                logger.debug("[LUXID] Phone-based lookup: no existing user for this phone")
+            except CrushProfile.MultipleObjectsReturned:
+                logger.warning(
+                    "[LUXID] Phone-based lookup: multiple profiles share phone %s…, skipping",
+                    _phone[:6],
+                )
+            except Exception as _phone_err:
+                logger.error(
+                    "[LUXID] Phone-based lookup error: %s", _phone_err, exc_info=True
+                )
 
         # Update CrushProfile for existing users.
         # During the connect flow (email user linking LuxID for the first

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1646,16 +1646,15 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                 )
                 _existing_user = _existing_profile.user
                 logger.info(
-                    "[LUXID] Phone-based lookup: connecting LuxID to existing user %s",
-                    _existing_user.email,
+                    "[LUXID] Phone-based lookup: connecting LuxID to existing user pk=%s",
+                    _existing_user.pk,
                 )
                 sociallogin.user = _existing_user
             except CrushProfile.DoesNotExist:
                 logger.debug("[LUXID] Phone-based lookup: no existing user for this phone")
             except CrushProfile.MultipleObjectsReturned:
                 logger.warning(
-                    "[LUXID] Phone-based lookup: multiple profiles share phone %s…, skipping",
-                    _phone[:6],
+                    "[LUXID] Phone-based lookup: multiple profiles share the same phone, skipping"
                 )
             except Exception as _phone_err:
                 logger.error(

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1638,7 +1638,8 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
         # _authenticate() will call _login() (not process_signup()), saving
         # the new SocialAccount link and logging the user in seamlessly.
         _phone = _claims.get("phone_number")
-        if _phone and _is_luxembourgish_phone(_phone) and not sociallogin.is_existing:
+        _is_connect_flow = getattr(sociallogin, "state", {}).get("process") == "connect"
+        if _phone and _is_luxembourgish_phone(_phone) and not sociallogin.is_existing and not _is_connect_flow:
             try:
                 _existing_profile = CrushProfile.objects.select_related("user").get(
                     phone_number=_phone,

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1650,6 +1650,13 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                     _existing_user.pk,
                 )
                 sociallogin.user = _existing_user
+                # This is now a connect, not a new signup.  Clear the signup
+                # thread-local flags set earlier in this handler so downstream
+                # post_save handlers (create_user_data_consent, welcome-email
+                # in create_crush_profile_from_luxid) don't incorrectly treat
+                # the existing account as a brand-new OAuth registration.
+                _thread_local.oauth_signup_request = None
+                _thread_local.oauth_consent_data = None
             except CrushProfile.DoesNotExist:
                 logger.debug("[LUXID] Phone-based lookup: no existing user for this phone")
             except CrushProfile.MultipleObjectsReturned:


### PR DESCRIPTION
## Purpose
* Fix a critical bug where LuxID OIDC claims released only in the `id_token` (e.g., `email`, `phone_number`) were being silently dropped when the `userinfo` endpoint response was present
* Allauth 65.x's internal `_pick_data()` prefers `userinfo` and ignores `id_token` entirely when `userinfo` is present, causing claims to be lost if LuxID releases them via different endpoints
* Implement proper merging of both `id_token` and `userinfo` sources across the codebase to ensure all claims are accessible regardless of which endpoint LuxID uses

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Changes Made

### `crush_lu/signals.py`
* **`_luxid_claims()` function**: Refactored to merge both `id_token` and `userinfo` dicts instead of using fallback logic. Now returns `{**id_token, **userinfo}` so `userinfo` wins for overlapping keys while `id_token`-only claims remain accessible
* **`update_crush_profile_from_luxid()` signal handler**: 
  - Updated to use `_luxid_claims()` for consistent claim extraction
  - Enhanced diagnostic logging to show which source contains the email claim
  - Added safety net to populate `user.email` if allauth's `_pick_data()` missed it
  - Implemented phone-based existing-user lookup to connect new LuxID logins to existing Crush.lu accounts when email doesn't match but verified phone does

### `crush_lu/providers/luxid/provider.py`
* **`extract_email_addresses()` method**: Updated to merge `id_token` and `userinfo` before calling parent's extraction logic, ensuring email addresses are found regardless of which endpoint LuxID releases them through

### `azureproject/adapters.py`
* **`populate_user()` method**: Updated LuxID/OpenID Connect branch to merge both OIDC token sources when extracting user claims (`given_name`, `family_name`, `email`)

## How to Test
* Run existing test suite to verify no regressions
* Manual testing: Authenticate with LuxID and verify that:
  - User email is correctly populated even if released only in `id_token`
  - User phone number is correctly extracted from merged claims
  - Phone-based lookup correctly connects new LuxID logins to existing accounts with matching verified phone numbers
  - Diagnostic logs show the correct email source

## What to Check
Verify that the following are valid:
* Email and phone claims are correctly extracted from both `id_token` and `userinfo` sources
* Phone-based account linking works for users registering with different email addresses
* Existing tests pass without modification
* Diagnostic logging provides useful debugging information

## Other Information
This fix addresses a regression introduced by allauth 65.x's stricter claim handling. The changes ensure backward compatibility while properly handling the nested OIDC response structure.

https://claude.ai/code/session_01WnmFd5vn6poWZMCXnYfEEX