### PR TITLE
feat: French localisation for Speed Dating activity option names

### DIFF
--- a/crush_lu/management/commands/populate_global_activity_options.py
+++ b/crush_lu/management/commands/populate_global_activity_options.py
@@ -13,28 +13,33 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write('Populating global activity options...\n')
 
-        # Define the standard options
         options_data = [
             # Phase 2: Presentation Style (3 options)
             {
                 'activity_type': 'presentation_style',
                 'activity_variant': 'music',
                 'display_name': 'With Favorite Music',
+                'display_name_fr': 'Avec ta musique préférée',
                 'description': 'Introduce yourself while your favorite song plays in the background',
+                'description_fr': 'Présente-toi pendant que ta chanson préférée joue en fond sonore',
                 'sort_order': 1
             },
             {
                 'activity_type': 'presentation_style',
                 'activity_variant': 'questions',
                 'display_name': '5 Predefined Questions',
+                'display_name_fr': '5 questions prédéfinies',
                 'description': 'Answer 5 fun questions about yourself (we provide the questions!)',
+                'description_fr': 'Réponds à 5 questions amusantes sur toi-même (on fournit les questions !)',
                 'sort_order': 2
             },
             {
                 'activity_type': 'presentation_style',
                 'activity_variant': 'picture_story',
                 'display_name': 'Share Favorite Picture & Story',
+                'display_name_fr': 'Partage une photo et une histoire',
                 'description': 'Show us your favorite photo and tell us why it matters to you',
+                'description_fr': 'Montre ta photo préférée et raconte pourquoi elle compte pour toi',
                 'sort_order': 3
             },
             # Phase 3: Speed Dating Twist (3 options)
@@ -42,21 +47,27 @@ class Command(BaseCommand):
                 'activity_type': 'speed_dating_twist',
                 'activity_variant': 'spicy_questions',
                 'display_name': 'Spicy Questions First',
+                'display_name_fr': 'Questions piquantes d\'abord',
                 'description': 'Break the ice with bold, fun questions right away',
+                'description_fr': 'Brise la glace avec des questions audacieuses et amusantes dès le départ',
                 'sort_order': 4
             },
             {
                 'activity_type': 'speed_dating_twist',
                 'activity_variant': 'forbidden_word',
                 'display_name': 'Forbidden Word Challenge',
+                'display_name_fr': 'Défi du mot interdit',
                 'description': 'Each pair gets a secret word they can\'t say during the date',
+                'description_fr': 'Chaque duo reçoit un mot secret qu\'il ne peut pas prononcer pendant le rendez-vous',
                 'sort_order': 5
             },
             {
                 'activity_type': 'speed_dating_twist',
                 'activity_variant': 'algorithm_extended',
                 'display_name': 'Algorithm\'s Choice Extended Time',
+                'display_name_fr': 'Choix de l\'algorithme — Temps prolongé',
                 'description': 'Trust our matching algorithm - your top match gets extra time!',
+                'description_fr': 'Fais confiance à notre algorithme — ton meilleur match obtient du temps en plus !',
                 'sort_order': 6
             },
             # Skip option: skip the presentation round entirely
@@ -64,7 +75,9 @@ class Command(BaseCommand):
                 'activity_type': 'presentation_style',
                 'activity_variant': 'skip_presentations',
                 'display_name': 'Skip — Go Straight to Speed Dating',
+                'display_name_fr': 'Passer — Aller directement au Speed Dating',
                 'description': 'Vote to skip the presentation round and jump directly into speed dating!',
+                'description_fr': 'Vote pour passer le tour des présentations et aller directement au speed dating !',
                 'sort_order': 10
             },
         ]

--- a/crush_lu/migrations/0145_globalactivityoption_display_name_fr.py
+++ b/crush_lu/migrations/0145_globalactivityoption_display_name_fr.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('crush_lu', '0144_add_last_minute_sms_templates'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='globalactivityoption',
+            name='display_name_fr',
+            field=models.CharField(blank=True, default='', max_length=200),
+        ),
+        migrations.AddField(
+            model_name='globalactivityoption',
+            name='description_fr',
+            field=models.TextField(blank=True, default=''),
+        ),
+    ]

--- a/crush_lu/models/events.py
+++ b/crush_lu/models/events.py
@@ -778,7 +778,9 @@ class GlobalActivityOption(models.Model):
         help_text=_("Unique identifier (e.g., 'music', 'spicy_questions')"),
     )
     display_name = models.CharField(max_length=200)
+    display_name_fr = models.CharField(max_length=200, blank=True, default="")
     description = models.TextField()
+    description_fr = models.TextField(blank=True, default="")
     is_active = models.BooleanField(
         default=True, help_text=_("Inactive options won't appear in voting")
     )
@@ -794,6 +796,20 @@ class GlobalActivityOption(models.Model):
         ordering = ["activity_type", "sort_order", "display_name"]
         verbose_name = _("Global Activity Option")
         verbose_name_plural = _("Global Activity Options")
