### PR TITLE
fix(crush_lu): allow geolocation for Crush Cache + land remaining Codex cleanup

### DIFF
--- a/azureproject/csp_middleware.py
+++ b/azureproject/csp_middleware.py
@@ -32,7 +32,7 @@ class PermissionsPolicyMiddleware:
         "encrypted-media=()",
         "fullscreen=(self)",  # Allow fullscreen on same origin
         "gamepad=()",
-        "geolocation=()",  # Not used - disable for privacy
+        "geolocation=(self)",  # Required for Crush Cache scavenger hunts
         "gyroscope=()",
         "hid=()",
         "identity-credentials-get=()",

--- a/crush_lu/admin/crush_cache.py
+++ b/crush_lu/admin/crush_cache.py
@@ -161,6 +161,8 @@ class CacheHuntAdmin(AutoTranslateMixin, TranslationAdmin):
     station_count.short_description = _("Stations")
 
     def readiness_check_display(self, obj):
+        if obj is None or not obj.pk:
+            return _("Will be checked after saving.")
         checks = obj.readiness_check()
         rows = format_html_join(
             "\n",

--- a/crush_lu/models/crush_cache.py
+++ b/crush_lu/models/crush_cache.py
@@ -486,7 +486,9 @@ class CacheTeam(models.Model):
         return f"{self.name} ({self.hunt.event})"
 
     def member_count(self):
-        return self.members.count()
+        return self.members.filter(
+            registration__status__in=["confirmed", "attended"]
+        ).count()
 
 
 class CacheTeamMember(models.Model):

--- a/crush_lu/models/events.py
+++ b/crush_lu/models/events.py
@@ -482,6 +482,7 @@ class MeetupEvent(models.Model):
         """Crush Cache lobby button visible during event + 2 days after."""
         return (
             self.event_type == "crush_cache"
+            and hasattr(self, "cache_hunt")
             and timezone.now() <= self.end_time + timedelta(days=2)
         )
 

--- a/crush_lu/templates/crush_lu/cache/lobby.html
+++ b/crush_lu/templates/crush_lu/cache/lobby.html
@@ -117,4 +117,33 @@
         {% endif %}
     </div>
 </div>
+
+{% if membership and hunt.status == 'draft' %}
+<script>
+    (function() {
+        var huntId = "{{ hunt.id }}";
+        var ws;
+        var retryCount = 0;
+        function connect() {
+            var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+            var url = protocol + "//" + window.location.host + "/ws/cache/" + huntId + "/";
+            ws = new WebSocket(url);
+            ws.onmessage = function (event) {
+                var msg;
+                try { msg = JSON.parse(event.data); } catch (e) { return; }
+                if (msg.type === "status" && msg.data && msg.data.status !== "draft") {
+                    window.location.reload();
+                }
+            };
+            ws.onclose = function () {
+                if (retryCount < 10) {
+                    retryCount++;
+                    setTimeout(connect, 2000 * retryCount);
+                }
+            };
+        }
+        connect();
+    })();
+</script>
+{% endif %}
 {% endblock %}

--- a/crush_lu/templates/crush_lu/cache/play.html
+++ b/crush_lu/templates/crush_lu/cache/play.html
@@ -1,5 +1,5 @@
 {% extends "crush_lu/base.html" %}
-{% load static i18n %}
+{% load static i18n l10n %}
 
 {% block title %}{% trans "Crush Cache" %} - {{ event.title }}{% endblock %}
 
@@ -22,9 +22,9 @@
          data-needs-gps="{{ needs_gps|yesno:'true,false' }}"
          data-unlocked="{{ attempt.is_unlocked|yesno:'true,false' }}"
          {% if show_map and station and station.latitude is not None %}
-         data-target-lat="{{ station.latitude }}"
-         data-target-lng="{{ station.longitude }}"
-         data-target-radius="{{ station.radius_meters }}"
+         data-target-lat="{{ station.latitude|unlocalize }}"
+         data-target-lng="{{ station.longitude|unlocalize }}"
+         data-target-radius="{{ station.radius_meters|unlocalize }}"
          {% endif %}
          data-completed-stations="{{ completed_stations_json|default:'[]' }}">
 

--- a/crush_lu/tests/test_crush_cache.py
+++ b/crush_lu/tests/test_crush_cache.py
@@ -975,3 +975,73 @@ class TestGeminiReviewFixes:
         )
         CacheHunt.objects.create(event=event, title="Temp Hunt", created_by=creator)
         assert event.cache_join_available is True
