### PR TITLE
Fix Priority 1 quick wins: message moderation, rejected CTA, waitlist position, silent errors

### DIFF
--- a/crush_lu/journey_translations.py
+++ b/crush_lu/journey_translations.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 """
 Wonderland Journey content translations for all supported languages.
 
@@ -1009,7 +1013,7 @@ def get_text(language: str, key: str, fallback_to_en: bool = True, **kwargs) -> 
     if isinstance(value, str) and kwargs:
         try:
             value = value.format(**kwargs)
-        except KeyError:
-            pass  # Ignore missing format keys
+        except KeyError as e:
+            logger.warning("Journey translation format key missing for %r: %s", key, e)
 
     return value

--- a/crush_lu/templates/crush_lu/_event_registration_success.html
+++ b/crush_lu/templates/crush_lu/_event_registration_success.html
@@ -5,6 +5,9 @@
             {% include "shared/icons/clock.html" with class="w-16 h-16 text-yellow-500 mx-auto" %}
         </div>
         <h3 class="text-2xl font-bold mb-2">{% trans "You're on the Waitlist!" %}</h3>
+        {% if waitlist_position %}
+        <p class="text-2xl font-bold text-yellow-600 dark:text-yellow-400 mb-1">#{{ waitlist_position }}</p>
+        {% endif %}
         <p class="text-gray-600 dark:text-gray-300 mb-6">
             {% trans "The event is currently full, but we'll notify you if a spot opens up." %}
         </p>

--- a/crush_lu/templates/crush_lu/profile_submitted.html
+++ b/crush_lu/templates/crush_lu/profile_submitted.html
@@ -618,9 +618,9 @@
                     {% endif %}
 
                     <div class="mb-4">
-                        <a href="{% url 'crush_lu:edit_profile' %}" class="btn-crush-primary gap-2">
-                            {% include "shared/icons/pencil.html" with class="w-5 h-5" %}
-                            <span>{% trans "Update Your Profile" %}</span>
+                        <a href="mailto:support@crush.lu" class="btn-crush-primary gap-2">
+                            {% include "shared/icons/envelope.html" with class="w-5 h-5" %}
+                            <span>{% trans "Contact Support" %}</span>
                         </a>
                     </div>
 

--- a/crush_lu/views_connections.py
+++ b/crush_lu/views_connections.py
@@ -841,9 +841,9 @@ def connection_detail(request, connection_id):
     other_user = connection.recipient if is_requester else connection.requester
     other_profile = getattr(other_user, "crushprofile", None)
 
-    # Get messages for this connection
+    # Get messages for this connection (exclude coach-hidden messages)
     connection_messages = (
-        ConnectionMessage.objects.filter(connection=connection)
+        ConnectionMessage.objects.filter(connection=connection, coach_approved=True)
         .select_related("sender")
         .order_by("sent_at")
     )

--- a/crush_lu/views_events.py
+++ b/crush_lu/views_events.py
@@ -990,12 +990,23 @@ def event_register(request, event_id):
                 logger.error(f"Failed to send event registration email: {e}")
 
             if request.headers.get("HX-Request"):
+                waitlist_position = None
+                if registration.status == "waitlist":
+                    waitlist_position = (
+                        EventRegistration.objects.filter(
+                            event=event,
+                            status="waitlist",
+                            registered_at__lt=registration.registered_at,
+                        ).count()
+                        + 1
+                    )
                 return render(
                     request,
                     "crush_lu/_event_registration_success.html",
                     {
                         "event": event,
                         "registration": registration,
+                        "waitlist_position": waitlist_position,
                     },
                 )
             return redirect("crush_lu:dashboard")


### PR DESCRIPTION
## Summary

- **Message moderation**: `ConnectionMessage.coach_approved` field existed on the model but was never checked in views — coaches setting it to `False` had no effect. Now `connection_detail` filters messages to `coach_approved=True`.
- **Rejected profile CTA**: The `rejected` state in `profile_submitted.html` showed an "Update Your Profile" button pointing to `edit_profile`, but rejected profiles cannot resubmit (blocked in the view). Replaced with a "Contact Support" mailto link matching what `profile_rejected.html` already shows.
- **Waitlist queue position**: After registering for a full event, the HTMX success screen now shows the user's position (#N) in the waitlist queue, computed via FIFO count of earlier waitlist registrations for the same event.
- **Silent translation errors**: `journey_translations.get_text()` was swallowing `KeyError` silently with `pass`. Replaced with `logger.warning()` so missing format keys surface in application logs.

## Test plan

- [ ] Run `pytest crush_lu/tests/test_connections.py crush_lu/tests/test_events.py -o "addopts=" -x` — 58 tests pass
- [ ] Register for a full event and verify waitlist position `#N` appears on the success screen
- [ ] Navigate to `/profile-submitted/` with a rejected submission and confirm "Contact Support" button opens mailto
- [ ] Confirm `python -c "import crush_lu.journey_translations"` imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)