### PR TITLE
feat(crush_lu): Crush Connect beta phase — candidate-open, receivers tester-gated

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -469,6 +469,15 @@ PRE_SCREENING_ENABLED = _env_bool("PRE_SCREENING_ENABLED", default=False)
 # in M8, so this flag can stay True in production once beta finishes.
 CRUSH_CONNECT_LAUNCHED = _env_bool("CRUSH_CONNECT_LAUNCHED", default=False)
 
+# Crush Connect BETA phase (candidate-open). When True (and LAUNCHED still False),
+# the candidate "in the Mix" track opens to any verified + LuxID member — they can
+# opt in and become discoverable — while the Premium/receiver track (Today's Drop)
+# stays limited to staff + hand-picked waitlist testers (CrushConnectWaitlist.
+# selected_as_tester), and €15 stays funnelled to the waitlist (PREMIUM_REDIRECTS_
+# TO_BETA). Ignored once LAUNCHED is True (full public launch). See crush_lu/
+# connect_phase.py for the phase helpers that read this.
+CRUSH_CONNECT_CANDIDATE_OPEN = _env_bool("CRUSH_CONNECT_CANDIDATE_OPEN", default=False)
+
 # During the "4 weeks / 4 matches" Crush Connect beta, funnel the Go-Premium flow
 # into the beta waitlist instead of the coach directory. Members with an in-flight
 # (pending) premium request are exempt so they can still manage it. Set False to

--- a/crush_lu/connect_phase.py
+++ b/crush_lu/connect_phase.py
@@ -1,0 +1,54 @@
+"""Crush Connect launch-phase helpers.
+
+Three phases, driven by two settings, so access can widen in stages:
+
+- **PRELAUNCH** (both flags off): staff only; everyone else lands on the
+  teaser / waitlist.
+- **BETA** (``CRUSH_CONNECT_CANDIDATE_OPEN`` on, ``CRUSH_CONNECT_LAUNCHED``
+  off): the candidate — "in the Mix" — track opens to any verified + LuxID
+  member (they can opt in and become discoverable), but the Premium/receiver
+  track (Today's Drop) stays limited to staff + hand-picked waitlist testers
+  (``CrushConnectWaitlist.selected_as_tester``). €15 stays funnelled to the
+  waitlist via ``PREMIUM_REDIRECTS_TO_BETA``.
+- **LAUNCHED** (``CRUSH_CONNECT_LAUNCHED`` on): everything public; the beta
+  flag is ignored.
+
+Keep the two access questions separate: ``candidate_access_open()`` gates the
+Mix/onboarding/catalogue/sparks surfaces; ``receiver_access_open(user)`` gates
+Today's Drop. Callers combine the latter with ``_user_is_connect_receiver_
+eligible`` (approved + coach) — this module only answers "does the *phase* let
+this user receive".
+"""
+
+from django.conf import settings
+
+
+def candidate_access_open():
+    """True when the candidate track (onboarding / Mix / catalogue / sparks) is
+    reachable by eligible members — full launch OR the beta candidate-open phase.
+    Staff bypass is handled separately at each call site."""
+    return bool(
+        getattr(settings, "CRUSH_CONNECT_LAUNCHED", False)
+        or getattr(settings, "CRUSH_CONNECT_CANDIDATE_OPEN", False)
+    )
+
+
+def is_selected_beta_tester(user):
+    """True if ``user`` is a hand-picked waitlist beta tester
+    (``CrushConnectWaitlist.selected_as_tester``)."""
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    waitlist = getattr(user, "crush_connect_waitlist", None)
+    return bool(waitlist and waitlist.selected_as_tester)
+
+
+def receiver_access_open(user):
+    """Whether this user's phase lets them reach the receiver track (Today's
+    Drop). Full launch opens it to every Premium member; the beta limits it to
+    staff + selected waitlist testers. Does NOT check coach/onboarded — callers
+    combine it with ``_user_is_connect_receiver_eligible``."""
+    if getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+        return True
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    return bool(getattr(user, "is_staff", False) or is_selected_beta_tester(user))

