### PR TITLE
Fix TV display showing presentations while voting is still open

### DIFF
--- a/crush_lu/tests/test_api.py
+++ b/crush_lu/tests/test_api.py
@@ -486,6 +486,43 @@ class VotingAPITests(SiteTestMixin, TestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_tv_display_open_voting_wins_over_seeded_queue(self):
+        """TV display stays on 'voting' while voting is open, even if a
+        presentation queue row already exists (regression: it used to jump
+        straight to 'presentations')."""
+        from crush_lu.models import PresentationQueue
+
+        self.client.login(username='voter@example.com', password='testpass123')
+        PresentationQueue.objects.create(
+            event=self.event, user=self.user, presentation_order=1, status="waiting"
+        )
+
+        response = self.client.get(
+            reverse('speed_dating_tv_display_data', args=[self.event.id])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['phase'], 'voting')
+
+    def test_tv_display_shows_presentations_once_voting_closed(self):
+        """When voting is no longer open, an existing queue drives the
+        'presentations' phase."""
+        from crush_lu.models import PresentationQueue
+
+        self.client.login(username='voter@example.com', password='testpass123')
+        PresentationQueue.objects.create(
+            event=self.event, user=self.user, presentation_order=1, status="presenting"
+        )
+        self.voting_session.is_active = False
+        self.voting_session.save()
+
+        response = self.client.get(
+            reverse('speed_dating_tv_display_data', args=[self.event.id])
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['phase'], 'presentations')
+
 
 @override_settings(**CRUSH_LU_URL_SETTINGS)
 class PushNotificationAPITests(SiteTestMixin, TestCase):

--- a/crush_lu/views_voting.py
+++ b/crush_lu/views_voting.py
@@ -862,9 +862,23 @@ def speed_dating_tv_display_data(request, event_id):
     phase = "welcome"
     phase_data: dict = {}
 
-    # Phase 3 — Speed Dating (most advanced phase wins)
+    voting_session = (
+        EventVotingSession.objects.select_related(
+            "winning_presentation_style", "winning_speed_dating_twist"
+        )
+        .filter(event=event)
+        .first()
+    )
+
+    # Resolve the phase from the most-advanced state, with one ordering rule:
+    # an OPEN voting window always wins over a presentation queue. end_voting()
+    # seeds the queue the instant voting ends, and a queue can also be seeded
+    # early by the coach, so checking the queue first would make the TV jump to
+    # "presentations" while attendees are still voting.
     pairs_qs = SpeedDatingPair.objects.filter(event=event)
+
     if pairs_qs.exists():
+        # Phase 3 — Speed Dating (most advanced phase wins)
         phase = "speed_dating"
         agg = pairs_qs.aggregate(max_round=Max("round_number"))
         current_round = agg["max_round"] or 1
@@ -872,114 +886,103 @@ def speed_dating_tv_display_data(request, event_id):
             "current_round": current_round,
             "total_pairs": pairs_qs.filter(round_number=current_round).count(),
         }
-    else:
+    elif voting_session and voting_session.is_voting_open:
+        # Phase 1 — Voting (open window takes precedence over a seeded queue)
+        phase = "voting"
+        pres_votes = (
+            EventActivityVote.objects.filter(
+                event=event,
+                selected_option__activity_type="presentation_style",
+            )
+            .values("selected_option__display_name", "selected_option__activity_variant")
+            .annotate(count=Count("id"))
+            .order_by("-count")
+        )
+        twist_votes = (
+            EventActivityVote.objects.filter(
+                event=event,
+                selected_option__activity_type="speed_dating_twist",
+            )
+            .values("selected_option__display_name", "selected_option__activity_variant")
+            .annotate(count=Count("id"))
+            .order_by("-count")
+        )
+        phase_data = {
+            "total_votes": voting_session.total_votes,
+            "time_remaining": int(voting_session.time_remaining),
+            "presentation_votes": [
+                {
+                    "name": v["selected_option__display_name"],
+                    "variant": v["selected_option__activity_variant"],
+                    "count": v["count"],
+                }
+                for v in pres_votes
+            ],
+            "twist_votes": [
+                {
+                    "name": v["selected_option__display_name"],
+                    "variant": v["selected_option__activity_variant"],
+                    "count": v["count"],
+                }
+                for v in twist_votes
+            ],
+        }
+    elif PresentationQueue.objects.filter(event=event).exists():
         # Phase 2 — Presentations
         # Stay in this phase for the entire lifetime of the PresentationQueue —
         # from the moment end_voting() seeds waiting rows until SpeedDatingPair
         # rows appear. Checking only for un-finished rows would cause the TV to
         # regress to voting/welcome in the handoff window after the last presenter
         # finishes but before the coach creates pairs.