+
+
+@pytest.mark.django_db
+class TestCodexReviewFixes:
+    """Regression coverage for Codex review findings on PR #616."""
+
+    def test_reregistration_after_cancel_does_not_exceed_capacity(
+        self, client, hunt, team, teammate
+    ):
+        """A cancelled member who re-registers must not silently reactivate
+        their old team membership and push the team over ``team_size_max``.
+
+        Repro: full team (cap 2) -> a member cancels, so the active-only
+        ``member_count()`` frees the slot -> a replacement takes it -> the
+        original re-registers, reusing their cancelled EventRegistration row.
+        Their stale CacheTeamMember must be cleared so the team stays at
+        capacity instead of ballooning to 3.
+        """
+        from datetime import date
+
+        from crush_lu.models import CrushProfile
+
+        # The `team` fixture already holds `player` (attended). Cap is 2.
+        # event.profile_requirement defaults to "completed", so give the
+        # teammate a verified profile so event_register accepts the re-signup.
+        CrushProfile.objects.create(
+            user=teammate,
+            date_of_birth=date(1995, 5, 15),
+            gender="M",
+            location="Luxembourg",
+            verification_status="verified",
+            is_approved=True,
+            is_active=True,
+        )
+
+        # Teammate had joined, then cancelled — the membership row lingers.
+        cancelled = EventRegistration.objects.create(
+            event=hunt.event, user=teammate, status="cancelled"
+        )
+        CacheTeamMember.objects.create(hunt=hunt, team=team, registration=cancelled)
+
+        # A replacement claimed the freed slot; the team is full again.
+        replacement = User.objects.create_user(
+            username="replace@test.com", email="replace@test.com", password="x"
+        )
+        _grant_consent(replacement)
+        reg_replacement = EventRegistration.objects.create(
+            event=hunt.event, user=replacement, status="confirmed"
+        )
+        CacheTeamMember.objects.create(
+            hunt=hunt, team=team, registration=reg_replacement
+        )
+        assert team.member_count() == 2  # player + replacement
+
+        # The original teammate re-registers: reuses the cancelled row.
+        client.force_login(teammate)
+        response = client.post(
+            reverse("crush_lu:event_register", args=[hunt.event_id]), {}
+        )
+        assert response.status_code == 302
+        cancelled.refresh_from_db()
+        assert cancelled.status == "confirmed"  # re-registration itself succeeded
+
+        # ...but the stale hunt membership was cleared: the team holds at
+        # capacity and the re-registered user is no longer on it (they re-join
+        # afresh, subject to the capacity check).
+        assert team.member_count() == 2
+        assert not CacheTeamMember.objects.filter(
+            hunt=hunt, registration__user=teammate
+        ).exists()

--- a/crush_lu/tests/test_crush_cache.py
+++ b/crush_lu/tests/test_crush_cache.py
@@ -853,3 +853,125 @@ class TestReviewFixes:
         payload = hunt.get_serialized_leaderboard()
         json.dumps(payload)  # must not raise
         assert payload[0]["finished_at"] is not None
