### PR TITLE
chore(deps): bump vulnerable npm dev-deps to clear Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,9 +1418,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1648,9 +1648,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "tailwindcss": "^4.1.18"
   },
   "overrides": {
-    "hono": "^4.12.14"
+    "hono": "^4.12.18",
+    "fast-uri": "^3.1.2",
+    "ip-address": "^10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Closes 7 open Dependabot alerts on `main` by raising the `overrides` floor in `package.json` for three **dev-only transitive** packages (all reached via `@playwright/mcp` → `@modelcontextprotocol/sdk`):

| Package    | Was     | Now      | Advisories closed |
|------------|---------|----------|-------------------|
| hono       | 4.12.14 | 4.12.18  | GHSA-qp7p-654g-cw7p, GHSA-hm8q-7f3q-5f36, GHSA-p77w-8qqv-26rm, GHSA-69xw-7hcm-h432 |
| fast-uri   | 3.1.0   | 3.1.2    | GHSA-v39h-62p7-jpjc, GHSA-q3j6-qgpj-74h6 (both **high**) |
| ip-address | 10.1.0  | 10.2.0   | GHSA-v2v4-37r5-5v8g |

No app/source code changes — diff is purely `package.json` (overrides block) + the resulting `package-lock.json` regeneration.

`npm audit` after the bump reports **0 vulnerabilities** total (was 7).

This is PR #1 of three planned to clear the GitHub security tab. Follow-ups:
- PR #2 — Python open-redirect + stack-trace hardening (`views_spa_auth.py`, `urls_crush.py`, `api_quiz.py`)
- PR #3 — JS XSS refactor in `quiz-display.js` + `alpine-components.js`

## Test plan

- [x] `npm install` succeeds and regenerates `package-lock.json` cleanly
- [x] `npm ls hono fast-uri ip-address --all` confirms 4.12.18 / 3.1.2 / 10.2.0
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build:css` succeeds (tailwind output unchanged in scope)
- [ ] Dependabot auto-closes alerts #24, #26, #30, #31, #32, #33, #34 once this branch merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)