### PR TITLE
Add urgent SMS follow-up button in last-minute mode

### DIFF
--- a/crush_lu/templates/crush_lu/_sms_invite_profile_row.html
+++ b/crush_lu/templates/crush_lu/_sms_invite_profile_row.html
@@ -56,6 +56,11 @@
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
                     {% trans "Sent" %}
                 </span>
+                <!-- In last-minute mode, allow sending an urgent follow-up even if already sent -->
+                <a x-show="isLastMinute" href="{{ p.sms_uri_last_minute }}" class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg>
+                    {% trans "Open SMS" %} 🚨
+                </a>
             {% else %}
                 <!-- Regular mode SMS button -->
                 <a x-show="isRegular" href="{{ p.sms_uri }}" class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors">

--- a/crush_lu/templates/crush_lu/_sms_invite_row_sent.html
+++ b/crush_lu/templates/crush_lu/_sms_invite_row_sent.html
@@ -3,3 +3,9 @@
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
     {% trans "Sent" %}
 </span>
+{% if sms_uri_last_minute %}
+<a x-show="isLastMinute" href="{{ sms_uri_last_minute }}" class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors">
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg>
+    {% trans "Open SMS" %} 🚨
+</a>
+{% endif %}

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -2615,6 +2615,43 @@ def coach_event_sms_invite(request, event_id):
     return render(request, "crush_lu/coach_event_sms_invite.html", context)
 
 
+def _build_last_minute_sms_uri(request, event, profile, coach_name):
+    """Build the last-minute SMS URI independently of the main view's nested helper."""
+    from urllib.parse import quote
+
+    from django.urls import reverse
+    from django.utils import translation as _translation
+    from django.utils.formats import date_format
+
+    from .models.site_config import CrushSiteConfig
+
+    config = CrushSiteConfig.get_config()
+    template_prefix = "sms_last_minute_invite_template"
+    lang = getattr(profile, "preferred_language", "en") or "en"
+    field = f"{template_prefix}_{lang}"
+    fallback_field = f"{template_prefix}_en"
+    template = getattr(config, field, None) or getattr(config, fallback_field, None)
+    if not template:
+        template = config.sms_event_invite_template_en
+    first_name = profile.user.first_name or ""
+    with _translation.override(lang):
+        profile_event_url = request.build_absolute_uri(
+            reverse("crush_lu:event_detail", args=[event.id])
+        )
+        event_title = event.title
+        event_date_str = date_format(
+            event.date_time, format="SHORT_DATE_FORMAT", use_l10n=True
+        )
+    sms_body = template.format(
+        first_name=first_name,
+        coach_name=coach_name,
+        event_title=event_title,
+        event_date=event_date_str,
+        event_url=profile_event_url,
+    )
+    return f"sms:{profile.phone_number}?body={quote(sms_body, safe='')}"
+
+
 @coach_required
 @require_http_methods(["POST"])
 def coach_log_event_sms_sent(request, event_id, submission_id):
@@ -2642,10 +2679,13 @@ def coach_log_event_sms_sent(request, event_id, submission_id):
             notes=_("Event invite SMS sent for: %(event)s") % {"event": event.title},
         )
 
+    sms_uri_last_minute = _build_last_minute_sms_uri(
+        request, event, submission.profile, coach.user.first_name or "Coach"
+    )
     return render(
         request,
         "crush_lu/_sms_invite_row_sent.html",
-        {"submission": submission, "event": event},
+        {"submission": submission, "event": event, "sms_uri_last_minute": sms_uri_last_minute},
     )
 
 
@@ -2673,10 +2713,13 @@ def coach_log_event_sms_sent_by_profile(request, event_id, profile_id):
             notes=_("Event invite SMS sent for: %(event)s") % {"event": event.title},
         )
 
+    sms_uri_last_minute = _build_last_minute_sms_uri(
+        request, event, profile, coach.user.first_name or "Coach"
+    )
     return render(
         request,
         "crush_lu/_sms_invite_row_sent.html",
-        {"event": event},
+        {"event": event, "sms_uri_last_minute": sms_uri_last_minute},
     )
 
 


### PR DESCRIPTION
## Purpose
* Adds an "Open SMS" button with urgent indicator (🚨) that appears in last-minute mode, allowing users to send a follow-up SMS even after an initial SMS has already been sent
* Provides a way to escalate communication when time is critical by enabling repeated SMS sends in last-minute scenarios

## Does this introduce a breaking change?
```
[x] No
```

## Pull Request Type
```
[x] Feature
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
  1. Navigate to the SMS invite profile row template in the application
  2. Verify that when `isLastMinute` is true, the red "Open SMS" 🚨 button appears alongside the "Sent" status
  3. Verify that the button links to `p.sms_uri_last_minute` endpoint
  4. Verify that the button is hidden when `isLastMinute` is false
  5. Confirm the button styling (red background, hover effect) matches the design system

## What to Check
Verify that the following are valid:
* The button only displays when `isLastMinute` Alpine.js condition is true
* The button uses the correct SMS URI endpoint (`sms_uri_last_minute`)
* The button styling and icon are consistent with the application's design system
* The button is properly positioned after the "Sent" status indicator
* The translation key `"Open SMS"` is properly handled by the i18n system

## Other Information
* This change adds a conditional UI element that respects the last-minute mode state
* The button uses Alpine.js `x-show` directive for conditional rendering
* Uses a red color scheme (bg-red-600/hover:bg-red-700) to indicate urgency

https://claude.ai/code/session_01LqBPYDuX3XLf4puBiz5ugA