### PR TITLE
fix(deps): Django 6.0.6 → 6.0.7 (PYSEC-2026-2090/2091/2092)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core Django
-Django==6.0.6  # Security patch (PYSEC-2026-197..201); requires Python 3.12+
+Django==6.0.7  # Security patch (PYSEC-2026-2090..2092: cache_page cookie leak, DomainNameValidator header injection, GDALRaster over-read); requires Python 3.12+
 djangorestframework==3.17.1
 djangorestframework-simplejwt==5.5.1
 django-crispy-forms==2.6


### PR DESCRIPTION
## Why

Three new advisories against Django 6.0.x were published after the last scheduled Security Scan passed on main (2026-07-05), so **every PR now fails the pip-audit gate** — PR #606 was just the first to hit it.

The one that matters for this codebase is **PYSEC-2026-2090**: `UpdateCacheMiddleware` / `cache_page()` cache responses that vary on cookies, letting remote attackers read private data from the shared cache. Our SEO views (`azureproject/views_seo.py`, `crush_lu/views_seo.py`) use `@cache_page(24h)` against the shared Redis cache, so this is a live pattern, not a theoretical hit. The other two (DomainNameValidator newline header injection, contrib.gis GDALRaster over-read) don't match current usage but come along with the patch.

## What

Single-line bump of the only Django pin: `requirements.txt` 6.0.6 → 6.0.7 (patch release). Same treatment as the previous 6.0.6 security bump.

## Sequencing

Merge this **before** re-running checks on #606 (its pip-audit runs against the merge ref, so it goes green once this is on main) and **before the staging→prod slot swap**, so 6.0.7 ships with the swap — production currently runs an older 6.0.x that is also in the affected range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)