### PR TITLE
Sort coach channel by name and render profile photos

### DIFF
--- a/crush_lu/migrations/0135_callattempt_whatsapp_sent_choice.py
+++ b/crush_lu/migrations/0135_callattempt_whatsapp_sent_choice.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('crush_lu', '0134_merge_20260422_2116'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='callattempt',
+            name='result',
+            field=models.CharField(
+                choices=[
+                    ('success', 'Call Completed'),
+                    ('failed', 'Call Failed'),
+                    ('sms_sent', 'SMS Sent'),
+                    ('whatsapp_sent', 'WhatsApp Sent'),
+                    ('event_invite_sms', 'Event Invite SMS'),
+                ],
+                help_text='Whether the call succeeded or failed',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -1097,6 +1097,7 @@ class CallAttempt(models.Model):
         ('success', _('Call Completed')),
         ('failed', _('Call Failed')),
         ('sms_sent', _('SMS Sent')),
+        ('whatsapp_sent', _('WhatsApp Sent')),
         ('event_invite_sms', _('Event Invite SMS')),
     ]
 

--- a/crush_lu/templates/crush_lu/_screening_call_section.html
+++ b/crush_lu/templates/crush_lu/_screening_call_section.html
@@ -124,6 +124,8 @@
                                     <span class="text-red-500">{% include "shared/icons/x-circle.html" with class="w-4 h-4 flex-shrink-0" %}</span>
                                 {% elif attempt.result == 'sms_sent' %}
                                     <span class="text-blue-500"><svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg></span>
+                                {% elif attempt.result == 'whatsapp_sent' %}
+                                    <span class="text-[#25D366]"><svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24"><path d="M20.52 3.48A11.78 11.78 0 0 0 12.06 0C5.5 0 .17 5.33.17 11.89c0 2.1.55 4.14 1.6 5.95L.06 24l6.32-1.66a11.86 11.86 0 0 0 5.68 1.45c6.55 0 11.89-5.33 11.89-11.89 0-3.18-1.24-6.16-3.44-8.42Z"/></svg></span>
                                 {% else %}
                                     <span class="text-green-500">{% include "shared/icons/check-circle.html" with class="w-4 h-4 flex-shrink-0" %}</span>
                                 {% endif %}
@@ -133,6 +135,8 @@
                                         <p>{% trans "Failed:" %} {{ attempt.get_failure_reason_display }}</p>
                                     {% elif attempt.result == 'sms_sent' %}
                                         <p>{% trans "SMS template sent" %}</p>
+                                    {% elif attempt.result == 'whatsapp_sent' %}
+                                        <p>{% trans "WhatsApp template sent" %}</p>
                                     {% else %}
                                         <p>{% trans "Call completed successfully" %}</p>
                                     {% endif %}
@@ -479,6 +483,8 @@
                                     <span class="text-red-500">{% include "shared/icons/x-circle.html" with class="w-4 h-4 flex-shrink-0" %}</span>
                                 {% elif attempt.result == 'sms_sent' %}
                                     <span class="text-blue-500"><svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg></span>
+                                {% elif attempt.result == 'whatsapp_sent' %}
+                                    <span class="text-[#25D366]"><svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24"><path d="M20.52 3.48A11.78 11.78 0 0 0 12.06 0C5.5 0 .17 5.33.17 11.89c0 2.1.55 4.14 1.6 5.95L.06 24l6.32-1.66a11.86 11.86 0 0 0 5.68 1.45c6.55 0 11.89-5.33 11.89-11.89 0-3.18-1.24-6.16-3.44-8.42Z"/></svg></span>
                                 {% else %}
                                     <span class="text-green-500">{% include "shared/icons/check-circle.html" with class="w-4 h-4 flex-shrink-0" %}</span>
                                 {% endif %}
@@ -488,6 +494,8 @@
                                         <p class="text-gray-700 dark:text-gray-200">{% trans "Failed:" %} {{ attempt.get_failure_reason_display }}</p>
                                     {% elif attempt.result == 'sms_sent' %}
                                         <p class="text-blue-700 dark:text-blue-300">{% trans "SMS template sent" %}</p>
+                                    {% elif attempt.result == 'whatsapp_sent' %}
+                                        <p class="text-[#1ebe57] dark:text-[#25D366]">{% trans "WhatsApp template sent" %}</p>
                                     {% else %}
                                         <p class="text-green-700 dark:text-green-300">{% trans "Call completed successfully" %}</p>
                                     {% endif %}

--- a/crush_lu/templates/crush_lu/_screening_tab.html
+++ b/crush_lu/templates/crush_lu/_screening_tab.html
@@ -135,6 +135,8 @@
                                     <span class="text-red-500">{% include "shared/icons/x-circle.html" with class="w-4 h-4 flex-shrink-0" %}</span>
                                 {% elif attempt.result == 'sms_sent' %}
                                     <span class="text-blue-500"><svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg></span>
+                                {% elif attempt.result == 'whatsapp_sent' %}
+                                    <span class="text-[#25D366]"><svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24"><path d="M20.52 3.48A11.78 11.78 0 0 0 12.06 0C5.5 0 .17 5.33.17 11.89c0 2.1.55 4.14 1.6 5.95L.06 24l6.32-1.66a11.86 11.86 0 0 0 5.68 1.45c6.55 0 11.89-5.33 11.89-11.89 0-3.18-1.24-6.16-3.44-8.42Z"/></svg></span>
                                 {% else %}
                                     <span class="text-green-500">{% include "shared/icons/check-circle.html" with class="w-4 h-4 flex-shrink-0" %}</span>
                                 {% endif %}
@@ -144,6 +146,8 @@
                                         <p class="text-gray-700 dark:text-gray-200">{% trans "Failed:" %} {{ attempt.get_failure_reason_display }}</p>
                                     {% elif attempt.result == 'sms_sent' %}
                                         <p class="text-blue-700 dark:text-blue-300">{% trans "SMS template sent" %}</p>
+                                    {% elif attempt.result == 'whatsapp_sent' %}
+                                        <p class="text-[#1ebe57] dark:text-[#25D366]">{% trans "WhatsApp template sent" %}</p>
                                     {% else %}
                                         <p class="text-green-700 dark:text-green-300">{% trans "Call completed successfully" %}</p>
                                     {% endif %}
@@ -195,7 +199,7 @@
                 </p>
                 {% if profile.phone_number and profile.phone_verified and sms_template_encoded %}
                     <div class="mt-4 pt-4 border-t border-purple-200 dark:border-purple-700">
-                        <p class="text-xs text-gray-600 dark:text-gray-400 mb-2">{% trans "Can't reach them? Send an SMS template:" %}</p>
+                        <p class="text-xs text-gray-600 dark:text-gray-400 mb-2">{% trans "Can't reach them? Send the outreach template:" %}</p>
                         <div class="flex flex-wrap items-center gap-2">
                             <a href="sms:{{ profile.phone_number }}?body={{ sms_template_encoded }}"
                                class="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors">
@@ -209,6 +213,20 @@
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
                                 {% trans "Log SMS Sent" %}
                             </button>
+                            {% if whatsapp_url %}
+                            <a href="{{ whatsapp_url }}" target="_blank" rel="noopener"
+                               class="inline-flex items-center gap-2 px-4 py-2 bg-[#25D366] hover:bg-[#1ebe57] text-white text-sm font-medium rounded-lg transition-colors">
+                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.52 3.48A11.78 11.78 0 0 0 12.06 0C5.5 0 .17 5.33.17 11.89c0 2.1.55 4.14 1.6 5.95L.06 24l6.32-1.66a11.86 11.86 0 0 0 5.68 1.45h.01c6.55 0 11.89-5.33 11.89-11.89 0-3.18-1.24-6.16-3.44-8.42ZM12.07 21.6h-.01a9.7 9.7 0 0 1-4.95-1.36l-.36-.21-3.75.98 1-3.66-.23-.38a9.69 9.69 0 0 1-1.49-5.18c0-5.36 4.36-9.72 9.73-9.72 2.6 0 5.04 1.01 6.88 2.85a9.66 9.66 0 0 1 2.85 6.87c0 5.36-4.36 9.81-9.67 9.81Zm5.6-7.27c-.31-.16-1.83-.9-2.11-1.01-.28-.1-.49-.16-.69.16-.21.31-.79 1-.97 1.21-.18.21-.36.23-.67.08-.31-.16-1.31-.48-2.49-1.54-.92-.82-1.54-1.83-1.72-2.14-.18-.31-.02-.48.13-.63.14-.14.31-.36.46-.54.16-.18.21-.31.31-.51.1-.21.05-.39-.03-.54-.08-.16-.69-1.66-.94-2.27-.25-.6-.51-.52-.69-.53-.18-.01-.39-.01-.6-.01-.21 0-.54.08-.83.39-.28.31-1.08 1.05-1.08 2.57 0 1.51 1.11 2.97 1.27 3.18.16.21 2.18 3.33 5.27 4.67.74.32 1.31.51 1.76.65.74.23 1.41.2 1.94.12.59-.09 1.83-.75 2.09-1.47.26-.72.26-1.34.18-1.47-.07-.13-.28-.21-.6-.36Z"/></svg>
+                                {% trans "Open WhatsApp" %}
+                            </a>
+                            <button hx-post="{% url 'crush_lu:coach_log_whatsapp_sent' submission.id %}"
+                                    hx-target="#screening-call-section-content"
+                                    hx-swap="innerHTML"
+                                    class="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                                {% trans "Log WhatsApp Sent" %}
+                            </button>
+                            {% endif %}
                         </div>
                     </div>
                 {% endif %}

--- a/crush_lu/templates/crush_lu/coach_member_overview.html
+++ b/crush_lu/templates/crush_lu/coach_member_overview.html
@@ -571,6 +571,8 @@
                                 <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-full">{% trans "Call Failed" %}</span>
                             {% elif attempt.result == 'sms_sent' %}
                                 <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full">{% trans "SMS Sent" %}</span>
+                            {% elif attempt.result == 'whatsapp_sent' %}
+                                <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full">{% trans "WhatsApp Sent" %}</span>
                             {% elif attempt.result == 'event_invite_sms' %}
                                 <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full">{% trans "Event Invite SMS" %}</span>
                             {% endif %}

--- a/crush_lu/templates/crush_lu/coach_verification_channel.html
+++ b/crush_lu/templates/crush_lu/coach_verification_channel.html
@@ -1,5 +1,5 @@
 {% extends 'crush_lu/base.html' %}
-{% load i18n static %}
+{% load i18n static crush_media %}
 
 {% block title %}{% trans "Verification Channel" %} - Crush.lu{% endblock %}
 
@@ -49,10 +49,16 @@
             {% with p=sub.profile %}
             <div class="px-6 py-5 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 {% if sub.language_match %}bg-purple-50/40 dark:bg-purple-900/10{% endif %}">
                 <div class="flex items-start gap-4 flex-1 min-w-0">
-                    {# Avatar disk — initial on gradient #}
+                    {# Avatar disk — primary photo if available, otherwise initial on gradient #}
+                    {% if p.photo_1 %}
+                    <div class="flex-shrink-0 w-12 h-12 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        <img src="{% profile_photo_url p 'photo_1' %}" alt="{{ p.display_name }}" class="w-full h-full object-cover" loading="lazy">
+                    </div>
+                    {% else %}
                     <div class="flex-shrink-0 w-12 h-12 rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-white font-semibold text-lg">
                         {{ p.display_name|slice:":1"|upper }}
                     </div>
+                    {% endif %}
                     <div class="flex-1 min-w-0">
                         {# Name row #}
                         <div class="flex items-center gap-2 flex-wrap mb-1">

--- a/crush_lu/templates/crush_lu/coach_verification_channel.html
+++ b/crush_lu/templates/crush_lu/coach_verification_channel.html
@@ -42,6 +42,45 @@
         {% endif %}
     </div>
 
+    {# Filter + sort bar #}
+    <form method="get" class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 mb-6 px-6 py-4 flex flex-wrap items-end gap-4">
+        <div class="flex flex-col">
+            <label for="filter-lang" class="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">{% trans "Language" %}</label>
+            <select name="lang" id="filter-lang" class="rounded-lg border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm">
+                <option value="">{% trans "Any" %}</option>
+                {% for code, info in language_options %}
+                <option value="{{ code }}" {% if filter_lang == code %}selected{% endif %}>{{ info.flag }} {{ info.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="flex flex-col">
+            <label for="filter-region" class="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">{% trans "Region" %}</label>
+            <input type="text" name="region" id="filter-region" value="{{ filter_region }}" placeholder="{% trans 'e.g. Luxembourg' %}" class="rounded-lg border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm w-44">
+        </div>
+        <div class="flex flex-col">
+            <label class="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">{% trans "Age" %}</label>
+            <div class="flex items-center gap-1">
+                <input type="number" name="age_min" min="18" max="99" value="{{ filter_age_min|default_if_none:'' }}" placeholder="{% trans 'Min' %}" class="rounded-lg border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm w-20">
+                <span class="text-gray-400">–</span>
+                <input type="number" name="age_max" min="18" max="99" value="{{ filter_age_max|default_if_none:'' }}" placeholder="{% trans 'Max' %}" class="rounded-lg border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm w-20">
+            </div>
+        </div>
+        <div class="flex flex-col">
+            <label for="filter-sort" class="text-xs uppercase tracking-wider text-gray-400 dark:text-gray-500 font-semibold mb-1">{% trans "Sort" %}</label>
+            <select name="sort" id="filter-sort" class="rounded-lg border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 text-sm">
+                <option value="urgency" {% if sort_mode == 'urgency' %}selected{% endif %}>{% trans "Urgency (oldest first)" %}</option>
+                <option value="name" {% if sort_mode == 'name' %}selected{% endif %}>{% trans "Name (A→Z)" %}</option>
+                <option value="match" {% if sort_mode == 'match' %}selected{% endif %}>{% trans "Best match for me" %}</option>
+            </select>
+        </div>
+        <div class="flex items-center gap-2 ml-auto">
+            <button type="submit" class="btn-crush-primary text-sm px-4 py-2">{% trans "Apply" %}</button>
+            {% if has_filters or sort_mode != 'urgency' %}
+            <a href="{% url 'crush_lu:coach_verification_channel' %}" class="text-sm text-gray-500 dark:text-gray-400 hover:text-crush-purple px-2 py-2">{% trans "Clear" %}</a>
+            {% endif %}
+        </div>
+    </form>
+
     {% if channel %}
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 overflow-hidden">
         <div class="divide-y divide-gray-100 dark:divide-gray-700">
@@ -65,6 +104,17 @@
                             <p class="font-semibold text-gray-900 dark:text-white">{{ p.display_name }}</p>
                             {% if p.age_display %}
                             <span class="text-sm text-gray-500 dark:text-gray-400">{{ p.age_display }}</span>
+                            {% endif %}
+                            {% if sub.is_recommended %}
+                            <span class="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 rounded-full">
+                                {% include "shared/icons/check-circle.html" with class="w-3 h-3" %}
+                                {% trans "Recommended" %}
+                            </span>
+                            {% endif %}
+                            {% if sort_mode == 'match' %}
+                            <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full" title="{% trans 'Match score for you' %}">
+                                {{ sub.match_score }}%
+                            </span>
                             {% endif %}
                             {% if sub.language_match %}
                             <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-crush-purple/10 text-crush-purple rounded-full">{% trans "Matches your languages" %}</span>

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -286,6 +286,7 @@ urlpatterns = [
     path('coach/review/<int:submission_id>/call-complete/', views.coach_mark_review_call_complete, name='coach_mark_review_call_complete'),
     path('coach/review/<int:submission_id>/call-attempt/', views.coach_log_failed_call, name='coach_log_failed_call'),
     path('coach/review/<int:submission_id>/sms-sent/', views.coach_log_sms_sent, name='coach_log_sms_sent'),
+    path('coach/review/<int:submission_id>/whatsapp-sent/', views.coach_log_whatsapp_sent, name='coach_log_whatsapp_sent'),
     path('coach/review/<int:submission_id>/pre-screening-reminder/', views.coach_send_pre_screening_reminder, name='coach_send_pre_screening_reminder'),
     path('coach/review/<int:submission_id>/screening-mode/', views.coach_set_screening_mode, name='coach_set_screening_mode'),
     path('coach/sessions/', views.coach_sessions, name='coach_sessions'),

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -140,6 +140,7 @@ from .views_coach import (  # noqa: F401
     coach_mark_review_call_complete,
     coach_log_failed_call,
     coach_log_sms_sent,
+    coach_log_whatsapp_sent,
     coach_review_profile,
     coach_send_pre_screening_reminder,
     coach_set_screening_mode,

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -3443,14 +3443,22 @@ def coach_verification_channel(request):
         sort_mode = "urgency"
     filter_lang = (request.GET.get("lang") or "").strip().lower()
     filter_region = (request.GET.get("region") or "").strip()
-    try:
-        filter_age_min = int(request.GET.get("age_min") or 0) or None
-    except ValueError:
-        filter_age_min = None
-    try:
-        filter_age_max = int(request.GET.get("age_max") or 0) or None
-    except ValueError:
-        filter_age_max = None
+
+    def _parse_age(raw):
+        # Clamp to [18, 120] so crafted query params can't push date.replace()
+        # past the year-range limits and 500 the page.
+        try:
+            value = int(raw or 0)
+        except (TypeError, ValueError):
+            return None
+        if value <= 0:
+            return None
+        return max(18, min(value, 120))
+
+    filter_age_min = _parse_age(request.GET.get("age_min"))
+    filter_age_max = _parse_age(request.GET.get("age_max"))
+    if filter_age_min and filter_age_max and filter_age_min > filter_age_max:
+        filter_age_min, filter_age_max = filter_age_max, filter_age_min
 
     qs = ProfileSubmission.objects.filter(
         status="pending", coach__isnull=True

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -893,30 +893,46 @@ def coach_log_sms_sent(request, submission_id):
     messages.success(request, _("SMS attempt logged."))
 
     if request.headers.get("HX-Request"):
-        # Build SMS template context for re-render
-        from urllib.parse import quote
-        from .models.site_config import CrushSiteConfig
-
-        sms_template_encoded = ""
         profile = submission.profile
-        if profile.phone_number and profile.phone_verified:
-            config = CrushSiteConfig.get_config()
-            lang = getattr(profile, "preferred_language", "en") or "en"
-            template_field = f"sms_template_{lang}"
-            template = (
-                getattr(config, template_field, config.sms_template_en)
-                or config.sms_template_en
-            )
-            coach_name = coach.user.first_name or "Your coach"
-            first_name = profile.user.first_name or ""
-            sms_body = template.format(first_name=first_name, coach_name=coach_name)
-            sms_template_encoded = quote(sms_body, safe="")
-
         context = {
             "submission": submission,
             "profile": profile,
-            "sms_template_encoded": sms_template_encoded,
         }
+        context.update(_build_outreach_context(coach, profile))
+        return render(request, "crush_lu/_screening_tab.html", context)
+
+    return redirect("crush_lu:coach_review_profile", submission_id=submission.id)
+
+
+@coach_required
+@require_http_methods(["POST"])
+def coach_log_whatsapp_sent(request, submission_id):
+    """Log a WhatsApp template sent attempt - HTMX endpoint."""
+    from .models import CallAttempt
+
+    coach = request.coach
+    submission = get_object_or_404(
+        ProfileSubmission.objects.select_related("profile__user"),
+        id=submission_id,
+        coach=coach,
+    )
+
+    CallAttempt.objects.create(
+        submission=submission,
+        result="whatsapp_sent",
+        coach=coach,
+        notes=_("WhatsApp template sent via coach review page"),
+    )
+
+    messages.success(request, _("WhatsApp attempt logged."))
+
+    if request.headers.get("HX-Request"):
+        profile = submission.profile
+        context = {
+            "submission": submission,
+            "profile": profile,
+        }
+        context.update(_build_outreach_context(coach, profile))
         return render(request, "crush_lu/_screening_tab.html", context)
 
     return redirect("crush_lu:coach_review_profile", submission_id=submission.id)
@@ -1059,25 +1075,9 @@ def coach_review_profile(request, submission_id):
     # Get social login provider if exists
     social_account = submission.profile.user.socialaccount_set.first()
 
-    # Build SMS template for coach outreach
-    sms_template_encoded = ""
     profile = submission.profile
     prefetch_related_objects([profile], "qualities", "defects", "sought_qualities")
-    if profile.phone_number and profile.phone_verified:
-        from urllib.parse import quote
-        from .models.site_config import CrushSiteConfig
-
-        config = CrushSiteConfig.get_config()
-        lang = getattr(profile, "preferred_language", "en") or "en"
-        template_field = f"sms_template_{lang}"
-        template = (
-            getattr(config, template_field, config.sms_template_en)
-            or config.sms_template_en
-        )
-        coach_name = coach.user.first_name or "Your coach"
-        first_name = profile.user.first_name or ""
-        sms_body = template.format(first_name=first_name, coach_name=coach_name)
-        sms_template_encoded = quote(sms_body, safe="")
+    outreach = _build_outreach_context(coach, profile)
 
     from django.conf import settings as _settings
 
@@ -1089,10 +1089,10 @@ def coach_review_profile(request, submission_id):
         "profile": profile,
         "form": form,
         "social_account": social_account,
-        "sms_template_encoded": sms_template_encoded,
         "pre_screening_enabled": pre_screening_enabled,
         "can_send_prescreening_sms": can_send_prescreening_sms,
     }
+    context.update(outreach)
     return render(request, "crush_lu/coach_review_profile.html", context)
 
 
@@ -1121,30 +1121,12 @@ def coach_set_screening_mode(request, submission_id):
     submission.screening_call_mode = mode
     submission.save(update_fields=["screening_call_mode"])
 
-    # Re-render the tab in place.
-    from urllib.parse import quote
-    from .models.site_config import CrushSiteConfig
-
     profile = submission.profile
-    sms_template_encoded = ""
-    if profile.phone_number and profile.phone_verified:
-        config = CrushSiteConfig.get_config()
-        lang = getattr(profile, "preferred_language", "en") or "en"
-        template_field = f"sms_template_{lang}"
-        template = (
-            getattr(config, template_field, config.sms_template_en)
-            or config.sms_template_en
-        )
-        coach_name = coach.user.first_name or "Your coach"
-        first_name = profile.user.first_name or ""
-        sms_body = template.format(first_name=first_name, coach_name=coach_name)
-        sms_template_encoded = quote(sms_body, safe="")
-
     context = {
         "submission": submission,
         "profile": profile,
-        "sms_template_encoded": sms_template_encoded,
     }
+    context.update(_build_outreach_context(coach, profile))
     return render(request, "crush_lu/_screening_tab.html", context)
 
 
@@ -3371,6 +3353,43 @@ def coach_team_stats(request):
 
 
 SORT_CHOICES = ("urgency", "name", "match")
+
+
+def _build_outreach_context(coach, profile):
+    """SMS-template + WhatsApp URL context for the screening tab partial.
+
+    Returns ``sms_template_encoded`` and ``whatsapp_url`` together so callers
+    don't drift apart. Both are empty strings when the candidate's phone
+    isn't verified — the gate matches the existing SMS path.
+    """
+    if not (profile.phone_number and profile.phone_verified):
+        return {"sms_template_encoded": "", "whatsapp_url": ""}
+
+    from urllib.parse import quote
+    import re
+    from .models.site_config import CrushSiteConfig
+
+    config = CrushSiteConfig.get_config()
+    lang = getattr(profile, "preferred_language", "en") or "en"
+    template_field = f"sms_template_{lang}"
+    template = (
+        getattr(config, template_field, config.sms_template_en)
+        or config.sms_template_en
+    )
+    coach_name = coach.user.first_name or "Your coach"
+    first_name = profile.user.first_name or ""
+    sms_body = template.format(first_name=first_name, coach_name=coach_name)
+    sms_template_encoded = quote(sms_body, safe="")
+
+    digits = re.sub(r"[^\d]", "", profile.phone_number)
+    whatsapp_url = (
+        f"https://wa.me/{digits}?text={sms_template_encoded}" if digits else ""
+    )
+
+    return {
+        "sms_template_encoded": sms_template_encoded,
+        "whatsapp_url": whatsapp_url,
+    }
 
 
 def _score_submission_for_coach(coach, submission, hours_waiting):

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -3381,7 +3381,6 @@ def coach_verification_channel(request):
     channel = list(
         ProfileSubmission.objects.filter(status="pending", coach__isnull=True)
         .select_related("profile__user")
-        .order_by("submitted_at")
     )
 
     coach_langs = set(coach.spoken_languages or [])
@@ -3393,6 +3392,8 @@ def coach_verification_channel(request):
         profile_langs = set(s.profile.event_languages or [])
         s.matched_languages = sorted(coach_langs & profile_langs)
         s.language_match = bool(s.matched_languages)
+
+    channel.sort(key=lambda s: (s.profile.display_name or "").casefold())
 
     my_pending = ProfileSubmission.objects.filter(coach=coach, status="pending").count()
 

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -3370,6 +3370,44 @@ def coach_team_stats(request):
     return render(request, "crush_lu/coach_team_stats.html", context)
 
 
+SORT_CHOICES = ("urgency", "name", "match")
+
+
+def _score_submission_for_coach(coach, submission, hours_waiting):
+    """Phase-1 coach matching score (0-100) plus human reason chips.
+
+    Pure function so it's easy to test and to relocate later if we promote
+    this into a CoachMatchSuggestion model.
+    """
+    score = 0
+    reasons = []
+
+    coach_langs = set(coach.spoken_languages or [])
+    profile_langs = set(submission.profile.event_languages or [])
+    if coach_langs & profile_langs:
+        score += 50
+        reasons.append("language")
+
+    waiting_score = min(hours_waiting, 72.0) / 72.0 * 30.0
+    score += waiting_score
+    if hours_waiting > 48:
+        reasons.append("waiting")
+
+    profile = submission.profile
+    completeness = 0
+    if profile.photo_1:
+        completeness += 10
+    if profile.bio:
+        completeness += 5
+    if profile.location:
+        completeness += 5
+    score += completeness
+    if completeness >= 15:
+        reasons.append("complete")
+
+    return round(score), reasons
+
+
 @coach_required
 def coach_verification_channel(request):
     """Coach-facing channel: every active coach sees all pending, unclaimed profiles
@@ -3378,10 +3416,49 @@ def coach_verification_channel(request):
     coach = request.coach
     now = timezone.now()
 
-    channel = list(
-        ProfileSubmission.objects.filter(status="pending", coach__isnull=True)
-        .select_related("profile__user")
-    )
+    sort_mode = request.GET.get("sort", "urgency")
+    if sort_mode not in SORT_CHOICES:
+        sort_mode = "urgency"
+    filter_lang = (request.GET.get("lang") or "").strip().lower()
+    filter_region = (request.GET.get("region") or "").strip()
+    try:
+        filter_age_min = int(request.GET.get("age_min") or 0) or None
+    except ValueError:
+        filter_age_min = None
+    try:
+        filter_age_max = int(request.GET.get("age_max") or 0) or None
+    except ValueError:
+        filter_age_max = None
+
+    qs = ProfileSubmission.objects.filter(
+        status="pending", coach__isnull=True
+    ).select_related("profile__user")
+
+    if filter_region:
+        qs = qs.filter(profile__location__icontains=filter_region)
+    if filter_age_min or filter_age_max:
+        today = now.date()
+
+        def _shift_year(d, years_back):
+            try:
+                return d.replace(year=d.year - years_back)
+            except ValueError:
+                return d.replace(year=d.year - years_back, day=28)
+
+        if filter_age_max:
+            earliest_dob = _shift_year(today, filter_age_max + 1)
+            qs = qs.filter(profile__date_of_birth__gt=earliest_dob)
+        if filter_age_min:
+            latest_dob = _shift_year(today, filter_age_min)
+            qs = qs.filter(profile__date_of_birth__lte=latest_dob)
+
+    channel = list(qs)
+
+    if filter_lang:
+        channel = [
+            s for s in channel
+            if filter_lang in (s.profile.event_languages or [])
+        ]
 
     coach_langs = set(coach.spoken_languages or [])
     for s in channel:
@@ -3392,8 +3469,17 @@ def coach_verification_channel(request):
         profile_langs = set(s.profile.event_languages or [])
         s.matched_languages = sorted(coach_langs & profile_langs)
         s.language_match = bool(s.matched_languages)
+        s.match_score, s.match_reasons = _score_submission_for_coach(coach, s, hours)
+        s.is_recommended = False
 
-    channel.sort(key=lambda s: (s.profile.display_name or "").casefold())
+    if sort_mode == "name":
+        channel.sort(key=lambda s: (s.profile.display_name or "").casefold())
+    elif sort_mode == "match":
+        channel.sort(key=lambda s: (-s.match_score, s.submitted_at))
+        for s in channel[:3]:
+            s.is_recommended = True
+    else:
+        channel.sort(key=lambda s: s.submitted_at)
 
     my_pending = ProfileSubmission.objects.filter(coach=coach, status="pending").count()
 
@@ -3403,6 +3489,14 @@ def coach_verification_channel(request):
         "channel_count": len(channel),
         "my_pending": my_pending,
         "at_capacity": not coach.can_accept_reviews(),
+        "sort_mode": sort_mode,
+        "sort_choices": SORT_CHOICES,
+        "filter_lang": filter_lang,
+        "filter_region": filter_region,
+        "filter_age_min": filter_age_min,
+        "filter_age_max": filter_age_max,
+        "has_filters": bool(filter_lang or filter_region or filter_age_min or filter_age_max),
+        "language_options": list(CrushCoach.LANGUAGE_DISPLAY.items()),
     }
     return render(request, "crush_lu/coach_verification_channel.html", context)
 


### PR DESCRIPTION
- Sort the verification channel list alphabetically by display_name
  (case-insensitive) so coaches can scan and find candidates faster.
  Urgency/waiting badges are unaffected since they're computed per-row.
- Show the profile's primary photo (photo_1) as the avatar, falling back
  to the gradient initial when no photo is uploaded. Uses the existing
  profile_photo_url tag so SAS-token storage works in production.

https://claude.ai/code/session_01MrTpJUoQ8QrGT75GfqLBNx