### PR TITLE
Auto-update /changelog/ on PR merge via changelog ingest endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,6 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/
 
 
 # PyBuilder

--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -36,7 +36,7 @@ from crush_lu.admin_views import (
     email_template_load_invitations,
     email_template_load_gifts,
 )
-from crush_lu import api_views, api_push, api_coach_push, api_pwa, views_oauth_popup, api_journey, views_wallet, api_referral, api_admin_sync, api_admin_hybrid, views_crush_spark, views_checkin, api_crush_connect, views_coach, api_quiz, views_quiz, views_notifications
+from crush_lu import api_views, api_push, api_coach_push, api_pwa, views_oauth_popup, api_journey, views_wallet, api_referral, api_admin_sync, api_admin_hybrid, api_admin_changelog, views_crush_spark, views_checkin, api_crush_connect, views_coach, api_quiz, views_quiz, views_notifications
 from crush_lu.wallet import passkit_service, google_callback
 from crush_lu.sitemaps import crush_sitemaps
 from crush_lu.views_seo import robots_txt
@@ -264,6 +264,10 @@ urlpatterns = [
     # Must stay language-neutral: the Function App uses hardcoded /api/admin/... paths.
     path('api/admin/hybrid-coach-sla-sweep/', api_admin_hybrid.sla_sweep, name='api_admin_sla_sweep'),
     path('api/admin/pre-screening-invites/', api_admin_hybrid.pre_screening_invites, name='api_admin_pre_screening_invites'),
+
+    # Changelog ingest (called by the Claude Code changelog routine on PR merge).
+    # Language-neutral path; auto-publishes to /changelog/. See docs/changelog-routine.md.
+    path('api/admin/changelog/ingest/', api_admin_changelog.ingest_changelog, name='api_admin_changelog_ingest'),
 
 
     # Live Quiz API (called from quiz-live.js WebSocket fallback)

--- a/crush_lu/api_admin_auth.py
+++ b/crush_lu/api_admin_auth.py
@@ -1,0 +1,48 @@
+"""
+Shared Bearer-token authentication for the ``/api/admin/...`` endpoints.
+
+These endpoints are called by Azure Function timer triggers and Claude Code
+routines, not by browsers, so they authenticate with a Bearer token matching
+``settings.ADMIN_API_KEY`` rather than a session/CSRF flow.
+
+This helper was previously duplicated verbatim in ``api_admin_sync`` and
+``api_admin_hybrid`` (the latter literally commented "cloned from
+api_admin_sync"). It now lives here so every admin endpoint shares one
+implementation.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+
+from django.conf import settings
+from django.http import JsonResponse
+
+logger = logging.getLogger(__name__)
+
+
+def authenticate_admin_request(request) -> bool:
+    """Return True iff the request carries a valid admin Bearer token.
+
+    Compares the ``Authorization: Bearer <token>`` header against
+    ``settings.ADMIN_API_KEY`` in constant time. Returns False (never raises)
+    when the header is missing/malformed or when ``ADMIN_API_KEY`` is unset.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return False
+    token = auth_header.replace("Bearer ", "", 1)
+    expected = getattr(settings, "ADMIN_API_KEY", None)
+    if not expected:
+        logger.error("ADMIN_API_KEY not configured; rejecting admin request")
+        return False
+    return secrets.compare_digest(token, expected)
+
+
+def unauthorized(request) -> JsonResponse:
+    """Standard 401 response for admin endpoints, with a logged warning."""
+    logger.warning(
+        "Unauthorized admin endpoint call from %s",
+        request.META.get("REMOTE_ADDR"),
+    )
+    return JsonResponse({"error": "Unauthorized"}, status=401)

--- a/crush_lu/api_admin_changelog.py
+++ b/crush_lu/api_admin_changelog.py
@@ -122,6 +122,16 @@ def ingest_changelog(request):
         related = note.get("related_commits", [])
         if not isinstance(related, list) or not all(isinstance(s, str) for s in related):
             return _bad_request(f"notes[{i}].related_commits must be a list of strings.")
+        # At least one SHA is required: idempotency is keyed on related_commits,
+        # so a note with none could never be deduped and every webhook
+        # re-delivery would publish a duplicate. Reject rather than accept a
+        # note that cannot be made idempotent.
+        related = [s.strip() for s in related if s.strip()]
+        if not related:
+            return _bad_request(
+                f"notes[{i}].related_commits must contain at least one commit SHA "
+                f"(required so re-delivered merges stay idempotent)."
+            )
         clean_notes.append({
             "category": category,
             "title": n_title,

--- a/crush_lu/api_admin_changelog.py
+++ b/crush_lu/api_admin_changelog.py
@@ -1,0 +1,172 @@
+"""
+Admin API endpoint that ingests changelog ("What's New") entries.
+
+Called by the Claude Code *changelog routine* when a PR is merged into ``main``.
+The routine runs in a cloud session that has the full git clone, composes the
+user-facing copy, then POSTs it here. This endpoint writes (and publishes) it
+to the production database so it appears on ``/changelog/`` — so production DB
+credentials never have to leave the server.
+
+- Auth: Bearer token matching ``settings.ADMIN_API_KEY`` (see
+  ``crush_lu.api_admin_auth``), like the other ``/api/admin/...`` endpoints.
+- Lives outside ``i18n_patterns`` so the caller can use a fixed, language-neutral
+  ``/api/admin/changelog/ingest/`` path.
+- Because entries can auto-publish with no human review, every incoming string
+  is passed through :func:`crush_lu.changelog_text.scrub` server-side — the
+  caller is never trusted to have removed emails / internal hosts / session URLs.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+
+from django.db import transaction
+from django.http import JsonResponse
+from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from crush_lu.api_admin_auth import authenticate_admin_request, unauthorized
+from crush_lu.changelog_text import scrub
+from crush_lu.models import PatchNote, PatchNoteCategory, PatchRelease
+
+logger = logging.getLogger(__name__)
+
+# Mirror the model field limits so oversized input is a clean 400, not a 500.
+_RELEASE_MAXLEN = {"version": 20, "slug": 80, "title": 140, "hero_summary": 280}
+_NOTE_TITLE_MAXLEN = 160
+_VALID_CATEGORIES = set(PatchNoteCategory.values)
+_SLUG_RE = re.compile(r"^[-\w]+\Z")  # same character set as Django's SlugField
+
+
+def _bad_request(msg: str) -> JsonResponse:
+    return JsonResponse({"success": False, "error": msg}, status=400)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def ingest_changelog(request):
+    """Create/update a PatchRelease and append PatchNotes from a JSON payload.
+
+    Body::
+
+        {
+          "release": {"version","slug","title","hero_summary","released_on","is_published"},
+          "notes":   [{"category","title","body","related_commits","order"}, ...]
+        }
+
+    Returns 201 with the release slug/url, 400 on invalid input, 401 if the
+    Bearer token is missing/wrong.
+    """
+    if not authenticate_admin_request(request):
+        return unauthorized(request)
+
+    try:
+        payload = json.loads(request.body or b"{}")
+    except (ValueError, TypeError):
+        return _bad_request("Body must be valid JSON.")
+
+    release_in = payload.get("release")
+    notes_in = payload.get("notes", [])
+    if not isinstance(release_in, dict):
+        return _bad_request("'release' object is required.")
+    if not isinstance(notes_in, list):
+        return _bad_request("'notes' must be a list.")
+
+    # --- validate + scrub the release -----------------------------------
+    slug = (release_in.get("slug") or "").strip()
+    version = (release_in.get("version") or "").strip()
+    title = scrub(release_in.get("title") or "")
+    hero_summary = scrub(release_in.get("hero_summary") or "")
+
+    if not slug or not _SLUG_RE.match(slug):
+        return _bad_request("'release.slug' is required and must be a valid slug.")
+    if not version:
+        return _bad_request("'release.version' is required.")
+    if not title:
+        return _bad_request("'release.title' is required.")
+    for field, value in (("version", version), ("slug", slug),
+                         ("title", title), ("hero_summary", hero_summary)):
+        if len(value) > _RELEASE_MAXLEN[field]:
+            return _bad_request(f"'release.{field}' exceeds {_RELEASE_MAXLEN[field]} characters.")
+
+    released_on_raw = release_in.get("released_on")
+    if released_on_raw:
+        try:
+            released_on = date.fromisoformat(released_on_raw)
+        except (ValueError, TypeError):
+            return _bad_request("'release.released_on' must be an ISO date (YYYY-MM-DD).")
+    else:
+        released_on = timezone.now().date()
+
+    # Auto-publish by default (per design); callers may override to stage drafts.
+    is_published = bool(release_in.get("is_published", True))
+
+    # --- validate + scrub the notes -------------------------------------
+    clean_notes = []
+    for i, note in enumerate(notes_in):
+        if not isinstance(note, dict):
+            return _bad_request(f"notes[{i}] must be an object.")
+        category = (note.get("category") or "").strip()
+        if category not in _VALID_CATEGORIES:
+            return _bad_request(
+                f"notes[{i}].category must be one of {sorted(_VALID_CATEGORIES)}."
+            )
+        n_title = scrub(note.get("title") or "")
+        if not n_title:
+            return _bad_request(f"notes[{i}].title is required.")
+        if len(n_title) > _NOTE_TITLE_MAXLEN:
+            return _bad_request(f"notes[{i}].title exceeds {_NOTE_TITLE_MAXLEN} characters.")
+        related = note.get("related_commits", [])
+        if not isinstance(related, list) or not all(isinstance(s, str) for s in related):
+            return _bad_request(f"notes[{i}].related_commits must be a list of strings.")
+        clean_notes.append({
+            "category": category,
+            "title": n_title,
+            "body": scrub(note.get("body") or ""),
+            "related_commits": related,
+            "order": int(note.get("order", i)),
+        })
+
+    # --- write -----------------------------------------------------------
+    defaults = {
+        "version": version,
+        "title": title,
+        "hero_summary": hero_summary,
+        "released_on": released_on,
+        "is_published": is_published,
+    }
+    with transaction.atomic():
+        release, created = PatchRelease.objects.update_or_create(
+            slug=slug, defaults=defaults,
+        )
+
+        # Idempotency: a merge webhook can fire more than once. Skip any note
+        # whose backing commit SHA already appears on this release.
+        existing_shas: set[str] = set()
+        for sha_list in release.notes.values_list("related_commits", flat=True):
+            existing_shas.update(sha_list or [])
+
+        notes_added = 0
+        for nd in clean_notes:
+            if nd["related_commits"] and any(s in existing_shas for s in nd["related_commits"]):
+                continue
+            PatchNote.objects.create(release=release, auto_generated=True, **nd)
+            existing_shas.update(nd["related_commits"])
+            notes_added += 1
+
+    logger.info(
+        "changelog ingest: slug=%s created=%s notes_added=%s published=%s",
+        slug, created, notes_added, is_published,
+    )
+    return JsonResponse({
+        "success": True,
+        "created": created,
+        "notes_added": notes_added,
+        "version": release.version,
+        "slug": release.slug,
+        "url": release.get_absolute_url(),
+        "is_published": release.is_published,
+    }, status=201)

--- a/crush_lu/api_admin_changelog.py
+++ b/crush_lu/api_admin_changelog.py
@@ -144,17 +144,21 @@ def ingest_changelog(request):
         )
 
         # Idempotency: a merge webhook can fire more than once. Skip any note
-        # whose backing commit SHA already appears on this release.
-        existing_shas: set[str] = set()
+        # whose backing commit SHA was *already persisted* on this release by an
+        # earlier request. We snapshot the pre-request SHAs and never add this
+        # request's own SHAs to it — otherwise multiple notes in a single
+        # payload that share the merge SHA would drop everything after the first.
+        # On a re-delivery those SHAs are persisted, so the whole payload is
+        # correctly skipped.
+        preexisting_shas: set[str] = set()
         for sha_list in release.notes.values_list("related_commits", flat=True):
-            existing_shas.update(sha_list or [])
+            preexisting_shas.update(sha_list or [])
 
         notes_added = 0
         for nd in clean_notes:
-            if nd["related_commits"] and any(s in existing_shas for s in nd["related_commits"]):
+            if nd["related_commits"] and any(s in preexisting_shas for s in nd["related_commits"]):
                 continue
             PatchNote.objects.create(release=release, auto_generated=True, **nd)
-            existing_shas.update(nd["related_commits"])
             notes_added += 1
 
     logger.info(

--- a/crush_lu/api_admin_hybrid.py
+++ b/crush_lu/api_admin_hybrid.py
@@ -23,6 +23,7 @@ import logging
 import uuid
 from datetime import timedelta
 
+from django.conf import settings
 from django.db import transaction
 from django.http import JsonResponse
 from django.utils import timezone

--- a/crush_lu/api_admin_hybrid.py
+++ b/crush_lu/api_admin_hybrid.py
@@ -20,42 +20,19 @@ thin scheduler. The contact-sync pattern in production already does this.
 from __future__ import annotations
 
 import logging
-import secrets
 import uuid
 from datetime import timedelta
 
-from django.conf import settings
 from django.db import transaction
 from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
+from crush_lu.api_admin_auth import authenticate_admin_request as _authenticate_admin_request
+from crush_lu.api_admin_auth import unauthorized as _unauthorized
+
 logger = logging.getLogger(__name__)
-
-
-# -------------------------------------------------------------------------
-# Bearer-token authentication (identical to api_admin_sync)
-# -------------------------------------------------------------------------
-
-def _authenticate_admin_request(request) -> bool:
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return False
-    token = auth_header.replace("Bearer ", "", 1)
-    expected = getattr(settings, "ADMIN_API_KEY", None)
-    if not expected:
-        logger.error("ADMIN_API_KEY not configured; rejecting admin request")
-        return False
-    return secrets.compare_digest(token, expected)
-
-
-def _unauthorized(request) -> JsonResponse:
-    logger.warning(
-        "Unauthorized hybrid admin endpoint call from %s",
-        request.META.get("REMOTE_ADDR"),
-    )
-    return JsonResponse({"error": "Unauthorized"}, status=401)
 
 
 def _hybrid_disabled() -> JsonResponse:

--- a/crush_lu/api_admin_sync.py
+++ b/crush_lu/api_admin_sync.py
@@ -7,37 +7,14 @@ Secured with Bearer token authentication
 
 import json
 import logging
-import secrets
 import threading
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
-from django.conf import settings
+from crush_lu.api_admin_auth import authenticate_admin_request as _authenticate_admin_request
 from crush_lu.services.graph_contacts import GraphContactsService, is_sync_enabled
 
 logger = logging.getLogger(__name__)
-
-
-def _authenticate_admin_request(request) -> bool:
-    """
-    Authenticate admin API request using Bearer token.
-
-    Returns:
-        bool: True if authenticated, False otherwise
-    """
-    auth_header = request.headers.get('Authorization', '')
-
-    if not auth_header.startswith('Bearer '):
-        return False
-
-    token = auth_header.replace('Bearer ', '', 1)
-    expected_token = getattr(settings, 'ADMIN_API_KEY', None)
-
-    if not expected_token:
-        logger.error("ADMIN_API_KEY not configured in settings")
-        return False
-
-    return secrets.compare_digest(token, expected_token)
 
 
 @csrf_exempt

--- a/crush_lu/api_admin_sync.py
+++ b/crush_lu/api_admin_sync.py
@@ -8,6 +8,7 @@ Secured with Bearer token authentication
 import json
 import logging
 import threading
+from django.conf import settings
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt

--- a/crush_lu/changelog_text.py
+++ b/crush_lu/changelog_text.py
@@ -1,0 +1,33 @@
+"""
+Text helpers for the public changelog ("What's New").
+
+`SECRET_PATTERNS` / `scrub()` strip content that must never appear in
+user-facing patch notes — internal email addresses, internal Azure hosts, and
+the Git trailer / session-URL lines Claude Code adds to commits.
+
+These were originally defined inside the `generate_patch_notes` management
+command. They live here so the command *and* the
+``/api/admin/changelog/ingest/`` endpoint apply the exact same red-line filter:
+the endpoint can auto-publish notes with no human review, so the server must
+scrub incoming text rather than trust the caller.
+"""
+from __future__ import annotations
+
+import re
+
+# Red-line filter patterns — we never surface these in public copy.
+SECRET_PATTERNS = [
+    re.compile(r"[\w\.-]+@[\w\.-]+\.\w+"),                          # emails
+    re.compile(r"https?://[\w\.-]+\.(azurewebsites|azure)\.net"),  # internal hosts
+    re.compile(r"https?://claude\.ai/code/\S+"),                   # co-author session urls
+    re.compile(r"co-authored-by:?[^\n]*", re.IGNORECASE),
+    re.compile(r"signed-off-by:?[^\n]*", re.IGNORECASE),
+]
+
+
+def scrub(text: str) -> str:
+    """Strip red-line patterns and collapse whitespace."""
+    cleaned = text or ""
+    for pat in SECRET_PATTERNS:
+        cleaned = pat.sub("", cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()

--- a/crush_lu/data/release_milestones.json
+++ b/crush_lu/data/release_milestones.json
@@ -70,5 +70,14 @@
         "released_on": "2026-04-17",
         "since": "2026-04-07",
         "until": "2026-04-18"
+    },
+    {
+        "version": "v1.8",
+        "slug": "v1-8-crush-connect",
+        "title": "Crush Connect, reimagined",
+        "hero_summary": "A warmer, privacy-first Crush Connect — a redesigned mobile experience and clearer, kinder wording throughout.",
+        "released_on": "2026-06-18",
+        "since": "2026-04-18",
+        "until": "2026-07-01"
     }
 ]

--- a/crush_lu/management/commands/generate_patch_notes.py
+++ b/crush_lu/management/commands/generate_patch_notes.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from crush_lu.changelog_text import scrub  # noqa: F401  (re-exported for callers/tests)
 from crush_lu.models import PatchNote, PatchNoteCategory, PatchRelease
 
 
@@ -122,27 +123,10 @@ SCOPE_BUCKETS = {
     "logging": "Under the hood",
 }
 
-# Red-line filter patterns — we never surface these in public copy
-SECRET_PATTERNS = [
-    re.compile(r"[\w\.-]+@[\w\.-]+\.\w+"),                       # emails
-    re.compile(r"https?://[\w\.-]+\.(azurewebsites|azure)\.net"),  # internal hosts
-    re.compile(r"https?://claude\.ai/code/\S+"),                  # co-author session urls
-    re.compile(r"co-authored-by:?[^\n]*", re.IGNORECASE),
-    re.compile(r"signed-off-by:?[^\n]*", re.IGNORECASE),
-]
-
 CONVENTIONAL_RE = re.compile(
     r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?!?:\s*(?P<subject>.+)$",
     re.IGNORECASE,
 )
-
-
-def scrub(text: str) -> str:
-    """Strip red-line patterns and collapse whitespace."""
-    cleaned = text or ""
-    for pat in SECRET_PATTERNS:
-        cleaned = pat.sub("", cleaned)
-    return re.sub(r"\s+", " ", cleaned).strip()
 
 
 def classify_commit(subject: str):

--- a/crush_lu/tests/test_api_admin_changelog.py
+++ b/crush_lu/tests/test_api_admin_changelog.py
@@ -114,6 +114,27 @@ class ChangelogIngestWriteTests(TestCase):
         self.assertEqual(second.json()["notes_added"], 0)
         self.assertEqual(PatchRelease.objects.get(slug="catchup-2026-06").notes.count(), 1)
 
+    def test_multiple_notes_sharing_merge_sha_are_all_kept(self):
+        # A single PR (one merge SHA) may yield several user-facing notes; the
+        # within-request dedupe must not drop notes 2..N just because they share
+        # the SHA. A re-delivery of the same payload must then add nothing.
+        payload = _valid_payload(sha="multi-sha")
+        payload["notes"].append({
+            "category": "feature",
+            "title": "Quiz Night",
+            "body": "A second user-facing item from the same merge.",
+            "related_commits": ["multi-sha"],
+            "order": 1,
+        })
+        first = self._post(payload)
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(first.json()["notes_added"], 2)
+        self.assertEqual(PatchRelease.objects.get(slug="catchup-2026-06").notes.count(), 2)
+
+        second = self._post(payload)
+        self.assertEqual(second.json()["notes_added"], 0)
+        self.assertEqual(PatchRelease.objects.get(slug="catchup-2026-06").notes.count(), 2)
+
     def test_release_fields_update_on_repost(self):
         self._post(_valid_payload())
         payload = _valid_payload(sha="another-sha")

--- a/crush_lu/tests/test_api_admin_changelog.py
+++ b/crush_lu/tests/test_api_admin_changelog.py
@@ -1,0 +1,185 @@
+"""
+Tests for the changelog ingest endpoint (POST /api/admin/changelog/ingest/).
+
+Covers:
+- Bearer-token auth (missing / wrong / correct) and method guard
+- A valid payload creating a *published* PatchRelease + PatchNote
+- Idempotency: re-posting the same merge SHA adds no duplicate note
+- Validation 400s (bad category, oversized title, invalid slug, bad JSON)
+- Server-side scrubbing of secrets/PII even though the caller is "trusted"
+
+The endpoint lives in the crush domain's URLconf, so these tests override
+ROOT_URLCONF the same way the rest of the crush_lu suite does.
+
+Run with: pytest crush_lu/tests/test_api_admin_changelog.py -v
+"""
+import json
+
+from django.test import Client, TestCase, override_settings
+
+from crush_lu.models import PatchNote, PatchRelease
+
+INGEST_URL = "/api/admin/changelog/ingest/"
+API_KEY = "test-admin-key"
+
+CRUSH_URLS = {"ROOT_URLCONF": "azureproject.urls_crush", "ADMIN_API_KEY": API_KEY}
+
+
+def _valid_payload(sha="abc123", slug="catchup-2026-06"):
+    return {
+        "release": {
+            "version": "v1.8",
+            "slug": slug,
+            "title": "Crush Connect, reimagined",
+            "hero_summary": "A warmer, privacy-first way to connect.",
+            "released_on": "2026-06-18",
+        },
+        "notes": [
+            {
+                "category": "improvement",
+                "title": "Crush Connect",
+                "body": "You're in the mix — clearer, warmer wording across Connect.",
+                "related_commits": [sha],
+                "order": 0,
+            }
+        ],
+    }
+
+
+@override_settings(**CRUSH_URLS)
+class ChangelogIngestAuthTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_missing_token_is_401(self):
+        resp = self.client.post(
+            INGEST_URL, data=json.dumps(_valid_payload()),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(PatchRelease.objects.count(), 0)
+
+    def test_wrong_token_is_401(self):
+        resp = self.client.post(
+            INGEST_URL, data=json.dumps(_valid_payload()),
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Bearer not-the-key",
+        )
+        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(PatchRelease.objects.count(), 0)
+
+    def test_get_is_405(self):
+        resp = self.client.get(INGEST_URL, HTTP_AUTHORIZATION=f"Bearer {API_KEY}")
+        self.assertEqual(resp.status_code, 405)
+
+
+@override_settings(**CRUSH_URLS)
+class ChangelogIngestWriteTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def _post(self, payload):
+        return self.client.post(
+            INGEST_URL, data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {API_KEY}",
+        )
+
+    def test_valid_payload_creates_published_release_and_note(self):
+        resp = self._post(_valid_payload())
+        self.assertEqual(resp.status_code, 201)
+        body = resp.json()
+        self.assertTrue(body["success"])
+        self.assertTrue(body["created"])
+        self.assertEqual(body["notes_added"], 1)
+
+        release = PatchRelease.objects.get(slug="catchup-2026-06")
+        self.assertTrue(release.is_published)
+        self.assertEqual(release.version, "v1.8")
+        self.assertEqual(release.notes.count(), 1)
+        note = release.notes.get()
+        self.assertEqual(note.title, "Crush Connect")
+        self.assertTrue(note.auto_generated)
+
+    def test_published_release_is_visible_on_changelog_list(self):
+        self._post(_valid_payload())
+        resp = self.client.get("/changelog/", follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Crush Connect, reimagined")
+
+    def test_same_merge_sha_is_idempotent(self):
+        self.assertEqual(self._post(_valid_payload(sha="dup-sha")).status_code, 201)
+        second = self._post(_valid_payload(sha="dup-sha"))
+        self.assertEqual(second.status_code, 201)
+        self.assertEqual(second.json()["notes_added"], 0)
+        self.assertEqual(PatchRelease.objects.get(slug="catchup-2026-06").notes.count(), 1)
+
+    def test_release_fields_update_on_repost(self):
+        self._post(_valid_payload())
+        payload = _valid_payload(sha="another-sha")
+        payload["release"]["title"] = "Crush Connect, even better"
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 201)
+        release = PatchRelease.objects.get(slug="catchup-2026-06")
+        self.assertEqual(release.title, "Crush Connect, even better")
+        self.assertEqual(release.notes.count(), 2)  # different SHA → appended
+
+
+@override_settings(**CRUSH_URLS)
+class ChangelogIngestValidationTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def _post(self, payload_or_raw, raw=False):
+        data = payload_or_raw if raw else json.dumps(payload_or_raw)
+        return self.client.post(
+            INGEST_URL, data=data, content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {API_KEY}",
+        )
+
+    def test_invalid_json_is_400(self):
+        resp = self._post("{not json", raw=True)
+        self.assertEqual(resp.status_code, 400)
+
+    def test_invalid_category_is_400(self):
+        payload = _valid_payload()
+        payload["notes"][0]["category"] = "marketing"
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(PatchRelease.objects.count(), 0)
+
+    def test_oversized_note_title_is_400(self):
+        payload = _valid_payload()
+        payload["notes"][0]["title"] = "x" * 200
+        self.assertEqual(self._post(payload).status_code, 400)
+
+    def test_invalid_slug_is_400(self):
+        payload = _valid_payload(slug="not a slug!")
+        self.assertEqual(self._post(payload).status_code, 400)
+
+    def test_missing_release_is_400(self):
+        self.assertEqual(self._post({"notes": []}).status_code, 400)
+
+
+@override_settings(**CRUSH_URLS)
+class ChangelogIngestScrubTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_secrets_are_scrubbed_server_side(self):
+        payload = _valid_payload()
+        payload["notes"][0]["body"] = (
+            "Shipped! ping me at dev@crush.lu or see "
+            "https://claude.ai/code/session_0123 Co-Authored-By: Claude"
+        )
+        resp = self.client.post(
+            INGEST_URL, data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {API_KEY}",
+        )
+        self.assertEqual(resp.status_code, 201)
+        body = PatchRelease.objects.get(slug="catchup-2026-06").notes.get().body
+        self.assertNotIn("dev@crush.lu", body)
+        self.assertNotIn("claude.ai/code", body)
+        self.assertNotIn("Co-Authored-By", body)
+        self.assertIn("Shipped!", body)

--- a/crush_lu/tests/test_api_admin_changelog.py
+++ b/crush_lu/tests/test_api_admin_changelog.py
@@ -181,6 +181,25 @@ class ChangelogIngestValidationTests(TestCase):
     def test_missing_release_is_400(self):
         self.assertEqual(self._post({"notes": []}).status_code, 400)
 
+    def test_empty_related_commits_is_400(self):
+        # A note with no commit SHA can never be deduped, so the ingest must
+        # reject it rather than accept a payload that would duplicate on retry.
+        payload = _valid_payload()
+        payload["notes"][0]["related_commits"] = []
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(PatchRelease.objects.count(), 0)
+
+    def test_missing_related_commits_is_400(self):
+        payload = _valid_payload()
+        del payload["notes"][0]["related_commits"]
+        self.assertEqual(self._post(payload).status_code, 400)
+
+    def test_blank_only_related_commits_is_400(self):
+        payload = _valid_payload()
+        payload["notes"][0]["related_commits"] = ["   ", ""]
+        self.assertEqual(self._post(payload).status_code, 400)
+
 
 @override_settings(**CRUSH_URLS)
 class ChangelogIngestScrubTests(TestCase):

--- a/docs/changelog-routine.md
+++ b/docs/changelog-routine.md
@@ -1,0 +1,261 @@
+# Changelog routine — auto-update `/changelog/` on PR merge
+
+This document describes how the public **"What's New"** changelog
+(`https://crush.lu/changelog/`) updates **automatically when a PR is merged into
+`main`**, using a [Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)
+routine plus the secured ingest endpoint added in PR #515.
+
+Production database credentials never leave the server: the routine composes the
+user-facing copy in an isolated cloud session and makes a **single authenticated
+HTTPS call** to Django, which does the write.
+
+```
+PR merged → main
+  └─(GitHub trigger)→ Claude Code routine (cloud session, full git clone)
+       • reads the merged PR + git log, decides if it is user-facing
+       • picks the current release window from release_milestones.json
+       • writes warm, plain-language copy and scrubs secrets
+       └─ POST (Bearer ADMIN_API_KEY) → /api/admin/changelog/ingest/
+             └─ Django upserts PatchRelease + PatchNote(is_published=True)
+                   → live on /changelog/
+```
+
+---
+
+## 1. The ingest endpoint (already deployed by this PR)
+
+`POST /api/admin/changelog/ingest/` — implemented in
+[`crush_lu/api_admin_changelog.py`](../crush_lu/api_admin_changelog.py).
+
+| Property | Value |
+| --- | --- |
+| **Auth** | `Authorization: Bearer <ADMIN_API_KEY>` (constant-time compare against `settings.ADMIN_API_KEY`). Missing/wrong → `401`. |
+| **Method** | `POST` only. Anything else → `405`. |
+| **Path** | Language-neutral (outside `i18n_patterns`), so the caller uses a fixed URL with no `/en/` prefix. |
+| **Scrubbing** | Every incoming string is passed through `crush_lu.changelog_text.scrub` **server-side** — emails, internal Azure hosts, `Co-Authored-By`/`Signed-off-by` trailers, and `claude.ai/code` session URLs are stripped even if the caller forgets. The caller is never trusted. |
+| **Idempotency** | Keyed on the **merge-commit SHA** in `notes[].related_commits`. A note whose SHA is already persisted on the release is skipped, so a re-delivered webhook (or a re-run) never duplicates a note. |
+| **Publish** | `release.is_published` defaults to `true` → live immediately. Set it to `false` to stage a draft for admin review. |
+
+### Request body
+
+```jsonc
+{
+  "release": {
+    "version":      "v1.8",                       // ≤ 20 chars, required
+    "slug":         "v1-8-crush-connect",          // ≤ 80 chars, valid slug, required (unique key)
+    "title":        "Crush Connect, reimagined",   // ≤ 140 chars, required
+    "hero_summary": "A warmer, privacy-first ...", // ≤ 280 chars, optional
+    "released_on":  "2026-06-19",                  // ISO date, optional (defaults to today)
+    "is_published": true                            // optional, defaults true
+  },
+  "notes": [
+    {
+      "category":        "improvement",            // one of: feature | improvement | fix | under_hood
+      "title":           "Clearer Crush Connect",  // ≤ 160 chars, required
+      "body":            "You're in the mix ...",   // plain text, optional
+      "related_commits": ["<MERGE_COMMIT_SHA>"],   // REQUIRED for idempotency — include the PR's merge SHA
+      "order":           0                          // optional sort key within the release
+    }
+  ]
+}
+```
+
+> **Idempotency contract:** always put the PR's **merge commit SHA** in every
+> note's `related_commits`. That is what makes a second delivery of the same PR
+> a no-op (`notes_added: 0`).
+
+### Response
+
+```jsonc
+// 201 Created
+{
+  "success": true,
+  "created": true,            // false if the release slug already existed (fields updated in place)
+  "notes_added": 1,           // 0 on a duplicate/re-delivery
+  "version": "v1.8",
+  "slug": "v1-8-crush-connect",
+  "url": "/changelog/v1-8-crush-connect/",
+  "is_published": true
+}
+```
+
+Error responses: `400` (invalid JSON / bad category / oversized field / invalid
+slug / missing release), `401` (bad token), `405` (wrong method).
+
+### Release model
+
+A `PatchRelease` is a dated card on the timeline; each `PatchNote` is one line
+item (feature / improvement / fix / under-the-hood) inside it. Multiple merged
+PRs in the same release window append notes to the **same** release (matched by
+`slug`), so the changelog groups a sprint's work under one heading.
+
+The current release windows live in
+[`crush_lu/data/release_milestones.json`](../crush_lu/data/release_milestones.json)
+(`version`, `slug`, `title`, `hero_summary`, `since`, `until`). The routine
+picks the entry whose `[since, until]` window contains the merge date.
+
+---
+
+## 2. Generate and store the API key
+
+The endpoint reuses the existing `settings.ADMIN_API_KEY`
+(`azureproject/settings.py` → `ADMIN_API_KEY = os.getenv("ADMIN_API_KEY")`) —
+the same key the Azure Function timer triggers already use. No new production
+secret is required if one is already set.
+
+If you need a fresh key:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(48))"
+```
+
+Set it in **two** places (they must match):
+
+1. **The server** — `ADMIN_API_KEY` app setting on the App Service (and on
+   staging, `test.crush.lu`). This is read at request time by Django.
+2. **The Claude routine** — as an environment variable the routine reads when
+   composing the `Authorization` header (see below). Store it as a routine
+   **secret**, never inline in the prompt or committed to the repo.
+
+---
+
+## 3. Configure the Claude Code routine
+
+Routines are configured in the Claude Code web UI
+(<https://code.claude.com/docs/en/claude-code-on-the-web>). Create a new routine
+on this repository with the settings below.
+
+### Trigger
+
+| Field | Value |
+| --- | --- |
+| **Event** | `pull_request` → `closed` |
+| **Condition** | `base.ref == "main"` **and** `pull_request.merged == true` |
+| **Repository** | `EuphoriaLux/Multi-Domain-Django-Platform` |
+
+Filtering on `merged == true` is important: GitHub fires `closed` for PRs that
+were *closed without merging* too, and those must not produce a changelog entry.
+
+### Environment
+
+| Variable | Purpose |
+| --- | --- |
+| `ADMIN_API_KEY` *(secret)* | Bearer token; must equal the server's `ADMIN_API_KEY`. |
+| `CHANGELOG_INGEST_URL` | `https://crush.lu/api/admin/changelog/ingest/` (prod) or `https://test.crush.lu/api/admin/changelog/ingest/` (staging). |
+
+**Network policy:** the routine must be allowed outbound HTTPS to `crush.lu`
+(and/or `test.crush.lu`). Pick a network policy on the environment that permits
+this host; a fully-isolated/no-egress policy will block the POST.
+
+### Routine prompt
+
+Paste the following as the routine's prompt. It is self-contained: it inspects
+the merged PR, decides whether it is user-facing, composes the note, and POSTs.
+
+````markdown
+A pull request was just merged into `main`. Your job is to update the public
+"What's New" changelog at /changelog/ if — and only if — this change is
+user-facing.
+
+## 1. Gather context
+- Read the merged PR title, body, labels, and the squash/merge commit message.
+- Capture the **merge commit SHA** (the SHA of the commit now on `main`). You
+  will send it back for idempotency, so a re-run never double-posts.
+
+## 2. Decide if it is user-facing
+Skip (do nothing, end the session) when the change is internal-only:
+dependency bumps, CI/build, refactors with no behavior change, tests, infra,
+docs, or anything a Crush member would never notice. When in doubt about a
+borderline case, skip — a missing note is better than noise.
+
+## 3. Choose the release window
+- Read `crush_lu/data/release_milestones.json`.
+- Pick the entry whose `[since, until]` date window contains today's date.
+- Use that entry's `version`, `slug`, `title`, and `hero_summary` for the
+  `release` object. (Appending to the same slug groups the sprint's PRs under
+  one card.) If no window matches, create a sensible new one: `version` like
+  `vX.Y`, a kebab-case `slug`, a short `title`, and `released_on` = today.
+
+## 4. Write the note (warm, plain language)
+- `category`: one of `feature`, `improvement`, `fix`, `under_hood`.
+- `title`: ≤ 160 chars, benefit-first, no jargon, no internal scope names.
+- `body`: 1–3 short sentences describing what changed for the member.
+- `related_commits`: `["<MERGE_COMMIT_SHA>"]` — REQUIRED.
+- Never include emails, internal hostnames, SHAs in prose, ticket IDs, employee
+  names, or `Co-Authored-By` / `claude.ai/code` lines. (The server scrubs these
+  too, but write clean copy regardless.)
+
+## 5. Publish
+POST the payload to the ingest endpoint. Read the URL and key from the
+environment — do not hard-code them:
+
+```bash
+curl -sS -X POST "$CHANGELOG_INGEST_URL" \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @payload.json
+```
+
+A `201` with `"success": true` means it is live. `notes_added: 0` means this
+PR's SHA was already recorded (a duplicate delivery) — that is fine, end the
+session. On `4xx`, fix the payload (most often an invalid `category` or an
+oversized `title`) and retry once. Do not commit anything to the repo.
+````
+
+---
+
+## 4. Test it
+
+### Endpoint (CI runs this automatically)
+
+```bash
+pytest crush_lu/tests/test_api_admin_changelog.py crush_lu/tests/test_changelog.py -q
+```
+
+### Manual smoke test
+
+```bash
+export ADMIN_API_KEY=...            # must match the server
+export CHANGELOG_INGEST_URL=https://test.crush.lu/api/admin/changelog/ingest/
+
+curl -sS -X POST "$CHANGELOG_INGEST_URL" \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "release": {
+          "version": "v1.8",
+          "slug": "v1-8-crush-connect",
+          "title": "Crush Connect, reimagined",
+          "released_on": "2026-06-19"
+        },
+        "notes": [{
+          "category": "improvement",
+          "title": "Crush Connect",
+          "body": "You'\''re in the mix — clearer, warmer wording across Connect.",
+          "related_commits": ["abc123"]
+        }]
+      }'
+# → 201, entry visible on /changelog/.
+# Re-POST the same related_commits SHA → "notes_added": 0 (idempotent).
+```
+
+### End-to-end
+
+1. Merge a small user-facing PR into `main`.
+2. The routine session starts from the GitHub trigger; watch its log.
+3. Confirm a `201` POST and that the entry appears on
+   `https://crush.lu/changelog/`.
+4. (Optional) Re-run the routine on the same PR and confirm `notes_added: 0`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `401 Unauthorized` | `ADMIN_API_KEY` in the routine ≠ the server's value, or the server's is unset. |
+| POST times out / DNS error | Network policy blocks egress to `crush.lu`. Choose a policy that allows it. |
+| `400 ... category must be one of [...]` | `category` not in `feature/improvement/fix/under_hood`. |
+| `400 ... exceeds N characters` | A field is over its limit (title 160, release.title 140, hero_summary 280). |
+| Entry not on `/changelog/` | `is_published` was sent as `false`, or the release window matched a different (unpublished) slug. |
+| Note missing after a re-run | Expected — the merge SHA was already recorded (idempotency). |

--- a/docs/changelog-routine.md
+++ b/docs/changelog-routine.md
@@ -256,6 +256,7 @@ curl -sS -X POST "$CHANGELOG_INGEST_URL" \
 | `401 Unauthorized` | `ADMIN_API_KEY` in the routine ≠ the server's value, or the server's is unset. |
 | POST times out / DNS error | Network policy blocks egress to `crush.lu`. Choose a policy that allows it. |
 | `400 ... category must be one of [...]` | `category` not in `feature/improvement/fix/under_hood`. |
+| `400 ... related_commits must contain at least one commit SHA` | A note omitted the merge SHA (or sent an empty/blank list). It is required so re-deliveries dedupe. |
 | `400 ... exceeds N characters` | A field is over its limit (title 160, release.title 140, hero_summary 280). |
 | Entry not on `/changelog/` | `is_published` was sent as `false`, or the release window matched a different (unpublished) slug. |
 | Note missing after a re-run | Expected — the merge SHA was already recorded (idempotency). |


### PR DESCRIPTION
## Purpose

Make the public "What's New" changelog (`/changelog/`) update **automatically when a PR is merged into `main`**. A Claude Code routine (configured per `docs/changelog-routine.md`) composes a user-facing note from the merged PR and POSTs it to a new secured Django endpoint that publishes it live. Production DB credentials never leave the server — the routine makes a single authenticated HTTPS call.

```
PR merged → main
  └─(GitHub trigger)→ Claude routine (cloud session, full git clone)
       • reads the merged PR + git log, skips non-user-facing merges
       • writes warm copy, scrubs secrets
       └─ POST (Bearer ADMIN_API_KEY) → /api/admin/changelog/ingest/
             └─ Django upserts PatchRelease + PatchNote (is_published=True) → live on /changelog/
```

## What's in this PR

- **`crush_lu/api_admin_changelog.py`** — new `POST /api/admin/changelog/ingest/`. Bearer auth (`ADMIN_API_KEY`), validates + scrubs the payload, upserts a `PatchRelease` and appends `PatchNote`s. **Idempotent on the merge-commit SHA** so a re-delivered webhook never duplicates a note. Auto-publishes by default (`is_published=True`; can be set to `false` to stage drafts for admin review).
- **`crush_lu/api_admin_auth.py`** — extracts the Bearer-token auth helper that was duplicated verbatim in `api_admin_sync` and `api_admin_hybrid` (the latter literally commented "cloned from api_admin_sync"); both now import it.
- **`crush_lu/changelog_text.py`** — moves `scrub()`/`SECRET_PATTERNS` out of the `generate_patch_notes` command so the command **and** the endpoint share one red-line filter. Because the endpoint can auto-publish with no human review, the server scrubs every incoming string (emails, internal Azure hosts, `Co-Authored-By`, `claude.ai/code` session URLs). The command re-exports `scrub` for existing callers/tests.
- **`azureproject/urls_crush.py`** — wires the language-neutral admin route next to the existing `/api/admin/...` endpoints.
- **`crush_lu/tests/test_api_admin_changelog.py`** — auth (401), method guard (405), valid publish (201), SHA idempotency, validation 400s (bad category / oversized title / invalid slug / bad JSON), and server-side scrubbing.
- **`docs/changelog-routine.md`** — end-to-end setup: the endpoint contract plus the exact Claude routine trigger (`pull_request.closed`, base=`main`, is merged=`true`), environment (`ADMIN_API_KEY`, `CHANGELOG_INGEST_URL`, `crush.lu` network access), and the routine prompt.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Feature
[x] Refactoring (no functional changes, no api changes)  — shared auth/scrub helpers
```

## How to test

```bash
pytest crush_lu/tests/test_api_admin_changelog.py crush_lu/tests/test_changelog.py -q
```

Manual:
```bash
curl -sS -X POST http://localhost:8000/api/admin/changelog/ingest/ \
  -H "Authorization: Bearer $ADMIN_API_KEY" -H "Content-Type: application/json" \
  -d '{"release":{"version":"v1.8","slug":"catchup-2026-06","title":"Crush Connect, reimagined","released_on":"2026-06-18"},"notes":[{"category":"improvement","title":"Crush Connect","body":"You'\''re in the mix.","related_commits":["abc123"]}]}'
# → 201; entry visible on /changelog/; re-POST same SHA → notes_added: 0
```

## Notes

- **Auth/secrets:** reuses the existing `settings.ADMIN_API_KEY` pattern; no new production secrets in GitHub Actions.
- **Validation environment:** the suite is pinned to Python 3.12 + Django 6.0 (per `requirements.txt`). This change was validated via `py_compile`, the standalone `scrub` filter, and URL resolution; the new tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FVf3suebAJis8qncwjDkv

---
_Generated by [Claude Code](https://claude.ai/code/session_018FVf3suebAJis8qncwjDkv)_