--- a/crush_lu/context_processors.py
+++ b/crush_lu/context_processors.py
@@ -124,10 +124,14 @@ def crush_user_context(request):
         # stays off every other page's query budget.
         connect_pending_sparks_count = 0
         try:
-            launched = getattr(settings, "CRUSH_CONNECT_LAUNCHED", False)
+            from crush_lu.connect_phase import candidate_access_open
+
+            # Candidates receive Sparks too, so the badge follows candidate access
+            # (open in the beta), not just the full launch flag.
+            connect_open = candidate_access_open()
             membership = getattr(request.user, "crush_connect_membership", None)
             nav_visible = request.user.is_staff or (
-                launched and membership is not None and membership.is_onboarded
+                connect_open and membership is not None and membership.is_onboarded
             )
             if nav_visible:
                 from .models import CuriositySpark

--- a/crush_lu/templatetags/crush_connect_tags.py
+++ b/crush_lu/templatetags/crush_connect_tags.py
@@ -23,12 +23,15 @@ def crush_connect_visible(user):
     """
     True if the Crush Connect entry point (teaser or app) should be visible.
 
-    Visible when the global launch flag is on, OR the user is staff (so
-    internal review and beta walkthroughs work before public launch).
-    Eligibility (approved profile + attended event) is enforced at the
-    view layer; this filter only controls nav/CTA visibility.
+    Visible when the candidate track is open (full launch OR the beta
+    candidate-open phase), OR the user is staff (so internal review and beta
+    walkthroughs work before public launch). Eligibility (approved profile +
+    LuxID) is enforced at the view layer; this filter only controls nav/CTA
+    visibility.
     """
-    if getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    from crush_lu.connect_phase import candidate_access_open
+
+    if candidate_access_open():
         return True
     return bool(user and user.is_authenticated and user.is_staff)
 