+
+    def get_display_name(self, language=None):
+        from django.utils.translation import get_language
+        lang = language or get_language() or "en"
+        if lang.startswith("fr") and self.display_name_fr:
+            return self.display_name_fr
+        return self.display_name
+
+    def get_description(self, language=None):
+        from django.utils.translation import get_language
+        lang = language or get_language() or "en"
+        if lang.startswith("fr") and self.description_fr:
+            return self.description_fr
+        return self.description
 
     def __str__(self):
         return f"{self.get_activity_type_display()}: {self.display_name}"

--- a/crush_lu/templates/crush_lu/event_activity_vote.html
+++ b/crush_lu/templates/crush_lu/event_activity_vote.html
@@ -34,8 +34,8 @@
                 {% if has_voted_both %}
                 <div class="bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-300 rounded-lg p-4 mb-4">
                     <strong>{% trans "✓ Current Votes:" %}</strong><br>
-                    {% blocktrans with style=presentation_vote.selected_option.display_name %}Presentation Style: <strong>{{ style }}</strong>{% endblocktrans %}<br>
-                    {% blocktrans with twist=twist_vote.selected_option.display_name %}Speed Dating Twist: <strong>{{ twist }}</strong>{% endblocktrans %}<br>
+                    {% blocktrans with style=presentation_vote.selected_option.get_display_name %}Presentation Style: <strong>{{ style }}</strong>{% endblocktrans %}<br>
+                    {% blocktrans with twist=twist_vote.selected_option.get_display_name %}Speed Dating Twist: <strong>{{ twist }}</strong>{% endblocktrans %}<br>
                     <small class="text-gray-500 dark:text-gray-400">{% trans "You can change your votes anytime before voting closes." %}</small>
                 </div>
                 {% elif presentation_vote or twist_vote %}
@@ -77,8 +77,8 @@
                                        data-option-id="{{ option.id }}"
                                        data-category="presentation">
                                 <label class="vote-option-label w-full cursor-pointer" for="presentation-{{ option.id }}">
-                                    <span class="font-semibold">{{ option.display_name }}</span>
-                                    <span class="block text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ option.description }}</span>
+                                    <span class="font-semibold">{{ option.get_display_name }}</span>
+                                    <span class="block text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ option.get_description }}</span>
                                 </label>
                             </div>
                             {% endfor %}
@@ -103,8 +103,8 @@
                                        data-option-id="{{ option.id }}"
                                        data-category="twist">
                                 <label class="vote-option-label w-full cursor-pointer" for="twist-{{ option.id }}">
-                                    <span class="font-semibold">{{ option.display_name }}</span>
-                                    <span class="block text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ option.description }}</span>
+                                    <span class="font-semibold">{{ option.get_display_name }}</span>
+                                    <span class="block text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ option.get_description }}</span>
                                 </label>
                             </div>
                             {% endfor %}

--- a/crush_lu/templates/crush_lu/event_voting_lobby.html
+++ b/crush_lu/templates/crush_lu/event_voting_lobby.html
@@ -77,8 +77,8 @@
                 {% elif has_voted_both %}
                 <div class="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 text-green-800 dark:text-green-300 rounded-lg p-4 mb-4">
                     <h5 class="font-semibold">{% trans "You've Voted on Both Categories!" %}</h5>
-                    <p class="mb-1">🎤 {% blocktrans with choice=presentation_vote.selected_option.display_name %}Presentation Style: <strong>{{ choice }}</strong>{% endblocktrans %}</p>
-                    <p class="mb-2">💕 {% blocktrans with choice=twist_vote.selected_option.display_name %}Speed Dating Twist: <strong>{{ choice }}</strong>{% endblocktrans %}</p>
+                    <p class="mb-1">🎤 {% blocktrans with choice=presentation_vote.selected_option.get_display_name %}Presentation Style: <strong>{{ choice }}</strong>{% endblocktrans %}</p>
+                    <p class="mb-2">💕 {% blocktrans with choice=twist_vote.selected_option.get_display_name %}Speed Dating Twist: <strong>{{ choice }}</strong>{% endblocktrans %}</p>
                     <a href="{% url 'crush_lu:event_voting_results' event.id %}" class="inline-flex items-center px-3 py-1 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 transition-colors mt-2">
                         {% trans "View Results" %}
                     </a>
@@ -138,7 +138,7 @@
                             {% for option in presentation_options %}
                             <div class="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
                                 <span class="w-1.5 h-1.5 bg-crush-purple rounded-full flex-shrink-0"></span>
-                                {{ option.display_name }}
+                                {{ option.get_display_name }}
                             </div>
                             {% endfor %}
                         </div>
@@ -155,7 +155,7 @@
                             {% for option in twist_options %}
                             <div class="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
                                 <span class="w-1.5 h-1.5 bg-crush-pink rounded-full flex-shrink-0"></span>
-                                {{ option.display_name }}
+                                {{ option.get_display_name }}
                             </div>
                             {% endfor %}
                         </div>

