### PR TITLE
Crush.lu: fix leaked template comments + design-review polish

### DIFF
--- a/crush_lu/management/commands/capture_screenshots.py
+++ b/crush_lu/management/commands/capture_screenshots.py
@@ -69,11 +69,15 @@ VIEWPORTS = {
 #   "member"     -> approved + consented member
 #   "onboarding" -> pre-submission user (steps 1-4, incl. the create-profile
 #                   builder form, which only renders before a profile is submitted)
-#   "review"     -> post-submission user whose profile is under coach review
-#                   (renders meet-coach / screening-call / profile-submitted)
+#   "verify"     -> finished profile, awaiting verification via the default path
+#                   (event/LuxID) with no submission -> the "get verified" state
+#                   that ends the normal onboarding flow
+#   "review"     -> Premium coach path only: post-submission user under coach
+#                   review (meet-coach / screening-call / profile-submitted)
 ANON = None
 MEMBER = "member"
 ONBOARDING = "onboarding"
+VERIFY = "verify"
 REVIEW = "review"
 # Staff user with an onboarded Crush Connect membership. Crush Connect gates
 # every page behind beta enrolment, but staff bypass the gates "to preview the
@@ -124,18 +128,23 @@ PAGES = [
     ("Onboarding", "onboarding-phone", "/onboarding/phone/", ONBOARDING),
     ("Onboarding", "onboarding-coach-intro", "/onboarding/coach-intro/", ONBOARDING),
     ("Onboarding", "create-profile", "/create-profile/", ONBOARDING),
-    # ── Coach review (post-submission user) ────────────────────────────────
-    ("Review", "onboarding-meet-coach", "/onboarding/meet-coach/", REVIEW),
-    ("Review", "onboarding-screening-call", "/onboarding/screening-call/", REVIEW),
-    ("Review", "profile-submitted", "/profile-submitted/", REVIEW),
+    # The real end of the default flow: profile done, awaiting event/LuxID
+    # verification (no submission → "get verified" state, not coach review).
+    ("Onboarding", "get-verified", "/profile-submitted/", VERIFY),
+    # ── Premium coach path (post-submission user; NOT the default flow) ──────
+    # Coach review only exists on the paid/Premium path. Grouped on its own so
+    # the gallery never presents it as the normal onboarding journey.
+    ("Premium (coach path)", "onboarding-meet-coach", "/onboarding/meet-coach/", REVIEW),
+    ("Premium (coach path)", "onboarding-screening-call", "/onboarding/screening-call/", REVIEW),
+    ("Premium (coach path)", "profile-submitted", "/profile-submitted/", REVIEW),
 ]
 
 # Which named page set maps to which user keys.
 PAGE_SETS = {
     "public": {ANON},
     "member": {MEMBER, CC},
-    "onboarding": {ONBOARDING, REVIEW},
-    "all": {ANON, MEMBER, CC, ONBOARDING, REVIEW},
+    "onboarding": {ONBOARDING, VERIFY, REVIEW},
+    "all": {ANON, MEMBER, CC, ONBOARDING, VERIFY, REVIEW},
 }
 
 # Paths that signal a page bounced us off the requested view.
@@ -218,7 +227,7 @@ class Command(BaseCommand):
         # Safety: the authenticated personas create/promote test users (incl. a
         # staff account) and write to the DB. Only do that against a local
         # target unless explicitly overridden. A public-only run is read-only.
-        needs_writes = bool(wanted_users & {MEMBER, CC, ONBOARDING, REVIEW})
+        needs_writes = bool(wanted_users & {MEMBER, CC, ONBOARDING, VERIFY, REVIEW})
         if (
             needs_writes
             and not options["allow_nonlocal"]
@@ -242,6 +251,8 @@ class Command(BaseCommand):
             sessions[ONBOARDING] = self._session_for(
                 self._ensure_onboarding_user(options["onboarding_user"])
             )
+        if VERIFY in wanted_users:
+            sessions[VERIFY] = self._session_for(self._ensure_verify_user())
         if REVIEW in wanted_users:
             sessions[REVIEW] = self._session_for(self._ensure_review_user())
         if CC in wanted_users:
@@ -277,7 +288,7 @@ class Command(BaseCommand):
                 (run_dir / viewport).mkdir(exist_ok=True)
                 self.stdout.write(self.style.MIGRATE_HEADING(f"\n[{viewport}]"))
                 # Group by user so each session needs only one browser context.
-                for user_key in (ANON, MEMBER, CC, ONBOARDING, REVIEW):
+                for user_key in (ANON, MEMBER, CC, ONBOARDING, VERIFY, REVIEW):
                     group = [pg for pg in pages if pg["user_key"] == user_key]
                     if not group:
                         continue
@@ -504,6 +515,34 @@ class Command(BaseCommand):
 
         self._grant_consent(user)
         self.stdout.write(f"  review user: {user.username}")
+        return user
+
+    def _ensure_verify_user(self):
+        """Default-path user: profile finished, awaiting verification via event
+        or LuxID, with NO ProfileSubmission — so /profile-submitted/ renders the
+        default 'get verified' state (the real end of onboarding) instead of the
+        Premium coach-review branch."""
+        username = "screenshot_verify@crush.lu"
+        user, _ = User.objects.get_or_create(
+            username=username,
+            defaults={"email": username, "first_name": "Screenshot", "last_name": "Verify"},
+        )
+        now = timezone.now()
+        profile, _ = CrushProfile.objects.get_or_create(user=user)
+        profile.welcome_seen_at = profile.welcome_seen_at or now
+        profile.phone_verified = True
+        profile.phone_verified_at = profile.phone_verified_at or now
+        profile.coach_intro_seen_at = profile.coach_intro_seen_at or now
+        # 'pending' (not 'incomplete'/'verified') keeps the user on the verify
+        # step without redirecting; no submission => the default branch.
+        profile.verification_status = "pending"
+        profile.is_active = True
+        profile.is_approved = False
+        profile.save()
+        ProfileSubmission.objects.filter(profile=profile).delete()
+
+        self._grant_consent(user)
+        self.stdout.write(f"  verify user: {user.username}")
         return user
 
     def _grant_consent(self, user):

--- a/crush_lu/templates/crush_lu/_screening_tab_calibration.html
+++ b/crush_lu/templates/crush_lu/_screening_tab_calibration.html
@@ -1,7 +1,5 @@
 {% load i18n %}
-{# Calibration call checklist — 3 sections for Coaches when the user
-   submitted pre-screening. The existing 5-section flow is in
-   _screening_tab.html. #}
+{# Calibration call checklist — 3 sections for Coaches when the user submitted pre-screening. The existing 5-section flow is in _screening_tab.html. #}
 
 <div id="screening-call-section-content">
   {% if submission.review_call_completed %}

--- a/crush_lu/templates/crush_lu/base.html
+++ b/crush_lu/templates/crush_lu/base.html
@@ -516,7 +516,7 @@
                                         {% endif %}
                                         <a class="dropdown-item" href="{% url 'crush_lu:event_list' %}">
                                             {% include "shared/icons/magnifying-glass.html" with class="w-4 h-4 inline mr-2" %}
-                                            {% trans "Browse All Events" %}
+                                            {% trans "Browse Events" %}
                                         </a>
                                     </div>
                                 </div>

--- a/crush_lu/templates/crush_lu/coach_review_profile.html
+++ b/crush_lu/templates/crush_lu/coach_review_profile.html
@@ -36,8 +36,7 @@
     </div>
 
     {% if submission.revision_round and submission.feedback_to_user %}
-    {# Resubmission banner — surfaces prior feedback so the coach reviews
-       against what was previously asked rather than re-reading the profile cold. #}
+    {# Resubmission banner — surfaces prior feedback so the coach reviews against what was previously asked rather than re-reading the profile cold. #}
     <div class="mb-6 bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-400 dark:border-amber-500 rounded-r-lg p-4">
         <div class="flex items-start gap-3">
             {% include "shared/icons/exclamation-triangle.html" with class="w-5 h-5 text-amber-600 dark:text-amber-300 flex-shrink-0 mt-0.5" %}

--- a/crush_lu/templates/crush_lu/crush_connect/_drop_card.html
+++ b/crush_lu/templates/crush_lu/crush_connect/_drop_card.html
@@ -101,10 +101,7 @@ Privacy contract (Crush Connect):
             </div>
         {% endif %}
 
-        {# Tag chips: languages + interests. Prefer the Connect membership data;
-           fall back to the legacy profile fields for migrated members who
-           haven't filled in the new wizard yet. Life/family details never
-           appear on the card. #}
+        {# Tag chips: languages + interests. Prefer the Connect membership data; fall back to the legacy profile fields for migrated members who haven't filled in the new wizard yet. Life/family details never appear on the card. #}
         {% if target_membership.languages or target_membership.interests.all %}
             <div class="flex flex-wrap gap-2 pt-1">
                 {% for lang in target_membership.languages_display %}

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step3_languages.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step3_languages.html
@@ -1,7 +1,5 @@
 {% load i18n %}
-{# Step 3 — Languages & interests. Peer-checked language chips + interest grid
-   with a small Alpine 8-cap counter. Self-contained (works in the wizard and
-   the edit page). selected_languages / selected_interest_ids come from the view. #}
+{# Step 3 — Languages & interests. Peer-checked language chips + interest grid with a small Alpine 8-cap counter. Self-contained (works in the wizard and the edit page). selected_languages / selected_interest_ids come from the view. #}
 <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-sm ring-1 ring-gray-200 dark:ring-slate-700 p-6 md:p-8 space-y-7">
     <div class="text-center">
         <div class="text-4xl mb-2">🗣️</div>

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step4_life.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step4_life.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{# Step 4 — Life basics. Height (optional) + work/education selects + smoking/
-   drinking peer-checked tiles. "prefer_not_say" is a valid, explicit choice. #}
+{# Step 4 — Life basics. Height (optional) + work/education selects + smoking/drinking peer-checked tiles. "prefer_not_say" is a valid, explicit choice. #}
 <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-sm ring-1 ring-gray-200 dark:ring-slate-700 p-6 md:p-8 space-y-6">
     <div class="text-center mb-2">
         <div class="text-4xl mb-2">🧩</div>

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step6_ideal_match.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step6_ideal_match.html
@@ -1,7 +1,5 @@
 {% load i18n %}
-{# Step 6 — Ideal match (the only HARD filters: gender + age). Gender peer-checked
-   tiles + the ageRangeSlider block (from the legacy Ideal Crush slider, bound
-   to the membership/form values). Empty gender selection = open to all. #}
+{# Step 6 — Ideal match (the only HARD filters: gender + age). Gender peer-checked tiles + the ageRangeSlider block (from the legacy Ideal Crush slider, bound to the membership/form values). Empty gender selection = open to all. #}
 <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-sm ring-1 ring-gray-200 dark:ring-slate-700 p-6 md:p-8 space-y-7">
     <div class="text-center">
         <div class="text-4xl mb-2">💘</div>

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step7_story.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_step7_story.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{# Step 7 — Your story. Prompt picker + one-line answer (+ optional second).
-   Consent is shown only in the wizard (hidden/relaxed on the edit page). #}
+{# Step 7 — Your story. Prompt picker + one-line answer (+ optional second). Consent is shown only in the wizard (hidden/relaxed on the edit page). #}
 <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-sm ring-1 ring-gray-200 dark:ring-slate-700 p-6 md:p-8 space-y-7"
      x-data="connectOnboarding"
      data-show-second-story="{% if form.story_answer_2.value %}true{% else %}false{% endif %}">

--- a/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_trait_chips.html
+++ b/crush_lu/templates/crush_lu/crush_connect/onboarding_steps/_trait_chips.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{# Reusable trait chip picker (peer-checked checkboxes, server-validated cap).
-   Params: field_name, choices_qs, selected_ids, heading, hint, field_errors. #}
+{# Reusable trait chip picker (peer-checked checkboxes, server-validated cap). Params: field_name, choices_qs, selected_ids, heading, hint, field_errors. #}
 <div>
     <label class="block text-sm font-semibold text-gray-900 dark:text-white mb-2">{{ heading }}</label>
     <div class="flex flex-wrap gap-1.5">

--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -92,7 +92,7 @@
     </div>
     <div class="flex-1 min-w-0">
         <p class="font-semibold text-indigo-900 dark:text-indigo-200 text-sm mb-0">{% trans "Connect LuxID to join the Crush Connect catalogue" %}</p>
-        <p class="text-indigo-700 dark:text-indigo-400 text-xs mb-0">{% trans "LuxID-verified members can be hand-picked by a Crush Coach as a match for Premium members — free, no subscription needed." %}</p>
+        <p class="text-indigo-800 dark:text-indigo-300 text-xs mb-0">{% trans "LuxID-verified members can be hand-picked by a Crush Coach as a match for Premium members — free, no subscription needed." %}</p>
     </div>
     {% if luxid_connect_url %}
     <a href="{{ luxid_connect_url }}" class="flex-shrink-0 inline-flex items-center gap-1 rounded-lg bg-indigo-600 hover:bg-indigo-700 px-3 py-2 text-xs font-semibold text-white no-underline transition-colors">

--- a/crush_lu/templates/crush_lu/my_events.html
+++ b/crush_lu/templates/crush_lu/my_events.html
@@ -16,7 +16,7 @@
     </div>
     <a href="{% url 'crush_lu:event_list' %}" class="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg text-sm font-medium transition-colors">
         {% include "shared/icons/calendar.html" with class="w-4 h-4" %}
-        {% trans "Browse all events" %}
+        {% trans "Browse Events" %}
     </a>
 </div>
 
@@ -78,7 +78,7 @@
         <p class="text-gray-500 dark:text-gray-400 mb-4">{% trans "Pick a meetup and get on the list." %}</p>
         <a href="{% url 'crush_lu:event_list' %}" class="btn-crush-primary inline-flex items-center gap-2 px-5 py-2.5">
             {% include "shared/icons/calendar.html" with class="w-4 h-4" %}
-            {% trans "Browse events" %}
+            {% trans "Browse Events" %}
         </a>
     </div>
     {% endif %}

--- a/crush_lu/templates/crush_lu/partials/_availability_window_list.html
+++ b/crush_lu/templates/crush_lu/partials/_availability_window_list.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-{# HTMX target: renders the list of availability windows. Swapped in after
-   add/remove POSTs from coach_settings.html. #}
+{# HTMX target: renders the list of availability windows. Swapped in after add/remove POSTs from coach_settings.html. #}
 <ul id="availability-list" class="space-y-2">
     {% for window in availability_windows %}
     <li class="flex flex-wrap items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">

--- a/crush_lu/templates/crush_lu/partials/_products.html
+++ b/crush_lu/templates/crush_lu/partials/_products.html
@@ -64,7 +64,7 @@
         </ul>
 
         <a href="{% url 'crush_lu:event_list' %}" class="inline-flex items-center justify-center gap-1.5 w-full py-2.5 rounded-xl border border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300 text-sm font-semibold hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
-          {% if has_attended_event %}{% trans "Browse more events" %}{% else %}{% trans "Browse events" %}{% endif %}
+          {% if has_attended_event %}{% trans "Browse more events" %}{% else %}{% trans "Browse Events" %}{% endif %}
         </a>
       </div>
     </div>

--- a/crush_lu/templates/crush_lu/partials/_verification_options.html
+++ b/crush_lu/templates/crush_lu/partials/_verification_options.html
@@ -79,7 +79,7 @@
           {% trans "Prefer to meet first? Our team verifies you in person at any event — no LuxID needed, and you start meeting people right away." %}
         </p>
         <a href="{% url 'crush_lu:event_list' %}" class="inline-flex w-full items-center justify-center rounded-lg bg-crush-purple px-4 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-crush-purple/90">
-          {% trans "Browse events" %}
+          {% trans "Browse Events" %}
         </a>
       </div>
 

--- a/crush_lu/templates/crush_lu/partials/_verification_options.html
+++ b/crush_lu/templates/crush_lu/partials/_verification_options.html
@@ -8,8 +8,7 @@
 <div class="flex justify-center px-4 pb-10">
   <div class="w-full max-w-3xl">
     {% if path_locked %}
-    {# A premium path is already chosen — don't re-offer all three (avoids
-       accidentally picking a second coach). Show a single summary instead. #}
+    {# A premium path is already chosen — don't re-offer all three (avoids accidentally picking a second coach). Show a single summary instead. #}
     <div class="mb-4 text-center">
       <h3 class="text-lg font-bold text-gray-900 dark:text-white">
         {% trans "You're on the Premium path" %}

--- a/crush_lu/templates/crush_lu/partials/bottom_nav.html
+++ b/crush_lu/templates/crush_lu/partials/bottom_nav.html
@@ -63,8 +63,7 @@
     </a>
 
     {% if user|crush_connect_nav_visible %}
-    {# Crush Connect tab — opens the Connect hub. Only when launched + onboarded
-       (staff bypass for preview). #}
+    {# Crush Connect tab — opens the Connect hub. Only when launched + onboarded (staff bypass for preview). #}
     <a href="{% url 'crush_lu:crush_connect_hub' %}"
        class="bottom-nav-item"
        x-bind:class="crushConnectActiveClass"

--- a/crush_lu/templates/crush_lu/privacy_policy.html
+++ b/crush_lu/templates/crush_lu/privacy_policy.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="flex justify-center">
-    <div class="w-full max-w-4xl">
+    <div class="w-full max-w-3xl">
         <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20">
             <div class="p-8">
                 <h1 class="text-3xl font-bold dark:text-white mb-4">{% trans "Privacy Policy" %}</h1>

--- a/crush_lu/templates/crush_lu/profile_submitted.html
+++ b/crush_lu/templates/crush_lu/profile_submitted.html
@@ -35,8 +35,7 @@
             <h2 class="mt-4 mb-1 text-xl md:text-2xl font-bold text-gray-900 dark:text-white">{% trans "Your profile is ready — now get verified" %}</h2>
             <p class="text-sm text-gray-500 dark:text-gray-400 mb-8">{% trans "One last step to activate your Crush.lu profile and start meeting real people." %}</p>
 
-            {# If the user already connected LuxID but isn't verified yet, reassure them.
-               (The view lazily verifies + redirects in the normal case, so this is an edge state.) #}
+            {# If the user already connected LuxID but isn't verified yet, reassure them (view lazily verifies + redirects normally; this is an edge state). #}
             {% if not luxid_connect_url %}
             <div class="mb-4 rounded-2xl border border-green-200 dark:border-green-700 bg-green-50 dark:bg-green-900/20 px-6 py-5 text-left">
                 <div class="flex items-center gap-3">
@@ -49,8 +48,7 @@
             </div>
             {% endif %}
 
-            {# Verification options (come to an event / LuxID) plus the Premium
-               teaser are presented by _verification_options.html at the bottom. #}
+            {# Verification options (event / LuxID) plus the Premium teaser are presented by _verification_options.html at the bottom. #}
 
             {% else %}
             {# ═══════════════════════════════════════════════════════════════ #}

--- a/crush_lu/templates/crush_lu/quiz_display.html
+++ b/crush_lu/templates/crush_lu/quiz_display.html
@@ -113,9 +113,7 @@
 
             {# Table grid — rendered imperatively via JS (CSP x-for can't access nested props) #}
             <div class="mx-auto w-full max-w-7xl flex-1 px-6 pb-6">
-                {# minmax(min(360px, 100%), 1fr) lets the card shrink below 360px on narrow viewports
-                   (mobile attendees viewing the projector URL) without producing horizontal overflow,
-                   while still preferring a 360px-wide card on tablet/desktop/projector. #}
+                {# minmax(min(360px, 100%), 1fr) lets the card shrink below 360px on narrow viewports (mobile attendees viewing the projector URL) without producing horizontal overflow, while still preferring a 360px-wide card on tablet/desktop/projector. #}
                 <div x-ref="tablegrid" class="grid gap-5" style="grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr));"></div>
 
                 {# Empty state / Quiz starts soon #}

--- a/crush_lu/templates/crush_lu/terms_of_service.html
+++ b/crush_lu/templates/crush_lu/terms_of_service.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="flex justify-center">
-    <div class="w-full max-w-4xl">
+    <div class="w-full max-w-3xl">
         <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20">
             <div class="p-8">
                 <h1 class="text-3xl font-bold dark:text-white mb-4">{% trans "Terms of Service" %}</h1>


### PR DESCRIPTION
## Summary

Follow-ups from a visual design review of Crush.lu. Two small, low-risk changes (the design-review gallery is not committed — code only):

### 1. Fix leaked multi-line `{# #}` template comments (14 across 13 templates)
Django only strips `{# … #}` comments when both markers are on the **same line**. Several were written across multiple lines, so Django rendered them verbatim — visible gray developer text showed up on `/profile-submitted/` (the "get verified" screen), with the same latent bug in `bottom_nav.html`, the Crush Connect onboarding steps, `coach_review_profile.html`, `quiz_display.html`, and others. Each is collapsed to a single line; a repo-wide scan now finds zero.

### 2. Design-review quick wins + screenshot-tool reframing
- **CTA copy:** unify the "Browse Events" button label (was "Browse All Events" / "Browse all events" / "Browse events"), consolidated onto the existing translated string so de/fr stay intact.
- **Legal pages:** constrain Privacy Policy and Terms of Service prose to `max-w-3xl` (matching Data Deletion) for a comfortable desktop reading measure.
- **Dashboard:** darken the LuxID catalogue helper text one step.
- **`capture_screenshots`:** add a `verify` persona that captures the real default step-5 "get verified" screen (no submission), and move `meet-coach` / `screening-call` / coach-review `profile-submitted` into a **"Premium (coach path)"** section so the gallery no longer presents the Premium-only coach review as the default onboarding flow.

## Test plan
- `capture_screenshots --pages onboarding` re-run: **0 flagged**; `/profile-submitted/` renders with no leaked comment text; new `Onboarding › get-verified` screen renders the default state.
- Repo-wide scan for multi-line `{# … #}` comments returns no matches.
- Legal-page widths and the unified CTA confirmed in a desktop re-capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)