### PR TITLE
Remove private attribute prefix from registration properties

### DIFF
--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -117,8 +117,8 @@
                 {# Check-in status icon (small, stacked with avatar) #}
                 <div class="relative flex-shrink-0" data-checkin-avatar>
                     {# Profile avatar #}
-                    {% if reg._photo_url %}
-                        <img src="{{ reg._photo_url }}" alt="" class="w-10 h-10 rounded-full object-cover">
+                    {% if reg.photo_url %}
+                        <img src="{{ reg.photo_url }}" alt="" class="w-10 h-10 rounded-full object-cover">
                     {% else %}
                         {% with display_name=reg.user.crushprofile.display_name|default:reg.user.first_name|default:reg.user.username %}
                         <div class="w-10 h-10 rounded-full bg-crush-purple/20 flex items-center justify-center text-crush-purple font-semibold text-sm">
@@ -170,9 +170,9 @@
                         {% endif %}
                     </div>
                     {# Coach line #}
-                    {% if reg._coach_name %}
+                    {% if reg.coach_name %}
                     <p class="text-xs text-crush-purple/70 dark:text-purple-400/70 mt-0.5">
-                        {% trans "Coach" %}: {{ reg._coach_name }}
+                        {% trans "Coach" %}: {{ reg.coach_name }}
                     </p>
                     {% endif %}
                     {# Check-in time #}

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -2235,7 +2235,7 @@ def coach_event_checkin(request, event_id):
     for reg in confirmed:
         try:
             profile = reg.user.crushprofile
-            reg._photo_url = (
+            reg.photo_url = (
                 _reverse(
                     "crush_lu:serve_profile_photo",
                     kwargs={"user_id": reg.user_id, "photo_field": "photo_1"},
@@ -2244,13 +2244,13 @@ def coach_event_checkin(request, event_id):
                 else None
             )
             sub = submissions_by_profile.get(profile.id)
-            reg._coach_name = (
+            reg.coach_name = (
                 f"{sub.coach.user.first_name} {sub.coach.user.last_name}".strip()
                 if sub and sub.coach else None
             )
         except Exception:
-            reg._photo_url = None
-            reg._coach_name = None
+            reg.photo_url = None
+            reg.coach_name = None
 
     # Quiz table assignment data
     import json


### PR DESCRIPTION
## Purpose
* Refactor registration object properties to use standard naming conventions instead of private attribute prefixes
* Change `_photo_url` to `photo_url` and `_coach_name` to `coach_name` for consistency and clarity
* Update both the view logic that sets these properties and the template that consumes them

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
```
# Navigate to coach event check-in page and verify:
# 1. Profile photos display correctly for registered participants
# 2. Coach names display correctly when assigned
# 3. No console errors or template rendering issues
```

## What to Check
Verify that the following are valid
* Profile photos load correctly in the coach event check-in view
* Coach names display properly when a coach is assigned to a submission
* No template rendering errors occur
* The check-in functionality works as expected

## Other Information
This is a straightforward refactoring that removes the underscore prefix convention from dynamically-added registration properties, making the code more readable and following standard Python naming conventions for public attributes.

https://claude.ai/code/session_018vmb1FD6KjaeNe7M2BrQMG