### PR TITLE
fix(urls): expose WhatsApp webhook on crush.lu domain

### DIFF
--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -18,6 +18,7 @@ from django.views.i18n import JavaScriptCatalog
 
 from .urls_shared import base_patterns, api_patterns
 from .views_spa_auth import spa_session_callback
+from hub.views_whatsapp import WhatsAppWebhookView
 from crush_lu.admin import crush_admin_site
 from crush_lu.admin.user_segments import user_segments_dashboard, segment_detail
 from crush_lu.admin.profile_reminders import profile_reminders_panel
@@ -329,6 +330,10 @@ urlpatterns = base_patterns + api_patterns + [
     # Mounted on crush.lu / test.crush.lu since the SPA's preview env can't
     # have its own subdomain — it uses test.crush.lu directly. Language-neutral.
     path('hub/', include('hub.urls')),
+
+    # WhatsApp webhook — public, signature-verified. Mounted here because
+    # api.crush.lu is not a bound custom domain on the production App Service slot.
+    path('api/webhooks/whatsapp/', WhatsAppWebhookView.as_view(), name='whatsapp_webhook_crush'),
 
     # Session→JWT bounce for the hub SPA. Lives on crush.lu because that's
     # where the allauth session cookie is set; mints a single-use code that


### PR DESCRIPTION
## Summary
- `api.crush.lu` is not bound as a custom domain on the production App Service slot, so Meta's verify-token handshake cannot reach the webhook at `urls_api.py`
- Mounts `WhatsAppWebhookView` at `/api/webhooks/whatsapp/` on `crush.lu` as well
- Webhook URL to use in Meta dashboard: `https://crush.lu/api/webhooks/whatsapp/`

## Test plan
- [ ] Merge and deploy to staging
- [ ] Swap staging → production
- [ ] In Meta dashboard, verify webhook at `https://crush.lu/api/webhooks/whatsapp/` with token `crush-wa-verify-7f3a`
- [ ] Dashboard shows "Verified ✓"

🤖 Generated with [Claude Code](https://claude.com/claude-code)