### PR TITLE
Add SPA session->JWT bridge and PR-preview CORS regex for hub.crush.lu

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -34,7 +34,9 @@ if DOTENV_PATH.exists():
         load_dotenv(dotenv_path=DOTENV_PATH)
     except Exception:
         # dotenv is optional; ignore if it's not installed or fails
-        logging.getLogger(__name__).debug("python-dotenv not available or failed to load .env")
+        logging.getLogger(__name__).debug(
+            "python-dotenv not available or failed to load .env"
+        )
 
 
 def _env_bool(name, default=False):
@@ -374,7 +376,9 @@ WALLET_GOOGLE_SERVICE_ACCOUNT_EMAIL = os.getenv(
 WALLET_GOOGLE_PRIVATE_KEY = os.getenv("WALLET_GOOGLE_PRIVATE_KEY", "")
 WALLET_GOOGLE_PRIVATE_KEY_PATH = os.getenv("WALLET_GOOGLE_PRIVATE_KEY_PATH", "")
 WALLET_GOOGLE_KEY_ID = os.getenv("WALLET_GOOGLE_KEY_ID", "")
-WALLET_GOOGLE_EVENT_TICKET_ENABLED = _env_bool("WALLET_GOOGLE_EVENT_TICKET_ENABLED", default=True)
+WALLET_GOOGLE_EVENT_TICKET_ENABLED = _env_bool(
+    "WALLET_GOOGLE_EVENT_TICKET_ENABLED", default=True
+)
 
 # Pre-screening questionnaire (Crush.lu). Off by default; enable in production
 # after all Phases have shipped and the Coach-facing rollout is ready.
@@ -518,7 +522,13 @@ SOCIALACCOUNT_PROVIDERS = {
 # Trust emails from these providers as verified (enables auto-linking to existing accounts)
 # When a user logs in with a social provider using an email that exists in the database,
 # the social account will be automatically linked if the provider is in this list.
-SOCIALACCOUNT_EMAIL_VERIFIED_PROVIDERS = ["google", "facebook", "microsoft", "apple", "luxid"]
+SOCIALACCOUNT_EMAIL_VERIFIED_PROVIDERS = [
+    "google",
+    "facebook",
+    "microsoft",
+    "apple",
+    "luxid",
+]
 
 
 # Use CustomSignupForm for Entreprinder (will be overridden by adapters for other domains)
@@ -542,7 +552,8 @@ if DEBUG:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
     EMAIL_HOST_USER = None  # Not needed for console backend
     import sys
-    if sys.stdout.encoding and 'utf' in sys.stdout.encoding.lower():
+
+    if sys.stdout.encoding and "utf" in sys.stdout.encoding.lower():
         print("📧 Email Backend: Console - Emails will print in terminal")
     else:
         print("[EMAIL] Backend: Console - Emails will print in terminal")
@@ -599,6 +610,25 @@ CORS_ALLOW_CREDENTIALS = False
 # Only apply CORS to the API surface; everything else on crush.lu / other
 # domains is server-rendered HTML and should not advertise CORS.
 CORS_URLS_REGEX = r"^/(hub|api)/.*$"
+
+# SWA per-PR preview environments get auto-generated hostnames like
+# `delightful-water-07d8c6e10-12.eastus2.azurestaticapps.net`. The production
+# hostname is in CORS_ALLOWED_ORIGINS; this regex covers preview branches so
+# PR builds of the hub SPA can call the staging slot.
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://delightful-water-07d8c6e10-\d+\.[\w-]+\.azurestaticapps\.net$",
+]
+
+# Hub SPA session→JWT exchange. Exact (scheme, netloc, path) match — never
+# prefix or startswith — to prevent open-redirect token exfiltration.
+SPA_CALLBACK_ALLOWED_RETURN_URLS = {
+    ("https", "hub.crush.lu", "/auth/callback"),
+}
+if DEBUG:
+    SPA_CALLBACK_ALLOWED_RETURN_URLS |= {
+        ("http", "localhost:3000", "/auth/callback"),
+        ("http", "127.0.0.1:3000", "/auth/callback"),
+    }
 
 
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = "http" if DEBUG else "https"
@@ -778,8 +808,12 @@ elif os.getenv("AZURE_ACCOUNT_NAME"):
     MEDIA_URL = f"https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/shared-media/"
 
     # Platform-specific base URLs (using dedicated containers)
-    CRUSH_MEDIA_BASE_URL = f"https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/crush-lu-media"
-    POWERUP_MEDIA_BASE_URL = f"https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/powerup-media"
+    CRUSH_MEDIA_BASE_URL = (
+        f"https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/crush-lu-media"
+    )
+    POWERUP_MEDIA_BASE_URL = (
+        f"https://{AZURE_ACCOUNT_NAME}.blob.core.windows.net/powerup-media"
+    )
 
     # Override content image URLs with platform-specific paths (if not explicitly set in env)
     if "SOCIAL_PREVIEW_IMAGE_URL" not in os.environ:
@@ -891,7 +925,7 @@ SECURE_CSP_REPORT_ONLY = {
         CSP.SELF,
         CSP.NONCE,
         CSP.UNSAFE_INLINE,  # TODO: Remove once HTMX/Alpine.js handlers use nonce-based scripts.
-                            # unsafe-inline negates nonce protection in script-src for CSP3 browsers.
+        # unsafe-inline negates nonce protection in script-src for CSP3 browsers.
         # CDN sources
         "https://unpkg.com",
         "https://cdn.jsdelivr.net",

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -611,12 +611,15 @@ CORS_ALLOW_CREDENTIALS = False
 # domains is server-rendered HTML and should not advertise CORS.
 CORS_URLS_REGEX = r"^/(hub|api)/.*$"
 
-# SWA per-PR preview environments get auto-generated hostnames like
-# `delightful-water-07d8c6e10-12.eastus2.azurestaticapps.net`. The production
-# hostname is in CORS_ALLOWED_ORIGINS; this regex covers preview branches so
-# PR builds of the hub SPA can call the staging slot.
+# SWA hostnames vary by region and SWA also injects a numeric segment, so the
+# real shape is e.g. `delightful-water-07d8c6e10-3.centralus.7.azurestaticapps.net`
+# for previews (and `delightful-water-07d8c6e10.centralus.7.azurestaticapps.net`
+# for production-style). The middle is one or more dotted segments, so this
+# regex allows zero or more `.<word-or-hyphen>` segments before
+# `.azurestaticapps.net`. Microsoft owns azurestaticapps.net so the suffix
+# anchor is sufficient — no third party can register under it.
 CORS_ALLOWED_ORIGIN_REGEXES = [
-    r"^https://delightful-water-07d8c6e10-\d+\.[\w-]+\.azurestaticapps\.net$",
+    r"^https://delightful-water-07d8c6e10(-\d+)?(\.[\w-]+)*\.azurestaticapps\.net$",
 ]
 
 # Hub SPA session→JWT exchange. Exact (scheme, netloc, path) match — never

--- a/azureproject/urls_api.py
+++ b/azureproject/urls_api.py
@@ -5,6 +5,7 @@ This urlconf is pure JSON API: no i18n, no HTML templates, no admin, no allauth
 pages. It exposes JWT auth endpoints and the /hub/* surface consumed by the
 Next.js SPA hosted at hub.crush.lu.
 """
+
 from django.http import HttpResponse
 from django.urls import include, path
 from rest_framework_simplejwt.views import (
@@ -13,6 +14,8 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
     TokenVerifyView,
 )
+
+from .views_spa_auth import ExchangeCodeView
 
 
 def health_check(request):
@@ -25,5 +28,10 @@ urlpatterns = [
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/token/verify/", TokenVerifyView.as_view(), name="token_verify"),
     path("api/token/logout/", TokenBlacklistView.as_view(), name="token_logout"),
+    path(
+        "api/token/exchange-code/",
+        ExchangeCodeView.as_view(),
+        name="token_exchange_code",
+    ),
     path("hub/", include("hub.urls")),
 ]

--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -17,6 +17,7 @@ from django.views.generic import TemplateView
 from django.views.i18n import JavaScriptCatalog
 
 from .urls_shared import base_patterns, api_patterns
+from .views_spa_auth import spa_session_callback
 from crush_lu.admin import crush_admin_site
 from crush_lu.admin.user_segments import user_segments_dashboard, segment_detail
 from crush_lu.admin.profile_reminders import profile_reminders_panel
@@ -315,6 +316,11 @@ urlpatterns = base_patterns + api_patterns + [
     # Mounted on crush.lu / test.crush.lu since the SPA's preview env can't
     # have its own subdomain — it uses test.crush.lu directly. Language-neutral.
     path('hub/', include('hub.urls')),
+
+    # Session→JWT bounce for the hub SPA. Lives on crush.lu because that's
+    # where the allauth session cookie is set; mints a single-use code that
+    # the SPA exchanges at api.crush.lu/api/token/exchange-code/.
+    path('api/auth/spa-callback/', spa_session_callback, name='spa_session_callback'),
 ]
 
 # Language-prefixed patterns (all user-facing pages)

--- a/azureproject/views_spa_auth.py
+++ b/azureproject/views_spa_auth.py
@@ -20,7 +20,7 @@ refresh tokens don't belong in URL history.
 """
 
 import secrets
-from urllib.parse import quote, urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -68,7 +68,16 @@ def spa_session_callback(request):
 
     code = secrets.token_urlsafe(32)
     cache.set(f"{CODE_CACHE_PREFIX}{code}", request.user.pk, timeout=CODE_TTL_SECONDS)
-    return HttpResponseRedirect(f"{return_url}?code={code}")
+
+    # Merge ?code=... into the return URL's existing query rather than
+    # f-string concatenation. f"{return_url}?code=..." breaks if the URL
+    # already has its own ?query (`...?foo=1?code=...` is malformed) or a
+    # #fragment. Today's whitelist has neither, but urlparse/urlunparse
+    # makes this resilient to any future entry.
+    parts = urlparse(return_url)
+    query = parse_qsl(parts.query, keep_blank_values=True) + [("code", code)]
+    redirect_url = urlunparse(parts._replace(query=urlencode(query)))
+    return HttpResponseRedirect(redirect_url)
 
 
 class ExchangeCodeView(APIView):

--- a/azureproject/views_spa_auth.py
+++ b/azureproject/views_spa_auth.py
@@ -1,0 +1,101 @@
+"""
+Session→JWT exchange for the hub.crush.lu SPA.
+
+Two-step authorization-code flow:
+
+1. The SPA (cross-origin, no session cookie reachable from api.crush.lu) sends
+   the browser to GET /api/auth/spa-callback/?return=<allowed-callback-url> on
+   crush.lu. If the user has a valid Django session AND is staff, this view
+   mints a single-use code, stores (code → user_id) in the cache for 60s, and
+   302s back to the return URL with ?code=ABC.
+
+2. The SPA reads the code from the URL, scrubs it, and POSTs it to
+   /api/token/exchange-code/ on api.crush.lu. That view pops the code (single
+   use), re-checks staff, and returns a SimpleJWT access/refresh pair as JSON.
+
+The split keeps the responsibilities narrow: crush.lu authorizes (it's where
+allauth + sessions live), api.crush.lu issues tokens (it's where the SPA
+already talks). The fragment-based "implicit" variant was rejected because
+refresh tokens don't belong in URL history.
+"""
+
+import secrets
+from urllib.parse import quote, urlparse
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.http import (
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    HttpResponseRedirect,
+)
+from django.urls import reverse
+from django.views.decorators.http import require_GET
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+CODE_CACHE_PREFIX = "spa_auth_code:"
+CODE_TTL_SECONDS = 60
+
+
+def _is_allowed_return_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return (
+        parsed.scheme,
+        parsed.netloc,
+        parsed.path,
+    ) in settings.SPA_CALLBACK_ALLOWED_RETURN_URLS
+
+
+@require_GET
+def spa_session_callback(request):
+    """Step 1: trade an authenticated staff session for a single-use code."""
+    return_url = request.GET.get("return", "")
+    if not _is_allowed_return_url(return_url):
+        return HttpResponseBadRequest("Invalid return URL.")
+
+    if not request.user.is_authenticated:
+        login_url = reverse("account_login")
+        # next= must be URL-encoded — its value contains its own ?return=...
+        # that would otherwise be parsed as a sibling query string by allauth.
+        next_target = f"{request.path}?return={quote(return_url, safe='')}"
+        return HttpResponseRedirect(f"{login_url}?next={quote(next_target, safe='')}")
+
+    if not request.user.is_staff:
+        return HttpResponseForbidden("Hub access requires staff.")
+
+    code = secrets.token_urlsafe(32)
+    cache.set(f"{CODE_CACHE_PREFIX}{code}", request.user.pk, timeout=CODE_TTL_SECONDS)
+    return HttpResponseRedirect(f"{return_url}?code={code}")
+
+
+class ExchangeCodeView(APIView):
+    """Step 2: pop the code (single-use) and return a JWT pair."""
+
+    authentication_classes = []
+    permission_classes = []
+
+    def post(self, request):
+        code = (request.data or {}).get("code")
+        if not isinstance(code, str) or not code:
+            return Response({"detail": "Missing code."}, status=400)
+
+        cache_key = f"{CODE_CACHE_PREFIX}{code}"
+        user_id = cache.get(cache_key)
+        if user_id is None:
+            return Response({"detail": "Invalid or expired code."}, status=401)
+        cache.delete(cache_key)
+
+        User = get_user_model()
+        try:
+            user = User.objects.get(pk=user_id, is_active=True)
+        except User.DoesNotExist:
+            return Response({"detail": "Invalid or expired code."}, status=401)
+
+        if not user.is_staff:
+            return Response({"detail": "Hub access requires staff."}, status=403)
+
+        refresh = RefreshToken.for_user(user)
+        return Response({"access": str(refresh.access_token), "refresh": str(refresh)})

--- a/azureproject/views_spa_auth.py
+++ b/azureproject/views_spa_auth.py
@@ -86,6 +86,16 @@ class ExchangeCodeView(APIView):
         user_id = cache.get(cache_key)
         if user_id is None:
             return Response({"detail": "Invalid or expired code."}, status=401)
+
+        # Atomic single-use claim: cache.add only succeeds when the key
+        # didn't already exist, so concurrent requests with the same code
+        # race here and only the first wins. Without this, two simultaneous
+        # exchanges could both pass the get() above and mint two JWT pairs
+        # from one code (django-redis-backed; LocMemCache also serializes
+        # add() per-process, and production.py forces Redis anyway).
+        consumed_key = f"{cache_key}:consumed"
+        if not cache.add(consumed_key, True, timeout=CODE_TTL_SECONDS):
+            return Response({"detail": "Invalid or expired code."}, status=401)
         cache.delete(cache_key)
 
         User = get_user_model()

--- a/azureproject/views_spa_auth.py
+++ b/azureproject/views_spa_auth.py
@@ -74,9 +74,20 @@ def spa_session_callback(request):
     # already has its own ?query (`...?foo=1?code=...` is malformed) or a
     # #fragment. Today's whitelist has neither, but urlparse/urlunparse
     # makes this resilient to any future entry.
+    #
+    # Strip any pre-existing `code` from the return URL before appending
+    # the fresh one. Otherwise an attacker-supplied `?code=stale` survives
+    # into the redirect, and many SPA parsers read the first value of a
+    # repeated key — they'd consume the stale code and fail.
     parts = urlparse(return_url)
-    query = parse_qsl(parts.query, keep_blank_values=True) + [("code", code)]
-    redirect_url = urlunparse(parts._replace(query=urlencode(query)))
+    preserved = [
+        (k, v)
+        for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        if k != "code"
+    ]
+    redirect_url = urlunparse(
+        parts._replace(query=urlencode(preserved + [("code", code)]))
+    )
     return HttpResponseRedirect(redirect_url)
 
 

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -1168,7 +1168,12 @@ class CallAttempt(models.Model):
         ]
 
     def __str__(self):
-        return f"Call attempt for {self.submission.profile.user.get_full_name()} - {self.result} - {self.attempt_date.strftime('%Y-%m-%d %H:%M')}"
+        profile = self.profile or (self.submission.profile if self.submission_id else None)
+        if profile and profile.user_id:
+            who = profile.user.get_full_name() or profile.user.get_username()
+        else:
+            who = "unknown"
+        return f"Call attempt for {who} - {self.result} - {self.attempt_date.strftime('%Y-%m-%d %H:%M')}"
 
     @property
     def is_failed(self):

--- a/hub/tests/test_spa_auth.py
+++ b/hub/tests/test_spa_auth.py
@@ -1,0 +1,201 @@
+"""
+Tests for the SPA session→JWT exchange (azureproject/views_spa_auth.py).
+
+Two surfaces:
+  - GET /api/auth/spa-callback/?return=<allowed-url>  on crush.lu  (bounce)
+  - POST /api/token/exchange-code/                     on api.crush.lu (exchange)
+
+Both live outside i18n_patterns and the bounce path is exempt from the
+Crush.lu consent middleware (/api/ prefix), so no consent boilerplate needed.
+"""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+
+from azureproject.views_spa_auth import CODE_CACHE_PREFIX
+
+pytestmark = pytest.mark.django_db
+
+CRUSH_HOST = "crush.lu"
+API_HOST = "api.crush.lu"
+ALLOWED_RETURN = "https://hub.crush.lu/auth/callback"
+
+
+@pytest.fixture
+def staff_user(db):
+    return get_user_model().objects.create_user(
+        username="staff@example.com",
+        email="staff@example.com",
+        password="staffpass123",
+        is_staff=True,
+    )
+
+
+@pytest.fixture
+def non_staff_user(db):
+    return get_user_model().objects.create_user(
+        username="user@example.com",
+        email="user@example.com",
+        password="userpass123",
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_code_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# /api/auth/spa-callback/  (crush.lu)
+# ---------------------------------------------------------------------------
+
+
+class TestSpaSessionCallback:
+    URL = "/api/auth/spa-callback/"
+
+    def test_missing_return_url_rejected(self, client):
+        resp = client.get(self.URL, HTTP_HOST=CRUSH_HOST)
+        assert resp.status_code == 400
+
+    def test_disallowed_return_url_rejected(self, client):
+        resp = client.get(
+            f"{self.URL}?return=https://attacker.example.com/auth/callback",
+            HTTP_HOST=CRUSH_HOST,
+        )
+        assert resp.status_code == 400
+
+    def test_prefix_attack_rejected(self, client):
+        # `https://hub.crush.lu.attacker.com/auth/callback` would slip past a
+        # naive startswith() check. Exact (scheme, netloc, path) match must reject.
+        resp = client.get(
+            f"{self.URL}?return=https://hub.crush.lu.attacker.com/auth/callback",
+            HTTP_HOST=CRUSH_HOST,
+        )
+        assert resp.status_code == 400
+
+    def test_anonymous_redirected_to_login(self, client):
+        resp = client.get(
+            f"{self.URL}?return={ALLOWED_RETURN}",
+            HTTP_HOST=CRUSH_HOST,
+        )
+        assert resp.status_code == 302
+        parsed = urlparse(resp.url)
+        assert parsed.path == "/accounts/login/"
+
+        # next= must decode to the original spa-callback URL with the return
+        # query intact — proves the double-encoding survives a parse round-trip.
+        next_value = parse_qs(parsed.query)["next"][0]
+        inner = urlparse(next_value)
+        assert inner.path == self.URL
+        assert parse_qs(inner.query)["return"][0] == ALLOWED_RETURN
+
+    def test_non_staff_forbidden(self, client, non_staff_user):
+        client.force_login(non_staff_user)
+        resp = client.get(
+            f"{self.URL}?return={ALLOWED_RETURN}",
+            HTTP_HOST=CRUSH_HOST,
+        )
+        assert resp.status_code == 403
+
+    def test_staff_gets_code_and_redirect(self, client, staff_user):
+        client.force_login(staff_user)
+        resp = client.get(
+            f"{self.URL}?return={ALLOWED_RETURN}",
+            HTTP_HOST=CRUSH_HOST,
+        )
+        assert resp.status_code == 302
+        assert resp.url.startswith(f"{ALLOWED_RETURN}?code=")
+
+        code = resp.url.split("?code=", 1)[1]
+        assert cache.get(f"{CODE_CACHE_PREFIX}{code}") == staff_user.pk
+
+
+# ---------------------------------------------------------------------------
+# /api/token/exchange-code/  (api.crush.lu)
+# ---------------------------------------------------------------------------
+
+
+class TestExchangeCode:
+    URL = "/api/token/exchange-code/"
+
+    def _seed_code(self, user, code="test-code-123"):
+        cache.set(f"{CODE_CACHE_PREFIX}{code}", user.pk, timeout=60)
+        return code
+
+    def test_missing_code_rejected(self, client):
+        resp = client.post(
+            self.URL, data={}, content_type="application/json", HTTP_HOST=API_HOST
+        )
+        assert resp.status_code == 400
+
+    def test_unknown_code_rejected(self, client):
+        resp = client.post(
+            self.URL,
+            data={"code": "nonexistent"},
+            content_type="application/json",
+            HTTP_HOST=API_HOST,
+        )
+        assert resp.status_code == 401
+
+    def test_valid_code_returns_jwt_pair(self, client, staff_user):
+        code = self._seed_code(staff_user)
+        resp = client.post(
+            self.URL,
+            data={"code": code},
+            content_type="application/json",
+            HTTP_HOST=API_HOST,
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert "access" in payload
+        assert "refresh" in payload
+        assert isinstance(payload["access"], str) and payload["access"]
+        assert isinstance(payload["refresh"], str) and payload["refresh"]
+
+    def test_code_is_single_use(self, client, staff_user):
+        code = self._seed_code(staff_user)
+        first = client.post(
+            self.URL,
+            data={"code": code},
+            content_type="application/json",
+            HTTP_HOST=API_HOST,
+        )
+        assert first.status_code == 200
+
+        replay = client.post(
+            self.URL,
+            data={"code": code},
+            content_type="application/json",
+            HTTP_HOST=API_HOST,
+        )
+        assert replay.status_code == 401
+
+    def test_inactive_user_rejected(self, client, staff_user):
+        staff_user.is_active = False
+        staff_user.save(update_fields=["is_active"])
+        code = self._seed_code(staff_user)
+        resp = client.post(
+            self.URL,
+            data={"code": code},
+            content_type="application/json",
+            HTTP_HOST=API_HOST,
+        )
+        assert resp.status_code == 401
+
+    def test_user_lost_staff_after_code_issued(self, client, staff_user):
+        code = self._seed_code(staff_user)
+        staff_user.is_staff = False
+        staff_user.save(update_fields=["is_staff"])
+
+        resp = client.post(
+            self.URL,
+            data={"code": code},
+            content_type="application/json",
+            HTTP_HOST=API_HOST,
+        )
+        assert resp.status_code == 403

--- a/hub/views.py
+++ b/hub/views.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 from rest_framework import generics, status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -13,7 +13,7 @@ from .serializers import (
 
 
 class MeView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
 
     def _customer_payload(self, user):
         profile, _ = HubProfile.objects.get_or_create(user=user)
@@ -53,7 +53,7 @@ class MeView(APIView):
 
 
 class RequestsView(generics.ListCreateAPIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
     serializer_class = HubRequestSerializer
 
     def get_queryset(self):
@@ -72,7 +72,7 @@ class RequestsView(generics.ListCreateAPIView):
 
 
 class ResourcesView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
 
     def get(self, request):
         queryset = HubResource.objects.filter(
@@ -83,7 +83,7 @@ class ResourcesView(APIView):
 
 
 class TimelineView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
 
     def get(self, request):
         queryset = HubTimelineEvent.objects.filter(user=request.user)


### PR DESCRIPTION
## Summary

Lands the Django side of the **Codex_Marketing_CRM (hub.crush.lu) ↔ crush.lu backend** integration. Most of this code already existed on disk; this PR commits it, plus one small addition for SWA preview environments.

- **`azureproject/views_spa_auth.py` (new)** — two-step session→JWT exchange. Bounce on `crush.lu` (where allauth session cookie lives) mints a 60s, single-use code; SPA exchanges it on `api.crush.lu`. Exact `(scheme, netloc, path)` whitelist match on the return URL prevents open-redirect token exfiltration.
- **Routes added**: `/api/auth/spa-callback/` (urls_crush) + `/api/token/exchange-code/` (urls_api).
- **`SPA_CALLBACK_ALLOWED_RETURN_URLS`** — whitelists `https://hub.crush.lu/auth/callback`; adds `localhost:3000` under DEBUG.
- **`CORS_ALLOWED_ORIGIN_REGEXES`** — covers SWA per-PR preview hostnames (`delightful-water-07d8c6e10-N.<region>.azurestaticapps.net`) so PR builds of the CRM SPA can call the staging slot.
- **`/hub/*` permissions** tightened from `IsAuthenticated` to `IsAdminUser` (bridge already requires `is_staff`; CRM is internal tooling).
- **`CallAttempt.__str__`** defensive against missing submission/profile (unrelated stability fix found during the same review).
- **12 tests** in `hub/tests/test_spa_auth.py` covering happy path, prefix attack, expired/replayed code, lost staff, inactive user.

v1 auth in the SPA is username/password against `/api/token/`. The bounce flow stays dormant until the SPA wires up `/auth/callback` (v2).

## Test plan

- [x] `pytest hub/tests/ -m "not playwright"` — 12/12 pass (DBHOST= for SQLite fallback)
- [ ] CI runs full test suite + validation
- [ ] Smoke staging slot after deploy:
  - [ ] `curl -X POST https://test.crush.lu/api/token/ -d '{"username":"<staff>","password":"<pwd>"}'` → returns `{access, refresh}`
  - [ ] `curl https://test.crush.lu/hub/me -H "Authorization: Bearer <access>"` → returns hub profile
  - [ ] Confirm `REDIS_URL` (or `AZURE_REDIS_CONNECTIONSTRING`) set on staging slot — required for v2 bounce, not v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)