@@ -43,14 +46,21 @@ def crush_connect_nav_visible(user):
     That means a Connect-onboarded membership is required. Staff bypass keeps
     internal review working before any user has onboarded.
     """
+    from crush_lu.connect_phase import is_selected_beta_tester
+
     if not user or not user.is_authenticated:
         return False
     if user.is_staff:
         return True
-    if not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
-        return False
     membership = getattr(user, "crush_connect_membership", None)
-    return bool(membership and membership.is_onboarded)
+    if not (membership and membership.is_onboarded):
+        return False
+    # Today's Drop is the receiver surface: shown post-launch to any onboarded
+    # member, and during the beta only to selected waitlist testers (who are the
+    # only non-staff members that reach it — see connect_phase.receiver_access_open).
+    if getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+        return True
+    return is_selected_beta_tester(user)
 
 
 @register.simple_tag

--- a/crush_lu/tests/test_crush_connect_beta_phase.py
+++ b/crush_lu/tests/test_crush_connect_beta_phase.py
@@ -1,0 +1,187 @@
+"""Access-matrix tests for the Crush Connect BETA phase (candidate-open).
+
+The beta (``CRUSH_CONNECT_CANDIDATE_OPEN`` on, ``CRUSH_CONNECT_LAUNCHED`` off)
+opens the candidate "in the Mix" track to any verified + LuxID member, while the
+Premium/receiver track (Today's Drop) stays limited to staff + selected waitlist
+testers. See ``crush_lu/connect_phase.py``.
+
+Backward-compat (both flags off = prelaunch, LAUNCHED on = full launch) is
+covered by the existing ``test_crush_connect*`` suites; here we exercise the new
+middle phase and the tester-gated receiver rule.
+"""
+
+import pytest
+
+from crush_lu.connect_phase import (
+    candidate_access_open,
+    is_selected_beta_tester,
+    receiver_access_open,
+)
+from crush_lu.models.crush_connect import CrushConnectWaitlist
+from crush_lu.tests.test_crush_connect import (
+    CONNECT_HOME_URL,
+    CONNECT_TEASER_URL,
+    _login_eligible,
+    _make_user,
+    _mark_attended,
+)
+
+
+def _select_tester(user):
+    return CrushConnectWaitlist.objects.create(user=user, selected_as_tester=True)
+
+
+# ---------------------------------------------------------------------------
+# Phase helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_access_open_matrix(settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = False
+    assert candidate_access_open() is False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    assert candidate_access_open() is True
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = False
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    assert candidate_access_open() is True
+
+
+@pytest.mark.django_db
+def test_receiver_access_open_beta_limited_to_testers(settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    tester = _make_user(username="t", premium=True)
+    _select_tester(tester)
+    plain = _make_user(username="p", premium=True)
+
+    assert is_selected_beta_tester(tester) is True
+    assert is_selected_beta_tester(plain) is False
+    assert receiver_access_open(tester) is True
+    assert receiver_access_open(plain) is False
+
+    # Full launch opens the receiver track to every Premium member.
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    assert receiver_access_open(plain) is True
+
+
+# ---------------------------------------------------------------------------
+# Access matrix via the Today's-Drop gate (_connect_access_blocker)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_beta_candidate_not_onboarded_routed_to_onboarding(client, settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="cand1", premium=False, has_luxid=True, onboarded=False)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code in (301, 302)
+    assert "/onboarding/" in resp.url
+
+
+@pytest.mark.django_db
+def test_beta_onboarded_candidate_routed_to_catalogue(client, settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="cand2", premium=False, has_luxid=True, onboarded=True)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code in (301, 302)
+    assert "/catalogue/" in resp.url
+
+
+@pytest.mark.django_db
+def test_beta_selected_tester_reaches_todays_drop(client, settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="tester", preferred_genders=["F"])  # premium + onboarded
+    _mark_attended(me)
+    _select_tester(me)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_beta_premium_non_tester_treated_as_candidate(client, settings):
+    """The key beta rule: a Premium member who is NOT a selected tester does not
+    get Today's Drop — they're routed to the candidate catalogue instead."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="prem", preferred_genders=["F"])  # premium, NOT a tester
+    _mark_attended(me)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code in (301, 302)
+    assert "/catalogue/" in resp.url
+
+
+@pytest.mark.django_db
+def test_beta_candidate_still_requires_luxid(client, settings):
+    """Candidate access still needs LuxID — a verified member without it is
+    bounced to the teaser even in beta."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="nolux", premium=False, has_luxid=False, onboarded=False)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code in (301, 302)
+    assert resp.url.endswith("/crush-connect/")  # teaser
+
+
+@pytest.mark.django_db
+def test_prelaunch_gates_everyone_including_testers(client, settings):
+    """Both flags off = unchanged prelaunch: even a selected tester hits the
+    teaser (the beta flag is what opens the door)."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = False
+    me = _make_user(username="pre", preferred_genders=["F"])
+    _mark_attended(me)
+    _select_tester(me)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code in (301, 302)
+    assert resp.url.endswith("/crush-connect/")  # teaser
+
+
+# ---------------------------------------------------------------------------
+# Teaser fast-path routing during beta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_teaser_routes_beta_tester_to_drop(client, settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="tt", preferred_genders=["F"])
+    _mark_attended(me)
+    _select_tester(me)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_TEASER_URL)
+    assert resp.status_code in (301, 302)
+    assert "/today/" in resp.url
+
+
+@pytest.mark.django_db
+def test_teaser_routes_beta_premium_non_tester_to_catalogue(client, settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="ptn", preferred_genders=["F"])  # premium, not a tester
+    _mark_attended(me)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_TEASER_URL)
+    assert resp.status_code in (301, 302)
+    assert "/catalogue/" in resp.url
+
+
+@pytest.mark.django_db
+def test_teaser_routes_beta_candidate_to_onboarding(client, settings):
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="ct", premium=False, has_luxid=True, onboarded=False)
+    _login_eligible(client, me)
+    resp = client.get(CONNECT_TEASER_URL)
+    assert resp.status_code in (301, 302)
+    assert "/onboarding/" in resp.url

