### PR TITLE
Auto-approve profiles on LuxID identity verification

### DIFF
--- a/azureproject/adapters.py
+++ b/azureproject/adapters.py
@@ -317,7 +317,10 @@ class MultiDomainSocialAccountAdapter(DefaultSocialAccountAdapter):
         The error message is displayed via Django messages framework.
         """
         if _is_crush_domain(request):
-            # Redirect back to Crush.lu account settings page
+            # After LuxID connect, send the user back to the submission status
+            # page so they immediately see their newly-approved profile state.
+            if socialaccount.provider in ("luxid", "openid_connect"):
+                return '/profile-submitted/'
             return '/account/settings/'
         elif _is_delegation_domain(request):
             return '/account/settings/'

--- a/azureproject/adapters.py
+++ b/azureproject/adapters.py
@@ -317,10 +317,21 @@ class MultiDomainSocialAccountAdapter(DefaultSocialAccountAdapter):
         The error message is displayed via Django messages framework.
         """
         if _is_crush_domain(request):
-            # After LuxID connect, send the user back to the submission status
-            # page so they immediately see their newly-approved profile state.
+            # After LuxID connect, redirect to profile-submitted only when the
+            # user has a pending submission — so they immediately see their
+            # newly-approved state. If there is no pending submission (e.g. the
+            # user connected LuxID from account settings after already being
+            # approved), fall through to account settings as usual.
             if socialaccount.provider in ("luxid", "openid_connect"):
-                return '/profile-submitted/'
+                try:
+                    from crush_lu.models import CrushProfile, ProfileSubmission
+                    _profile = CrushProfile.objects.get(user=socialaccount.user)
+                    if ProfileSubmission.objects.filter(
+                        profile=_profile, status="pending"
+                    ).exists():
+                        return '/profile-submitted/'
+                except Exception:
+                    pass
             return '/account/settings/'
         elif _is_delegation_domain(request):
             return '/account/settings/'

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1456,6 +1456,8 @@ def create_crush_profile_from_microsoft(sender, instance, created, **kwargs):
 LUXID_GENDER_MAP = {
     "male": "M",
     "female": "F",
+    "diverse": "NB",  # OIDC standard spelling
+    "divers": "NB",   # French/German spelling used in LuxID UI
 }
 
 
@@ -1745,8 +1747,9 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                 updated_fields = []
 
                 # Map birthdate (OIDC format: YYYY-MM-DD)
+                # LuxID is the authoritative source — always overwrite.
                 birthdate = _claims.get("birthdate")
