### PR TITLE
Expose hub API and JWT logout for CRM SPA on crush.lu

### DIFF
--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -310,6 +310,11 @@ urlpatterns = base_patterns + api_patterns + [
 
     # Standard Django Admin (all platforms)
     path('admin/', admin.site.urls),
+
+    # Hub API for the CRM SPA (Codex_Marketing_CRM) hosted at hub.crush.lu.
+    # Mounted on crush.lu / test.crush.lu since the SPA's preview env can't
+    # have its own subdomain — it uses test.crush.lu directly. Language-neutral.
+    path('hub/', include('hub.urls')),
 ]
 
 # Language-prefixed patterns (all user-facing pages)

--- a/azureproject/urls_shared.py
+++ b/azureproject/urls_shared.py
@@ -12,7 +12,11 @@ Usage:
 """
 from django.urls import path, include
 from django.http import HttpResponse
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.views import (
+    TokenBlacklistView,
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 from .views import csp_report
 from crush_lu.views_language import set_language_with_profile
@@ -45,4 +49,5 @@ base_patterns = [
 api_patterns = [
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/token/logout/', TokenBlacklistView.as_view(), name='token_logout'),
 ]


### PR DESCRIPTION
## Summary
- Mounts `/hub/me`, `/hub/requests`, `/hub/resources`, `/hub/timeline` on the `crush.lu` urlconf so the [Codex_Marketing_CRM](https://github.com/EuphoriaLux/Codex_Marketing_CRM) SPA can reach them via `crush.lu` (prod) and `test.crush.lu` (preview).
- Adds `/api/token/logout/` (`TokenBlacklistView`) to the shared `api_patterns` in `urls_shared.py` to round out the JWT surface that's already there.

## Why this lives on `crush.lu` and not `api.crush.lu`
The CRM SPA is hosted on Azure Static Web Apps. Its preview environments share env vars with the build, so they can't have a dedicated subdomain pointing at a separate staging API. Both prod and preview must therefore talk to `crush.lu` / `test.crush.lu` directly. The `api.crush.lu` host in `domains.py` exists but isn't bound on the App Service (no DNS, no cert), so it isn't reachable today.

## Follow-up in the CRM repo (not blocking this PR)
`.github/workflows/azure-static-web-apps-delightful-water-07d8c6e10.yml` line 26 needs to drop the `/api` suffix:
```yaml
NEXT_PUBLIC_API_BASE_URL: ${{ github.event_name == 'pull_request' && 'https://test.crush.lu' || 'https://crush.lu' }}
```
The TS client already prefixes `/api/...` and `/hub/...` itself, so the current `/api` in the base URL produces broken `https://crush.lu/api/api/token/` calls.

## Test plan
- [ ] CI green on this branch
- [ ] After merge + deploy: `curl -X POST https://crush.lu/api/token/logout/ -H 'Content-Type: application/json' -d '{}'` returns 400 (missing refresh token), not 404 — confirms route is live.
- [ ] `curl https://crush.lu/hub/me` returns 401 (auth required), not 404.
- [ ] CORS preflight from `https://hub.crush.lu` to `/hub/me` succeeds (already allow-listed in `settings.py`).
- [ ] Once CRM workflow PR is merged, hub.crush.lu login succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)