--- a/crush_lu/views_crush_connect.py
+++ b/crush_lu/views_crush_connect.py
@@ -20,6 +20,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
+from crush_lu.connect_phase import candidate_access_open, receiver_access_open
 from crush_lu.decorators import coach_required, crush_login_required
 from crush_lu.email_helpers import send_crush_connect_catalogue_welcome
 from crush_lu.models import CrushConnectMembership, CrushProfile
@@ -119,7 +120,7 @@ def _connect_access_blocker(user):
     if user.is_staff:
         return None
 
-    if not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     membership = getattr(user, "crush_connect_membership", None)
@@ -137,6 +138,11 @@ def _connect_access_blocker(user):
         # Candidate-only members don't get Drops — show their catalogue state.
         return redirect("crush_lu:crush_connect_catalogue_status")
 
+    if not receiver_access_open(user):
+        # Beta phase: a Premium member who isn't a selected waitlist tester stays
+        # on the candidate side (Today's Drop is limited to the tester cohort).
+        return redirect("crush_lu:crush_connect_catalogue_status")
+
     return None
 
 
@@ -150,7 +156,7 @@ def _hub_access_blocker(user):
     if user.is_staff:
         return None
 
-    if not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     membership = getattr(user, "crush_connect_membership", None)
@@ -207,7 +213,7 @@ def _onboarding_gate(request):
     user = request.user
     done_url = _connect_done_url(user)
 
-    if not user.is_staff and not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser"), None, done_url
 
     # Grandfather already-onboarded members (and bounce excluded ones) BEFORE the
@@ -509,7 +515,7 @@ def crush_connect_profile_edit(request):
     ``onboarded_at`` / ``onboarding_step``.
     """
     user = request.user
-    if not user.is_staff and not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     membership = getattr(user, "crush_connect_membership", None)
@@ -586,7 +592,7 @@ def crush_connect_catalogue_status(request):
     """
     user = request.user
 
-    if not user.is_staff and not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     if _user_is_connect_receiver_eligible(user):
@@ -809,7 +815,7 @@ def crush_connect_spark_compose(request, user_id: int):
     )
 
     user = request.user
-    if not user.is_staff and not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     target = get_object_or_404(
@@ -987,7 +993,7 @@ def crush_connect_sparks_received(request):
     )
 
     user = request.user
-    if not user.is_staff and not getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
+    if not user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     # Pending Sparks are immutable records — a recipient who lost catalogue
@@ -1247,9 +1253,7 @@ def crush_connect_experience(request, slug):
     if slug not in CONNECT_EXPERIENCES:
         raise Http404
 
-    if not request.user.is_staff and not getattr(
-        settings, "CRUSH_CONNECT_LAUNCHED", False
-    ):
+    if not request.user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
     membership = getattr(request.user, "crush_connect_membership", None)

--- a/crush_lu/views_static.py
+++ b/crush_lu/views_static.py
@@ -179,17 +179,17 @@ def crush_coach(request):
 
 def crush_connect_teaser(request):
     """Crush Connect teaser page with waitlist."""
-    from django.conf import settings as _settings
+    from crush_lu.connect_phase import candidate_access_open, receiver_access_open
 
-    # Post-launch fast-path: if Crush Connect is live and the visitor can
-    # actually use it, send them past the teaser. Two tracks (asymmetric
-    # model): Premium receivers land on Today's Drop, LuxID candidates on
-    # the catalogue status page; either onboards first if needed. Staff are
-    # never auto-redirected so they can still preview the teaser itself.
+    # Fast-path: if the candidate track is open (full launch OR beta) and the
+    # visitor can actually use it, send them past the teaser. Two tracks
+    # (asymmetric model): Premium receivers land on Today's Drop, LuxID
+    # candidates on the catalogue status page; either onboards first if needed.
+    # Staff are never auto-redirected so they can still preview the teaser itself.
     if (
         request.user.is_authenticated
         and not request.user.is_staff
-        and getattr(_settings, "CRUSH_CONNECT_LAUNCHED", False)
+        and candidate_access_open()
     ):
         profile = getattr(request.user, "crushprofile", None)
         if profile and profile.is_approved:
