### PR TITLE
Fix test failure: seed all standard options in data migration, expect 8 active options

### DIFF
--- a/crush_lu/migrations/0147_deactivate_algorithm_extended_add_new_twists.py
+++ b/crush_lu/migrations/0147_deactivate_algorithm_extended_add_new_twists.py
@@ -1,9 +1,96 @@
 """
-Data migration: deactivate the removed algorithm_extended GlobalActivityOption
-and ensure open_conversation / theme_based rows exist and are active.
+Data migration: deactivate the removed algorithm_extended GlobalActivityOption,
+seed all standard options so fresh environments (including test DBs) don't rely
+solely on the populate_global_activity_options management command.
 """
 
 from django.db import migrations
+
+STANDARD_OPTIONS = [
+    # Presentation Style variants (Phase 2)
+    {
+        "activity_type": "presentation_style",
+        "activity_variant": "music",
+        "display_name": "With Favorite Music",
+        "display_name_fr": "Avec ta musique préférée",
+        "description": "Introduce yourself while your favorite song plays in the background",
+        "description_fr": "Présente-toi pendant que ta chanson préférée joue en fond sonore",
+        "is_active": True,
+        "sort_order": 1,
+    },
+    {
+        "activity_type": "presentation_style",
+        "activity_variant": "questions",
+        "display_name": "5 Predefined Questions",
+        "display_name_fr": "5 questions prédéfinies",
+        "description": "Answer 5 fun questions about yourself (we provide the questions!)",
+        "description_fr": "Réponds à 5 questions amusantes sur toi-même (on fournit les questions !)",
+        "is_active": True,
+        "sort_order": 2,
+    },
+    {
+        "activity_type": "presentation_style",
+        "activity_variant": "picture_story",
+        "display_name": "Share Favorite Picture & Story",
+        "display_name_fr": "Partage une photo et une histoire",
+        "description": "Show us your favorite photo and tell us why it matters to you",
+        "description_fr": "Montre ta photo préférée et raconte pourquoi elle compte pour toi",
+        "is_active": True,
+        "sort_order": 3,
+    },
+    # Speed Dating Twist variants (Phase 3)
+    {
+        "activity_type": "speed_dating_twist",
+        "activity_variant": "spicy_questions",
+        "display_name": "Spicy Questions First",
+        "display_name_fr": "Questions piquantes d'abord",
+        "description": "Break the ice with bold, fun questions right away",
+        "description_fr": "Brise la glace avec des questions audacieuses et amusantes dès le départ",
+        "is_active": True,
+        "sort_order": 4,
+    },
+    {
+        "activity_type": "speed_dating_twist",
+        "activity_variant": "forbidden_word",
+        "display_name": "Forbidden Word Challenge",
+        "display_name_fr": "Défi du mot interdit",
+        "description": "Each pair gets a secret word they can't say during the date",
+        "description_fr": "Chaque duo reçoit un mot secret qu'il ne peut pas prononcer pendant le rendez-vous",
+        "is_active": True,
+        "sort_order": 5,
+    },
+    {
+        "activity_type": "speed_dating_twist",
+        "activity_variant": "open_conversation",
+        "display_name": "Open Conversation",
+        "display_name_fr": "Conversation libre",
+        "description": "No rules — just enjoy a natural, free-flowing conversation",
+        "description_fr": "Pas de règles — profitez simplement d'une conversation naturelle et libre",
+        "is_active": True,
+        "sort_order": 6,
+    },
+    {
+        "activity_type": "speed_dating_twist",
+        "activity_variant": "theme_based",
+        "display_name": "Theme Based Conversation",
+        "display_name_fr": "Conversation à thème",
+        "description": "Each pair receives a theme to guide and inspire their conversation",
+        "description_fr": "Chaque duo reçoit un thème pour guider et inspirer leur conversation",
+        "is_active": True,
+        "sort_order": 7,
+    },
+    # Skip option
+    {
+        "activity_type": "presentation_style",
+        "activity_variant": "skip_presentations",
+        "display_name": "Skip — Go Straight to Speed Dating",
+        "display_name_fr": "Passer — Aller directement au Speed Dating",
+        "description": "Vote to skip the presentation round and jump directly into speed dating!",
+        "description_fr": "Vote pour passer le tour des présentations et aller directement au speed dating !",
+        "is_active": True,
+        "sort_order": 10,
+    },
+]
 
 
 def replace_algorithm_extended(apps, schema_editor):
@@ -14,33 +101,15 @@ def replace_algorithm_extended(apps, schema_editor):
         is_active=False
     )
 
-    # Upsert open_conversation
-    GlobalActivityOption.objects.update_or_create(
-        activity_variant="open_conversation",
-        defaults={
-            "activity_type": "speed_dating_twist",
-            "display_name": "Open Conversation",
-            "display_name_fr": "Conversation libre",
-            "description": "No rules — just enjoy a natural, free-flowing conversation",
-            "description_fr": "Pas de règles — profitez simplement d'une conversation naturelle et libre",
-            "is_active": True,
-            "sort_order": 6,
-        },
-    )
-
-    # Upsert theme_based
-    GlobalActivityOption.objects.update_or_create(
-        activity_variant="theme_based",
-        defaults={
-            "activity_type": "speed_dating_twist",
-            "display_name": "Theme Based Conversation",
-            "display_name_fr": "Conversation à thème",
-            "description": "Each pair receives a theme to guide and inspire their conversation",
-            "description_fr": "Chaque duo reçoit un thème pour guider et inspirer leur conversation",
-            "is_active": True,
-            "sort_order": 7,
-        },
-    )
+    # Upsert all standard options so fresh DBs (e.g. test environments) are
+    # fully seeded without depending solely on the management command.
+    for option in STANDARD_OPTIONS:
+        variant = option.pop("activity_variant")
+        GlobalActivityOption.objects.update_or_create(
+            activity_variant=variant,
+            defaults=option,
+        )
+        option["activity_variant"] = variant  # restore for idempotency
 
 
 def reverse_replace(apps, schema_editor):

--- a/crush_lu/tests/test_signals.py
+++ b/crush_lu/tests/test_signals.py
@@ -41,7 +41,7 @@ class TestSetupEventVoting(TestCase):
         """A voting-enabled event should auto-populate GlobalActivityOption if missing."""
         event = self._create_event()
         from crush_lu.models import GlobalActivityOption
-        self.assertEqual(GlobalActivityOption.objects.filter(is_active=True).count(), 7)
+        self.assertEqual(GlobalActivityOption.objects.filter(is_active=True).count(), 8)
 
     def test_voting_event_gets_voting_session(self):
         """A voting-enabled event should auto-create an EventVotingSession."""


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Migration `0147` previously only created the 2 new twist options (`open_conversation`, `theme_based`), causing the signal's `if not exists()` guard to skip `populate_global_activity_options` on fresh DBs (including test environments)
- This left test DBs with only 2 active `GlobalActivityOption` records instead of the expected 8
- Fix: migration now upserts all 8 standard options (idempotent — safe on production DBs that already have them)
- Test assertion updated from `7` → `8` (3 presentation + 4 twists + 1 skip)

## Test plan

- [ ] `crush_lu/tests/test_signals.py::TestSetupEventVoting::test_voting_event_gets_global_options` passes
- [ ] All other signal tests unaffected
- [ ] Running migration on an existing DB with full data produces no unexpected changes

https://claude.ai/code/session_01FKDY1wWmQLtwWezgkPzGsU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKDY1wWmQLtwWezgkPzGsU)_