### PR TITLE
Surface Crush Connect profile-edit link in nav + Today's Drop

### DIFF
--- a/crush_lu/templates/crush_lu/base.html
+++ b/crush_lu/templates/crush_lu/base.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load analytics %}
 {% load seo_tags %}
+{% load crush_connect_tags %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:'en' }}">
 <head>
@@ -398,6 +399,12 @@
                                             {% trans "Ideal Crush" %}
                                             <span class="inline-block rounded-full bg-crush-pink px-1.5 py-0.5 text-[10px] font-bold text-white uppercase leading-none ml-1">{% trans "New" %}</span>
                                         </a>
+                                        {% if user|crush_connect_nav_visible %}
+                                        <a class="dropdown-item" href="{% url 'crush_lu:crush_connect_profile_edit' %}">
+                                            {% include "shared/icons/pencil.html" with class="w-4 h-4 inline mr-2" %}
+                                            {% trans "Edit your Connect profile" %}
+                                        </a>
+                                        {% endif %}
                                         {% elif profile_completion_status == 'incomplete' %}
                                         <a class="dropdown-item" href="{% url 'crush_lu:create_profile' %}">
                                             {% include "shared/icons/arrow-path.html" with class="w-4 h-4 inline mr-2" %}
@@ -662,6 +669,12 @@
                                             {% trans "Ideal Crush" %}
                                             <span class="inline-block rounded-full bg-crush-pink px-1.5 py-0.5 text-[10px] font-bold text-white uppercase leading-none ml-1">{% trans "New" %}</span>
                                         </a>
+                                        {% if user|crush_connect_nav_visible %}
+                                        <a class="dropdown-item" href="{% url 'crush_lu:crush_connect_profile_edit' %}">
+                                            {% include "shared/icons/pencil.html" with class="w-4 h-4 inline mr-2" %}
+                                            {% trans "Edit your Connect profile" %}
+                                        </a>
+                                        {% endif %}
                                         {% elif profile_completion_status == 'incomplete' %}
                                         <a class="dropdown-item" href="{% url 'crush_lu:create_profile' %}">
                                             {% include "shared/icons/arrow-path.html" with class="w-4 h-4 inline mr-2" %}
@@ -902,6 +915,12 @@
                                     {% trans "Ideal Crush" %}
                                     <span class="inline-block rounded-full bg-crush-pink px-1.5 py-0.5 text-[10px] font-bold text-white uppercase leading-none ml-1">{% trans "New" %}</span>
                                 </a>
+                                {% if user|crush_connect_nav_visible %}
+                                <a class="nav-link block" href="{% url 'crush_lu:crush_connect_profile_edit' %}">
+                                    {% include "shared/icons/pencil.html" with class="w-4 h-4 inline mr-2" %}
+                                    {% trans "Edit your Connect profile" %}
+                                </a>
+                                {% endif %}
                                 {% elif profile_completion_status == 'incomplete' %}
                                 <a class="nav-link block" href="{% url 'crush_lu:create_profile' %}">
                                     {% include "shared/icons/arrow-path.html" with class="w-4 h-4 inline mr-2" %}
@@ -972,6 +991,12 @@
                                     {% trans "Ideal Crush" %}
                                     <span class="inline-block rounded-full bg-crush-pink px-1.5 py-0.5 text-[10px] font-bold text-white uppercase leading-none ml-1">{% trans "New" %}</span>
                                 </a>
