### PR TITLE
Improve voting session state tracking and rating feedback

### DIFF
--- a/crush_lu/models/events.py
+++ b/crush_lu/models/events.py
@@ -992,6 +992,20 @@ class EventVotingSession(models.Model):
         return timezone.now() > self.voting_end_time
 
     @property
+    def has_concluded(self):
+        """True once voting is over by *either* path.
+
+        Covers the natural end (window elapsed, ``has_ended``) and a manual
+        early end via :meth:`end_voting` — which deactivates the session and
+        records a winner without moving ``voting_end_time``. A recorded
+        winner is a reliable conclusion signal because ``calculate_winner``
+        only runs from finalization paths. Use this to decide whether to
+        show post-voting UI (results / presentation CTA); use ``has_ended``
+        specifically when gating first-time queue creation.
+        """
+        return self.has_ended or bool(self.winning_presentation_style_id)
+
+    @property
     def time_until_start(self):
         """Seconds until voting starts (negative if already started)"""
         return (self.voting_start_time - timezone.now()).total_seconds()

--- a/crush_lu/models/events.py
+++ b/crush_lu/models/events.py
@@ -981,6 +981,17 @@ class EventVotingSession(models.Model):
         return self.is_active and self.voting_start_time <= now <= self.voting_end_time
 
     @property
+    def has_ended(self):
+        """True only once the voting window has actually closed.
+
+        Distinct from ``not is_voting_open``, which is also true *before*
+        voting starts or while the session is inactive. Use this to gate
+        winner calculation and presentation queue creation so they never
+        run prematurely.
+        """
+        return timezone.now() > self.voting_end_time
+
+    @property
     def time_until_start(self):
         """Seconds until voting starts (negative if already started)"""
         return (self.voting_start_time - timezone.now()).total_seconds()

--- a/crush_lu/templates/crush_lu/event_presentations.html
+++ b/crush_lu/templates/crush_lu/event_presentations.html
@@ -224,7 +224,11 @@
 
                             {% if user_has_rated %}
                             <div class="rating-submitted">
-                                {% trans "✓ You've responded. Thanks!" %}
+                                {% if user_rating_is_positive %}
+                                    {% trans "✓ You chose ❤️ Yes! — Thanks!" %}
+                                {% else %}
+                                    {% trans "✓ You chose 👎 Pass — Thanks!" %}
+                                {% endif %}
                             </div>
                             {% else %}
                             <div id="impression-buttons" data-presenter-id="{{ current_presentation.user.id }}" class="flex justify-center gap-4">