-        queue_exists = PresentationQueue.objects.filter(event=event).exists()
-
-        if queue_exists:
-            phase = "presentations"
-            # Prefer the currently presenting row; fall back to next waiting.
-            # Both can be None when all presentations are done (100 % progress).
-            current_presenter = (
-                PresentationQueue.objects.filter(event=event, status="presenting")
-                .select_related("user__crushprofile")
-                .first()
-            ) or (
-                PresentationQueue.objects.filter(event=event, status="waiting")
-                .select_related("user__crushprofile")
-                .order_by("presentation_order")
-                .first()
+        phase = "presentations"
+        # Prefer the currently presenting row; fall back to next waiting.
+        # Both can be None when all presentations are done (100 % progress).
+        current_presenter = (
+            PresentationQueue.objects.filter(event=event, status="presenting")
+            .select_related("user__crushprofile")
+            .first()
+        ) or (
+            PresentationQueue.objects.filter(event=event, status="waiting")
+            .select_related("user__crushprofile")
+            .order_by("presentation_order")
+            .first()
+        )
+        completed = PresentationQueue.objects.filter(event=event, status="completed").count()
+        total = PresentationQueue.objects.filter(event=event).exclude(status="skipped").count()
+        presenter_name = ""
+        if current_presenter:
+            profile = getattr(current_presenter.user, "crushprofile", None)
+            presenter_name = (
+                (profile.display_name if profile else None)
+                or current_presenter.user.first_name
+                or "Anonymous"
             )
-            completed = PresentationQueue.objects.filter(event=event, status="completed").count()
-            total = PresentationQueue.objects.filter(event=event).exclude(status="skipped").count()
-            presenter_name = ""
-            if current_presenter:
-                profile = getattr(current_presenter.user, "crushprofile", None)
-                presenter_name = (
-                    (profile.display_name if profile else None)
-                    or current_presenter.user.first_name
-                    or "Anonymous"
-                )
+        phase_data = {
+            "presenter_name": presenter_name,
+            "completed_count": completed,
+            "total_count": total,
+            "progress_pct": int(completed / total * 100) if total else 0,
+        }
+    elif voting_session:
+        # Voting window closed and no queue yet; lazily finalize if end_voting()
+        # was never called. Must use end_voting() (not just calculate_winner) to
+        # also mark the session inactive and initialize the presentation queue.
+        if (
+            not voting_session.winning_presentation_style_id
+            and timezone.now() > voting_session.voting_end_time
+        ):
+            voting_session.end_voting()
+        if voting_session.winning_presentation_style_id:
+            phase = "voting_results"
             phase_data = {
-                "presenter_name": presenter_name,
-                "completed_count": completed,
-                "total_count": total,
-                "progress_pct": int(completed / total * 100) if total else 0,
+                "winning_style": voting_session.winning_presentation_style.display_name,
+                "winning_twist": (
+                    voting_session.winning_speed_dating_twist.display_name
+                    if voting_session.winning_speed_dating_twist
+                    else None
+                ),
+                "total_votes": voting_session.total_votes,
             }
-        else:
-            # Phase 1 — Voting
-            try:
-                voting_session = EventVotingSession.objects.select_related(
-                    "winning_presentation_style", "winning_speed_dating_twist"
-                ).get(event=event)
-
-                if voting_session.is_voting_open:
-                    phase = "voting"
-                    pres_votes = (
-                        EventActivityVote.objects.filter(
-                            event=event,
-                            selected_option__activity_type="presentation_style",
-                        )
-                        .values("selected_option__display_name", "selected_option__activity_variant")
-                        .annotate(count=Count("id"))
-                        .order_by("-count")
-                    )
-                    twist_votes = (
-                        EventActivityVote.objects.filter(
-                            event=event,
-                            selected_option__activity_type="speed_dating_twist",
-                        )
-                        .values("selected_option__display_name", "selected_option__activity_variant")
-                        .annotate(count=Count("id"))
-                        .order_by("-count")
-                    )
-                    phase_data = {
-                        "total_votes": voting_session.total_votes,
-                        "time_remaining": int(voting_session.time_remaining),
-                        "presentation_votes": [
-                            {
-                                "name": v["selected_option__display_name"],
-                                "variant": v["selected_option__activity_variant"],
-                                "count": v["count"],
-                            }
-                            for v in pres_votes
-                        ],
-                        "twist_votes": [
-                            {
-                                "name": v["selected_option__display_name"],
-                                "variant": v["selected_option__activity_variant"],
-                                "count": v["count"],
-                            }
-                            for v in twist_votes
-                        ],
-                    }
-                else:
-                    # Voting window closed; lazily finalize if end_voting() was never called.
-                    # Must use end_voting() (not just calculate_winner) to also mark the
-                    # session inactive and initialize the presentation queue.
-                    if (
-                        not voting_session.winning_presentation_style_id
-                        and timezone.now() > voting_session.voting_end_time
-                    ):
-                        voting_session.end_voting()
-                    if voting_session.winning_presentation_style_id:
-                        phase = "voting_results"
-                        phase_data = {
-                            "winning_style": voting_session.winning_presentation_style.display_name,
-                            "winning_twist": (
-                                voting_session.winning_speed_dating_twist.display_name
-                                if voting_session.winning_speed_dating_twist
-                                else None
-                            ),
-                            "total_votes": voting_session.total_votes,
-                        }
-            except EventVotingSession.DoesNotExist:
-                pass
 
     return JsonResponse(
         {


### PR DESCRIPTION
## Summary
- The speed-dating TV display (`/events/<id>/tv/`) was jumping straight to the **presentations** screen while voting was still open, as seen on `https://test.crush.lu/fr/events/19/tv/`.
- Root cause: `speed_dating_tv_display_data` resolved the phase by checking for a `PresentationQueue` **before** checking whether voting was open. A queue is seeded the instant `end_voting()` runs (and can also be seeded early by a coach), so the display skipped past the live-voting screen.
- Fix: reorder phase resolution so an **open voting window wins over a seeded queue**, while keeping `speed_dating` (pairs) as the most-advanced phase and preserving the `presentations` → `voting_results` ordering once voting has closed.

New phase priority in `speed_dating_tv_display_data`:
1. `speed_dating` — any `SpeedDatingPair` exists
2. `voting` — voting session exists **and** is currently open
3. `presentations` — a `PresentationQueue` exists
4. `voting_results` — voting closed and finalized
5. `welcome` — default

## Test plan
- [ ] `test_tv_display_open_voting_wins_over_seeded_queue` — open voting + existing queue → phase `voting`
- [ ] `test_tv_display_shows_presentations_once_voting_closed` — closed voting + queue → phase `presentations`
- [ ] Verify on `https://test.crush.lu/fr/events/19/tv/` that the display shows the live voting screen until voting actually ends

Note: tests were added but could not be executed locally (this environment runs Python 3.11, project requires Django 6.0 / Python 3.12) — relying on CI to run them.

https://claude.ai/code/session_01T1ea3yd9qNvuzt5qijZT1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1ea3yd9qNvuzt5qijZT1c)_