### PR TITLE
chore(deps): merge all approved dependabot PRs (#400–#405)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "crush-lu",
       "version": "1.0.0",
       "dependencies": {
-        "alpinejs": "^3.15.11",
+        "alpinejs": "^3.15.12",
         "htmx.org": "^2.0.10"
       },
       "devDependencies": {
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/alpinejs": {
-      "version": "3.15.11",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.11.tgz",
-      "integrity": "sha512-m26gkTg/MId8O+F4jHKK3vB3SjbFxxk/JHP+qzmw1H6aQrZuPAg4CUoAefnASzzp/eNroBjrRQe7950bNeaBJw==",
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
+      "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "~3.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "htmx.org": "^2.0.10"
       },
       "devDependencies": {
-        "@playwright/mcp": "^0.0.70",
+        "@playwright/mcp": "^0.0.73",
         "@tailwindcss/cli": "^4.2.4",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.19",
@@ -436,14 +436,14 @@
       }
     },
     "node_modules/@playwright/mcp": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.70.tgz",
-      "integrity": "sha512-Kl0a6l9VL8rvT1oBou3hS5yArjwWV9UlwAkq+0skfK1YVg8XfmmNaAmwZhMeNx/ZhGiWXfCllo6rD/jvZz+WuA==",
+      "version": "0.0.73",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.73.tgz",
+      "integrity": "sha512-2hq+nPq8esA3mi3bjEpBH5A3LkVqnSCJXw7NO2N7frJTzKsu8qdTQyvPl1jk83rPuIY6ALCdEBI60tdTODeNEA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0-alpha-1774999321000",
-        "playwright-core": "1.60.0-alpha-1774999321000"
+        "playwright": "1.60.0-alpha-1777669338000",
+        "playwright-core": "1.60.0-alpha-1777669338000"
       },
       "bin": {
         "playwright-mcp": "cli.js"
@@ -2219,13 +2219,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0-alpha-1774999321000",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1774999321000.tgz",
-      "integrity": "sha512-Bd5DkzYKG+2g1jLO6NeTXmGLbBYSFffJIOsR4l4hUBkJvzvGGdLZ7jZb2tOtb0WIoWXQKdQj3Ap6WthV4DBS8w==",
+      "version": "1.60.0-alpha-1777669338000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1777669338000.tgz",
+      "integrity": "sha512-r5G2ZvpIJZHj53GKmUfoQiXHix5bjeObqysV4flfmFNykTjebI9bwdRBuW37pOQP25yjbArkxlsnT5APaWT8zg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0-alpha-1774999321000"
+        "playwright-core": "1.60.0-alpha-1777669338000"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0-alpha-1774999321000",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1774999321000.tgz",
-      "integrity": "sha512-ams3Zo4VXxeOg5ZTTh16GkE8g48Bmxo/9pg9gXl9SVKlVohCU7Jaog7XntY8yFuzENA6dJc1Fz7Z/NNTm9nGEw==",
+      "version": "1.60.0-alpha-1777669338000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1777669338000.tgz",
+      "integrity": "sha512-CbBF+YtjGGK2mWKdH6iiSNIB9v9Sq8owcUrTy1cw6FgMZavspM6ZSpidQQgQXz/1scQFrM110jrtJqTYwnjbeA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tailwindcss/cli": "^4.2.4",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.19",
-        "@upstash/context7-mcp": "^2.2.0",
+        "@upstash/context7-mcp": "^2.2.3",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.1.18"
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@upstash/context7-mcp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@upstash/context7-mcp/-/context7-mcp-2.2.0.tgz",
-      "integrity": "sha512-AYcvmMWaf2HsZMdp8eURiHwGB+0MF4IDkG9IB22Th9OfoCWL5rldeSL7pEFxxaWBcRl0yOga1exo+1Ga4d2vMA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@upstash/context7-mcp/-/context7-mcp-2.2.3.tgz",
+      "integrity": "sha512-AZoARvwR1MA6TeMAXFDXg0LnA0DWdEervrrJxEXb3X8I2LAFRIdGWZG7keawHz5FYwFZ4M8oyuvtnoRemRb0SQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "htmx.org": "^2.0.10"
   },
   "devDependencies": {
-    "@playwright/mcp": "^0.0.70",
+    "@playwright/mcp": "^0.0.73",
     "@tailwindcss/cli": "^4.2.4",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@tailwindcss/cli": "^4.2.4",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.19",
-    "@upstash/context7-mcp": "^2.2.0",
+    "@upstash/context7-mcp": "^2.2.3",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.1.18"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:check": "prettier --check \"**/*.{html,js,css}\""
   },
   "dependencies": {
-    "alpinejs": "^3.15.11",
+    "alpinejs": "^3.15.12",
     "htmx.org": "^2.0.10"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ psycopg2-binary==2.9.12  # Updated from 2.9.10 (security & bug fixes)
 django-allauth==65.16.1  # Updated from 65.1.0 (latest stable)
 PyJWT==2.12.1  # Updated from 2.11.0 (CVE-2026-32597: crit header bypass)
 cryptography>=47.0.0  # Required for JWT token verification with RSA keys (CVE-2026-26007, OpenSSL fixes)
-google-auth==2.49.2  # Required for Google Wallet API authentication
+google-auth==2.50.0  # Required for Google Wallet API authentication
 
 # Storage
 django-storages==1.14.6  # Updated from 1.14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,4 +73,4 @@ pytest==9.0.3
 pytest-django==4.12.0
 pytest-playwright==0.7.2
 pytest-mock==3.15.1  # Provides 'mocker' fixture for mocking
-playwright==1.58.0
+playwright==1.59.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Build dependencies (security-critical)
 pip>=26.1  # CVE-2025-8869 fix
-setuptools>=80.10.2  # CVE-2024-6345, PYSEC-2025-49 fixes
+setuptools>=82.0.1  # CVE-2024-6345, PYSEC-2025-49 fixes
 wheel>=0.47.0
 
 # Core Django


### PR DESCRIPTION
## Summary

Consolidates all 6 open dependabot PRs into a single merge:

| PR | Change |
|----|--------|
| #400 | `setuptools` ≥ 80.10.2 → ≥ 82.0.1 |
| #401 | `google-auth` 2.49.2 → 2.50.0 |
| #402 | `playwright` (pip) 1.58.0 → 1.59.0 |
| #403 | `alpinejs` 3.15.11 → 3.15.12 |
| #404 | `@upstash/context7-mcp` 2.2.0 → 2.2.3 |
| #405 | `@playwright/mcp` 0.0.70 → 0.0.73 |

All branches merged cleanly with no conflicts. Once this PR is merged, the individual dependabot PRs (#400–#405) can be closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWE8WjNVjwBoDE7E5DT8vD)_