### PR TITLE
Expose /api/token/exchange-code/ on shared api_patterns

### DIFF
--- a/azureproject/urls_shared.py
+++ b/azureproject/urls_shared.py
@@ -19,6 +19,7 @@ from rest_framework_simplejwt.views import (
 )
 
 from .views import csp_report
+from .views_spa_auth import ExchangeCodeView
 from crush_lu.views_language import set_language_with_profile
 
 
@@ -45,9 +46,15 @@ base_patterns = [
 ]
 
 # JWT API patterns - included by domains that need API authentication
-# Used by Crush.lu and PowerUP for mobile app / API access
+# Used by Crush.lu and PowerUP for mobile app / API access.
+# exchange-code lives here so the hub SPA's session-bounce flow can complete
+# at https://crush.lu/api/token/exchange-code/ (the SPA's API base host) —
+# the spa_session_callback that mints the code is mounted on crush.lu in
+# urls_crush.py, and the cache backing it is shared (Redis in production),
+# so the exchange would 401 from any domain that doesn't own the code anyway.
 api_patterns = [
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/token/logout/', TokenBlacklistView.as_view(), name='token_logout'),
+    path('api/token/exchange-code/', ExchangeCodeView.as_view(), name='token_exchange_code'),
 ]


### PR DESCRIPTION
## Summary

Small follow-up to #412. The hub SPA's API base URL is `https://crush.lu` (path form — `api.crush.lu` DNS isn't bound). The bounce mint route `/api/auth/spa-callback/` is on `crush.lu`, but the exchange route was only in `urls_api.py` (api.crush.lu standalone urlconf), so the SPA's `POST https://crush.lu/api/token/exchange-code/` would 404.

This moves the route into `urls_shared.api_patterns` so it's served on every domain that includes those patterns — most importantly `crush.lu`.

## Why it's safe to expose broadly

- The view requires a valid code from cache.
- The cache namespace is shared (Redis in production).
- Codes are only minted by `spa_session_callback` (mounted on `crush.lu` only).
- The bounce-side whitelist (`SPA_CALLBACK_ALLOWED_RETURN_URLS`) restricts where codes can be issued for.
- Domains that don't host the SPA will simply never have any codes to redeem.

`urls_api.py` keeps its own copy — removing it would change behavior if/when api.crush.lu DNS gets bound, and the duplication is contained within Django's per-domain urlconf system (no name conflict because each request resolves against one urlconf at a time).

## Test plan

- [x] `pytest hub/tests/` — 12/12 still pass
- [ ] CI green
- [ ] Post-deploy: `curl -X POST https://test.crush.lu/api/token/exchange-code/ -d '{}'` → expect **400** (currently 404)
- [ ] Post-swap: same on `https://crush.lu/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)