### PR TITLE
Retire user-facing "catalogue" wording in Crush Connect

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -1556,7 +1556,7 @@ def send_crush_connect_catalogue_welcome(user, request):
         )
 
         with translation.override(lang):
-            subject = _("You're in the Crush Connect catalogue")
+            subject = _("You're in Crush Connect")
             html_message = render_to_string(
                 'crush_lu/emails/crush_connect_catalogue_welcome.html', context
             )

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2236,8 +2236,8 @@ def auto_approve_profile_on_luxid_connect(sender, request, sociallogin, **kwargs
             messages.success(
                 request,
                 _(
-                    "Your LuxID is now connected — you can join the "
-                    "Crush Connect catalogue."
+                    "Your LuxID is now connected — you can join "
+                    "Crush Connect."
                 ),
             )
         return

--- a/crush_lu/templates/crush_lu/crush_connect.html
+++ b/crush_lu/templates/crush_lu/crush_connect.html
@@ -126,9 +126,9 @@
 
         <!-- Catalogue entry (LuxID, free) -->
         <div class="mt-10 rounded-2xl bg-white dark:bg-slate-800 ring-1 ring-gray-200 dark:ring-slate-700 p-6 md:p-8 text-center animate-on-scroll">
-            <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">{% trans "Enter the catalogue for free" %}</h3>
+            <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">{% trans "Join Crush Connect for free" %}</h3>
             <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-                {% trans "Connect your LuxID and opt in to Crush Connect — you'll appear as a candidate a Crush Coach can pick for a Premium member's match, no subscription needed. LuxID identity verification is what keeps the catalogue real people only." %}
+                {% trans "Connect your LuxID and opt in to Crush Connect — you'll appear as a candidate a Crush Coach can pick for a Premium member's match, no subscription needed. LuxID identity verification is what keeps Crush Connect real people only." %}
             </p>
         </div>
     </div>
@@ -240,12 +240,12 @@
                 <div class="flex-shrink-0 w-8 h-8 rounded-full bg-green-100 dark:bg-green-900/40 flex items-center justify-center">
                     <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
                 </div>
-                <span class="text-gray-900 dark:text-white font-medium">{% trans "LuxID verified — you can enter the candidate catalogue" %}</span>
+                <span class="text-gray-900 dark:text-white font-medium">{% trans "LuxID verified — you can join Crush Connect" %}</span>
                 {% else %}
                 <div class="flex-shrink-0 w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
                     <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01"/></svg>
                 </div>
-                <span class="text-gray-500 dark:text-gray-400">{% trans "Connect LuxID to enter the candidate catalogue" %}</span>
+                <span class="text-gray-500 dark:text-gray-400">{% trans "Connect LuxID to join Crush Connect" %}</span>
                 {% endif %}
             </div>
 

--- a/crush_lu/templates/crush_lu/crush_connect/_connect_subnav.html
+++ b/crush_lu/templates/crush_lu/crush_connect/_connect_subnav.html
@@ -23,7 +23,7 @@ chip/pill utility classes already in the Tailwind build.
     {% else %}
     <a href="{% url 'crush_lu:crush_connect_catalogue_status' %}"
        class="{{ base }} {% if active == 'crush_connect_catalogue_status' %}{{ on }}{% else %}{{ off }}{% endif %}">
-      {% include "shared/icons/heart.html" with class="w-4 h-4" %}<span>{% trans "Catalogue" %}</span>
+      {% include "shared/icons/heart.html" with class="w-4 h-4" %}<span>{% trans "My Connect" %}</span>
     </a>
     {% endif %}
 

--- a/crush_lu/templates/crush_lu/crush_connect/catalogue_status.html
+++ b/crush_lu/templates/crush_lu/crush_connect/catalogue_status.html
@@ -1,7 +1,7 @@
 {% extends 'crush_lu/crush_connect/_base_connect.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "You're in the catalogue — Crush Connect" %}{% endblock %}
+{% block title %}{% trans "You're in the mix — Crush Connect" %}{% endblock %}
 
 {% block connect_content %}
 <div class="max-w-2xl mx-auto px-4 py-8 pb-24 lg:pb-10">
@@ -9,13 +9,13 @@
     <header class="mb-5">
         <span class="inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r from-crush-purple to-crush-pink px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white mb-4">
             {% include "shared/icons/sparkles.html" with class="w-3.5 h-3.5" %}
-            {% trans "In the catalogue" %}
+            {% trans "You're in" %}
         </span>
         <h1 class="font-display text-3xl md:text-4xl font-semibold tracking-tight text-gray-900 dark:text-white mb-2">
-            {% trans "You're in the catalogue." %}
+            {% trans "You're in the mix." %}
         </h1>
         <p class="text-gray-600 dark:text-gray-300">
-            {% trans "Your LuxID is verified and your story is live. A Crush Coach can now introduce you to a Premium member as a hand-picked match — we'll tell you the moment it happens." %}
+            {% trans "You've opted in — your LuxID is verified and your story is live. A Crush Coach can now hand-pick you as a match for a Premium member, and we'll tell you the moment it happens." %}
         </p>
     </header>
 
@@ -98,7 +98,7 @@
             {% trans "Want your own curated matches?" %}
         </h2>
         <p class="relative text-sm leading-relaxed text-gray-600 dark:text-gray-300 max-w-sm mx-auto mb-5">
-            {% trans "In the catalogue, others can be matched with you. With Premium, a personal coach picks matches for you — delivered in your own weekly Drop." %}
+            {% trans "Right now, others can be matched with you. With Premium, a personal coach picks matches for you — delivered in your own weekly Drop." %}
         </p>
         <a href="{% url 'crush_lu:premium_choose_coach' %}" class="btn-crush-primary inline-flex items-center gap-2">
             {% trans "Discover Premium" %}
@@ -107,7 +107,7 @@
     </div>
 
     <p class="mt-5 text-center text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-        {% trans "Your full name and exact age are never shown. Photos stay blurred until you both Spark. Leave the catalogue anytime from settings." %}
+        {% trans "Your full name and exact age are never shown. Photos stay blurred until you both Spark. Leave Crush Connect anytime from settings." %}
     </p>
 
 </div>

--- a/crush_lu/templates/crush_lu/crush_connect/hub.html
+++ b/crush_lu/templates/crush_lu/crush_connect/hub.html
@@ -20,7 +20,7 @@
             {% if is_receiver %}
                 {% trans "Your coach hand-picks one match a week. No feed, no games — just a real introduction when it's right." %}
             {% else %}
-                {% trans "You're in the catalogue. A coach can introduce you as a hand-picked match — no feed, no games." %}
+                {% trans "You're in the mix. A coach can introduce you as a hand-picked match — no feed, no games." %}
             {% endif %}
         </p>
         <div class="relative flex flex-wrap gap-2 mt-4">
@@ -69,7 +69,7 @@
                 {% include "shared/icons/sparkles.html" with class="w-5 h-5 text-crush-purple" %}
             </div>
             <div class="flex-1 min-w-0">
-                <p class="font-semibold text-gray-900 dark:text-white mb-0.5">{% trans "You're in the catalogue" %}</p>
+                <p class="font-semibold text-gray-900 dark:text-white mb-0.5">{% trans "You're in the mix" %}</p>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mb-0">{% trans "A coach can introduce you as a match." %}</p>
             </div>
             {% include "shared/icons/chevron-right.html" with class="w-5 h-5 text-gray-400 shrink-0" %}

--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -91,7 +91,7 @@
         {% include "shared/icons/shield-check.html" with class="w-5 h-5 text-indigo-600 dark:text-indigo-400" %}
     </div>
     <div class="flex-1 min-w-0">
-        <p class="font-semibold text-indigo-900 dark:text-indigo-200 text-sm mb-0">{% trans "Connect LuxID to join the Crush Connect catalogue" %}</p>
+        <p class="font-semibold text-indigo-900 dark:text-indigo-200 text-sm mb-0">{% trans "Connect LuxID to join Crush Connect" %}</p>
         <p class="text-indigo-800 dark:text-indigo-300 text-xs mb-0">{% trans "LuxID-verified members can be hand-picked by a Crush Coach as a match for Premium members — free, no subscription needed." %}</p>
     </div>
     {% if luxid_connect_url %}

--- a/crush_lu/templates/crush_lu/emails/crush_connect_catalogue_welcome.html
+++ b/crush_lu/templates/crush_lu/emails/crush_connect_catalogue_welcome.html
@@ -1,14 +1,14 @@
 {% extends "crush_lu/emails/base_email.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "You're in the Crush Connect catalogue" %} - Crush.lu{% endblock %}
+{% block title %}{% trans "You're in Crush Connect" %} - Crush.lu{% endblock %}
 
-{% block header_title %}{% trans "You're in the catalogue!" %} ✨{% endblock %}
+{% block header_title %}{% trans "You're in the mix!" %} ✨{% endblock %}
 
 {% block content %}
 <h2>{% blocktrans with first_name=first_name %}Great news, {{ first_name }}!{% endblocktrans %}</h2>
 
-<p><strong>{% trans "You're now in the Crush Connect catalogue." %}</strong> {% trans "Your LuxID is verified and your story is live — a Crush Coach can now hand-pick you as a match for a Premium member." %}</p>
+<p><strong>{% trans "You've opted in to Crush Connect." %}</strong> {% trans "Your LuxID is verified and your story is live — a Crush Coach can now hand-pick you as a match for a Premium member." %}</p>
 
 <p><strong>{% trans "What this means:" %}</strong></p>
 <ul>
@@ -24,7 +24,7 @@
 
 <a href="{{ premium_url }}" class="button">{% trans "Discover Premium" %}</a>
 
-<p>{% blocktrans %}You can review your story or leave the catalogue anytime from your <a href="{{ dashboard_url }}">dashboard</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}You can review your story or leave Crush Connect anytime from your <a href="{{ dashboard_url }}">dashboard</a>.{% endblocktrans %}</p>
 
 <p>
     {% trans "Cheers," %}<br>

--- a/crush_lu/templates/crush_lu/partials/_verification_journey.html
+++ b/crush_lu/templates/crush_lu/partials/_verification_journey.html
@@ -34,7 +34,7 @@
 <div class="flex items-center gap-2 -mt-3 mb-5 px-4 py-2 rounded-lg border border-indigo-200 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20">
   {% include "shared/icons/shield-check.html" with class="w-4 h-4 text-indigo-600 dark:text-indigo-400 flex-shrink-0" %}
   <p class="text-xs text-indigo-700 dark:text-indigo-300 flex-1 mb-0">
-    {% trans "Connect LuxID to enter the Crush Connect catalogue and become discoverable to Premium members." %}
+    {% trans "Connect LuxID to join Crush Connect and become discoverable to Premium members." %}
   </p>
   {% if luxid_connect_url %}
   <a href="{{ luxid_connect_url }}" class="flex-shrink-0 text-xs font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400">{% trans "Connect" %}</a>

--- a/crush_lu/templates/crush_lu/partials/_verification_options.html
+++ b/crush_lu/templates/crush_lu/partials/_verification_options.html
@@ -55,7 +55,7 @@
         </div>
         <h4 class="mb-1 font-bold text-gray-900 dark:text-white">{% trans "Verify with LuxID" %}</h4>
         <p class="mb-4 flex-1 text-xs text-gray-500 dark:text-gray-400">
-          {% trans "Connect your LuxID government identity and get verified in seconds — no call, no waiting. LuxID also unlocks the Crush Connect catalogue, where a Crush Coach can pick you as a match." %}
+          {% trans "Connect your LuxID government identity and get verified in seconds — no call, no waiting. LuxID also unlocks Crush Connect, where a Crush Coach can pick you as a match." %}
         </p>
         {% if luxid_connect_url %}
         <a href="{{ luxid_connect_url }}" class="inline-flex w-full items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-indigo-700">
@@ -94,7 +94,7 @@
           <span class="mb-1 inline-block text-[0.7rem] font-bold uppercase tracking-wide text-amber-600 dark:text-amber-300">{% trans "Crush Connect" %}</span>
           <h4 class="mb-1 font-bold text-gray-900 dark:text-white">{% trans "4 weeks, 4 coach-picked matches" %}</h4>
           <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-            {% trans "Connect LuxID (free) to enter the candidate catalogue so a Crush Coach can pick you for a Premium member's match. Go Premium to receive your own — 4 matches over 4 weeks, one hand-picked each week. Free for the first month." %}
+            {% trans "Connect LuxID (free) to join Crush Connect so a Crush Coach can pick you for a Premium member's match. Go Premium to receive your own — 4 matches over 4 weeks, one hand-picked each week. Free for the first month." %}
           </p>
           <a href="{% url 'crush_lu:premium_choose_coach' %}" class="inline-flex items-center gap-1 text-sm font-semibold text-amber-600 no-underline hover:text-amber-700 dark:text-amber-300">
             {% trans "Join the Beta" %} <span aria-hidden="true">→</span>

--- a/crush_lu/tests/test_crush_connect.py
+++ b/crush_lu/tests/test_crush_connect.py
@@ -1013,7 +1013,7 @@ def test_catalogue_status_renders_for_onboarded_candidate(client, settings):
     resp = client.get(CATALOGUE_STATUS_URL)
     assert resp.status_code == 200
     body = resp.content.decode()
-    assert "catalogue" in body.lower()
+    assert "in the mix" in body.lower()
 
 
 @pytest.mark.django_db

--- a/crush_lu/views_crush_connect.py
+++ b/crush_lu/views_crush_connect.py
@@ -257,8 +257,8 @@ def _emit_onboarding_complete(request, done_url):
         messages.success(
             request,
             _(
-                "Welcome to Crush Connect — you're now in the "
-                "catalogue and can be matched by a Crush Coach."
+                "Welcome to Crush Connect — you're in the mix and can "
+                "be matched by a Crush Coach."
             ),
         )
         send_crush_connect_catalogue_welcome(user, request)


### PR DESCRIPTION
## Purpose

The candidate/opt-in state was shown to users as **"the catalogue"** — an internal term for the dating pool that reads cold and leaks an implementation concept. This PR replaces all user-facing copy with the warmer **"You're in the mix"** framing, and leads the candidate surfaces with a clear **"You've opted in"** affirmation.

**Copy only** — no view logic, models, eligibility gates, or routes change. Internal identifiers (URL/view/template names, `is_catalogue_eligible`, the email template filename) are intentionally left as-is.

## User-facing surfaces updated

- `crush_connect/catalogue_status.html` — badge "You're in", H1 "You're in the mix.", opt-in lead, footer "Leave Crush Connect".
- `crush_connect/hub.html` — candidate subtitle + access card "You're in the mix".
- `crush_connect/_connect_subnav.html` — candidate nav tab "My Connect".
- `emails/crush_connect_catalogue_welcome.html` — title/header/body.
- `crush_connect.html` (teaser), `dashboard.html`, `partials/_verification_*.html` — funnel copy now says "join Crush Connect" instead of "the catalogue".
- `views_crush_connect.py`, `email_helpers.py`, `signals.py` — onboarding success message, welcome-email subject, and LuxID-connect message.
- `tests/test_crush_connect.py` — assert "in the mix" (was "catalogue").

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[x] Code style update (copy/UX wording)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
```

## How to test
Log in as an onboarded candidate (verified + LuxID, no Premium) and open the Connect hub and `/crush-connect/catalogue/`; confirm it reads "You're in the mix." / "You've opted in", the nav tab says "My Connect", and the word "catalogue" appears nowhere in rendered copy. Trigger the candidate welcome email and confirm its wording.

## Note
These change i18n msgids, so FR/DE/LU fall back to English until `makemessages` + translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FVf3suebAJis8qncwjDkv

---
_Generated by [Claude Code](https://claude.ai/code/session_018FVf3suebAJis8qncwjDkv)_