### PR TITLE
Speed up test suite: 3m57s → 57s fresh / ~20s repeat locally, lighter CI

### DIFF
--- a/.github/workflows/test-and-validate.yml
+++ b/.github/workflows/test-and-validate.yml
@@ -40,23 +40,20 @@ jobs:
         run: |
           python -m pip install --upgrade "pip>=26.1.1" "setuptools>=82.0.1" "wheel>=0.47.0"
           pip install -r requirements.txt
-          pip install pytest pytest-django pytest-cov pytest-xdist
+          pip install pytest pytest-django pytest-xdist
 
+      # No --cov: the Codecov upload had been failing for months (no
+      # CODECOV_TOKEN configured) and nothing consumed the report, so the
+      # coverage tracing overhead was pure waste. If coverage is wanted
+      # again, add CODECOV_TOKEN to repo secrets, reinstall pytest-cov,
+      # and set COVERAGE_CORE=sysmon to keep the tracing cheap.
       - name: Run tests (parallel with pytest-xdist, SQLite)
         env:
           SECRET_KEY: 'ci-test-key'
           USE_AZURE_STORAGE: 'False'
         run: |
-          pytest -m "not playwright" --tb=short -q -x -n auto --cov --cov-report=xml --cov-report=term
+          pytest -m "not playwright" --tb=short -q -x -n auto
         continue-on-error: false
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
 
   lint:
     name: Lint and Format Check

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ crm_plan/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+# pytest --reuse-db files (per-xdist-worker: test_db.sqlite3_gw0, ...)
+test_db.sqlite3*
 media/
 staticfiles/
 

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -296,6 +296,15 @@ else:
             "NAME": BASE_DIR / "db.sqlite3",
         }
     }
+    if not os.environ.get("CI"):
+        # File-based test DB (instead of :memory:) so pytest's --reuse-db can
+        # skip replaying all migrations on every local run. pytest-xdist gives
+        # each worker its own suffixed file (test_db.sqlite3_gw0, ...). Run
+        # `pytest --create-db` after pulling new migrations or after a
+        # `-m playwright` run (transaction=True teardown flushes seeded data).
+        # CI runners are ephemeral — nothing to reuse — so they keep the
+        # faster in-memory default (GitHub Actions always sets CI=true).
+        DATABASES["default"]["TEST"] = {"NAME": BASE_DIR / "test_db.sqlite3"}
 
 
 # Password validation

--- a/conftest.py
+++ b/conftest.py
@@ -84,6 +84,11 @@ def pytest_configure(config):
     # live_server uses ports like localhost:12345, which don't match Site domains
     settings.SITE_ID = 1
 
+    # Production PBKDF2 costs ~0.25s per hash and the suite creates users at
+    # ~560 call sites — hashing alone dominated the run. check_password() is
+    # hasher-agnostic, so auth/login tests behave identically under MD5.
+    settings.PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
 
 @pytest.fixture(scope='session', autouse=True)
 def _patch_static_storage():
@@ -135,10 +140,10 @@ def _user_model():
     return get_user_model()
 
 
-@pytest.fixture(scope='session')
-def django_db_modify_db_settings():
-    """Allow database modifications in tests."""
-    pass
+# NOTE: do not define a no-op ``django_db_modify_db_settings`` fixture here.
+# One existed and silently disabled pytest-django's per-xdist-worker test DB
+# naming, which breaks any file-based test database (all workers collide on
+# one file). The upstream fixture chain must stay in effect.
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/crush_lu/tests/test_quiz.py
+++ b/crush_lu/tests/test_quiz.py
@@ -363,6 +363,17 @@ class TestQuizStartRotationFailure:
     must surface the failure to the host instead of activating a quiz
     with no future-round seating."""
 
+    @pytest.fixture(autouse=True)
+    def _keep_test_connection_open(self, monkeypatch):
+        """database_sync_to_async calls close_old_connections() around every
+        hop; inside pytest-django's atomic test wrapper autocommit is off, so
+        Django closes the connection mid-transaction. In-memory SQLite only
+        survives because close() is a no-op there — a file-based test DB dies
+        with "Cannot operate on a closed database"."""
+        monkeypatch.setattr(
+            "channels.db.close_old_connections", lambda *a, **kw: None
+        )
+
     def _make_consumer(self, quiz):
         """Build a QuizConsumer instance bound to ``quiz`` without
         going through WebsocketCommunicator (which pulls in daphne).

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ DJANGO_SETTINGS_MODULE = azureproject.settings
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = --tb=short -q -x -n auto -m "not playwright" --reuse-db
+addopts = --tb=short -q -x -n auto --dist worksteal -m "not playwright" --reuse-db
 # Only dirs whose tests are actually collected (python_files = test_*.py).
 # entreprinder/tests.py, arborist/tests.py and power_up/tests.py exist but are
 # NOT matched by that pattern — and all three have drifted (404s / DB errors);


### PR DESCRIPTION
## Why

Full local suite took **3m57s** (1,505 tests, 16 xdist workers); the CI pytest step was **736s of a 773s job**. Two costs dominated, plus CI was paying for coverage nobody received.

## What was slow

1. **Password hashing** — production-strength PBKDF2 at ~0.25s/hash, with users created at ~560 call sites. The four `TestRotationInvariants` tests alone (38s+32s+30s+12s) are almost pure hashing.
2. **Migration replay** — the test DB was in-memory SQLite, so `--reuse-db` in `pytest.ini` was a no-op: every run replayed ~226 migrations in each of 16 workers (~35s setup on the slowest).
3. **Wasted coverage** — CI ran `--cov` then the Codecov upload failed every run ("Token required", no `CODECOV_TOKEN` configured) and nothing consumes the report.

## Changes

- **MD5 password hasher in tests** (`conftest.py`): `check_password()` is hasher-agnostic and nothing asserts on algorithm — verified across the suite.
- **File-based test DB locally** (`settings.py`, gated on `not CI`): makes `--reuse-db` real, skipping migration replay on repeat runs. `--no-migrations` was ruled out: 26 `RunPython` data migrations seed Traits/Qualities/Connect questions tests depend on. Run `pytest --create-db` after pulling new migrations or after a `-m playwright` run.
- **Removed a no-op `django_db_modify_db_settings` fixture** (`conftest.py`): it silently disabled pytest-django's per-worker DB naming — harmless with in-memory SQLite, fatal with file-based DBs (all 16 workers collide on one file).
- **Fixed 2 latent test bugs** (`test_quiz.py::TestQuizStartRotationFailure`): channels' `database_sync_to_async` calls `close_old_connections()` inside pytest-django's atomic wrapper, closing the connection mid-transaction. They only passed because closing an *in-memory* SQLite DB is a documented no-op.
- **`--dist worksteal`** (`pytest.ini`): long-tail tests no longer leave workers idle.
- **CI**: dropped `--cov` and the always-failing Codecov step. To restore coverage later: add `CODECOV_TOKEN` to secrets, reinstall `pytest-cov`, and set `COVERAGE_CORE=sysmon`.

## Measured results (local, 16 workers)

| Run | Before | After |
|---|---|---|
| Full suite, fresh DB | 3m57s | **57s** |
| Full suite, repeat (`--reuse-db`) | 3m57s | **~20s** |

Verified: two consecutive full runs green (1478 passed, 27 skipped, 0 failed), plus a `CI=true` run confirming the in-memory path CI uses still works. CI should also drop substantially from the hasher change + coverage removal (hashing hurts more on 4-core runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)