+                                {% if user|crush_connect_nav_visible %}
+                                <a class="nav-link block" href="{% url 'crush_lu:crush_connect_profile_edit' %}">
+                                    {% include "shared/icons/pencil.html" with class="w-4 h-4 inline mr-2" %}
+                                    {% trans "Edit your Connect profile" %}
+                                </a>
+                                {% endif %}
 
                             {% elif profile_status == 'pending' %}
                                 {# PENDING REVIEW: Status + browse events #}

--- a/crush_lu/templates/crush_lu/crush_connect/home.html
+++ b/crush_lu/templates/crush_lu/crush_connect/home.html
@@ -32,6 +32,11 @@
                 {{ count }} people, hand-picked for you this week. Take a moment with each — your next Drop arrives next week.
             {% endblocktrans %}
         </p>
+        <p class="mt-3">
+            <a href="{% url 'crush_lu:crush_connect_profile_edit' %}" class="text-sm font-medium text-crush-purple dark:text-crush-pink hover:underline">
+                {% trans "Edit your Connect profile" %} →
+            </a>
+        </p>
     </header>
 
     {# Cards stack #}

--- a/crush_lu/tests/test_crush_connect_onboarding.py
+++ b/crush_lu/tests/test_crush_connect_onboarding.py
@@ -693,3 +693,37 @@ def test_admin_pages_load(client):
     assert client.get(
         f"/crush-admin/crush_lu/crushconnectmembership/{m.pk}/change/"
     ).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Edit-page discoverability (links into crush_connect_profile_edit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_today_drop_shows_edit_profile_link(client, settings):
+    """Premium (receiver) members land on Today's Drop — it must link to the
+    Connect profile editor (the gap this change closes)."""
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    me = _make_user(username="me", preferred_genders=["F"], onboarded=True)
+    _mark_attended(me)
+    _seed_pool_for(me, n=3)
+    _login_eligible(client, me)
+
+    resp = client.get("/en/crush-connect/today/")
+    assert resp.status_code == 200
+    assert "/crush-connect/profile/" in resp.content.decode()
+
+
+@pytest.mark.django_db
+def test_nav_edit_link_gated_on_onboarded(settings):
+    """The nav 'Edit your Connect profile' item is gated by
+    crush_connect_nav_visible — shown to onboarded members, hidden otherwise."""
+    from crush_lu.templatetags.crush_connect_tags import crush_connect_nav_visible
+
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    onboarded = _make_user(username="on", onboarded=True)
+    not_onboarded = _make_user(username="off", onboarded=False)
+
+    assert crush_connect_nav_visible(onboarded) is True
+    assert crush_connect_nav_visible(not_onboarded) is False


### PR DESCRIPTION
## Purpose

Follow-up to the Crush Connect onboarding work. The profile editor at `/crush-connect/profile/` (`crush_connect_profile_edit`) already exists and is server-gated on `membership.is_onboarded`, but it was only linked from **one** place — the candidate `catalogue_status.html`. **Premium (receiver) members land on Today's Drop, which had no link**, and there was no entry point in the global navigation, so most members couldn't find where to edit their Connect answers.

This adds the missing links. No view/model/URL/migration changes.

## Changes
- **`crush_connect/home.html`** (Today's Drop): an "Edit your Connect profile" link in the hero header.
- **`base.html`**: the same item added to the desktop "My Crush" dropdown, the account dropdown, and both mobile nav sections — each gated by `{% if user|crush_connect_nav_visible %}` so it shows only to onboarded members (the filter also handles the launch flag + staff bypass; it's the same one `bottom_nav.html` already uses).
- Reuses the **already-translated** `{% trans "Edit your Connect profile" %}` string (zero new i18n) and the existing `dropdown-item` + `pencil` icon pattern next to "Edit Profile" / "Ideal Crush".

`catalogue_status.html` already had the link and is unchanged — both onboarding tracks now have an in-page path, plus a persistent nav entry.

## Does this introduce a breaking change?
```
[x] No
```

## Pull Request Type
```
[x] Feature (UI/navigation)
```

## How to Test
- `pytest crush_lu/tests/test_crush_connect_onboarding.py -m "not playwright"`
- Manual (onboarded member, `CRUSH_CONNECT_LAUNCHED` on):
  - `/en/crush-connect/today/` shows the link → click → `/crush-connect/profile/` renders.
  - Desktop "My Crush"/account dropdowns and the mobile menu show "Edit your Connect profile"; a not-yet-onboarded user does not see it.

## Tests added
- `test_today_drop_shows_edit_profile_link` — Today's Drop links to the editor.
- `test_nav_edit_link_gated_on_onboarded` — `crush_connect_nav_visible` gates the nav item (true for onboarded, false otherwise).

https://claude.ai/code/session_01SZs2vLgQMdYZJUamCVA6mN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZs2vLgQMdYZJUamCVA6mN)_