### PR TITLE
Crush profile stats: granular 5-year age bands up to 60+ (#190)

### DIFF
--- a/crush_lu/admin/filters.py
+++ b/crush_lu/admin/filters.py
@@ -146,51 +146,39 @@ class PhoneVerificationFilter(admin.SimpleListFilter):
 
 
 class AgeRangeFilter(admin.SimpleListFilter):
-    """Filter profiles by age range"""
+    """Filter profiles by age range (5-year bands, only 60+ grouped)."""
     title = 'Age Range'
     parameter_name = 'age_range'
 
+    # value -> (min_age, max_age); max_age None means open-ended (60+)
+    RANGES = {
+        '18-24': (18, 24),
+        '25-29': (25, 29),
+        '30-34': (30, 34),
+        '35-39': (35, 39),
+        '40-44': (40, 44),
+        '45-49': (45, 49),
+        '50-54': (50, 54),
+        '55-59': (55, 59),
+        '60+': (60, None),
+    }
+
     def lookups(self, request, model_admin):
-        return (
-            ('18-24', '18-24 years'),
-            ('25-29', '25-29 years'),
-            ('30-34', '30-34 years'),
-            ('35-39', '35-39 years'),
-            ('40-49', '40-49 years'),
-            ('50+', '50+ years'),
-        )
+        return tuple((value, f'{value} years') for value in self.RANGES)
 
     def queryset(self, request, queryset):
-        if not self.value():
+        if not self.value() or self.value() not in self.RANGES:
             return queryset
 
         today = date.today()
+        min_age, max_age = self.RANGES[self.value()]
 
-        if self.value() == '18-24':
-            max_birth = date(today.year - 18, today.month, today.day)
-            min_birth = date(today.year - 25, today.month, today.day)
-        elif self.value() == '25-29':
-            max_birth = date(today.year - 25, today.month, today.day)
-            min_birth = date(today.year - 30, today.month, today.day)
-        elif self.value() == '30-34':
-            max_birth = date(today.year - 30, today.month, today.day)
-            min_birth = date(today.year - 35, today.month, today.day)
-        elif self.value() == '35-39':
-            max_birth = date(today.year - 35, today.month, today.day)
-            min_birth = date(today.year - 40, today.month, today.day)
-        elif self.value() == '40-49':
-            max_birth = date(today.year - 40, today.month, today.day)
-            min_birth = date(today.year - 50, today.month, today.day)
-        elif self.value() == '50+':
-            max_birth = date(today.year - 50, today.month, today.day)
-            min_birth = date(today.year - 100, today.month, today.day)
-        else:
-            return queryset
-
-        return queryset.filter(
-            date_of_birth__gt=min_birth,
-            date_of_birth__lte=max_birth
-        )
+        max_birth = date(today.year - min_age, today.month, today.day)
+        queryset = queryset.filter(date_of_birth__lte=max_birth)
+        if max_age is not None:
+            min_birth = date(today.year - max_age - 1, today.month, today.day)
+            queryset = queryset.filter(date_of_birth__gt=min_birth)
+        return queryset
 
 
 class LastLoginFilter(admin.SimpleListFilter):

--- a/crush_lu/admin/newsletter.py
+++ b/crush_lu/admin/newsletter.py
@@ -86,7 +86,23 @@ class NewsletterAdminForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         segment_field = self.fields.get('segment_key')
         if segment_field:
-            segment_field.widget = forms.Select(choices=_get_segment_choices())
+            choices = _get_segment_choices()
+            # Preserve a stored segment_key that the current definitions no
+            # longer offer (e.g. a segment that was split or retired) so an
+            # existing draft stays editable and keeps its target instead of
+            # tripping the "must select a segment" validation on save.
+            current = getattr(self.instance, 'segment_key', '') or ''
+            known = set()
+            for value, label in choices:
+                if isinstance(label, (list, tuple)):
+                    known.update(key for key, _ in label)
+                else:
+                    known.add(value)
+            if current and current not in known:
+                choices.append(
+                    ('Retired', [(current, f'{current} (retired segment)')])
+                )
+            segment_field.widget = forms.Select(choices=choices)
             segment_field.help_text = (
                 'Only used when audience is "Specific user segment".'
             )

--- a/crush_lu/admin/user_segments.py
+++ b/crush_lu/admin/user_segments.py
@@ -109,13 +109,17 @@ def get_demographic_stats():
             else 0
         )
 
-    # Age range distribution (using helper)
+    # Age range distribution (using helper). 5-year bands, only 60+ grouped.
     age_ranges = [
         ("18-24", 18, 24),
         ("25-29", 25, 29),
         ("30-34", 30, 34),
         ("35-39", 35, 39),
-        ("40+", 40, None),
+        ("40-44", 40, 44),
+        ("45-49", 45, 49),
+        ("50-54", 50, 54),
+        ("55-59", 55, 59),
+        ("60+", 60, None),
     ]
     age_dist = []
     profiles_with_dob = active_profiles.exclude(date_of_birth__isnull=True)