@@ -372,7 +376,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     const data = await response.json();
 
                     if (data.success) {
-                        impressionContainer.outerHTML = `<div class="rating-submitted">✓ ${data.message}</div>`;
+                        const choiceLabel = data.is_positive
+                            ? '{% trans "❤️ Yes!" %}'
+                            : '{% trans "👎 Pass" %}';
+                        impressionContainer.outerHTML = `<div class="rating-submitted">✓ ${'{% trans "You chose" %}'} ${choiceLabel} — ${data.message}</div>`;
                     } else {
                         alert(data.error || 'Failed to submit response');
                         impressionContainer.querySelectorAll('.impression-btn').forEach(b => b.disabled = false);

--- a/crush_lu/templates/crush_lu/event_presentations.html
+++ b/crush_lu/templates/crush_lu/event_presentations.html
@@ -359,6 +359,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const csrfToken = '{{ csrf_token }}';
         const ratingUrl = `{% url 'crush_lu:submit_presentation_rating' event.id 0 %}`.replace('/0/', `/${presenterId}/`);
 
+        {% trans "❤️ Yes!" as yes_label %}
+        {% trans "👎 Pass" as pass_label %}
+        {% trans "You chose" as chose_label %}
+        const labelYes = '{{ yes_label|escapejs }}';
+        const labelPass = '{{ pass_label|escapejs }}';
+        const labelChose = '{{ chose_label|escapejs }}';
+
         impressionContainer.querySelectorAll('.impression-btn').forEach(btn => {
             btn.addEventListener('click', async () => {
                 impressionContainer.querySelectorAll('.impression-btn').forEach(b => b.disabled = true);
@@ -376,10 +383,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     const data = await response.json();
 
                     if (data.success) {
-                        const choiceLabel = data.is_positive
-                            ? '{% trans "❤️ Yes!" %}'
-                            : '{% trans "👎 Pass" %}';
-                        impressionContainer.outerHTML = `<div class="rating-submitted">✓ ${'{% trans "You chose" %}'} ${choiceLabel} — ${data.message}</div>`;
+                        const choiceLabel = data.is_positive ? labelYes : labelPass;
+                        impressionContainer.outerHTML = `<div class="rating-submitted">✓ ${labelChose} ${choiceLabel} — ${data.message}</div>`;
                     } else {
                         alert(data.error || 'Failed to submit response');
                         impressionContainer.querySelectorAll('.impression-btn').forEach(b => b.disabled = false);

--- a/crush_lu/views_voting.py
+++ b/crush_lu/views_voting.py
@@ -312,7 +312,7 @@ def event_voting_results(request, event_id):
         user_has_voted_both = presentation_vote and twist_vote
 
         # If voting ended and user hasn't voted, redirect back to voting with message
-        if not voting_session.is_voting_open and not user_has_voted_both:
+        if voting_session.has_ended and not user_has_voted_both:
             messages.warning(
                 request,
                 _(
@@ -351,8 +351,10 @@ def event_voting_results(request, event_id):
         else:
             option.vote_percentage = 0
 
-    # If voting has ended, calculate winners and initialize presentation queue
-    if not voting_session.is_voting_open:
+    # If voting has ended, calculate winners and initialize presentation queue.
+    # Guard on has_ended (window actually closed) rather than `not is_voting_open`,
+    # which is also true before voting starts and would build the queue early.
+    if voting_session.has_ended:
         # Calculate winners if not already done
         if not voting_session.winning_presentation_style:
             voting_session.calculate_winner()

--- a/crush_lu/views_voting.py
+++ b/crush_lu/views_voting.py
@@ -311,8 +311,8 @@ def event_voting_results(request, event_id):
 
         user_has_voted_both = presentation_vote and twist_vote
 
-        # If voting ended and user hasn't voted, redirect back to voting with message
-        if voting_session.has_ended and not user_has_voted_both:
+        # If voting concluded and user hasn't voted, redirect back to voting with message
+        if voting_session.has_concluded and not user_has_voted_both:
             messages.warning(
                 request,
                 _(
@@ -351,12 +351,15 @@ def event_voting_results(request, event_id):
         else:
             option.vote_percentage = 0
 
-    # If voting has ended, calculate winners and initialize presentation queue.
-    # Guard on has_ended (window actually closed) rather than `not is_voting_open`,
-    # which is also true before voting starts and would build the queue early.
-    if voting_session.has_ended:
-        # Calculate winners if not already done
-        if not voting_session.winning_presentation_style:
+    # Show post-voting UI once voting has concluded — either the window
+    # closed (has_ended) or a coach ended it early (end_voting records a
+    # winner). Only create the queue on first natural close; a manual end
+    # already initialized it via end_voting().
+    if voting_session.has_concluded:
+        # Calculate winners if not already done (natural close that was
+        # never finalized elsewhere). Guard on has_ended so this never runs
+        # before the window actually closes.
+        if not voting_session.winning_presentation_style and voting_session.has_ended:
             voting_session.calculate_winner()
             voting_session.initialize_presentation_queue()
             voting_session.save()

--- a/crush_lu/views_voting.py
+++ b/crush_lu/views_voting.py
@@ -503,12 +503,16 @@ def event_presentations(request, event_id):
         event=event, status="completed"
     ).count()
 
-    # Check if user has rated current presenter
+    # Check if user has rated current presenter, and what they chose
     user_has_rated = False
+    user_rating_is_positive = None
     if current_presentation:
-        user_has_rated = PresentationRating.objects.filter(
+        existing_rating = PresentationRating.objects.filter(
             event=event, presenter=current_presentation.user, rater=request.user
-        ).exists()
+        ).first()
+        if existing_rating is not None:
+            user_has_rated = True
+            user_rating_is_positive = existing_rating.is_positive
 
     # Get voting session and winning presentation style
     voting_session = get_object_or_404(EventVotingSession, event=event)
@@ -521,6 +525,7 @@ def event_presentations(request, event_id):
         "total_presentations": total_presentations,
         "completed_presentations": completed_presentations,
         "user_has_rated": user_has_rated,
+        "user_rating_is_positive": user_rating_is_positive,
         "winning_style": winning_style,
         "is_presenting": current_presentation
         and current_presentation.user == request.user,
@@ -717,10 +722,14 @@ def get_current_presenter_api(request, event_id):
     )
 
     if current_presentation:
-        # Check if user has rated this presenter
-        user_has_rated = PresentationRating.objects.filter(
+        # Check if user has rated this presenter, and what they chose
+        existing_rating = PresentationRating.objects.filter(
             event=event, presenter=current_presentation.user, rater=request.user
-        ).exists()
+        ).first()
+        user_has_rated = existing_rating is not None
+        user_rating_is_positive = (
+            existing_rating.is_positive if existing_rating is not None else None
+        )
 
         # Calculate time remaining
         time_remaining = 90
@@ -743,6 +752,7 @@ def get_current_presenter_api(request, event_id):
                 ),
                 "time_remaining": time_remaining,
                 "user_has_rated": user_has_rated,
+                "user_rating_is_positive": user_rating_is_positive,
                 "is_presenting": current_presentation.user == request.user,
             }
         )


### PR DESCRIPTION
## Purpose
* Add a new `has_ended` property to `EventVotingSession` to distinguish between voting windows that have actually closed versus those that haven't started yet
* Fix premature winner calculation and presentation queue initialization that could occur before voting starts
* Enhance user feedback by displaying which rating choice (Yes/Pass) the user selected, rather than generic confirmation
* Refactor rating lookup to retrieve the actual rating object so we can access its `is_positive` attribute

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
  1. Create an event with a voting session scheduled for the future
  2. Verify that before voting starts, the presentation queue is not initialized and winners are not calculated
  3. Submit a rating (Yes or Pass) during voting and verify the confirmation message displays your choice
  4. Verify the API endpoint returns the user's rating choice in the response
  5. After voting ends, verify winners are calculated and the presentation queue is initialized

## What to Check
Verify that the following are valid
* Winner calculation and presentation queue initialization only occur after the voting window has actually closed, not before it starts
* User ratings display the specific choice (❤️ Yes or 👎 Pass) in confirmation messages
* The API response includes the user's rating choice for frontend display
* Existing voting functionality remains unchanged

## Other Information
The key insight is that `not is_voting_open` is true both before voting starts AND after it ends, which caused premature queue initialization. The new `has_ended` property explicitly checks if the current time is past the voting end time, ensuring winner calculation only happens at the right moment.

https://claude.ai/code/session_0118SghNSFLtGZvDsg6Kpz7A