### PR TITLE
Improve responsiveness and spacing of dashboard cards

### DIFF
--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -148,18 +148,18 @@
     {% if profile.is_approved %}
     <!-- Ideal Crush Preferences Card -->
     <a href="{% url 'crush_lu:crush_preferences' %}"
-       class="block no-underline group relative overflow-hidden rounded-xl bg-gradient-to-r from-crush-purple to-crush-pink p-5 text-white shadow-lg hover:shadow-xl transition-shadow">
-        <div class="relative z-10 flex items-center justify-between">
-            <div class="flex items-center gap-4">
+       class="block no-underline group relative overflow-hidden rounded-xl bg-gradient-to-r from-crush-purple to-crush-pink p-4 sm:p-5 text-white shadow-lg hover:shadow-xl transition-shadow">
+        <div class="relative z-10 flex items-center justify-between gap-3">
+            <div class="flex items-center gap-3 sm:gap-4 min-w-0">
                 <span class="flex-shrink-0 flex items-center justify-center w-10 h-10 sm:w-14 sm:h-14">{% include "crush_lu/includes/ghost-story-blushing-reader.html" with class="w-full h-full" %}</span>
-                <div>
-                    <div class="flex items-center gap-2 mb-1">
-                        <h5 class="font-bold text-white text-lg mb-0">{% trans "Your Ideal Crush" %}</h5>
+                <div class="min-w-0">
+                    <div class="flex items-center gap-2 mb-1 flex-wrap">
+                        <h5 class="font-bold text-white text-lg leading-tight mb-0">{% trans "Your Ideal Crush" %}</h5>
                         {% if not has_crush_preferences %}
                         <span class="inline-block rounded-full bg-white px-2 py-0.5 text-xs font-bold text-crush-purple uppercase">{% trans "New" %}</span>
                         {% endif %}
                     </div>
-                    <p class="text-white/90 text-sm mb-0">
+                    <p class="text-white/90 text-sm mb-0 hidden sm:block">
                         {% if has_crush_preferences %}
                             {% trans "Update your preferences" %}
                         {% else %}
@@ -168,12 +168,15 @@
                     </p>
                 </div>
             </div>
-            <span class="inline-flex items-center gap-1 rounded-lg bg-white/20 px-4 py-2 text-sm font-semibold text-white group-hover:bg-white/30 transition-colors">
+            <span class="hidden sm:inline-flex items-center gap-1 rounded-lg bg-white/20 px-4 py-2 text-sm font-semibold text-white group-hover:bg-white/30 transition-colors flex-shrink-0">
                 {% if has_crush_preferences %}
                     {% trans "Update" %}
                 {% else %}
                     {% trans "Set up now" %}
                 {% endif %}
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </span>
+            <span class="inline-flex sm:hidden items-center justify-center rounded-full bg-white/20 p-2 text-white/90 group-hover:bg-white/30 transition-colors flex-shrink-0">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
             </span>
         </div>


### PR DESCRIPTION
### Motivation
- Improve the mobile and small-screen layout of the dashboard cards to prevent text truncation and cramped spacing. 
- Provide simplified action affordances on small screens while preserving full CTA labels on larger screens. 
- Ensure icon and text containers can shrink/wrap correctly to avoid overflow in narrow layouts. 

### Description
- Updated `crush_lu/templates/crush_lu/dashboard.html` to adjust paddings and gaps (e.g. `p-4 sm:p-5`, `gap-3`, `sm:gap-4`) and to add `min-w-0` to enable proper truncation. 
- Made descriptive texts responsive by hiding detail lines on small screens using `hidden sm:block` and added `flex-wrap`/`leading-tight` to allow better wrapping. 
- Reworked action affordances to show a compact icon-only action on small screens and full label+icon buttons on larger screens by toggling classes like `hidden sm:inline-flex` and adding an `sm:hidden` icon variant. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8452af8e083308fbf4e45ea397fb1)