@@ -139,7 +143,11 @@ def get_demographic_stats():
         ("25-29", 25, 29),
         ("30-34", 30, 34),
         ("35-39", 35, 39),
-        ("40+", 40, None),
+        ("40-44", 40, 44),
+        ("45-49", 45, 49),
+        ("50-54", 50, 54),
+        ("55-59", 55, 59),
+        ("60+", 60, None),
     ]
     gender_age_matrix = []
     for gender_code, gender_label in matrix_genders:
@@ -292,7 +300,11 @@ def get_segment_definitions():
     age_25_29 = _age_range_queryset(active, 25, 29)
     age_30_34 = _age_range_queryset(active, 30, 34)
     age_35_39 = _age_range_queryset(active, 35, 39)
-    age_40_plus = _age_range_queryset(active, 40)
+    age_40_44 = _age_range_queryset(active, 40, 44)
+    age_45_49 = _age_range_queryset(active, 45, 49)
+    age_50_54 = _age_range_queryset(active, 50, 54)
+    age_55_59 = _age_range_queryset(active, 55, 59)
+    age_60_plus = _age_range_queryset(active, 60)
 
     # Gender x Age cross-segments (approved profiles, wider bands)
     gender_m_age_18_24 = _age_range_queryset(approved.filter(gender="M"), 18, 24)
@@ -663,11 +675,43 @@ def get_segment_definitions():
                     "color": "orange",
                 },
                 {
-                    "name": "Age 40+",
-                    "key": "age_40_plus",
-                    "description": "Active profiles aged 40 and over",
-                    "queryset": age_40_plus,
-                    "count": age_40_plus.count(),
+                    "name": "Age 40-44",
+                    "key": "age_40_44",
+                    "description": "Active profiles aged 40-44",
+                    "queryset": age_40_44,
+                    "count": age_40_44.count(),
+                    "color": "orange",
+                },
+                {
+                    "name": "Age 45-49",
+                    "key": "age_45_49",
+                    "description": "Active profiles aged 45-49",
+                    "queryset": age_45_49,
+                    "count": age_45_49.count(),
+                    "color": "red",
+                },
+                {
+                    "name": "Age 50-54",
+                    "key": "age_50_54",
+                    "description": "Active profiles aged 50-54",
+                    "queryset": age_50_54,
+                    "count": age_50_54.count(),
+                    "color": "red",
+                },
+                {
+                    "name": "Age 55-59",
+                    "key": "age_55_59",
+                    "description": "Active profiles aged 55-59",
+                    "queryset": age_55_59,
+                    "count": age_55_59.count(),
+                    "color": "red",
+                },
+                {
+                    "name": "Age 60+",
+                    "key": "age_60_plus",
+                    "description": "Active profiles aged 60 and over",
+                    "queryset": age_60_plus,
+                    "count": age_60_plus.count(),
                     "color": "red",
                 },
             ],
@@ -1093,11 +1137,14 @@ def user_segments_dashboard(request):
     today = date.today()
     age_ranges = [
         {"label": "18-24", "min": 18, "max": 24},
-        {"label": "25-30", "min": 25, "max": 30},
-        {"label": "31-35", "min": 31, "max": 35},
-        {"label": "36-40", "min": 36, "max": 40},
-        {"label": "41-50", "min": 41, "max": 50},
-        {"label": "50+", "min": 51, "max": 999},
+        {"label": "25-29", "min": 25, "max": 29},
+        {"label": "30-34", "min": 30, "max": 34},
+        {"label": "35-39", "min": 35, "max": 39},
+        {"label": "40-44", "min": 40, "max": 44},
+        {"label": "45-49", "min": 45, "max": 49},
+        {"label": "50-54", "min": 50, "max": 54},
+        {"label": "55-59", "min": 55, "max": 59},
+        {"label": "60+", "min": 60, "max": 999},
     ]
     age_lang_matrix = [
         {"label": ar["label"], "cells": [0] * len(lang_codes), "total": 0}

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -744,8 +744,16 @@ class CrushProfile(models.Model):
             return "30-34"
         elif age < 40:
             return "35-39"
+        elif age < 45:
+            return "40-44"
+        elif age < 50:
+            return "45-49"
+        elif age < 55:
+            return "50-54"
+        elif age < 60:
+            return "55-59"
         else:
-            return "40+"
+            return "60+"
 
     def get_age_range(self):
         """Method version of age_range for templates"""

--- a/crush_lu/newsletter_service.py
+++ b/crush_lu/newsletter_service.py
@@ -109,12 +109,28 @@ def get_newsletter_recipients(newsletter):
     return users.distinct()
 
 
+# Segment keys retired when their bucket was split into finer segments.
+# Existing newsletters may still reference the old key, so we expand it to
+# the union of the current keys it became (issue #190: age 40+ -> 5 bands).
+LEGACY_SEGMENT_ALIASES = {
+    "age_40_plus": (
+        "age_40_44",
+        "age_45_49",
+        "age_50_54",
+        "age_55_59",
+        "age_60_plus",
+    ),
+}
+
+
 def _get_segment_users(segment_key):
     """
     Resolve a segment key to a User queryset.
 
     Uses get_segment_definitions() from user_segments.py to find the queryset,
-    then maps profile/activity querysets to User objects.
+    then maps profile/activity querysets to User objects. Retired keys are
+    resolved via LEGACY_SEGMENT_ALIASES so older newsletters still reach
+    recipients.
     """
     from .admin.user_segments import get_segment_definitions
 
@@ -148,6 +164,13 @@ def _get_segment_users(segment_key):
                         f"'{model_name}' has no user mapping"
                     )
                     return User.objects.none()
