### PR TITLE
Fix Crush Connect onboarding interest picker under CSP-friendly Alpine

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -13100,23 +13100,6 @@ document.addEventListener("alpine:init", function () {
         };
     });
 
-    // Reusable textarea character counter. CSP-friendly (the Alpine CSP build
-    // forbids inline expressions like `count = $event.target.value.length`):
-    // wrap a single <textarea> and bind `@input="update"` + `x-text="count"`.
-    Alpine.data("charCounter", function () {
-        return {
-            count: 0,
-            init: function () {
-                var ta = this.$el.querySelector("textarea");
-                this.count = ta ? ta.value.length : 0;
-            },
-            update: function () {
-                var ta = this.$el.querySelector("textarea");
-                this.count = ta ? ta.value.length : 0;
-            },
-        };
-    });
-
     // Auto-redirect countdown shown on the profile-approved state of profile_submitted.html.
     // Reads the destination URL from data-dashboard-url to stay language-prefix–safe.
     Alpine.data("approvedCountdown", () => ({

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -13048,6 +13048,7 @@ document.addEventListener("alpine:init", function () {
         return {
             interestMax: 8,
             interestCount: 0,
+            storyCount: 0,
             _showSecondStory: false,
 
             get showSecondStory() {
@@ -13056,26 +13057,62 @@ document.addEventListener("alpine:init", function () {
             get notShowSecondStory() {
                 return !this._showSecondStory;
             },
-            get atInterestCap() {
-                return this.interestCount >= this.interestMax;
-            },
 
             init: function () {
-                // Pre-checked interests (back-edit / validation re-render).
-                this.interestCount = this.$el.querySelectorAll(
-                    'input[name="interests"]:checked',
-                ).length;
+                // Interests (step 3): count pre-checked boxes and enforce the
+                // cap by toggling `disabled` imperatively. The CSP-friendly
+                // Alpine build forbids expressions (e.g. "atCap && !checked")
+                // inside x-bind:disabled, so the cap is handled here in JS.
+                this._syncInterests();
+                // Story answer (step 7): seed the character counter from the
+                // server-rendered value.
+                var ta = this.$el.querySelector('textarea[name="story_answer"]');
+                this.storyCount = ta ? ta.value.length : 0;
                 this._showSecondStory =
                     this.$el.getAttribute("data-show-second-story") === "true";
             },
 
             onInterestChange: function () {
-                this.interestCount = this.$el.querySelectorAll(
-                    'input[name="interests"]:checked',
-                ).length;
+                this._syncInterests();
             },
+
+            _syncInterests: function () {
+                var boxes = this.$el.querySelectorAll('input[name="interests"]');
+                var checked = 0;
+                boxes.forEach(function (b) {
+                    if (b.checked) checked++;
+                });
+                this.interestCount = checked;
+                var atCap = checked >= this.interestMax;
+                boxes.forEach(function (b) {
+                    b.disabled = atCap && !b.checked;
+                });
+            },
+
+            onStoryInput: function () {
+                var ta = this.$el.querySelector('textarea[name="story_answer"]');
+                this.storyCount = ta ? ta.value.length : 0;
+            },
+
             toggleSecondStory: function () {
                 this._showSecondStory = !this._showSecondStory;
+            },
+        };
+    });
+
+    // Reusable textarea character counter. CSP-friendly (the Alpine CSP build
+    // forbids inline expressions like `count = $event.target.value.length`):
+    // wrap a single <textarea> and bind `@input="update"` + `x-text="count"`.
+    Alpine.data("charCounter", function () {
+        return {
+            count: 0,
+            init: function () {
+                var ta = this.$el.querySelector("textarea");
+                this.count = ta ? ta.value.length : 0;
+            },
+            update: function () {
+                var ta = this.$el.querySelector("textarea");
+                this.count = ta ? ta.value.length : 0;
             },
         };
     });

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step3_languages.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step3_languages.html
@@ -43,7 +43,6 @@
                 <label class="cursor-pointer block">
                     <input type="checkbox" name="interests" value="{{ interest.pk }}" class="peer hidden"
                            @change="onInterestChange"
-                           x-bind:disabled="atInterestCap && !$el.checked"
                            {% if interest.pk in selected_interest_ids %}checked{% endif %}>
                     <span class="inline-block px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all duration-200
                                  border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step7_story.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step7_story.html
@@ -32,13 +32,13 @@
     {# Story answer #}
     <div>
         <label for="{{ form.story_answer.id_for_label }}" class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">{{ form.story_answer.label }}</label>
-        <div x-data="{ count: '{{ form.story_answer.value|default_if_none:'' }}'.length }">
+        <div>
             <textarea name="{{ form.story_answer.name }}" id="{{ form.story_answer.id_for_label }}" rows="3" maxlength="200"
                       placeholder="{% trans 'Keep it human — one sentence the right kind of person will recognise.' %}"
-                      class="input-crush w-full" x-on:input="count = $event.target.value.length">{{ form.story_answer.value|default_if_none:'' }}</textarea>
+                      class="input-crush w-full" @input="onStoryInput">{{ form.story_answer.value|default_if_none:'' }}</textarea>
             <div class="mt-1 flex items-center justify-between text-xs">
                 <span class="text-gray-400 dark:text-gray-500">{% trans "You can edit this anytime from your Connect profile." %}</span>
-                <span class="text-gray-400 dark:text-gray-500"><span x-text="count"></span>/200</span>
+                <span class="text-gray-400 dark:text-gray-500"><span x-text="storyCount"></span>/200</span>
             </div>
         </div>
         {% if form.story_answer.errors %}<p class="text-sm text-red-600 dark:text-red-400 mt-1">{{ form.story_answer.errors|join:" " }}</p>{% endif %}

--- a/crush_lu/templates/crush_lu/crush_connect/spark_compose.html
+++ b/crush_lu/templates/crush_lu/crush_connect/spark_compose.html
@@ -29,7 +29,7 @@
             <label for="spark-message" class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
                 {% trans "What made you curious? (optional)" %}
             </label>
-            <div x-data="charCounter">
+            <div x-data="charCounter" data-max-length="200">
                 <textarea
                     name="message"
                     id="spark-message"
@@ -37,10 +37,10 @@
                     maxlength="200"
                     placeholder="{% trans 'One honest line — it goes a long way.' %}"
                     class="input-crush w-full"
-                    @input="update"
+                    @input="updateCount"
                 ></textarea>
                 <div class="mt-1 text-right text-xs text-gray-400 dark:text-gray-500">
-                    <span x-text="count"></span>/200
+                    <span x-text="charDisplay"></span>
                 </div>
             </div>
         </div>

--- a/crush_lu/templates/crush_lu/crush_connect/spark_compose.html
+++ b/crush_lu/templates/crush_lu/crush_connect/spark_compose.html
@@ -29,7 +29,7 @@
             <label for="spark-message" class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">
                 {% trans "What made you curious? (optional)" %}
             </label>
-            <div x-data="{ count: 0 }">
+            <div x-data="charCounter">
                 <textarea
                     name="message"
                     id="spark-message"
@@ -37,7 +37,7 @@
                     maxlength="200"
                     placeholder="{% trans 'One honest line — it goes a long way.' %}"
                     class="input-crush w-full"
-                    x-on:input="count = $event.target.value.length"
+                    @input="update"
                 ></textarea>
                 <div class="mt-1 text-right text-xs text-gray-400 dark:text-gray-500">
                     <span x-text="count"></span>/200


### PR DESCRIPTION
## Purpose

Bugfix follow-up to #491. On onboarding **step 3** (`/…/crush-connect/onboarding/3/`) the **Interests & hobbies** chips could not be clicked.

## Root cause

The site loads Alpine's **CSP-friendly build**, which rejects arbitrary JS expressions in directives. The interest checkboxes used:

```html
x-bind:disabled="atInterestCap && !$el.checked"
```

That expression (`&&`, `!`, `$el.checked`) is rejected, Alpine throws, and the inputs are left `disabled="disabled"` — so the chips are unclickable. (The language chips above use pure-CSS `peer-checked`, which is why only the interests were affected.)

Console signature:
```
Alpine Error: Alpine is unable to interpret the following expression using the
CSP-friendly build: "atInterestCap && !$el.checked"
```

## Fix

Keep templates to property/method references only (the pattern the existing `ageRangeSlider`/`traitSelector` components already follow):

- **Interest picker (step 3):** removed the `x-bind:disabled` expression. The 8-item cap is now enforced imperatively in the `connectOnboarding` component (`_syncInterests()` toggles `disabled` on unchecked boxes once 8 are selected). Server-side `clean_interests` (1–8) is unchanged, so the cap holds even without JS.
- **Story counter (step 7):** replaced inline `x-data="{ count … }"` + `count = $event…` with `@input="onStoryInput"` + `x-text="storyCount"`.
- **Spark compose page (`spark_compose.html`):** the pre-existing counter had the identical CSP-incompatible inline binding (its character count was also silently broken in production). Switched it to a small reusable, CSP-safe `charCounter` component.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
```

## How to Test
- Run tests:
  ```
  pytest crush_lu/tests/test_crush_connect_onboarding.py -v
  pytest crush_lu/tests/test_crush_connect.py -k spark -v
  ```
- Manual: open `/en/crush-connect/onboarding/3/`, confirm interest chips toggle, the `n/8` counter updates, and selecting an 8th disables the remaining unchecked chips. Confirm no Alpine CSP errors in the console.

## Notes
- Static-file change (`alpine-components.js`) → the deploy must run `collectstatic` (and cache-bust) for the updated JS to be served.

https://claude.ai/code/session_01SZs2vLgQMdYZJUamCVA6mN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZs2vLgQMdYZJUamCVA6mN)_