### PR TITLE
Deploy build stamp: gate smoke on the new build actually serving

### DIFF
--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -103,6 +103,9 @@ jobs:
           # Oryx extracts with: tar -xzf antenv.tar.gz -C /antenv
           # So the tar must contain bin/, lib/, etc. directly (not antenv/bin/, antenv/lib/)
           tar czf antenv.tar.gz -C antenv .
+          # Build stamp: /readyz/ exposes it so the pipeline (and post-swap
+          # checks) can verify which commit a container is actually serving.
+          echo "{\"commit\": \"${GITHUB_SHA}\", \"built_at\": \"$(date -u +%FT%TZ)\"}" > build_info.json
           zip -r deploy.zip . -x "*.git*" -x "*__pycache__*" -x "*.pyc" -x "node_modules/*" -x "tailwind-src/*" -x ".github/*" -x "tests/*" -x "*.md" -x "antenv/*"
           echo "✅ Deployment package built locally (with antenv.tar.gz)"
 
@@ -150,6 +153,22 @@ jobs:
             wait "$pid" || failed=1
           done
           exit $failed
+
+      - name: Wait for new build to serve
+        # A zip deploy + restart returns while the OLD container still
+        # answers (healthz/readyz pass on it too), so poll until /readyz/
+        # reports this run's commit before judging the deployment.
+        run: |
+          echo "Waiting for staging to serve ${GITHUB_SHA}..."
+          for i in $(seq 1 60); do
+            if curl -s --max-time 10 https://test.crush.lu/readyz/ | grep -q "${GITHUB_SHA}"; then
+              echo "✅ staging serves ${GITHUB_SHA}"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "❌ staging never reported ${GITHUB_SHA} within 10 minutes"
+          exit 1
 
       - name: Smoke Test
         # Deep checks against the staging slot: /readyz/ (DB, migrations,

--- a/azureproject/middleware.py
+++ b/azureproject/middleware.py
@@ -156,13 +156,14 @@ class HealthCheckMiddleware:
         if request.path in ['/healthz/', '/healthz']:
             return HttpResponse("OK", status=200, content_type="text/plain")
         if request.path in ['/readyz/', '/readyz']:
-            from azureproject.readiness import run_readiness_checks
+            from azureproject.readiness import build_info, run_readiness_checks
 
             all_passed, results = run_readiness_checks()
-            return JsonResponse(
-                {"status": "ok" if all_passed else "fail", "checks": results},
-                status=200 if all_passed else 503,
-            )
+            payload = {"status": "ok" if all_passed else "fail", "checks": results}
+            build = build_info()
+            if build:
+                payload["build"] = build
+            return JsonResponse(payload, status=200 if all_passed else 503)
         return self.get_response(request)
 
 

--- a/azureproject/readiness.py
+++ b/azureproject/readiness.py
@@ -74,6 +74,27 @@ CHECKS = (
 )
 
 
+def build_info():
+    """
+    Return the build stamp written by CI into the deploy package, or None.
+
+    The deploy workflow writes build_info.json (commit sha + timestamp) next
+    to manage.py before zipping. Exposing it in /readyz/ lets the pipeline
+    wait until the *new* build is actually serving (a zip deploy + restart
+    leaves the old container answering for a while), and lets a post-swap
+    check assert production runs the expected commit.
+    """
+    import json
+
+    from django.conf import settings
+
+    try:
+        with open(settings.BASE_DIR / "build_info.json", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return None
+
+
 def run_readiness_checks():
     """Run all checks; return (all_passed, {name: "ok" | "fail: ExcName"})."""
     results = {}

--- a/crush_lu/tests/test_readiness.py
+++ b/crush_lu/tests/test_readiness.py
@@ -8,6 +8,8 @@ out, and 503 with per-check detail otherwise.
 """
 
 import json
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from django.conf import settings
@@ -100,6 +102,24 @@ class ReadyzTests(TestCase):
         self.assertEqual(payload["status"], "fail")
         for value in payload["checks"].values():
             self.assertTrue(value.startswith("fail:"))
+
+    def test_readyz_includes_build_stamp_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "build_info.json").write_text(
+                '{"commit": "abc123", "built_at": "2026-07-06T00:00:00Z"}',
+                encoding="utf-8",
+            )
+            with override_settings(BASE_DIR=Path(tmp)):
+                response = self.client.get("/readyz/")
+        payload = json.loads(response.content)
+        self.assertEqual(payload["build"]["commit"], "abc123")
+
+    def test_readyz_omits_build_stamp_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with override_settings(BASE_DIR=Path(tmp)):
+                response = self.client.get("/readyz/")
+        payload = json.loads(response.content)
+        self.assertNotIn("build", payload)
 
     def test_storage_check_fails_when_container_missing(self):
         # Azure-style backend: exists() on a blob returns False for a missing


### PR DESCRIPTION
## What

Follow-up to #576, fixing its first live deploy run (failed smoke): `az webapp deploy --restart` returns while the **old** container still answers, and `/healthz/`+`/readyz/` pass on it too — so the smoke gate judged stale code. Today that was a false red (the deploy actually succeeded; `/readyz/` went live minutes later and is green on staging); on future deploys it would be a false green, which is worse.

- CI writes `build_info.json` (commit sha + build timestamp) into the deploy zip.
- `/readyz/` exposes it as a `build` key when present (omitted when absent — dev/test unaffected).
- The deploy workflow now polls `/readyz/` until it reports the run's commit (up to 10 min, matching the 600s startup budget) **before** running the smoke suite.
- Bonus for the upcoming swap: after swapping, `https://crush.lu/readyz/` shows exactly which commit production is serving.

## Tests

- `crush_lu/tests/test_readiness.py`: 9 pass (2 new: build stamp present/absent).
- Staging is currently green end-to-end: `/readyz/` reports all four checks ok against the live staging stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)