+
+    alias_keys = LEGACY_SEGMENT_ALIASES.get(segment_key)
+    if alias_keys:
+        users = User.objects.none()
+        for alias_key in alias_keys:
+            users = users | _get_segment_users(alias_key)
+        return users.distinct()
 
     logger.error(f"Segment key not found: {segment_key}")
     return User.objects.none()

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -125,61 +125,28 @@ def coach_dashboard(request):
             "date_of_birth", "gender"
         )
     )
+    # 5-year age bands with only 60+ grouped together (see issue #190).
     age_buckets = [
         {
-            "label": "18-24",
-            "min": 18,
-            "max": 24,
+            "label": label,
+            "min": lo,
+            "max": hi,
             "count": 0,
             "count_f": 0,
             "count_m": 0,
             "count_other": 0,
-        },
-        {
-            "label": "25-30",
-            "min": 25,
-            "max": 30,
-            "count": 0,
-            "count_f": 0,
-            "count_m": 0,
-            "count_other": 0,
-        },
-        {
-            "label": "31-35",
-            "min": 31,
-            "max": 35,
-            "count": 0,
-            "count_f": 0,
-            "count_m": 0,
-            "count_other": 0,
-        },
-        {
-            "label": "36-40",
-            "min": 36,
-            "max": 40,
-            "count": 0,
-            "count_f": 0,
-            "count_m": 0,
-            "count_other": 0,
-        },
-        {
-            "label": "41-50",
-            "min": 41,
-            "max": 50,
-            "count": 0,
-            "count_f": 0,
-            "count_m": 0,
-            "count_other": 0,
-        },
-        {
-            "label": "50+",
-            "min": 51,
-            "max": 999,
-            "count": 0,
-            "count_f": 0,
-            "count_m": 0,
-            "count_other": 0,
-        },
+        }
+        for label, lo, hi in [
+            ("18-24", 18, 24),
+            ("25-29", 25, 29),
+            ("30-34", 30, 34),
+            ("35-39", 35, 39),
+            ("40-44", 40, 44),
+            ("45-49", 45, 49),
+            ("50-54", 50, 54),
+            ("55-59", 55, 59),
+            ("60+", 60, 999),
+        ]
     ]
     for dob, gender in dob_gender_list:
         age = today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))


### PR DESCRIPTION
## Summary

Closes #190. The age statistics on Crush Profiles previously collapsed everyone over **40** (admin) or **50** (coach dashboard) into a single bucket, hiding the older end of the member base. This expands the banding to consistent **5-year bands with only 60+ grouped**:

`18-24 · 25-29 · 30-34 · 35-39 · 40-44 · 45-49 · 50-54 · 55-59 · 60+`

## Changes

Applied to every age-banding surface so the numbers match across the app:

| File | What changed |
|---|---|
| `crush_lu/views_coach.py` | Coach dashboard age distribution + age × language matrix (was 50+) |
| `crush_lu/admin/user_segments.py` | Admin demographics distribution, gender × age matrix, age × language matrix, and the clickable age segments (was 40+) |
| `crush_lu/admin/filters.py` | Admin `AgeRangeFilter` list filter (was 50+), refactored to a data-driven `RANGES` map |
| `crush_lu/models/profiles.py` | `CrushProfile.age_range` privacy display (was 40+), harmonized with the stats |

**Out of scope:** `analytics.py`'s `age_distribution` is intentionally left unchanged — it is based on `preferred_age_min` (the partner age a member is *looking for*), a different metric from the member's own age.

## Notes

- Templates and the segment system render the bands via loops / dynamic keys, so widening from 5 → 9 columns needed no template changes.
- Banding verified contiguous (18 → 60+, no gaps/overlaps, only 60+ grouped). Boundaries are inclusive and non-overlapping (e.g. a member who turns 60 today lands in `60+`, not `55-59`).
- Full Django check/test suite runs in CI (Django isn't installed in the authoring environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbEzNddA2xBEdUksp8WrfB)_