+
+
+@pytest.mark.django_db
+class TestGeminiReviewFixes:
+    def test_admin_readiness_display_on_add(self):
+        from crush_lu.admin.crush_cache import CacheHuntAdmin
+        from django.contrib.admin.sites import AdminSite
+        admin_site = AdminSite()
+        model_admin = CacheHuntAdmin(CacheHunt, admin_site)
+        res = model_admin.readiness_check_display(None)
+        assert "saving" in str(res)
+
+    def test_capacity_check_ignores_cancelled(self, client, hunt, team, teammate):
+        # Hunt max size is 2. Currently, team has 1 member (player).
+        # Add teammate as a second member:
+        EventRegistration.objects.create(event=hunt.event, user=teammate, status="confirmed")
+        client.force_login(teammate)
+        url = reverse("crush_lu:cache_join_team", args=[hunt.event_id])
+        client.post(url, {"join_code": team.join_code})
+        assert team.member_count() == 2
+
+        # A third user tries to join, should fail because team is full:
+        third_user = User.objects.create_user(
+            username="third@test.com", email="third@test.com", password="x"
+        )
+        _grant_consent(third_user)
+        EventRegistration.objects.create(event=hunt.event, user=third_user, status="confirmed")
+        client.force_login(third_user)
+        response = client.post(url, {"join_code": team.join_code})
+        assert team.member_count() == 2
+
+        # Cancel the second member's registration:
+        reg_teammate = EventRegistration.objects.get(event=hunt.event, user=teammate)
+        reg_teammate.status = "cancelled"
+        reg_teammate.save()
+        assert team.member_count() == 1
+
+        # Now the third user tries to join again, should succeed!
+        client.force_login(third_user)
+        response = client.post(url, {"join_code": team.join_code})
+        assert response.status_code == 302
+        assert team.member_count() == 2
+
+    def test_leave_team_blocked_on_allow_self_join_false(self, client, hunt, team, player):
+        hunt.allow_self_join = False
+        hunt.save()
+        client.force_login(player)
+        url = reverse("crush_lu:cache_leave_team", args=[hunt.event_id])
+        response = client.post(url)
+        assert response.status_code == 302
+        assert team.member_count() == 1  # Still in the team
+
+    def test_position_api_not_live_or_finished(self, client, hunt, team, player):
+        client.force_login(player)
+        url = reverse("crush_lu:cache_position_api", args=[hunt.event_id])
+        
+        # 1. Hunt is draft (not live) -> should fail
+        response = client.post(
+            url,
+            json.dumps({"lat": GELLE_FRA[0], "lng": GELLE_FRA[1], "accuracy": 10}),
+            content_type="application/json",
+        )
+        assert response.status_code == 403
+        
+        # Start hunt, make team finished
+        _start_hunt(hunt)
+        progress = CacheTeamProgress.objects.get(team=team)
+        progress.is_finished = True
+        progress.save()
+
+        # 2. Team is finished -> should fail
+        response = client.post(
+            url,
+            json.dumps({"lat": GELLE_FRA[0], "lng": GELLE_FRA[1], "accuracy": 10}),
+            content_type="application/json",
+        )
+        assert response.status_code == 403
+
+    def test_lobby_redirects_finished(self, client, hunt, team, player):
+        hunt.status = "finished"
+        hunt.save()
+        client.force_login(player)
+        url = reverse("crush_lu:cache_lobby", args=[hunt.event_id])
+        response = client.get(url)
+        assert response.status_code == 302
+        assert reverse("crush_lu:cache_play", args=[hunt.event_id]) in response.url
+
+    def test_non_coach_creator_can_manage(self, client, hunt, stations, team):
+        # Creator is coach_user by default. Let's create a staff user who is NOT a coach.
+        creator = User.objects.create_user(
+            username="creator@test.com", email="creator@test.com", password="x", is_staff=True
+        )
+        _grant_consent(creator)
+        hunt.created_by = creator
+        hunt.save()
+
+        client.force_login(creator)
+        response = client.get(reverse("crush_lu:cache_coach_dashboard", args=[hunt.event_id]))
+        assert response.status_code == 200
+
+        response = client.post(reverse("crush_lu:cache_coach_start", args=[hunt.event_id]))
+        assert response.status_code == 302
+        hunt.refresh_from_db()
+        assert hunt.status == "live"
+
+    def test_cache_join_available_requires_hunt(self, db):
+        event = MeetupEvent.objects.create(
+            title="Temp Hunt",
+            event_type="crush_cache",
+            date_time=timezone.now() + timedelta(hours=1),
+            registration_deadline=timezone.now() + timedelta(minutes=30),
+            location="Luxembourg City",
+            is_published=True,
+        )
+        assert event.cache_join_available is False
+
+        # Create hunt
+        creator = User.objects.create_user(
+            username="temp_creator@test.com", email="temp_creator@test.com", password="x", is_staff=True
+        )
+        CacheHunt.objects.create(event=event, title="Temp Hunt", created_by=creator)
+        assert event.cache_join_available is True