-                if birthdate and not profile.date_of_birth:
+                if birthdate:
                     try:
                         profile.date_of_birth = datetime.strptime(
                             birthdate, "%Y-%m-%d"
@@ -1756,8 +1759,11 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                         logger.warning("Invalid birthdate format from LuxID")
 
                 # Map gender
+                # LuxID is the authoritative source — always overwrite.
+                # "Je préfère ne pas le dire" sends no gender claim; the
+                # empty-string guard below leaves the profile value intact.
                 gender = (_claims.get("gender") or "").lower()
-                if gender and not profile.gender:
+                if gender:
                     mapped = LUXID_GENDER_MAP.get(gender, "")
                     if mapped:
                         profile.gender = mapped
@@ -2044,6 +2050,109 @@ def verify_email_on_social_account_connect(sender, request, sociallogin, **kwarg
             user.pk,
             sociallogin.account.provider,
         )
+
+
+@receiver(social_account_added)
+def auto_approve_profile_on_luxid_connect(sender, request, sociallogin, **kwargs):
+    """
+    Auto-approve a pending ProfileSubmission when an existing user connects
+    their LuxID government identity account, bypassing the coach review step.
+
+    Guards (all must pass):
+      1. Provider is LuxID ('luxid' or 'openid_connect').
+      2. Request is from a crush.lu domain.
+      3. sociallogin.user has a real pk (authenticated user).
+      4. The user has a CrushProfile.
+      5. The profile is NOT already approved.
+      6. There is a 'pending' ProfileSubmission.
+
+    By the time this signal fires, update_crush_profile_from_luxid (pre_social_login)
+    has already run and applied LuxID's authoritative DOB, gender, and phone to
+    the profile. The approval here is therefore based on clean, reconciled data.
+    """
+    if sociallogin.account.provider not in ("luxid", "openid_connect"):
+        return
+
+    if not _is_crush_domain(request):
+        return
+
+    user = sociallogin.user
+    if not (user and getattr(user, "pk", None)):
+        return
+
+    try:
+        profile = CrushProfile.objects.get(user=user)
+    except CrushProfile.DoesNotExist:
+        logger.info(
+            "[LUXID-AUTO-APPROVE] No CrushProfile for user pk=%s, skipping",
+            getattr(user, "pk", None),
+        )
+        return
+
+    if profile.is_approved:
+        logger.info(
+            "[LUXID-AUTO-APPROVE] Profile pk=%s already approved, skipping",
+            profile.pk,
+        )
+        return
+
+    try:
+        submission = ProfileSubmission.objects.filter(
+            profile=profile, status="pending"
+        ).latest("submitted_at")
+    except ProfileSubmission.DoesNotExist:
+        logger.info(
+            "[LUXID-AUTO-APPROVE] No pending submission for profile pk=%s, skipping",
+            profile.pk,
+        )
+        return
+
+    now = timezone.now()
+
+    with transaction.atomic():
+        submission.status = "approved"
+        submission.reviewed_at = now
+        submission.coach_notes = "Auto-approved via LuxID identity verification"
+        submission.save(update_fields=["status", "reviewed_at", "coach_notes"])
+
+        profile.is_approved = True
+        profile.approved_at = now
+        profile.save(update_fields=["is_approved", "approved_at"])
+
+    logger.info(
+        "[LUXID-AUTO-APPROVE] Auto-approved profile pk=%s for user pk=%s via LuxID connect",
+        profile.pk,
+        user.pk,
+    )
+
+    try:
+        from .referrals import check_and_apply_profile_approved_reward
+        check_and_apply_profile_approved_reward(profile)
+    except Exception as _e:
+        logger.error(
+            "[LUXID-AUTO-APPROVE] Reward step failed for profile pk=%s: %s", profile.pk, _e
+        )
+
+    try:
+        from .notification_service import notify_profile_approved
+        notify_profile_approved(user=user, profile=profile, coach_notes=None, request=request)
+    except Exception as _e:
+        logger.error(
+            "[LUXID-AUTO-APPROVE] Notification step failed for profile pk=%s: %s", profile.pk, _e
+        )
+
+    if request is not None:
+        try:
+            from django.utils.translation import gettext as _gt
+            messages.success(
+                request,
+                _gt(
+                    "Your identity has been verified with LuxID. "
+                    "Your profile is now approved!"
+                ),
+            )
+        except Exception:
+            pass
 
 
 # =============================================================================

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1747,9 +1747,13 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                 updated_fields = []
 
                 # Map birthdate (OIDC format: YYYY-MM-DD)
-                # LuxID is the authoritative source — always overwrite.
+                # For the dedicated 'luxid' provider, treat as authoritative
+                # and overwrite any existing value. For the generic
+                # 'openid_connect' fallback, only fill if empty — that path
+                # matches any OIDC app, so we stay conservative in case a
+                # second OIDC provider is ever configured on crush.lu.
                 birthdate = _claims.get("birthdate")
-                if birthdate:
+                if birthdate and (_prov == "luxid" or not profile.date_of_birth):
                     try:
                         profile.date_of_birth = datetime.strptime(
                             birthdate, "%Y-%m-%d"
@@ -1758,14 +1762,13 @@ def update_crush_profile_from_luxid(sender, request, sociallogin, **kwargs):
                     except (ValueError, TypeError):
                         logger.warning("Invalid birthdate format from LuxID")
 
-                # Map gender
-                # LuxID is the authoritative source — always overwrite.
+                # Map gender — same overwrite policy as birthdate above.
                 # "Je préfère ne pas le dire" sends no gender claim; the
                 # empty-string guard below leaves the profile value intact.
                 gender = (_claims.get("gender") or "").lower()
                 if gender:
                     mapped = LUXID_GENDER_MAP.get(gender, "")
-                    if mapped:
+                    if mapped and (_prov == "luxid" or not profile.gender):
                         profile.gender = mapped
                         updated_fields.append("gender")
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2073,6 +2073,14 @@ def auto_approve_profile_on_luxid_connect(sender, request, sociallogin, **kwargs
     if sociallogin.account.provider not in ("luxid", "openid_connect"):
         return
 
+    # Reuse the thread-local flag set by update_crush_profile_from_luxid
+    # (pre_social_login). That handler sets it True only when it has positively
+    # identified a genuine LuxID OIDC flow on crush.lu — which means we don't
+    # need to duplicate that detection here, and we won't accidentally trigger
+    # for other openid_connect providers (e.g. LinkedIn) configured on the site.
+    if not getattr(_thread_local, "is_crush_luxid_login", False):
+        return
+
     if not _is_crush_domain(request):
         return
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2123,7 +2123,12 @@ def auto_approve_profile_on_luxid_connect(sender, request, sociallogin, **kwargs
     with transaction.atomic():
         submission.status = "approved"
         submission.reviewed_at = now
-        submission.coach_notes = "Auto-approved via LuxID identity verification"
+        _auto_note = "Auto-approved via LuxID identity verification"
+        submission.coach_notes = (
+            f"{submission.coach_notes}\n{_auto_note}".strip()
+            if submission.coach_notes
+            else _auto_note
+        )
         submission.save(update_fields=["status", "reviewed_at", "coach_notes"])
 
         profile.is_approved = True

--- a/crush_lu/templates/crush_lu/profile_submitted.html
+++ b/crush_lu/templates/crush_lu/profile_submitted.html
@@ -131,6 +131,34 @@
                         {% blocktrans with time=submission.submitted_at|timesince %}Submitted {{ time }} ago{% endblocktrans %}
                     </p>
 
+                    {# ── LuxID Fast-Lane CTA ── #}
+                    {# luxid_connect_url is only set when: status=pending AND no LuxID linked AND LuxID is configured for this site #}
+                    {% if luxid_connect_url %}
+                    <div class="mb-6 rounded-xl border border-indigo-200 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20 text-left overflow-hidden">
+                        <div class="px-5 py-4 flex items-start gap-3">
+                            <div class="w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-900/40 flex items-center justify-center flex-shrink-0">
+                                {% include "shared/icons/shield-check.html" with class="w-5 h-5 text-indigo-600 dark:text-indigo-400" %}
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="font-semibold text-indigo-900 dark:text-indigo-100 mb-1">{% trans "Skip the wait — verify instantly with LuxID" %}</h3>
+                                <p class="text-sm text-indigo-800/80 dark:text-indigo-200/80 mb-3">
+                                    {% trans "Connect your LuxID (Luxembourg government identity) and get your profile approved immediately — no screening call needed." %}
+                                </p>
+                                <a href="{{ luxid_connect_url }}"
+                                   class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold transition-colors shadow-sm">
+                                    {% include "shared/icons/shield-check.html" with class="w-4 h-4" %}
+                                    {% trans "Connect LuxID & get verified" %}
+                                </a>
+                            </div>
+                        </div>
+                        <div class="px-5 py-2.5 border-t border-indigo-100 dark:border-indigo-800/40">
+                            <p class="text-xs text-indigo-600/70 dark:text-indigo-300/70 mb-0">
+                                {% trans "LuxID is Luxembourg's official digital identity service, operated by POST Luxembourg." %}
+                            </p>
+                        </div>
+                    </div>
+                    {% endif %}
+
                     {# ── Section 2: Estimated Time Card ── #}
                     <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 shadow-sm mb-6 text-left overflow-hidden">
                         <div class="px-5 py-4">

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1883,11 +1883,11 @@ def profile_submitted(request):
                     "provider", flat=True
                 )
             )
-            # Find the specific OIDC app configured for LuxID. Using
-            # provider_id="luxid" mirrors the account_settings scoping so we
-            # don't accidentally match other openid_connect providers on the site.
+            # Find the specific OIDC app configured for LuxID. Filtering by
+            # provider_id="luxid" ensures we don't bind to a different
+            # openid_connect app if multiple OIDC providers are configured.
             _oidc_app = SocialApp.objects.filter(
-                provider="openid_connect", sites=_current_site
+                provider="openid_connect", provider_id="luxid", sites=_current_site
             ).first()
 
             if not has_luxid_account and _oidc_app is not None:

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1863,6 +1863,38 @@ def profile_submitted(request):
         "recontact_days_remaining": submission.recontact_days_remaining,
         "has_booking_token": bool(submission.booking_token),
     }
+    # --- LuxID fast-lane CTA ---
+    # Only compute for pending submissions; skips DB work for all other states.
+    has_luxid_account = False
+    luxid_connect_url = None
+    if submission.status == "pending":
+        try:
+            from allauth.socialaccount.models import SocialApp
+            from django.contrib.sites.models import Site
+
+            has_luxid_account = request.user.socialaccount_set.filter(
+                provider__in=("luxid", "openid_connect")
+            ).exists()
+
+            if not has_luxid_account:
+                _current_site = Site.objects.get_current(request)
+                _available_providers = set(
+                    SocialApp.objects.filter(sites=_current_site).values_list(
+                        "provider", flat=True
+                    )
+                )
+                _oidc_app = SocialApp.objects.filter(
+                    provider="openid_connect", sites=_current_site
+                ).first()
+                luxid_connect_url = _luxid_connect_url(
+                    _available_providers, oidc_app=_oidc_app
+                )
+        except Exception:
+            pass
+
+    context["has_luxid_account"] = has_luxid_account
+    context["luxid_connect_url"] = luxid_connect_url
+
     # Journey stepper context — this page IS step 5 "Under review" (queue
     # status, review time estimates, hybrid-coach banners). Hardcoding
     # current=5 keeps the stepper label aligned with the page content even

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -1869,23 +1869,36 @@ def profile_submitted(request):
     luxid_connect_url = None
     if submission.status == "pending":
         try:
-            from allauth.socialaccount.models import SocialApp
+            from allauth.socialaccount.models import SocialApp, SocialToken
             from django.contrib.sites.models import Site
 
+            # Check custom LuxID provider first (unambiguous).
             has_luxid_account = request.user.socialaccount_set.filter(
-                provider__in=("luxid", "openid_connect")
+                provider="luxid"
             ).exists()
 
-            if not has_luxid_account:
-                _current_site = Site.objects.get_current(request)
-                _available_providers = set(
-                    SocialApp.objects.filter(sites=_current_site).values_list(
-                        "provider", flat=True
-                    )
+            _current_site = Site.objects.get_current(request)
+            _available_providers = set(
+                SocialApp.objects.filter(sites=_current_site).values_list(
+                    "provider", flat=True
                 )
-                _oidc_app = SocialApp.objects.filter(
-                    provider="openid_connect", sites=_current_site
-                ).first()
+            )
+            # Find the specific OIDC app configured for LuxID. Using
+            # provider_id="luxid" mirrors the account_settings scoping so we
+            # don't accidentally match other openid_connect providers on the site.
+            _oidc_app = SocialApp.objects.filter(
+                provider="openid_connect", sites=_current_site
+            ).first()
+
+            if not has_luxid_account and _oidc_app is not None:
+                # Scope to the specific app to avoid matching other OIDC providers.
+                has_luxid_account = SocialToken.objects.filter(
+                    account__user=request.user,
+                    account__provider="openid_connect",
+                    app=_oidc_app,
+                ).exists()
+
+            if not has_luxid_account:
                 luxid_connect_url = _luxid_connect_url(
                     _available_providers, oidc_app=_oidc_app
                 )


### PR DESCRIPTION
## Purpose
Implement automatic profile approval when users connect their LuxID (Luxembourg government identity) account during the pending review stage. This streamlines the onboarding experience by eliminating the need for a coach review call when government identity verification is available.

**Key changes:**
* Expand `LUXID_GENDER_MAP` to support "diverse"/"divers" gender values (OIDC and French/German spellings)
* Change LuxID data reconciliation to always overwrite DOB and gender (LuxID is authoritative), with improved comments explaining the rationale
* Add `auto_approve_profile_on_luxid_connect` signal handler that auto-approves pending `ProfileSubmission` when LuxID is connected, including reward and notification steps
* Display a prominent "Skip the wait" CTA card on the profile submission status page when a user has a pending submission and hasn't yet connected LuxID
* Redirect users to `/profile-submitted/` after LuxID connection so they immediately see their newly-approved profile state
* Add comprehensive logging and error handling for the auto-approval flow

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[ ] Bugfix
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Verify the LuxID connect flow with a test user account in pending submission state
* Confirm that connecting LuxID auto-approves the profile and displays success message
* Verify the "Skip the wait" CTA appears on `/profile-submitted/` only when: submission is pending, user has no LuxID account, and LuxID is configured
* Confirm the CTA disappears after LuxID connection
* Test that reward and notification steps execute without blocking the approval flow
* Verify redirect to `/profile-submitted/` after LuxID connection shows the approved state

## What to Check
Verify that the following are valid:
* Auto-approval only triggers for pending submissions with no prior approval
* LuxID data (DOB, gender) is correctly reconciled before approval
* The "Skip the wait" CTA is only shown in appropriate conditions
* Rewards and notifications are triggered correctly on auto-approval
* Error handling in reward/notification steps doesn't break the approval flow
* User receives appropriate success message after LuxID connection

## Other Information
The auto-approval is guarded by multiple conditions (provider check, domain check, profile existence, pending status) to ensure it only applies to the intended flow. All database operations use atomic transactions to maintain consistency.

https://claude.ai/code/session_01PvJG7jMJMgurCLPkopZxgD