### PR TITLE
docs: Update README with 9 platforms, new features, and project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,21 @@
 [![Django 5.1](https://img.shields.io/badge/django-5.1-green.svg)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Multi-domain Django application serving 6 distinct platforms from a single codebase, deployed on Azure App Service.
+Multi-domain Django application serving 9 distinct platforms from a single codebase, deployed on Azure App Service.
 
 ## Platforms
 
 | Domain | Description | Type |
 |--------|-------------|------|
 | [crush.lu](https://crush.lu) | Privacy-first event-based dating for Luxembourg | Full-featured |
+| [api.crush.lu](https://api.crush.lu) | REST API for the hub.crush.lu CRM SPA | API |
 | [vinsdelux.com](https://vinsdelux.com) | Wine vineyard adoption concept explainer | Static |
 | [entreprinder.lu](https://entreprinder.lu) | Entrepreneur networking with Tinder-style matching | Full-featured |
 | [power-up.lu](https://power-up.lu) | Corporate/investor information site | Static |
+| [portal.powerup.lu](https://portal.powerup.lu) | Power-Up CRM & customer portal | Full-featured |
 | [tableau.lu](https://tableau.lu) | AI Art e-commerce platform | Static |
 | [delegations.lu](https://delegations.lu) | Crush.lu delegation features | Full-featured |
+| [arborist.lu](https://arborist.lu) | Tree services informational site (i18n: EN/DE/FR) | Static |
 
 ## Tech Stack
 
@@ -25,7 +28,8 @@ Multi-domain Django application serving 6 distinct platforms from a single codeb
 | Framework | Django 5.1, Python 3.10+ |
 | Database | SQLite (dev), PostgreSQL (prod) |
 | Frontend | Tailwind CSS, HTMX, Alpine.js (CSP build) |
-| Authentication | Django Allauth, LinkedIn OAuth2, JWT |
+| Authentication | Django Allauth, LuxID OIDC (POST Luxembourg), LinkedIn OAuth2, JWT (SimpleJWT) |
+| API | Django REST Framework, JWT auth, CORS (django-cors-headers) |
 | Storage | Local filesystem (dev), Azure Blob Storage (prod) |
 | Email | Console (dev), Microsoft Graph API (prod) |
 | Deployment | Azure App Service, GitHub Actions CI/CD |
@@ -123,6 +127,29 @@ Run all commands with the virtual environment activated: `python manage.py <comm
 | `create_sample_crush_profiles` | Creates sample user profiles for testing |
 | `cleanup_orphan_storage` | Cleans orphaned files in Azure Blob Storage |
 | `reset_local_dev` | Resets local development environment |
+| `send_pre_screening_invites` | Sends pre-screening invitations to pending profiles |
+| `send_newsletter` | Sends newsletter emails to subscribed users |
+| `send_wallet_notification` | Sends push notifications for Apple/Google Wallet passes |
+| `create_advent_calendar` | Creates the advent calendar event series |
+| `create_google_wallet_class` | Creates/updates the Google Wallet pass class |
+| `generate_crush_quiz` | Generates quiz questions for Quiz Night events |
+| `generate_patch_notes` | Generates patch note entries from git history |
+| `populate_event_attendees` | Backfills attendee records for existing events |
+| `recalculate_match_scores` | Recalculates compatibility scores for all profile pairs |
+| `reprocess_photos` | Reprocesses uploaded profile photos (resize, optimize) |
+| `update_journey_translations` | Updates translation strings for journey content |
+| `verify_phone` | Manually triggers phone verification for a user |
+| `validate_timeline_events` | Checks hub timeline events for data integrity |
+| `sla_tick` | Processes SLA timers for open hub requests (run periodically) |
+| `sync_contacts_to_outlook` | Syncs user contacts to Outlook/Exchange |
+| `cleanup_outlook_contacts` | Removes stale contacts from Outlook/Exchange |
+| `check_translations` | Reports missing or fuzzy translation strings |
+| `configure_event_forms` | Sets up custom registration form fields for an event |
+| `backfill_user_consent` | Backfills GDPR consent records for existing users |
+| `check_missing_consent` | Reports users without a valid consent record |
+| `check_push_subscription_health` | Reports stale or invalid push subscriptions |
+| `check_pwa_push_activation` | Checks PWA push notification activation rates |
+| `business_plan_metrics` | Exports business plan KPIs to a report |
 
 #### Journey Command Arguments
 
@@ -194,11 +221,13 @@ Target deployment time: 2-3 minutes.
 ### Production Domains
 
 All domains are served from a single Azure App Service instance:
-- crush.lu, www.crush.lu
+- crush.lu, www.crush.lu, api.crush.lu
 - vinsdelux.com, www.vinsdelux.com
-- powerup.lu, www.powerup.lu
-- power-up.lu, www.power-up.lu
+- entreprinder.lu, www.entreprinder.lu
+- power-up.lu, www.power-up.lu, powerup.lu, www.powerup.lu, portal.powerup.lu
 - tableau.lu, www.tableau.lu
+- delegations.lu, www.delegations.lu
+- arborist.lu, www.arborist.lu
 
 ### Production Environment Variables
 
@@ -215,6 +244,10 @@ AZURE_ACCOUNT_KEY=<storage-key>
 GRAPH_TENANT_ID=<tenant-id>
 GRAPH_CLIENT_ID=<client-id>
 GRAPH_CLIENT_SECRET=<client-secret>
+
+# LuxID OIDC (POST Luxembourg CIAM)
+LUXID_CLIENT_ID=<client-id>
+LUXID_CLIENT_SECRET=<client-secret>
 ```
 
 ## Project Structure
@@ -225,17 +258,26 @@ entreprinder/
 │   ├── domains.py         # Centralized domain configuration
 │   ├── middleware.py      # Domain routing, health checks
 │   ├── urls_crush.py      # Crush.lu URL config
+│   ├── urls_api.py        # api.crush.lu URL config (hub REST API)
+│   ├── urls_arborist.py   # Arborist URL config
+│   ├── urls_portal.py     # portal.powerup.lu URL config
 │   ├── urls_vinsdelux.py  # VinsDelux URL config
+│   ├── views_spa_auth.py  # Session→JWT bridge for hub.crush.lu SPA
 │   └── production.py      # Production settings
 ├── crush_lu/              # Dating platform (full-featured)
 │   ├── management/        # Management commands
+│   ├── providers/luxid/   # LuxID OIDC provider (POST Luxembourg CIAM)
 │   ├── templates/         # Django templates
 │   └── tests/             # pytest tests
+├── hub/                   # REST API for hub.crush.lu CRM SPA
+├── arborist/              # Tree services informational site (i18n)
 ├── vinsdelux/             # Wine adoption concept explainer (static)
 ├── entreprinder/          # Entrepreneur networking
-├── power_up/              # Corporate site (static)
+├── power_up/              # Corporate site + CRM portal
+│   ├── crm/               # Agent CRM/ticketing module
+│   └── onboarding/        # Customer onboarding module
 ├── tableau/               # AI Art shop (static)
-├── crush_delegation/      # Delegation features
+├── delegations/           # Delegation features
 ├── locale/                # i18n translations (en, de, fr)
 ├── infra/                 # Azure Bicep templates
 ├── static/                # Tailwind CSS, Alpine.js components
@@ -251,10 +293,14 @@ Domain-based routing is configured in `azureproject/domains.py`:
 |------|-------------------|-------------|
 | localhost, 127.0.0.1 | Uses `DEV_DEFAULT` | crush.lu |
 | crush.lu | `urls_crush.py` | - |
-| vinsdelux.com | `urls_vinsdelux.py` | - |
+| api.crush.lu | `urls_api.py` | api.localhost |
+| vinsdelux.com | `urls_vinsdelux.py` | vinsdelux.localhost |
 | entreprinder.lu | `urls_entreprinder.py` | - |
-| power-up.lu, powerup.lu | `urls_power_up.py` | - |
-| tableau.lu | `urls_tableau.py` | - |
+| power-up.lu, powerup.lu | `urls_power_up.py` | power-up.localhost |
+| portal.powerup.lu | `urls_portal.py` | portal.localhost |
+| tableau.lu | `urls_tableau.py` | tableau.localhost |
+| delegations.lu | `urls_delegations.py` | delegation.localhost |
+| arborist.lu | `urls_arborist.py` | arborist.localhost |
 | *.azurewebsites.net | `urls_entreprinder.py` | - |
 
 ## Code Quality
@@ -279,6 +325,74 @@ Configuration in `pyproject.toml` (88 character line length).
   - Email backend configuration
   - Internationalization (i18n) system
   - Troubleshooting guides
+
+## Recently Shipped Features
+
+### Hub CRM SPA API (`api.crush.lu`)
+
+A dedicated REST API subdomain that backs the `hub.crush.lu` CRM single-page application. Built with Django REST Framework and SimpleJWT.
+
+- **Session → JWT bridge**: `POST /api/token/exchange-code/` lets the cross-origin SPA swap a short-lived one-time code (set in the crush.lu session) for an access/refresh token pair.
+- **Models**: `HubProfile`, `HubRequest`, `HubResource`, `HubTimelineEvent` — covering the full CRM surface.
+- **Endpoints**: `/api/hub/me`, `/api/hub/requests`, `/api/hub/resources`, `/api/hub/timeline`.
+- **CORS** scoped to `https://hub.crush.lu` and PR-preview origins.
+
+### LuxID OIDC Authentication
+
+Crush.lu now supports login via **LuxID** (POST Luxembourg CIAM), the Luxembourg national digital identity provider. The integration uses a custom allauth provider (`crush_lu.providers.luxid`) with a dedicated `/accounts/luxid/` URL namespace so it coexists cleanly with the generic OIDC provider used by LinkedIn.
+
+- Claims are merged from both the `id_token` and the `userinfo` endpoint.
+- Existing accounts matched by email are linked automatically on first LuxID login.
+- Phone verification is expanded to cross-border countries.
+
+### Phone Verification & 7-Step Onboarding
+
+- OTP phone verification modal with rate limiting on both sending and submission.
+- `intl-tel-input` flag remains visible after verification completes.
+- Full **7-step onboarding journey** for new Crush.lu users: phone verification, profile details, photo upload, coach verification, ideal-crush preferences, and final review.
+
+### Auth UX Improvements
+
+- Password visibility toggle on login and signup forms.
+- Real-time password strength meter on signup.
+- Sign-up reassurance copy to reduce drop-off.
+- **Email verification is now mandatory** — accounts cannot access protected views until their email address is confirmed.
+
+### Quiz Night
+
+- Coach host controls (pause, resume, force-rotate) and rotation edge-case guards.
+- Countdown timer, pause screen, and graceful `display_name` fallback.
+- HTTP polling fallback when WebSocket state arrives without table data.
+- Continuous polling on the waiting screen so check-ins appear live.
+- Full i18n support with language-prefixed URLs (`/en/`, `/de/`, `/fr/`).
+
+### Pre-Screening & Hybrid Coach Review
+
+- Automated pre-screening invitations (`send_pre_screening_invites`).
+- Hybrid review workflow: coaches complete a calibration screening call, then the system routes profiles to a standard approval or revision flow.
+
+### Apple Wallet Tickets
+
+Crush.lu events support Apple Wallet passes (`.pkpass`). iOS Safari compatibility was fixed by disabling gzip compression on pass responses.
+
+### Changelog Page
+
+A marketing-ready changelog is available at [crush.lu/changelog/](https://crush.lu/changelog/) and auto-generated from tagged releases.
+
+### Internationalisation (i18n)
+
+German (DE) and French (FR) translations now cover coach emails, booking confirmation flow, hybrid-review UX strings, and arborist.lu page content.
+
+### Power-Up Portal (`portal.powerup.lu`)
+
+A new subdomain hosts a two-tier portal:
+- `/power-admin/` — Agent CRM & ticketing UI for internal teams.
+- `/crm/` and `/onboarding/` — Customer-facing portal (Entra SSO, Phase 3).
+- Full Django admin at `/admin/` for superusers.
+
+### Arborist.lu
+
+A new informational site for Luxembourg tree services, fully internationalised (EN/DE/FR) with sitemap and custom robots.txt.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Entreprinder
 
 [![Deploy](https://github.com/EuphoriaLux/Entreprinder/actions/workflows/deploy-azure-app-service-optimized.yml/badge.svg)](https://github.com/EuphoriaLux/Entreprinder/actions/workflows/deploy-azure-app-service-optimized.yml)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Django 5.1](https://img.shields.io/badge/django-5.1-green.svg)](https://www.djangoproject.com/)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![Django 6.0](https://img.shields.io/badge/django-6.0-green.svg)](https://www.djangoproject.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Multi-domain Django application serving 9 distinct platforms from a single codebase, deployed on Azure App Service.
@@ -25,7 +25,7 @@ Multi-domain Django application serving 9 distinct platforms from a single codeb
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | Django 5.1, Python 3.10+ |
+| Framework | Django 6.0, Python 3.12+ |
 | Database | SQLite (dev), PostgreSQL (prod) |
 | Frontend | Tailwind CSS, HTMX, Alpine.js (CSP build) |
 | Authentication | Django Allauth, LuxID OIDC (POST Luxembourg), LinkedIn OAuth2, JWT (SimpleJWT) |
@@ -58,7 +58,7 @@ Visit http://localhost:8000 (routes to Crush.lu by default).
 
 ### Prerequisites
 
-- Python 3.10 or higher
+- Python 3.12 or higher
 - Node.js 20+ (for Tailwind CSS)
 - Git
 


### PR DESCRIPTION
## Purpose

This PR updates the README documentation to reflect the current state of the multi-domain Django application, which now serves 9 distinct platforms (up from 6). It documents recently shipped features including the Hub CRM REST API, LuxID OIDC authentication, phone verification, Quiz Night, pre-screening workflows, Apple Wallet support, and new subdomains (api.crush.lu, portal.powerup.lu, arborist.lu).

The changes provide:
- Updated platform inventory with new domains and their purposes
- Expanded tech stack documentation (LuxID OIDC, Django REST Framework, CORS)
- Complete list of new management commands
- Updated project structure reflecting new apps (hub, arborist, delegations rename)
- Domain routing configuration table with localhost mappings
- Comprehensive "Recently Shipped Features" section documenting major additions

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

N/A — This is a documentation-only change to the README.md file.

## What to Check

- Verify all 9 platforms are correctly listed with accurate descriptions and URLs
- Confirm tech stack section reflects current dependencies (LuxID OIDC, DRF, CORS)
- Check that management commands list is complete and accurate
- Validate domain routing table matches actual configuration
- Ensure project structure diagram reflects current app organization
- Review "Recently Shipped Features" section for clarity and completeness

## Other Information

This documentation update serves as a reference snapshot of the application's current capabilities and architecture. All information is derived from the actual codebase structure and should be kept in sync as new features are added.

https://claude.ai/code/session_01NB3b8B6EuHFU1MDrRcPJBd