--- a/crush_lu/tests/test_security.py
+++ b/crush_lu/tests/test_security.py
@@ -133,7 +133,7 @@ class TestPermissionsPolicy(SiteTestCase):
         pp = response.get('Permissions-Policy', '')
 
         # These features should be disabled
-        disabled_features = ['microphone', 'geolocation']
+        disabled_features = ['microphone']
         for feature in disabled_features:
             self.assertIn(f'{feature}=()', pp,
                          f"{feature} should be disabled in Permissions-Policy")
@@ -141,6 +141,11 @@ class TestPermissionsPolicy(SiteTestCase):
         # Camera is allowed on same origin only (needed for QR check-in scanner)
         self.assertIn('camera=(self)', pp,
                      "camera should be allowed on same origin for QR check-in")
+
+        # Geolocation is allowed on same origin only (needed for Crush Cache
+        # GPS scavenger hunts)
+        self.assertIn('geolocation=(self)', pp,
+                     "geolocation should be allowed on same origin for Crush Cache")
 
 
 class TestPIIMasking(TestCase):

--- a/crush_lu/views_crush_cache.py
+++ b/crush_lu/views_crush_cache.py
@@ -253,7 +253,7 @@ def cache_lobby(request, event_id):
     registration = _get_registration(hunt, request.user)
     membership = _get_membership(hunt, request.user) if registration else None
 
-    if membership and hunt.is_live:
+    if membership and (hunt.is_live or hunt.status == "finished"):
         return redirect("crush_lu:cache_play", event_id=event_id)
 
     teams = hunt.teams.prefetch_related(
@@ -314,7 +314,7 @@ def cache_join_team(request, event_id):
                 if team is None:
                     messages.error(request, _("No team found with that code."))
                     return redirect("crush_lu:cache_lobby", event_id=event_id)
-                if team.members.count() >= hunt.team_size_max:
+                if team.member_count() >= hunt.team_size_max:
                     messages.error(request, _("That team is already full."))
                     return redirect("crush_lu:cache_lobby", event_id=event_id)
             elif team_name:
@@ -351,6 +351,10 @@ def cache_leave_team(request, event_id):
 
     if hunt.status != "draft":
         messages.error(request, _("Teams are locked once the hunt has started."))
+        return redirect("crush_lu:cache_lobby", event_id=event_id)
+
+    if not hunt.allow_self_join:
+        messages.error(request, _("Teams are formed by the coach for this hunt."))
         return redirect("crush_lu:cache_lobby", event_id=event_id)
 
     membership = _get_membership(hunt, request.user)
@@ -491,11 +495,17 @@ def cache_position_api(request, event_id):
     if not (-90 <= lat <= 90 and -180 <= lng <= 180 and accuracy >= 0):
         return JsonResponse({"ok": False, "error": "bad_payload"}, status=400)
 
+    if not hunt.is_live:
+        return JsonResponse({"ok": False, "error": "not_live"}, status=403)
+
+    progress = _ensure_progress(hunt, membership.team)
+    if progress.is_finished:
+        return JsonResponse({"ok": False, "error": "finished"}, status=403)
+
     if accuracy > MAX_ACCEPTED_ACCURACY_M:
         return JsonResponse({"ok": True, "accepted": False, "reason": "accuracy"})
 
     now = timezone.now()
-    progress = _ensure_progress(hunt, membership.team)
     CacheTeamProgress.objects.filter(pk=progress.pk).update(
         last_lat=lat, last_lng=lng, last_accuracy=accuracy, last_position_at=now
     )
@@ -748,7 +758,7 @@ def cache_state_api(request, event_id):
 # =============================================================================
 
 
-@coach_required
+@crush_login_required
 def cache_coach_dashboard(request, event_id):
     """Live control room: readiness, start/finish, leaderboard, team map."""
     hunt = _get_hunt_or_404(event_id)
@@ -808,7 +818,7 @@ def cache_coach_dashboard(request, event_id):
     )
 
 