@@ -197,9 +197,15 @@ def crush_connect_teaser(request):
             excluded = membership and membership.excluded_by_coach
             if not excluded:
                 onboarded = bool(membership and membership.is_onboarded)
-                if onboarded and profile.assigned_coach_id:
+                if (
+                    onboarded
+                    and profile.assigned_coach_id
+                    and receiver_access_open(request.user)
+                ):
                     # Onboarded Premium receiver → their Drop (grandfathered;
-                    # receiving Drops doesn't require LuxID).
+                    # receiving Drops doesn't require LuxID). During the beta this
+                    # also requires being a selected tester; other Premium members
+                    # fall through to the candidate catalogue below.
                     return redirect("crush_lu:crush_connect_home")
                 if onboarded and profile.has_luxid_connected:
                     # Onboarded candidate (LuxID) → catalogue status.


### PR DESCRIPTION
## Summary

Adds a **middle "beta" phase** between prelaunch and full launch, so Crush Connect can open to eligible members **without** turning on the public €15 product. This is the access mechanism for the "recruit → preselect → comp" beta.

New setting **`CRUSH_CONNECT_CANDIDATE_OPEN`** (default **OFF** — nothing changes in production until it's flipped).

### The three phases

| Phase | Flags | Candidate track ("in the Mix") | Receiver track (Today's Drop) | €15 |
|---|---|---|---|---|
| **Prelaunch** | both off | staff only | staff only | funnelled to waitlist |
| **Beta** | `CANDIDATE_OPEN` on | **any verified + LuxID member** | **staff + selected waitlist testers** | funnelled to waitlist |
| **Launched** | `LAUNCHED` on | everyone | any Premium member | on sale |

### Behaviour in beta (`CANDIDATE_OPEN` on, `LAUNCHED` off)
- Any verified + LuxID member can opt in, become discoverable, and appear in testers' Drops.
- A Premium member who **isn't** a selected tester is routed to the candidate catalogue — **not** Today's Drop.
- €15 self-serve stays funnelled to the waitlist via the existing `PREMIUM_REDIRECTS_TO_BETA` (default on), so no purchase happens during the beta — no new €15 code needed.

## Design

Phase logic is centralized in the new **`crush_lu/connect_phase.py`**:
- `candidate_access_open()` — Mix / onboarding / catalogue / sparks reachable
- `receiver_access_open(user)` — Today's Drop: full launch → any Premium; beta → staff + selected testers
- `is_selected_beta_tester(user)` — reads `CrushConnectWaitlist.selected_as_tester`

Threaded through both access-blockers, the onboarding/profile-edit/catalogue/sparks/experiences gates, the teaser fast-path, `crush_connect_visible` / `crush_connect_nav_visible`, and the Sparks badge.

## Backward compatibility
`candidate_access_open()` collapses to the old `LAUNCHED` check when the beta flag is off, and `receiver_access_open()` returns True under full launch — so **prelaunch and launched behaviour are unchanged**. The full existing Connect suites pass untouched.

## Tests
New `test_crush_connect_beta_phase.py` covers the access matrix: candidate → onboarding, onboarded candidate → catalogue, selected tester → Today's Drop, **premium-non-tester → catalogue** (the key rule), LuxID still required, prelaunch gates everyone (incl. testers), and teaser fast-path routing. Full `crush_lu/tests` suite green.

## To run the beta
1. `CRUSH_CONNECT_CANDIDATE_OPEN=true` (leave `CRUSH_CONNECT_LAUNCHED=false`)
2. Mark your picks `selected_as_tester` on the waitlist
3. Assign each a coach (comped Premium) — that's what makes them a receiver

🤖 Generated with [Claude Code](https://claude.com/claude-code)