### PR TITLE
Fix Crush Connect gate forms: Alpine $el vs $root in child-input handlers

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -13402,10 +13402,10 @@ document.addEventListener("alpine:init", function () {
                 this._syncInterests();
                 // Story answer (step 7): seed the character counter from the
                 // server-rendered value.
-                var ta = this.$el.querySelector('textarea[name="story_answer"]');
+                var ta = this.$root.querySelector('textarea[name="story_answer"]');
                 this.storyCount = ta ? ta.value.length : 0;
                 this._showSecondStory =
-                    this.$el.getAttribute("data-show-second-story") === "true";
+                    this.$root.getAttribute("data-show-second-story") === "true";
             },
 
             onInterestChange: function () {
@@ -13413,7 +13413,9 @@ document.addEventListener("alpine:init", function () {
             },
 
             _syncInterests: function () {
-                var boxes = this.$el.querySelectorAll('input[name="interests"]');
+                // $root, not $el: also invoked via @change on the checkboxes,
+                // where $el is the checkbox itself and the queries find nothing.
+                var boxes = this.$root.querySelectorAll('input[name="interests"]');
                 var checked = 0;
                 boxes.forEach(function (b) {
                     if (b.checked) checked++;
@@ -13426,7 +13428,7 @@ document.addEventListener("alpine:init", function () {
             },
 
             onStoryInput: function () {
-                var ta = this.$el.querySelector('textarea[name="story_answer"]');
+                var ta = this.$root.querySelector('textarea[name="story_answer"]');
                 this.storyCount = ta ? ta.value.length : 0;
             },
 
@@ -13450,14 +13452,16 @@ document.addEventListener("alpine:init", function () {
                 this._sync();
             },
             _sync: function () {
-                var radios = this.$el.querySelectorAll('input[type="radio"][data-gate]');
+                // $root, not $el: invoked via @change on child radios, where
+                // $el is the radio itself and the queries find nothing.
+                var radios = this.$root.querySelectorAll('input[type="radio"][data-gate]');
                 var picked = {};
                 radios.forEach(function (r) {
                     if (r.checked && r.value) picked[r.name] = true;
                 });
                 this.count = Object.keys(picked).length;
 
-                var rows = this.$el.querySelectorAll("[data-gate-row]");
+                var rows = this.$root.querySelectorAll("[data-gate-row]");
                 rows.forEach(function (row) {
                     var selected = false;
                     row.querySelectorAll('input[type="radio"][data-gate]').forEach(function (r) {
@@ -13482,7 +13486,9 @@ document.addEventListener("alpine:init", function () {
                 this._sync();
             },
             _sync: function () {
-                var radios = this.$el.querySelectorAll('input[type="radio"][data-gate]');
+                // $root, not $el: invoked via @change on child radios, where
+                // $el is the radio itself and the queries find nothing.
+                var radios = this.$root.querySelectorAll('input[type="radio"][data-gate]');
                 var answered = {};
                 radios.forEach(function (r) {
                     if (r.checked) answered[r.name] = true;
@@ -13493,7 +13499,7 @@ document.addEventListener("alpine:init", function () {
                 });
                 var total = Object.keys(names).length;
                 var done = Object.keys(answered).length;
-                var submit = this.$el.querySelector("[data-gate-submit]");
+                var submit = this.$root.querySelector("[data-gate-submit]");
                 if (submit) submit.disabled = total === 0 || done < total;
             },
         };


### PR DESCRIPTION
## Problem

On `test.crush.lu/fr/crush-connect/today/`, the "Answer & connect" button on Drop cards stays grayed out (disabled) even after answering all three Read-the-Photo questions, so no Spark can ever be sent.

## Root cause

The site runs the **CSP build of Alpine.js**. In `connectGateCard` (and the two sibling components), `_sync()` queries the DOM through `this.$el`. That works from `init()` (where `$el` is the `x-data` form), but when the same method runs from `@change="onPick"` on a child radio, `$el` in that evaluation scope is **the radio input itself** — the queries match nothing and the handler silently no-ops. No console error is produced, which is why this survived unnoticed.

It was never caught live because the Crush Connect eligible pool on staging was empty until today (stale seed users pre-dated the M8 `photo_share_consent` requirement), so the gate card was never rendered.

Verified live on staging: evaluating `onPick` scoped to the radio does nothing, scoped to the form enables the button; hot-patching `_sync` to anchor on the form makes the real click flow work end-to-end.

## Fix

Anchor DOM queries on `this.$root` (the `x-data` element) instead of `this.$el`, matching the existing convention elsewhere in `alpine-components.js`. Applied to the three components sharing the pattern:

- `connectGateCard` — Drop card / spark compose answer gate (the reported bug)
- `connectGatePicker` — onboarding step 7 question picker (counter + row styling)
- `connectOnboarding` — step 3 interest cap counter, step 7 story character counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