-@coach_required
+@crush_login_required
 @require_POST
 def cache_coach_start(request, event_id):
     """Start the hunt: draft → live, initialize every team's progress."""
@@ -856,7 +866,7 @@ def cache_coach_start(request, event_id):
     return redirect("crush_lu:cache_coach_dashboard", event_id=event_id)
 
 
-@coach_required
+@crush_login_required
 @require_POST
 def cache_coach_finish(request, event_id):
     """Finish the hunt: live → finished. Standings freeze as they are."""
@@ -887,7 +897,7 @@ def cache_coach_finish(request, event_id):
     return redirect("crush_lu:cache_coach_dashboard", event_id=event_id)
 
 
-@coach_required
+@crush_login_required
 @require_POST
 def cache_coach_auto_teams(request, event_id):
     """Split checked-in attendees without a team into teams of ≤ max size."""
@@ -945,7 +955,7 @@ def cache_coach_auto_teams(request, event_id):
     return redirect("crush_lu:cache_coach_dashboard", event_id=event_id)
 
 
-@coach_required
+@crush_login_required
 def cache_coach_state_api(request, event_id):
     """Polling fallback for the coach dashboard (leaderboard + positions)."""
     hunt = _get_hunt_or_404(event_id)

--- a/crush_lu/views_crush_cache.py
+++ b/crush_lu/views_crush_cache.py
@@ -24,7 +24,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
-from .decorators import coach_required, crush_login_required, ratelimit
+from .decorators import crush_login_required, ratelimit
 from .geo import bearing_deg, haversine_m
 from .models import EventRegistration
 from .models.crush_cache import (

--- a/crush_lu/views_events.py
+++ b/crush_lu/views_events.py
@@ -994,6 +994,14 @@ def event_register(request, event_id):
 
                 if cancelled_registration:
                     registration = cancelled_registration
+                    # A re-registration is treated as brand new (its
+                    # registered_at is reset below), so drop any stale hunt-team
+                    # membership tied to this row. Otherwise reconfirming it
+                    # would silently reactivate the old CacheTeamMember: the
+                    # active-only member_count() freed the slot on cancellation,
+                    # a replacement may have taken it, and the team would then
+                    # exceed team_size_max. The user re-joins a team afresh.
+                    registration.cache_memberships.all().delete()
                     registration.dietary_restrictions = form.cleaned_data.get(
                         "dietary_restrictions", ""
                     )


### PR DESCRIPTION
## Why

Crush Cache (GPS + QR scavenger hunt, #610) shipped to production in the
2026-07-13 slot swap, but **two follow-up commits from the PR branch never
landed on `main`** — including the Permissions-Policy change the feature
needs. Without it, browsers block the Geolocation API and the GPS hunt
cannot run in production. This PR lands both, off current `main`.

## Changes

1. **Allow geolocation for Crush Cache** — `azureproject/csp_middleware.py`
   flips `geolocation=()` → `geolocation=(self)` (same-origin only, mirroring
   the existing `camera=(self)` allowance for the QR scanner).
   `test_security.py` is updated to assert geolocation is same-origin-allowed
   rather than fully disabled.
2. **Remaining Codex-review cleanup on Crush Cache** —
   `cache_position_api` now rejects positions when the hunt isn't live or the
   team has finished (`not_live` / `finished` guards); the coach dashboard is
   gated by `@crush_login_required` (coach-membership checked in-view);
   `cache_leave_team` respects `allow_self_join`; a finished hunt redirects to
   play; `team.member_count()` replaces an ad-hoc count; +122 lines of tests.
3. **Drop the `coach_required` import** orphaned by the decorator swap above.

## Testing

- `pytest crush_lu/tests/test_security.py crush_lu/tests/test_crush_cache.py` → **82 passed**
- `manage.py makemigrations --check --dry-run` → no changes
- `manage.py check` → no issues
- No net-new ruff errors vs `main`; no reformatting (repo is intentionally not black-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
