### PR TITLE
fix(crush_lu): stop rendering multi-line {# #} notes as page text

### DIFF
--- a/crush_lu/templates/crush_lu/connection_detail.html
+++ b/crush_lu/templates/crush_lu/connection_detail.html
@@ -409,9 +409,11 @@
                         {% trans "Messages" %}
                     </h3>
 
-                    {# Message list — polls for the other side's replies. connection-chat.js
+                    {% comment %}
+                       Message list — polls for the other side's replies. connection-chat.js
                        pauses the poll while the tab is hidden and keeps the scroll pinned
-                       to the newest message unless the reader scrolled up. #}
+                       to the newest message unless the reader scrolled up.
+                    {% endcomment %}
                     <div id="messages-container" class="space-y-3 mb-6 max-h-96 overflow-y-auto"
                          hx-get="{% url 'crush_lu:connection_messages' connection.id %}"
                          hx-trigger="every 20s, chat:refresh"

--- a/crush_lu/templates/crush_lu/crush_connect/_base_connect.html
+++ b/crush_lu/templates/crush_lu/crush_connect/_base_connect.html
@@ -4,8 +4,10 @@
 Shared Crush Connect shell. Children override the connect_content block;
 title / mobile_page_title / extra_js pass through to base.html.
 {% endcomment %}
-{# The floating WhatsApp button overlaps Connect's option tiles/cards — keep
-   the whole Connect area free of it. #}
+{% comment %}
+The floating WhatsApp button overlaps Connect's option tiles/cards — keep
+the whole Connect area free of it.
+{% endcomment %}
 {% block whatsapp_button %}{% endblock %}
 
 {% block content %}

--- a/crush_lu/templates/crush_lu/crush_connect/_waitlist_join.html
+++ b/crush_lu/templates/crush_lu/crush_connect/_waitlist_join.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-{# Crush Connect waitlist join — shared by the teaser and the catalogue status
+{% comment %}
+   Crush Connect waitlist join — shared by the teaser and the catalogue status
    page. The catalogue page needs it because the teaser's fast-path redirects
    every approved + LuxID member away during the BETA phase, which would
    otherwise leave them no way onto the waitlist that gates the receiver track
@@ -12,7 +13,8 @@
    expressions.
 
    A selected tester sees the ordinary waitlist position like everyone else:
-   `selected_as_tester` is an internal flag and is never surfaced to the member. #}
+   `selected_as_tester` is an internal flag and is never surfaced to the member.
+{% endcomment %}
 <div data-on-waitlist="{{ on_waitlist|yesno:'true,false' }}"
      data-position="{{ waitlist_position|default:'0' }}"
      data-total="{{ total_waitlist }}"
@@ -35,9 +37,11 @@
             <svg class="w-5 h-5 text-crush-purple dark:text-crush-pink" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
         </div>
         <div class="flex-1">
-            {# Pre-join state — hidden once the join succeeds (no reload).
+            {% comment %}
+               Pre-join state — hidden once the join succeeds (no reload).
                x-show="notJoined" (bare getter) instead of "!isJoined": the
-               Alpine CSP build forbids negation/inline expressions. #}
+               Alpine CSP build forbids negation/inline expressions.
+            {% endcomment %}
             <div x-show="notJoined">
                 <p class="text-gray-500 dark:text-gray-400 mb-3">{% trans "Not on the waitlist yet" %}</p>
                 <button type="button" @click="joinWaitlist" class="btn-crush-primary inline-flex items-center gap-2">

--- a/crush_lu/templates/crush_lu/crush_connect/catalogue_status.html
+++ b/crush_lu/templates/crush_lu/crush_connect/catalogue_status.html
@@ -100,10 +100,12 @@
     </a>
     {% endif %}
 
-    {# Premium upsell. Before the public launch, Premium is invite-only: the
+    {% comment %}
+       Premium upsell. Before the public launch, Premium is invite-only: the
        receiver gate reads CrushConnectWaitlist.selected_as_tester, so the CTA
        is "join the waitlist", not the coach directory. Linking the directory
-       here during BETA would loop premium → teaser → back to this page. #}
+       here during BETA would loop premium → teaser → back to this page.
+    {% endcomment %}
     <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-crush-purple/10 to-crush-pink/10 ring-1 ring-gray-200 dark:ring-slate-700 p-6">
         <div class="absolute -right-4 -top-3 w-24 h-24 opacity-50 pointer-events-none">
             {% include "crush_lu/includes/ghost-story-inlove.html" with class="w-full h-full" %}

--- a/crush_lu/templates/crush_lu/partials/_connect_status_strip.html
+++ b/crush_lu/templates/crush_lu/partials/_connect_status_strip.html
@@ -13,9 +13,11 @@
     2b. Opted in + photo     → green "You're in the Mix" confirmation (launch flag / staff).
 {% endcomment %}
 {% if connect_excluded %}
-{# Coach-excluded members see no strip at all — checked FIRST so an excluded
+{% comment %}
+   Coach-excluded members see no strip at all — checked FIRST so an excluded
    member (even one with no LuxID linked, or who unlinks it after exclusion) is
-   never invited into a Connect flow the onboarding gate would only bounce. #}
+   never invited into a Connect flow the onboarding gate would only bounce.
+{% endcomment %}
 {% elif not has_luxid_connected %}
 {# LuxID catalogue prompt — verified via coach/admin, but not selectable in Crush Connect until LuxID is linked #}
 <div class="flex items-center gap-3 mb-5 p-4 rounded-xl border border-indigo-200 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/20">

--- a/crush_lu/tests/test_template_hygiene.py
+++ b/crush_lu/tests/test_template_hygiene.py
@@ -1,0 +1,35 @@
+"""Template hygiene guards.
+
+Django's ``{# ... #}`` comment syntax is single-line only: the lexer never
+matches an opener whose ``#}`` sits on a later line, so the whole block is
+emitted as visible page text (this leaked internal beta notes on the Connect
+catalogue page and teaser, found in the 2026-07-10 staging dry-run). Multi-line
+notes must use ``{% comment %} ... {% endcomment %}``.
+"""
+
+from pathlib import Path
+
+import crush_lu
+
+TEMPLATES_DIR = Path(crush_lu.__file__).resolve().parent / "templates"
+
+
+def test_no_multiline_template_comments():
+    offenders = []
+    for template in sorted(TEMPLATES_DIR.rglob("*.html")):
+        for lineno, line in enumerate(
+            template.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            # Every {# opened on a line must close on that same line, else
+            # Django renders the "comment" as literal text.
+            tail = line
+            while "{#" in tail:
+                tail = tail.split("{#", 1)[1]
+                if "#}" not in tail:
+                    offenders.append(f"{template.relative_to(TEMPLATES_DIR)}:{lineno}")
+                    break
+                tail = tail.split("#}", 1)[1]
+    assert not offenders, (
+        "Multi-line {# ... #} renders as visible text — use "
+        "{% comment %}...{% endcomment %} instead: " + ", ".join(offenders)
+    )


### PR DESCRIPTION
## What

Django's `{# ... #}` comment is **single-line only** — the lexer never matches an opener whose `#}` sits on a later line, so the whole block renders as visible page text.

Found during the 2026-07-10 staging dry-run of the Connect beta phase: the catalogue status page and the teaser's waitlist card displayed internal implementation notes to members — including the sentence "*`selected_as_tester` is an internal flag and is never surfaced to the member*", shown to the member.

## Leaking sites fixed (converted to `{% comment %}`)

- `crush_connect/_waitlist_join.html` (x2) — leaked on **both** the teaser and catalogue page; the teaser leak would go live on prod immediately after the pending swap, before any beta flag flips
- `crush_connect/catalogue_status.html` — premium upsell block
- `partials/_connect_status_strip.html` — rendered **only for coach-excluded members**, telling exactly those members that exclusion is hidden from them
- `connection_detail.html` — messages card on the connection chat page
- `crush_connect/_base_connect.html` — not visibly rendered today (outside any block in an extending template), fixed defensively

## Guard

`crush_lu/tests/test_template_hygiene.py` scans all `crush_lu` templates and fails on any `{#` that doesn't close on its own line, so the next multi-line pseudo-comment fails CI instead of shipping.

## Verification

- Repo-wide sweep: no remaining multi-line `{#` in any app's templates
- `pytest crush_lu/tests/test_template_hygiene.py crush_lu/tests/test_crush_connect_beta_phase.py` → 20 passed
- black + ruff clean on the new test

⚠️ Swap note: main currently ships this leak; merging this before the staging→prod slot swap keeps the prod teaser clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)