### PR TITLE
Center flex container in dashboard profile section

### DIFF
--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -144,7 +144,7 @@
         </div>
     </div>
 
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col justify-center gap-6">
     {% if profile.is_approved %}
     <!-- Ideal Crush Preferences Card -->
     <a href="{% url 'crush_lu:crush_preferences' %}"


### PR DESCRIPTION
## Purpose
* Add `justify-center` utility class to the flex container in the dashboard profile section to center-align its child elements vertically

## Does this introduce a breaking change?
```
[x] No
[ ] Yes
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
  - Navigate to the dashboard page
  - Verify that the profile cards (Ideal Crush Preferences, etc.) are now vertically centered within their container

## What to Check
Verify that the following are valid
* Profile cards in the dashboard are visually centered within the flex container
* Layout remains responsive across different screen sizes
* No visual regressions in other dashboard sections

## Other Information
This is a minor styling adjustment using Tailwind CSS utilities to improve the visual alignment of dashboard elements.

https://claude.ai/code/session_012DjahjUa83p3iziqfHRLjq