### PR TITLE
feat(crush_lu): surface mutual matches and polish post-event attendee UX

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -968,6 +968,74 @@ def send_connection_accepted_notification(recipient, connection, accepter, reque
     )
 
 
+def send_mutual_match_email(recipient, connection, other_user, request):
+    """
+    Notify a user that an event connection became mutual ("It's a Match!").
+
+    Both attendees independently requested each other; the backend has already
+    fast-tracked the connection (same-gender → ``shared``, cross-gender →
+    ``accepted`` with a coach assigned). This email differs from the generic
+    "your request was accepted" notification in copy and CTA.
+
+    Args:
+        recipient: User receiving the email
+        connection: EventConnection from recipient's perspective
+        other_user: the other half of the match
+        request: Django request for domain detection
+    """
+    from django.utils import translation
+    from django.utils.translation import gettext as _
+
+    if not can_send_email(recipient, 'new_connections'):
+        logger.info(
+            f"Skipping mutual match email to {recipient.email} - user unsubscribed"
+        )
+        return 0
+
+    lang = get_user_preferred_language(user=recipient, request=request, default='en')
+
+    if hasattr(other_user, 'crushprofile'):
+        other_name = other_user.crushprofile.display_name
+    else:
+        other_name = other_user.first_name
+
+    event = connection.event
+    event_title = event.title if event else "a Crush.lu event"
+
+    is_same_gender = connection.is_same_gender
+    coach = connection.assigned_coach
+    coach_name = coach.user.first_name if coach and coach.user else ""
+
+    connection_url = get_user_language_url(
+        recipient, 'crush_lu:connection_detail', request,
+        kwargs={'connection_id': connection.id}
+    )
+
+    context = get_email_context_with_unsubscribe(
+        recipient, request,
+        first_name=recipient.first_name,
+        other_name=other_name,
+        event_title=event_title,
+        connection_url=connection_url,
+        is_same_gender=is_same_gender,
+        coach_name=coach_name,
+    )
+
+    with translation.override(lang):
+        subject = _("It's a match! 🎉")
+        html_message = render_to_string('crush_lu/emails/mutual_match.html', context)
+        plain_message = strip_tags(html_message)
+
+    return send_domain_email(
+        subject=subject,
+        message=plain_message,
+        html_message=html_message,
+        recipient_list=[recipient.email],
+        request=request,
+        fail_silently=False,
+    )
+
+
 def send_new_message_notification(recipient, message, request):
     """
     Notify user that they received a new message.

--- a/crush_lu/notification_service.py
+++ b/crush_lu/notification_service.py
@@ -34,6 +34,7 @@ class NotificationType(Enum):
     NEW_MESSAGE = 'new_message'
     NEW_CONNECTION = 'new_connection'
     CONNECTION_ACCEPTED = 'connection_accepted'
+    MUTUAL_MATCH = 'mutual_match'
     EVENT_REMINDER = 'event_reminder'
     EVENT_REGISTRATION = 'event_registration'
     EVENT_WAITLIST = 'event_waitlist'
@@ -56,6 +57,7 @@ class NotificationType(Enum):
             'new_message': 'new_messages',
             'new_connection': 'new_connections',
             'connection_accepted': 'new_connections',
+            'mutual_match': 'new_connections',
             'event_reminder': 'event_reminders',
             'event_registration': 'event_reminders',
             'event_waitlist': 'event_reminders',
@@ -209,7 +211,11 @@ class NotificationService:
                 if message:
                     return push_notifications.send_new_message_notification(user, message) or {}
 
-            elif notification_type in (NotificationType.NEW_CONNECTION, NotificationType.CONNECTION_ACCEPTED):
+            elif notification_type in (
+                NotificationType.NEW_CONNECTION,
+                NotificationType.CONNECTION_ACCEPTED,
+                NotificationType.MUTUAL_MATCH,
+            ):
                 connection = context.get('connection')
                 if connection:
                     return push_notifications.send_new_connection_notification(user, connection) or {}
@@ -301,6 +307,15 @@ class NotificationService:
                 if connection and request:
                     result = email_helpers.send_connection_accepted_notification(
                         user, connection, accepter, request
+                    )
+                    return result == 1
+
+            elif notification_type == NotificationType.MUTUAL_MATCH:
+                connection = context.get('connection')
+                other_user = context.get('other_user')
+                if connection and other_user and request:
+                    result = email_helpers.send_mutual_match_email(
+                        user, connection, other_user, request
                     )
                     return result == 1
 
@@ -403,6 +418,20 @@ def notify_connection_accepted(recipient, connection, accepter, request=None) ->
         notification_type=NotificationType.CONNECTION_ACCEPTED,
         context={'connection': connection, 'accepter': accepter},
         request=request
+    )
+
+
+def notify_mutual_match(user, other_user, connection, request=None) -> NotificationResult:
+    """
+    Send "It's a Match!" notification when both attendees independently
+    requested a connection. Use this in place of notify_connection_accepted
+    when the fast-track mutual flow is triggered.
+    """
+    return NotificationService.notify(
+        user=user,
+        notification_type=NotificationType.MUTUAL_MATCH,
+        context={'connection': connection, 'other_user': other_user},
+        request=request,
     )
 
 

--- a/crush_lu/templates/crush_lu/_request_connection_form.html
+++ b/crush_lu/templates/crush_lu/_request_connection_form.html
@@ -1,5 +1,14 @@
 {% load i18n %}
-<div id="connection-actions-{{ recipient.id }}" class="space-y-2" role="status" aria-live="polite">
+<div id="connection-actions-{{ recipient.id }}" class="space-y-2" role="status" aria-live="polite"
+     x-data='{
+        prefill(text) {
+            const ta = $refs.note;
+            if (!ta) return;
+            ta.value = text + (ta.value && !ta.value.startsWith(text) ? " " + ta.value : "");
+            ta.focus();
+            ta.setSelectionRange(ta.value.length, ta.value.length);
+        }
+     }'>
     <form hx-post="{% url 'crush_lu:request_connection_inline' event.id recipient.id %}"
           hx-target="#connection-actions-{{ recipient.id }}"
           hx-swap="outerHTML"
@@ -7,9 +16,27 @@
         {% csrf_token %}
         <div>
             <textarea name="note"
+                      x-ref="note"
                       rows="2"
                       placeholder="{% trans 'Add a note (optional)...' %}"
                       class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500"></textarea>
+            <div class="flex flex-wrap gap-1.5 mt-1.5">
+                <button type="button"
+                        @click='prefill("{% trans "I really enjoyed our chat about" %}")'
+                        class="text-xs px-2 py-1 rounded-full bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 hover:bg-purple-100 dark:hover:bg-purple-900/50 transition-colors">
+                    {% trans "I really enjoyed our chat about…" %}
+                </button>
+                <button type="button"
+                        @click='prefill("{% trans "What stood out to me about you was" %}")'
+                        class="text-xs px-2 py-1 rounded-full bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 hover:bg-purple-100 dark:hover:bg-purple-900/50 transition-colors">
+                    {% trans "What stood out about you…" %}
+                </button>
+                <button type="button"
+                        @click='prefill("{% trans "I&#39;d love to continue our conversation on" %}")'
+                        class="text-xs px-2 py-1 rounded-full bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 hover:bg-purple-100 dark:hover:bg-purple-900/50 transition-colors">
+                    {% trans "Let's continue our conversation…" %}
+                </button>
+            </div>
         </div>
         <div class="flex flex-col sm:flex-row gap-2">
             <button type="submit"

--- a/crush_lu/templates/crush_lu/coach_connections.html
+++ b/crush_lu/templates/crush_lu/coach_connections.html
@@ -166,6 +166,12 @@
 
                             <!-- Status & Action -->
                             <div class="flex items-center gap-3 sm:flex-col sm:items-end">
+                                {% if conn.is_mutual_annotated %}
+                                    <span class="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-semibold rounded-full bg-gradient-to-r from-crush-purple to-crush-pink text-white">
+                                        {% include "shared/icons/heart.html" with class="w-3 h-3" %}
+                                        {% trans "Mutual match" %}
+                                    </span>
+                                {% endif %}
                                 {% if conn.status == 'pending' %}
                                     <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300 rounded-full">{% trans "Pending" %}</span>
                                 {% elif conn.status == 'accepted' %}

--- a/crush_lu/templates/crush_lu/emails/mutual_match.html
+++ b/crush_lu/templates/crush_lu/emails/mutual_match.html
@@ -1,0 +1,56 @@
+{% extends "crush_lu/emails/base_email.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "It's a match!" %} - Crush.lu{% endblock %}
+
+{% block header_title %}{% trans "It's a match!" %} 💞{% endblock %}
+
+{% block content %}
+<h2>{% blocktrans with first_name=first_name %}Great news, {{ first_name }}!{% endblocktrans %}</h2>
+
+<p>
+    {% blocktrans with name=other_name title=event_title %}You and <strong>{{ name }}</strong> both wanted to stay in touch after <strong>{{ title }}</strong>.{% endblocktrans %}
+</p>
+
+{% if is_same_gender %}
+<div class="info-box">
+    <strong>{% trans "Contact information has been shared." %}</strong>
+    <p style="margin: 10px 0 0 0;">
+        {% blocktrans with name=other_name %}You can now reach out to {{ name }} directly. Open the connection to see how to get in touch.{% endblocktrans %}
+    </p>
+</div>
+{% else %}
+<div class="info-box">
+    <strong>
+        {% if coach_name %}
+            {% blocktrans with name=coach_name %}Coach {{ name }} will personally introduce you.{% endblocktrans %}
+        {% else %}
+            {% trans "A Crush Coach will personally introduce you." %}
+        {% endif %}
+    </strong>
+    <p style="margin: 10px 0 0 0;">
+        {% trans "We'll be in touch within 48 hours with a personalized introduction. No pressure, no awkwardness — your coach handles the first step." %}
+    </p>
+</div>
+{% endif %}
+
+<p style="text-align: center;">
+    <a href="{{ connection_url }}" class="button">{% trans "View your match" %}</a>
+</p>
+
+<p><strong>{% trans "Why this is exciting:" %}</strong></p>
+<ul>
+    <li>{% trans "You both took the first step independently — no guesswork." %}</li>
+    <li>{% trans "You shared a real moment at the event." %}</li>
+    <li>{% trans "There's a real foundation for what comes next." %}</li>
+</ul>
+
+<p>
+    {% trans "Take your time, be yourself, and enjoy it." %}<br>
+    <strong>{% trans "The Crush.lu Team" %}</strong>
+</p>
+{% endblock %}
+
+{% block footer_message %}
+{% trans "You're receiving this because someone you connected with at an event wanted to connect with you too." %}<br>
+{% endblock %}

--- a/crush_lu/templates/crush_lu/event_attendees.html
+++ b/crush_lu/templates/crush_lu/event_attendees.html
@@ -40,6 +40,11 @@
                 </span>
             </button>
         </div>
+    {% elif attendee.connection_status == 'mutual_match' %}
+        <span class="inline-flex items-center gap-1 px-2.5 py-1 text-sm font-semibold rounded-full bg-gradient-to-r from-crush-purple to-crush-pink text-white shadow-sm">
+            {% include "shared/icons/heart.html" with class="w-3 h-3" %}
+            {% trans "It's a match!" %}
+        </span>
     {% elif attendee.connection_status == 'mutual' %}
         <span class="inline-flex items-center gap-1 px-2.5 py-1 text-sm font-semibold bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 rounded-full">
             {% include "shared/icons/heart.html" with class="w-3 h-3" %}
@@ -147,6 +152,37 @@
             {% trans "You can also send a Crush Spark - an anonymous admirer journey reviewed by a coach before delivery." %}
         </p>
     </div>
+
+    <!-- Interest hint: aggregate, non-identifying -->
+    {% if incoming_pending_count %}
+    <div class="rounded-xl p-[2px] bg-gradient-to-r from-crush-purple to-crush-pink mb-6">
+        <div class="bg-white dark:bg-gray-800 rounded-[10px] p-4">
+            <div class="flex items-start gap-3">
+                <div class="shrink-0 w-10 h-10 rounded-full bg-gradient-to-br from-crush-purple to-crush-pink flex items-center justify-center text-white">
+                    {% include "shared/icons/heart.html" with class="w-5 h-5" %}
+                </div>
+                <div class="min-w-0">
+                    <h5 class="font-semibold mb-1 dark:text-white">
+                        {% blocktrans count count=incoming_pending_count %}Someone here wants to connect with you{% plural %}{{ count }} people here want to connect with you{% endblocktrans %}
+                    </h5>
+                    <p class="text-sm text-gray-500 dark:text-gray-400 mb-0">
+                        {% trans "Browse the room and tap “Request Connection” on anyone who caught your eye. If they're already on your side, it becomes a match instantly." %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Spark deadline countdown -->
+    {% if spark_deadline_active and spark_deadline %}
+    <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg px-4 py-2.5 mb-6 flex items-center gap-2 text-sm">
+        <span class="text-amber-500">⏳</span>
+        <span class="text-amber-800 dark:text-amber-300">
+            {% blocktrans with countdown=spark_deadline|timeuntil %}<strong>{{ countdown }}</strong> left to send Crush Sparks and request connections.{% endblocktrans %}
+        </span>
+    </div>
+    {% endif %}
 
     <!-- Cross-gender connection limit info -->
     {% if cross_gender_remaining is not None %}

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -2883,8 +2883,11 @@ def coach_connections(request):
             Q(assigned_coach=coach) | Q(assigned_coach__isnull=True)
         )
 
-    # Use mutual annotation to avoid N+1 queries
-    connections_qs = connections_qs.annotate_is_mutual()
+    # Use mutual annotation to avoid N+1 queries, then push mutual matches to the
+    # top of the list so coaches triage the most actionable rows first.
+    connections_qs = connections_qs.annotate_is_mutual().order_by(
+        "-is_mutual_annotated", "-requested_at"
+    )
 
     # Paginate
     paginator = Paginator(connections_qs, 20)

--- a/crush_lu/views_connections.py
+++ b/crush_lu/views_connections.py
@@ -33,6 +33,7 @@ from .notification_service import (
     notify_new_message,
     notify_new_connection,
     notify_connection_accepted,
+    notify_mutual_match,
 )
 
 
@@ -85,29 +86,40 @@ def event_attendees(request, event_id):
     spark_count = len(sent_sparks)
     sparks_remaining = event.max_sparks_per_event - spark_count
 
+    # Privacy-preserving "interest hint": how many people requested a connection
+    # with this user for this event but haven't been reciprocated yet.
+    incoming_pending_count = sum(
+        1 for c in received_connections.values() if c.status == "pending"
+    )
+
     # Build attendee data with connection status
+    active_statuses = ("accepted", "coach_reviewing", "coach_approved", "shared")
     attendee_data = []
     for reg in attendees:
         attendee_user = reg.user
         connection_status = None
         connection_id = None
 
-        if attendee_user.id in sent_connections:
-            conn = sent_connections[attendee_user.id]
-            if conn.status in ("accepted", "coach_reviewing", "coach_approved", "shared"):
-                connection_status = "mutual"
+        sent_conn = sent_connections.get(attendee_user.id)
+        recv_conn = received_connections.get(attendee_user.id)
+        is_two_sided = sent_conn is not None and recv_conn is not None
+
+        if sent_conn is not None:
+            if sent_conn.status in active_statuses:
+                # Both sides requested independently → distinct mutual_match badge.
+                # One-sided accept (recipient accepted our request) keeps the plain "mutual".
+                connection_status = "mutual_match" if is_two_sided else "mutual"
             else:
                 connection_status = "sent"
-            connection_id = conn.id
-        elif attendee_user.id in received_connections:
-            conn = received_connections[attendee_user.id]
-            if conn.status in ("accepted", "coach_reviewing", "coach_approved", "shared"):
+            connection_id = sent_conn.id
+        elif recv_conn is not None:
+            if recv_conn.status in active_statuses:
                 connection_status = "mutual"
-            elif conn.status == "pending":
+            elif recv_conn.status == "pending":
                 connection_status = "received"
             else:
                 connection_status = "sent"  # declined or other non-actionable
-            connection_id = conn.id
+            connection_id = recv_conn.id
 
         attendee_data.append(
             {
@@ -165,10 +177,12 @@ def event_attendees(request, event_id):
         "attendees": attendee_data,
         "grouped_attendees": grouped_attendees,
         "spark_deadline_active": spark_deadline_active,
+        "spark_deadline": deadline,
         "sparks_remaining": sparks_remaining,
         "cross_gender_remaining": cross_gender_remaining,
         "event_coaches": event_coaches,
         "own_profile": own_profile,
+        "incoming_pending_count": incoming_pending_count,
     }
     return render(request, "crush_lu/event_attendees.html", context)
 
@@ -274,20 +288,20 @@ def request_connection(request, event_id, user_id):
         # Notifications outside transaction to avoid blocking
         if reverse_connection:
             try:
-                notify_connection_accepted(
-                    recipient=recipient,
+                notify_mutual_match(
+                    user=recipient,
+                    other_user=request.user,
                     connection=connection,
-                    accepter=request.user,
                     request=request,
                 )
-                notify_connection_accepted(
-                    recipient=request.user,
+                notify_mutual_match(
+                    user=request.user,
+                    other_user=recipient,
                     connection=reverse_connection,
-                    accepter=recipient,
                     request=request,
                 )
             except Exception as e:
-                logger.error(f"Failed to send mutual connection notifications: {e}")
+                logger.error(f"Failed to send mutual match notifications: {e}")
 
             if connection.is_same_gender:
                 messages.success(
@@ -439,20 +453,20 @@ def request_connection_inline(request, event_id, user_id):
         # Notifications outside transaction to avoid blocking
         if is_mutual:
             try:
-                notify_connection_accepted(
-                    recipient=recipient,
+                notify_mutual_match(
+                    user=recipient,
+                    other_user=request.user,
                     connection=connection,
-                    accepter=request.user,
                     request=request,
                 )
-                notify_connection_accepted(
-                    recipient=request.user,
+                notify_mutual_match(
+                    user=request.user,
+                    other_user=recipient,
                     connection=reverse_connection,
-                    accepter=recipient,
                     request=request,
                 )
             except Exception as e:
-                logger.error(f"Failed to send mutual connection notifications: {e}")
+                logger.error(f"Failed to send mutual match notifications: {e}")
 
         if not is_mutual:
             # Notify recipient about the connection request


### PR DESCRIPTION
The backend already fast-tracks a connection when both attendees independently
request each other (same-gender → shared, cross-gender → coach-assisted), but
the user-facing experience didn't reflect that. This change makes the mutual
moment visible and tightens the surrounding flow.

- Distinct "It's a match!" notification path: new MUTUAL_MATCH notification
  type, send_mutual_match_email helper, and emails/mutual_match.html template
  with copy that branches on same-gender (contacts shared) vs cross-gender
  (coach intro within 48h). Replaces the generic notify_connection_accepted
  calls in the mutual branch of request_connection and request_connection_inline.
- New mutual_match status on the attendee page: when both sides have requested
  each other, the card shows a gradient "It's a match!" pill instead of the
  plain green "Connected!" used for one-sided accepts.
- Privacy-preserving interest hint: aggregate count of pending incoming
  requests on the attendee page nudges users to browse without revealing
  identities.
- Visible spark-deadline countdown using the existing
  spark_request_deadline_hours so the 7-day window stops expiring silently.
- Icebreaker chips in the inline connection request form pre-fill the note
  textarea, raising note quality for coach review.
- Coach triage: coach_connections is reordered by is_mutual_annotated so
  mutual matches surface first, and rows now carry a "Mutual match" pill.

No new models, migrations, URLs, or settings.