### PR TITLE
fix(crush_lu): apply beta receiver gate consistently (Codex review of #601)

### DIFF
--- a/crush_lu/templatetags/crush_connect_tags.py
+++ b/crush_lu/templatetags/crush_connect_tags.py
@@ -39,14 +39,17 @@ def crush_connect_visible(user):
 @register.filter
 def crush_connect_nav_visible(user):
     """
-    True if the **Today's Drop** nav tab should be visible to this user.
+    True if the persistent Crush Connect nav (navbar / bottom nav / subnav)
+    should be visible to this user.
 
-    Stricter than ``crush_connect_visible``: we only show the tab when the
-    user can actually reach the Drop page without bouncing through the teaser.
-    That means a Connect-onboarded membership is required. Staff bypass keeps
-    internal review working before any user has onboarded.
+    Stricter than ``crush_connect_visible``: shown only to Connect-onboarded
+    members, so the nav appears once someone is actually in — for BOTH tracks
+    (candidates and receivers) whenever the candidate track is open (beta or full
+    launch). The Drop link within routes a non-receiver to their catalogue
+    status, so beta candidates keep their Connect / Profile / Sparks navigation.
+    Staff bypass keeps internal review working before anyone has onboarded.
     """
-    from crush_lu.connect_phase import is_selected_beta_tester
+    from crush_lu.connect_phase import candidate_access_open
 
     if not user or not user.is_authenticated:
         return False
@@ -55,12 +58,7 @@ def crush_connect_nav_visible(user):
     membership = getattr(user, "crush_connect_membership", None)
     if not (membership and membership.is_onboarded):
         return False
-    # Today's Drop is the receiver surface: shown post-launch to any onboarded
-    # member, and during the beta only to selected waitlist testers (who are the
-    # only non-staff members that reach it — see connect_phase.receiver_access_open).
-    if getattr(settings, "CRUSH_CONNECT_LAUNCHED", False):
-        return True
-    return is_selected_beta_tester(user)
+    return candidate_access_open()
 
 
 @register.simple_tag

--- a/crush_lu/tests/test_crush_connect_beta_phase.py
+++ b/crush_lu/tests/test_crush_connect_beta_phase.py
@@ -19,12 +19,18 @@ from crush_lu.connect_phase import (
 )
 from crush_lu.models.crush_connect import CrushConnectWaitlist
 from crush_lu.tests.test_crush_connect import (
+    CATALOGUE_STATUS_URL,
     CONNECT_HOME_URL,
     CONNECT_TEASER_URL,
     _login_eligible,
     _make_user,
     _mark_attended,
+    _surface_in_drop,
 )
+
+# crush_connect_hub is served at /crush-connect/home/ (the shared landing for
+# both tracks); Today's Drop lives at /crush-connect/today/ (CONNECT_HOME_URL).
+HUB_URL = "/en/crush-connect/home/"
 
 
 def _select_tester(user):
@@ -185,3 +191,79 @@ def test_teaser_routes_beta_candidate_to_onboarding(client, settings):
     resp = client.get(CONNECT_TEASER_URL)
     assert resp.status_code in (301, 302)
     assert "/onboarding/" in resp.url
+
+
+# ---------------------------------------------------------------------------
+# Regressions from the Codex review of the beta-phase PR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_beta_premium_non_tester_has_no_drop_catalogue_loop(client, settings):
+    """P1: a Premium non-tester must land on the catalogue and STAY — /today/
+    routes to /catalogue/, and /catalogue/ must not bounce back to /today/."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="prem", preferred_genders=["F"])  # premium, not a tester
+    _mark_attended(me)
+    _login_eligible(client, me)
+
+    resp = client.get(CONNECT_HOME_URL)
+    assert resp.status_code in (301, 302)
+    assert "/catalogue/" in resp.url
+
+    # The catalogue renders instead of bouncing back — the loop is broken.
+    resp = client.get(CATALOGUE_STATUS_URL)
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_beta_hub_classifies_non_tester_as_candidate(client, settings):
+    """P2: the shared hub must not show receiver UI (Drop card / coach pick) to a
+    beta Premium non-tester; a selected tester still gets the receiver track."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="prem", preferred_genders=["F"])
+    _mark_attended(me)
+    _login_eligible(client, me)
+
+    resp = client.get(HUB_URL)
+    assert resp.status_code == 200
+    assert resp.context["is_receiver"] is False
+    assert resp.context["track"] == "candidate"
+
+    _select_tester(me)
+    resp = client.get(HUB_URL)
+    assert resp.context["is_receiver"] is True
+    assert resp.context["track"] == "receiver"
+
+
+@pytest.mark.django_db
+def test_beta_nav_visible_for_onboarded_candidate(settings):
+    """P2: onboarded candidates keep the persistent Connect nav during beta, not
+    just selected testers."""
+    from crush_lu.templatetags.crush_connect_tags import crush_connect_nav_visible
+
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    candidate = _make_user(username="cand", premium=False, onboarded=True)
+    assert crush_connect_nav_visible(candidate) is True
+    not_onboarded = _make_user(username="no", premium=False, onboarded=False)
+    assert crush_connect_nav_visible(not_onboarded) is False
+
+
+@pytest.mark.django_db
+def test_beta_spark_compose_blocked_for_non_tester(client, settings):
+    """P2: a beta Premium non-tester holding a stale Drop snapshot cannot open the
+    Spark compose / first-mover send flow."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="prem", preferred_genders=["F"])  # premium, not a tester
+    _mark_attended(me)
+    her = _make_user(username="her", gender="F", premium=False)
+    _surface_in_drop(me, her)  # stale snapshot from an old Drop
+    _login_eligible(client, me)
+
+    resp = client.get(f"/en/crush-connect/spark/{her.pk}/")
+    assert resp.status_code in (301, 302)
+    assert "/catalogue/" in resp.url

--- a/crush_lu/views_crush_connect.py
+++ b/crush_lu/views_crush_connect.py
@@ -72,6 +72,21 @@ def _user_is_connect_receiver_eligible(user) -> bool:
     return profile.assigned_coach_id is not None
 
 
+def _user_can_receive_now(user) -> bool:
+    """Whether the receiver track (Today's Drop) is reachable for ``user`` right
+    now: Premium-eligible (approved + coach) AND the phase lets them receive
+    (full launch, or a selected tester in beta).
+
+    Single source of truth for the receiver/candidate split — used by the access
+    blocker, the catalogue/hub routing, the onboarding-completion copy, and the
+    Spark first-mover gate — so a beta non-tester is treated as a candidate
+    everywhere (and never bounced in a Drop ⇄ catalogue loop). Staff are handled
+    by callers via ``or user.is_staff``; ``receiver_access_open`` also lets staff
+    through, but a coachless staff member is not receiver-eligible here.
+    """
+    return _user_is_connect_receiver_eligible(user) and receiver_access_open(user)
+
+
 def _user_is_connect_candidate_eligible(user) -> bool:
     """Verified profile + LuxID linked: may opt in to the candidate catalogue.
 
@@ -134,13 +149,9 @@ def _connect_access_blocker(user):
             return redirect("crush_lu:crush_connect_teaser")
         return redirect("crush_lu:crush_connect_onboarding")
 
-    if not _user_is_connect_receiver_eligible(user):
-        # Candidate-only members don't get Drops — show their catalogue state.
-        return redirect("crush_lu:crush_connect_catalogue_status")
-
-    if not receiver_access_open(user):
-        # Beta phase: a Premium member who isn't a selected waitlist tester stays
-        # on the candidate side (Today's Drop is limited to the tester cohort).
+    if not _user_can_receive_now(user):
+        # Candidate-only members — no coach, or (in beta) a Premium member who
+        # isn't a selected tester — don't get Drops; show their catalogue state.
         return redirect("crush_lu:crush_connect_catalogue_status")
 
     return None
@@ -189,7 +200,7 @@ def _connect_done_url(user) -> str:
     """Where a finished member lands: receivers (Premium) → Today's Drop,
     candidates (LuxID-only) → catalogue status. Staff count as receivers so
     they can preview the Drop."""
-    is_receiver = _user_is_connect_receiver_eligible(user) or user.is_staff
+    is_receiver = _user_can_receive_now(user) or user.is_staff
     return (
         "crush_lu:crush_connect_home"
         if is_receiver
@@ -254,7 +265,7 @@ def _emit_onboarding_complete(request, done_url):
     """Success message (per track) + candidate welcome email. Ported from the
     legacy single-page view."""
     user = request.user
-    is_receiver = _user_is_connect_receiver_eligible(user) or user.is_staff
+    is_receiver = _user_can_receive_now(user) or user.is_staff
     if is_receiver:
         messages.success(
             request, _("Welcome to Crush Connect — your first Drop is ready.")
@@ -406,9 +417,7 @@ def crush_connect_onboarding_step(request, step: int):
                 initial["preferred_age_max"] = profile.preferred_age_max
         form = form_class(instance=membership, initial=initial)
 
-    is_receiver = (
-        _user_is_connect_receiver_eligible(request.user) or request.user.is_staff
-    )
+    is_receiver = _user_can_receive_now(request.user) or request.user.is_staff
     context = {
         "form": form,
         "membership": membership,
@@ -595,7 +604,10 @@ def crush_connect_catalogue_status(request):
     if not user.is_staff and not candidate_access_open():
         return redirect("crush_lu:crush_connect_teaser")
 
-    if _user_is_connect_receiver_eligible(user):
+    if _user_can_receive_now(user):
+        # Only forward to Today's Drop if they can actually receive now — a beta
+        # Premium non-tester stays here on the candidate catalogue (else the two
+        # views would bounce /today/ ⇄ /catalogue/ forever).
         return redirect("crush_lu:crush_connect_home")
     if not user.is_staff and not _user_is_connect_candidate_eligible(user):
         return redirect("crush_lu:crush_connect_teaser")
@@ -667,7 +679,7 @@ def crush_connect_hub(request):
     if blocker is not None:
         return blocker
 
-    is_receiver = _user_is_connect_receiver_eligible(user) or user.is_staff
+    is_receiver = _user_can_receive_now(user) or user.is_staff
     membership = getattr(user, "crush_connect_membership", None)
     coach = getattr(user, "crushcoach", None)
 
@@ -844,6 +856,12 @@ def crush_connect_spark_compose(request, user_id: int):
             messages.info(request, _("This member isn't available right now."))
             return redirect("crush_lu:crush_connect_home")
     else:
+        # First-mover (sending) is a receiver action. In beta a Premium non-tester
+        # can still hold a stale ConnectDailyDrop snapshot (old link, or after
+        # being deselected) — gate the send on receiver access, not just
+        # can_send_spark's Premium/onboarded/surfaced checks.
+        if not user.is_staff and not receiver_access_open(user):
+            return redirect("crush_lu:crush_connect_catalogue_status")
         allowed, reason = can_send_spark(user, target)
         if not allowed:
             if reason == "already_sparked":
@@ -1259,7 +1277,7 @@ def crush_connect_experience(request, slug):
     membership = getattr(request.user, "crush_connect_membership", None)
     context = {
         "experience": CONNECT_EXPERIENCES[slug],
-        "is_receiver": _user_is_connect_receiver_eligible(request.user),
+        "is_receiver": _user_can_receive_now(request.user),
         "is_onboarded": membership is not None and membership.onboarded_at is not None,
         "other_experiences": [
             {"slug": s, **exp} for s, exp in CONNECT_EXPERIENCES.items() if s != slug


### PR DESCRIPTION
## Summary

Follow-up to #601 addressing the Codex review. #601 gated the entry **doors** on `candidate_access_open()`, but several downstream *"is this user a receiver?"* decisions still checked coach-only eligibility (`_user_is_connect_receiver_eligible`) without `receiver_access_open()`. So during beta a **Premium non-tester** was misclassified as a receiver in a few places — including an infinite redirect loop.

The fix is a single source of truth: **`_user_can_receive_now(user)` = receiver-eligible AND `receiver_access_open(user)`**, and every receiver/candidate split now routes through it.

## Findings addressed

| # | Sev | Issue | Fix |
|---|---|---|---|
| 1 | **P1** | `crush_connect_catalogue_status` forwarded any coach-holder to Today's Drop, so a beta Premium non-tester bounced `/today/` ⇄ `/catalogue/` forever | Forward only when `_user_can_receive_now`; otherwise the catalogue renders. Access-blocker's two-step receiver check collapses into the helper |
| 2 | P2 | Hub classified anyone with a coach as `is_receiver` → showed Drop card / coach-pick UI to non-testers | `is_receiver` / `track` use the helper |
| 3 | P2 | `crush_connect_nav_visible` was over-restricted to selected testers, hiding the **entire** Connect nav (navbar / bottom nav / subnav) from beta candidates | Reverted to candidate access (onboarded + `candidate_access_open`) so candidates keep Connect / Profile / Sparks |
| 4 | P2 | Spark compose first-mover path only checked `can_send_spark` (Premium/onboarded/surfaced), so a non-tester with a stale Drop snapshot could send | Gate the first-mover branch on `receiver_access_open` |

Onboarding-completion copy and the experiences/onboarding `is_receiver` context also route through the helper for consistency.

## Backward compatibility
Under full launch `receiver_access_open()` is `True`, so `_user_can_receive_now == ` the old coach-only check — launched and prelaunch behaviour are unchanged. All 232 existing Connect tests pass.

## Tests
Adds four regressions to `test_crush_connect_beta_phase.py`: the no-loop landing, hub candidate classification (+ tester still gets receiver), nav visible for onboarded candidates, and the Spark-compose block for non-testers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)