--- a/crush_lu/templates/crush_lu/event_voting_results.html
+++ b/crush_lu/templates/crush_lu/event_voting_results.html
@@ -126,8 +126,8 @@
                                  id="option-{{ option.id }}-card">
                                 <div class="flex flex-wrap justify-between items-start gap-y-1 mb-2">
                                     <div class="flex-1 min-w-0 pr-2">
-                                        <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.display_name }}</h5>
-                                        <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.description }}</p>
+                                        <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.get_display_name }}</h5>
+                                        <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.get_description }}</p>
                                     </div>
                                     <div class="text-end flex-shrink-0">
                                         {% if option.is_winner %}
@@ -162,8 +162,8 @@
                                  id="option-{{ option.id }}-card">
                                 <div class="flex flex-wrap justify-between items-start gap-y-1 mb-2">
                                     <div class="flex-1 min-w-0 pr-2">
-                                        <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.display_name }}</h5>
-                                        <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.description }}</p>
+                                        <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.get_display_name }}</h5>
+                                        <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.get_description }}</p>
                                     </div>
                                     <div class="text-end flex-shrink-0">
                                         {% if option.is_winner %}
@@ -335,8 +335,8 @@
                          id="option-{{ option.id }}-card">
                         <div class="flex flex-wrap justify-between items-start gap-y-1 mb-2">
                             <div class="flex-1 min-w-0 pr-2">
-                                <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.display_name }}</h5>
-                                <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.description }}</p>
+                                <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.get_display_name }}</h5>
+                                <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.get_description }}</p>
                             </div>
                             <div class="text-end flex-shrink-0 flex flex-col gap-1">
                                 {% if option.is_winner %}
@@ -374,8 +374,8 @@
                          id="option-{{ option.id }}-card">
                         <div class="flex flex-wrap justify-between items-start gap-y-1 mb-2">
                             <div class="flex-1 min-w-0 pr-2">
-                                <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.display_name }}</h5>
-                                <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.description }}</p>
+                                <h5 class="mb-0.5 text-sm font-semibold dark:text-white">{{ option.get_display_name }}</h5>
+                                <p class="text-gray-500 dark:text-gray-400 text-xs mb-0">{{ option.get_description }}</p>
                             </div>
                             <div class="text-end flex-shrink-0 flex flex-col gap-1">
                                 {% if option.is_winner %}


### PR DESCRIPTION
## Problem

The voting lobby and vote form showed activity option names ("With Favorite Music", "Forbidden Word Challenge", etc.) in English regardless of the user's language. These names are stored in `GlobalActivityOption.display_name` — a plain database field rendered as `{{ option.display_name }}` in the template. The `.po` translation system cannot translate database values.

## Solution

Add `display_name_fr` and `description_fr` fields to `GlobalActivityOption` with `get_display_name()` / `get_description()` methods that return the correct language based on the active Django locale (falls back to English).

## Changes

- `crush_lu/models/events.py` — add `display_name_fr`, `description_fr` fields and `get_display_name()` / `get_description()` methods to `GlobalActivityOption`
- `crush_lu/migrations/0145_globalactivityoption_display_name_fr.py` — migration for the two new fields
- `crush_lu/templates/crush_lu/event_activity_vote.html` — use `get_display_name` / `get_description` instead of raw field access
- `crush_lu/templates/crush_lu/event_voting_lobby.html` — same
- `crush_lu/templates/crush_lu/event_voting_results.html` — same
- `crush_lu/management/commands/populate_global_activity_options.py` — add French translations for all 7 options

## French translations added

| English | French |
|---|---|
| With Favorite Music | Avec ta musique préférée |
| 5 Predefined Questions | 5 questions prédéfinies |
| Share Favorite Picture & Story | Partage une photo et une histoire |
| Spicy Questions First | Questions piquantes d'abord |
| Forbidden Word Challenge | Défi du mot interdit |
| Algorithm's Choice Extended Time | Choix de l'algorithme — Temps prolongé |
| Skip — Go Straight to Speed Dating | Passer — Aller directement au Speed Dating |

## Deployment steps

After merging, run on the server:
```bash
python manage.py migrate
python manage.py populate_global_activity_options
```

The `populate` command uses `update_or_create` so it is safe to re-run — it will fill `display_name_fr` / `description_fr` on existing rows without affecting any other data.

## Test plan
- [ ] Run `python manage.py migrate && python manage.py populate_global_activity_options`
- [ ] Visit `/fr/events/<id>/voting/lobby/` — activity option names should appear in French
- [ ] Visit `/fr/events/<id>/voting/` (vote form) — option names and descriptions in French
- [ ] Visit `/en/events/<id>/voting/lobby/` — English names unchanged
- [ ] Confirm `get_display_name()` falls back to English when `display_name_fr` is empty

https://claude.ai/code/session_018eELzZSXGWCPFwdTEHdE2N

---
_Generated by [Claude Code](https://claude.ai/code/session_018eELzZSXGWCPFwdTEHdE2N)_