### PR TITLE
Add WhatsApp notifications opt-in preference

### DIFF
--- a/crush_lu/migrations/0142_emailpreference_whatsapp_opt_in.py
+++ b/crush_lu/migrations/0142_emailpreference_whatsapp_opt_in.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crush_lu", "0141_connection_window_hours"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="emailpreference",
+            name="whatsapp_opt_in",
+            field=models.BooleanField(
+                default=False,
+                help_text="User has opted in to receive WhatsApp notifications",
+            ),
+        ),
+    ]

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -1802,6 +1802,10 @@ class EmailPreference(models.Model):
         default=False,  # OFF by default - GDPR compliance
         help_text=_("Marketing emails, newsletters, promotions (requires explicit opt-in)")
     )
+    whatsapp_opt_in = models.BooleanField(
+        default=False,
+        help_text=_("User has opted in to receive WhatsApp notifications")
+    )
 
     # Master unsubscribe switch
     unsubscribed_all = models.BooleanField(

--- a/crush_lu/templates/crush_lu/account_settings.html
+++ b/crush_lu/templates/crush_lu/account_settings.html
@@ -457,7 +457,7 @@
             </div>
             <div class="p-6">
                 {% if user.crushprofile and user.crushprofile.phone_number and user.crushprofile.phone_verified %}
-                <form method="post" action="{% url 'crush_lu:update_email_preferences' %}">
+                <form method="post" action="{% url 'crush_lu:update_whatsapp_preference' %}">
                     {% csrf_token %}
                     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
                         {% trans "Receive notifications via WhatsApp on:" %}

--- a/crush_lu/templates/crush_lu/account_settings.html
+++ b/crush_lu/templates/crush_lu/account_settings.html
@@ -447,6 +447,56 @@
             </div>
         </div>
 
+        <!-- WhatsApp Notifications Card -->
+        <div id="whatsapp-notifications" class="bg-white dark:bg-gray-800 rounded-xl shadow-lg mb-6 overflow-hidden">
+            <div class="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+                <h5 class="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                    {% include "shared/icons/chat-bubble-left-right.html" with class="w-5 h-5 text-green-600" %}
+                    {% trans "WhatsApp Notifications" %}
+                </h5>
+            </div>
+            <div class="p-6">
+                {% if user.crushprofile and user.crushprofile.phone_number and user.crushprofile.phone_verified %}
+                <form method="post" action="{% url 'crush_lu:update_email_preferences' %}">
+                    {% csrf_token %}
+                    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                        {% trans "Receive notifications via WhatsApp on:" %}
+                        <strong class="text-gray-900 dark:text-white ml-1">{{ user.crushprofile.phone_number }}</strong>
+                    </p>
+
+                    <label class="flex items-start cursor-pointer">
+                        <div class="relative mt-0.5">
+                            <input type="checkbox" class="sr-only peer" name="whatsapp_opt_in"
+                                   {% if email_prefs.whatsapp_opt_in %}checked{% endif %}>
+                            <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-100 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white dark:bg-gray-800 after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"></div>
+                        </div>
+                        <div class="ml-3">
+                            <strong class="text-gray-900 dark:text-white">{% trans "Enable WhatsApp Notifications" %}</strong>
+                            <p class="text-gray-500 dark:text-gray-400 text-sm">
+                                {% trans "Match alerts, new messages, and event reminders sent to your WhatsApp number." %}
+                            </p>
+                        </div>
+                    </label>
+
+                    <div class="mt-6">
+                        <button type="submit" class="btn-crush-primary px-6 py-2 rounded-lg inline-flex items-center">
+                            {% include "shared/icons/check.html" with class="w-5 h-5" %}{% trans "Save Preferences" %}
+                        </button>
+                    </div>
+                </form>
+                {% else %}
+                <div class="flex items-start gap-3 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg">
+                    {% include "shared/icons/exclamation-triangle.html" with class="w-5 h-5 text-amber-600 mt-0.5 shrink-0" %}
+                    <p class="text-sm text-amber-800 dark:text-amber-200">
+                        {% trans "A verified phone number is required to enable WhatsApp notifications." %}
+                        <a href="{% url 'crush_lu:edit_profile' %}" class="underline font-medium">{% trans "Update your profile" %}</a>
+                        {% trans "to add and verify your number." %}
+                    </p>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
         <!-- Push Notifications Card (shown to all, JS detects browser support) -->
         <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg mb-6 overflow-hidden"
              x-data="pushPreferences"

--- a/crush_lu/urls.py
+++ b/crush_lu/urls.py
@@ -212,6 +212,7 @@ urlpatterns = [
     # Account settings
     path('account/settings/', views.account_settings, name='account_settings'),
     path('account/settings/email-preferences/', views.update_email_preferences, name='update_email_preferences'),
+    path('account/settings/whatsapp-preference/', views.update_whatsapp_preference, name='update_whatsapp_preference'),
     path('account/set-password/', views.set_password, name='set_password'),
     path('account/disconnect/<int:social_account_id>/', views.disconnect_social_account, name='disconnect_social_account'),
     path('account/link-apple/', views.apple_relay_link_prompt, name='apple_link_prompt'),

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -98,6 +98,7 @@ from .views_account import (  # noqa: F401
     data_deletion_status,
     account_settings,
     update_email_preferences,
+    update_whatsapp_preference,
     api_update_email_preference,
     email_unsubscribe,
     set_password,

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -600,7 +600,6 @@ def update_email_preferences(request):
     email_prefs.email_new_connections = "email_new_connections" in request.POST
     email_prefs.email_new_messages = "email_new_messages" in request.POST
     email_prefs.email_marketing = "email_marketing" in request.POST
-    email_prefs.whatsapp_opt_in = "whatsapp_opt_in" in request.POST
 
     email_prefs.save()
 

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -613,8 +613,24 @@ def update_whatsapp_preference(request):
     """Update only the WhatsApp opt-in preference without touching email settings."""
     from .models import EmailPreference
 
+    wants_opt_in = "whatsapp_opt_in" in request.POST
+
+    # Server-side guard: opt-in requires a verified phone number regardless of
+    # what the UI shows — the form toggle is hidden for unverified users but
+    # a crafted POST must not create inconsistent state.
+    if wants_opt_in:
+        try:
+            profile = request.user.crushprofile
+            has_verified_phone = bool(profile.phone_number and profile.phone_verified)
+        except Exception:
+            has_verified_phone = False
+
+        if not has_verified_phone:
+            messages.error(request, _("A verified phone number is required to enable WhatsApp notifications."))
+            return redirect("crush_lu:account_settings")
+
     email_prefs = EmailPreference.get_or_create_for_user(request.user)
-    email_prefs.whatsapp_opt_in = "whatsapp_opt_in" in request.POST
+    email_prefs.whatsapp_opt_in = wants_opt_in
     email_prefs.save(update_fields=["whatsapp_opt_in"])
 
     messages.success(request, _("WhatsApp notification preference updated."))
@@ -650,6 +666,15 @@ def api_update_email_preference(request):
 
     if key not in VALID_KEYS:
         return JsonResponse({"success": False, "error": "Invalid preference key"}, status=400)
+
+    if key == "whatsapp_opt_in" and value:
+        try:
+            profile = request.user.crushprofile
+            has_verified_phone = bool(profile.phone_number and profile.phone_verified)
+        except Exception:
+            has_verified_phone = False
+        if not has_verified_phone:
+            return JsonResponse({"success": False, "error": "Verified phone number required"}, status=400)
 
     email_prefs = EmailPreference.get_or_create_for_user(request.user)
     setattr(email_prefs, key, value)

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -610,6 +610,20 @@ def update_email_preferences(request):
 
 @login_required
 @require_http_methods(["POST"])
+def update_whatsapp_preference(request):
+    """Update only the WhatsApp opt-in preference without touching email settings."""
+    from .models import EmailPreference
+
+    email_prefs = EmailPreference.get_or_create_for_user(request.user)
+    email_prefs.whatsapp_opt_in = "whatsapp_opt_in" in request.POST
+    email_prefs.save(update_fields=["whatsapp_opt_in"])
+
+    messages.success(request, _("WhatsApp notification preference updated."))
+    return redirect("crush_lu:account_settings")
+
+
+@login_required
+@require_http_methods(["POST"])
 def api_update_email_preference(request):
     """
     JSON API endpoint for updating a single email preference toggle.

--- a/crush_lu/views_account.py
+++ b/crush_lu/views_account.py
@@ -600,6 +600,7 @@ def update_email_preferences(request):
     email_prefs.email_new_connections = "email_new_connections" in request.POST
     email_prefs.email_new_messages = "email_new_messages" in request.POST
     email_prefs.email_marketing = "email_marketing" in request.POST
+    email_prefs.whatsapp_opt_in = "whatsapp_opt_in" in request.POST
 
     email_prefs.save()
 
@@ -624,6 +625,7 @@ def api_update_email_preference(request):
         "email_new_connections",
         "email_new_messages",
         "email_marketing",
+        "whatsapp_opt_in",
     }
 
     try:


### PR DESCRIPTION
## Purpose
* Add WhatsApp notifications feature to allow users to opt-in to receive notifications via WhatsApp
* Extend the EmailPreference model with a `whatsapp_opt_in` boolean field
* Display a new WhatsApp Notifications card in account settings that shows the user's verified phone number and allows toggling the preference
* Only show the WhatsApp notification option to users who have a verified phone number on their profile

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Apply the migration
```
python manage.py migrate
```

* Test the code
  1. Log in as a user with a verified phone number
  2. Navigate to account settings
  3. Verify the WhatsApp Notifications card appears with the verified phone number displayed
  4. Toggle the "Enable WhatsApp Notifications" checkbox and save preferences
  5. Verify the preference is persisted and the checkbox state is maintained on page reload
  6. Log in as a user without a verified phone number
  7. Verify the WhatsApp Notifications card shows the warning message with a link to update the profile

## What to Check
Verify that the following are valid:
* The WhatsApp Notifications card only appears for users with verified phone numbers
* The warning message and profile update link display correctly for users without verified phone numbers
* The `whatsapp_opt_in` preference is correctly saved and retrieved
* The preference can be toggled via both the form submission and the API endpoint
* The UI matches the existing design patterns (dark mode support, styling consistency)

## Other Information
* The migration adds a new `whatsapp_opt_in` field to the `EmailPreference` model with a default value of `False`
* The view `update_email_preferences` and API endpoint `api_update_email_preference` have been updated to handle the new preference
* The feature respects GDPR compliance by requiring explicit opt-in (default is OFF)

https://claude.ai/code/session_01F39Z1ARCT3cvYYRkRzgMz2