### PR TITLE
chore(crush_lu): add local debug-QA tooling (seed + login windows + sqlite runner)

### DIFF
--- a/crush_lu/management/commands/seed_debug_profiles.py
+++ b/crush_lu/management/commands/seed_debug_profiles.py
@@ -1,0 +1,523 @@
+"""
+Seed a labeled, loginable *debug cast* for manual QA of the Crush.lu signup
+journey and the core Crush Connect interactions.
+
+Creates ~10 accounts sharing one password, each with a **verified allauth
+EmailAddress** so they can actually log in under the project's mandatory
+email-verification setting (the other seeders skip this, so their accounts
+cannot complete email login).
+
+Signup stages (log in, hit /en/onboarding/, land on the named step):
+    debug_new@crush.lu       -> Welcome            (nothing done yet)
+    debug_phone@crush.lu     -> Verify number      (welcome seen, phone unverified)
+    debug_draft@crush.lu     -> Build profile (4)  (phone verified, mid-build)
+    debug_pending@crush.lu   -> Profile submitted  (pending coach review)
+    debug_approved@crush.lu  -> Dashboard          (verified member)
+
+Crush Connect cast (asymmetric model — needs a small supporting cast):
+    debug_receiver@crush.lu  -> Premium receiver + beta tester; gets Today's Drop
+    debug_cand_1..3@crush.lu -> candidates that appear in the receiver's Drop
+    debug_sender@crush.lu    -> 2nd Premium actor; sends the pending Spark to receiver
+  Seeded interactions: receiver's Drop = the 3 candidates; a mutual MATCH
+  (receiver x cand_1, accepted Spark); a PENDING Spark received by the receiver.
+
+LOCAL-ONLY: refuses to run on Azure (WEBSITE_HOSTNAME set) or when DEBUG is
+False, unless --force. These are shared, known-password accounts.
+
+Usage:
+    python manage.py seed_debug_profiles --reset
+    python manage.py seed_debug_profiles --reset --skip-photos
+"""
+
+import os
+
+from allauth.account.models import EmailAddress
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from crush_lu.models import CrushProfile, ProfileSubmission
+from crush_lu.models.crush_connect import (
+    ConnectInterest,
+    CrushConnectMembership,
+    CrushConnectWaitlist,
+    CuriositySpark,
+)
+from crush_lu.models.profiles import CrushCoach, UserDataConsent
+from crush_lu.onboarding_connect import TOTAL_STEPS
+
+# Reuse the proven helpers from the Connect seeder rather than duplicating them.
+from crush_lu.management.commands.create_connect_test_users import (
+    _ensure_spark_prompt,
+    _fake_user_data,
+    _fetch_user_data,
+    _test_dob,
+    _weighted_location,
+)
+
+_PREFIX = "debug_"
+_EMAIL_DOMAIN = "crush.lu"
+
+# Which stages get realistic content fields / an uploaded photo.
+_WITH_CONTENT = {"draft", "pending", "approved", "receiver", "sender", "candidate"}
+_WITH_PHOTO = {"pending", "approved", "receiver", "sender", "candidate"}
+_CONNECT_ROLES = {"receiver", "sender", "candidate"}
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed ~10 loginable debug accounts covering every signup stage and the "
+        "core Crush Connect interactions (drop, match, pending spark)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--password",
+            default="debug2025",
+            help="Password for all created users (default: debug2025)",
+        )
+        parser.add_argument(
+            "--skip-photos",
+            action="store_true",
+            help="Skip randomuser.me photo download (faster, offline)",
+        )
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Delete existing debug_* users first",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Override the local-only safety guard (NOT for production)",
+        )
+
+    # ------------------------------------------------------------------ #
+
+    def handle(self, *args, **options):
+        self._guard_local(force=options["force"])
+
+        password = options["password"]
+        skip_photos = options["skip_photos"]
+        self._phone_seq = 0
+
+        if options["reset"]:
+            self._delete_existing()
+
+        coach = self._ensure_coach(skip_photos)
+        prompt = _ensure_spark_prompt()
+
+        self.stdout.write("\nCreating signup-stage accounts...")
+        for suffix, stage, gender in (
+            ("new", "new", "female"),
+            ("phone", "phone", "male"),
+            ("draft", "draft", "female"),
+            ("pending", "pending", "male"),
+            ("approved", "approved", "female"),
+        ):
+            self._create_account(
+                suffix,
+                gender=gender,
+                stage=stage,
+                password=password,
+                skip_photos=skip_photos,
+            )
+
+        self.stdout.write("\nCreating Crush Connect cast...")
+        receiver = self._create_account(
+            "receiver",
+            gender="male",
+            stage="receiver",
+            password=password,
+            skip_photos=skip_photos,
+            coach=coach,
+            prompt=prompt,
+        )
+        sender = self._create_account(
+            "sender",
+            gender="female",
+            stage="sender",
+            password=password,
+            skip_photos=skip_photos,
+            coach=coach,
+            prompt=prompt,
+        )
+        candidates = [
+            self._create_account(
+                f"cand_{i}",
+                gender="female" if i % 2 else "male",
+                stage="candidate",
+                password=password,
+                skip_photos=skip_photos,
+                prompt=prompt,
+            )
+            for i in range(1, 4)
+        ]
+
+        self._wire_connect(receiver, sender, candidates)
+        self._print_summary(password)
+
+    # ------------------------------------------------------------------ #
+    # Safety + reset
+    # ------------------------------------------------------------------ #
+
+    def _guard_local(self, *, force):
+        if force:
+            return
+        on_azure = bool(os.environ.get("WEBSITE_HOSTNAME"))
+        if on_azure or not settings.DEBUG:
+            raise CommandError(
+                "Refusing to seed shared debug accounts outside local dev "
+                "(WEBSITE_HOSTNAME is set or DEBUG=False). Pass --force to override."
+            )
+
+    def _delete_existing(self):
+        qs = User.objects.filter(username__startswith=_PREFIX)
+        count = qs.count()
+        qs.delete()  # cascades to profile, membership, waitlist, sparks, drops, email
+        self.stdout.write(f"Deleted {count} existing debug_* users.")
+
+    def _ensure_coach(self, skip_photos):
+        coach = CrushCoach.objects.filter(is_active=True).first()
+        if coach is None:
+            self.stdout.write("No active coach found — running create_crush_coaches...")
+            call_command("create_crush_coaches", skip_photos=skip_photos)
+            coach = CrushCoach.objects.filter(is_active=True).first()
+        if coach is None:
+            raise CommandError(
+                "Could not obtain an active CrushCoach (create_crush_coaches failed)."
+            )
+        return coach
+
+    # ------------------------------------------------------------------ #
+    # Account creation
+    # ------------------------------------------------------------------ #
+
+    def _next_phone(self):
+        self._phone_seq += 1
+        return f"+352 661 {self._phone_seq:03d} 100"
+
+    def _create_account(
+        self, suffix, *, gender, stage, password, skip_photos, coach=None, prompt=None
+    ):
+        username = f"{_PREFIX}{suffix}"
+        email = f"{username}@{_EMAIL_DOMAIN}"
+
+        if User.objects.filter(username=username).exists():
+            self.stdout.write(f"  skip {email} (exists — use --reset to rebuild)")
+            return User.objects.get(username=username)
+
+        want_photo = stage in _WITH_PHOTO and not skip_photos
+        user_data = _fetch_user_data(gender) if want_photo else _fake_user_data(gender)
+        gender_code = "M" if gender == "male" else "F"
+        now = timezone.now()
+
+        user = User.objects.create_user(
+            username=username,
+            email=email,
+            password=password,
+            first_name=user_data["first_name"],
+            last_name=user_data["last_name"],
+        )
+        # Recent activity so candidates pass the 30-day inactivity cutoff.
+        User.objects.filter(pk=user.pk).update(last_login=now)
+
+        # The piece every other seeder omits: a verified email so login works
+        # under ACCOUNT_EMAIL_VERIFICATION = "mandatory".
+        EmailAddress.objects.create(user=user, email=email, verified=True, primary=True)
+
+        # Consent gate: CrushConsentMiddleware bounces any authenticated user
+        # without recorded consent to /consent/confirm/ on every page. Real
+        # users consent at signup, so record it here (else all debug accounts
+        # get stuck on the consent page instead of their target).
+        UserDataConsent.objects.update_or_create(
+            user=user,
+            defaults={"crushlu_consent_given": True, "crushlu_consent_date": now},
+        )
+
+        kwargs = self._profile_kwargs(stage, gender_code, now, coach)
+        kwargs["user"] = user
+        # Phone fields must be set at create() time — the model's save() locks
+        # them on update (crush_lu/models/profiles.py save() phone-lock).
+        profile = CrushProfile.objects.create(**kwargs)
+
+        if want_photo and user_data.get("photo_data"):
+            try:
+                profile.photo_1.save(
+                    f"{user.pk}_photo1.jpg",
+                    ContentFile(user_data["photo_data"]),
+                    save=True,
+                )
+            except Exception as exc:  # network / storage hiccup — non-fatal
+                self.stderr.write(f"  photo save failed for {email}: {exc}")
+
+        self._create_submission(profile, stage, now)
+        if stage in _CONNECT_ROLES:
+            self._wire_connect_membership(user, stage, prompt, now)
+
+        self.stdout.write(f"  {stage:<9} {email}")
+        return user
+
+    def _profile_kwargs(self, stage, gender_code, now, coach):
+        """Field recipe per stage (caller adds `user`). Gates are read by
+        crush_lu/onboarding.py get_current_step (first failing gate wins)."""
+        kwargs = {"preferred_language": "en"}
+
+        # --- Journey markers + verification status ---
+        if stage == "new":
+            kwargs.update(
+                welcome_seen_at=None,
+                coach_intro_seen_at=None,
+                phone_verified=False,
+                verification_status="incomplete",
+            )
+        elif stage == "phone":
+            kwargs.update(
+                welcome_seen_at=now,
+                coach_intro_seen_at=None,
+                phone_verified=False,
+                verification_status="incomplete",
+            )
+        elif stage == "draft":
+            kwargs.update(
+                welcome_seen_at=now,
+                coach_intro_seen_at=now,
+                phone_number=self._next_phone(),
+                phone_verified=True,
+                phone_verified_at=now,
+                verification_status="incomplete",
+                draft_data={"step": 2, "note": "half-filled debug draft"},
+            )
+        else:  # pending / approved / receiver / sender / candidate
+            kwargs.update(
+                welcome_seen_at=now,
+                coach_intro_seen_at=now,
+                phone_number=self._next_phone(),
+                phone_verified=True,
+                phone_verified_at=now,
+            )
+            if stage == "pending":
+                kwargs.update(
+                    verification_status="pending",
+                    completion_status="submitted",
+                    is_approved=False,
+                )
+            else:
+                # Realistic per-persona verification method: candidates self-serve
+                # via LuxID, Premium (receiver/sender) go through paid coach review,
+                # the plain approved member was verified in person at an event.
+                method = {
+                    "candidate": "luxid",
+                    "receiver": "premium_coach",
+                    "sender": "premium_coach",
+                }.get(stage, "coach_event")
+                kwargs.update(
+                    is_approved=True,
+                    is_active=True,
+                    approved_at=now,
+                    verification_status="verified",
+                    verification_method=method,
+                    completion_status="submitted",
+                )
+
+        # --- Content fields ---
+        kwargs.update(gender=gender_code, date_of_birth=_test_dob())
+        if stage in _WITH_CONTENT:
+            kwargs.update(
+                location=_weighted_location(),
+                bio=f"Debug {stage} account — local QA only.",
+                interests="hiking, photography, travel",
+                show_full_name=True,
+                show_exact_age=True,
+            )
+
+        # --- Premium (receiver track) ---
+        if stage in ("receiver", "sender"):
+            kwargs.update(assigned_coach=coach, assigned_coach_at=now)
+
+        return kwargs
+
+    def _create_submission(self, profile, stage, now):
+        # Match the current flow (crush_lu/views.py create_profile ~line 678): a
+        # fresh "pending" submit creates NO ProfileSubmission, and LuxID / event-
+        # verified members never get one either. The row exists only for the paid
+        # coach-review path — so only the Premium accounts carry an approved
+        # submission with a completed review call.
+        if stage in ("receiver", "sender"):
+            ProfileSubmission.objects.create(
+                profile=profile,
+                coach=profile.assigned_coach,
+                status="approved",
+                coach_notes="Auto-created debug profile (paid coach review)",
+                review_call_completed=True,
+                review_call_date=now,
+                reviewed_at=now,
+            )
+
+    def _wire_connect_membership(self, user, stage, prompt, now):
+        membership = CrushConnectMembership.objects.create(
+            user=user,
+            onboarded_at=now,
+            # The real wizard sets onboarded_at only at the LAST step, alongside
+            # onboarding_step=TOTAL_STEPS (views_crush_connect.py). Set both so a
+            # seeded member reads as fully onboarded, not "in the mix at step 1".
+            onboarding_step=TOTAL_STEPS,
+            onboarding_started_at=now,
+            photo_share_consent=True,  # Read-the-Photo consent — required to surface
+            languages=["en", "fr"],
+            story_prompt=prompt,
+            story_answer=(
+                "Looking for a genuine connection"
+                if stage != "candidate"
+                else "Open to meeting interesting people"
+            ),
+        )
+        self._assign_gate_questions(membership, now)
+        # The wizard also collects interests — give them a few so the profile
+        # isn't empty (otherwise they look half-onboarded).
+        membership.interests.set(ConnectInterest.objects.order_by("?")[:3])
+
+        # LuxID makes them catalogue-eligible. The receiver needs it too, so it
+        # can appear in the sender's Drop and thus receive the pending Spark.
+        from allauth.socialaccount.models import SocialAccount
+
+        SocialAccount.objects.create(
+            user=user,
+            provider="luxid",
+            uid=f"luxid-debug-{user.pk}",
+            extra_data={"sub": f"luxid-debug-{user.pk}"},
+        )
+
+        # Beta receiver gate: connect_phase.receiver_access_open() lets a
+        # selected waitlist tester reach Today's Drop in the beta phase.
+        # (The CrushConnectWaitlist model docstring predates this and is stale.)
+        if stage in ("receiver", "sender"):
+            CrushConnectWaitlist.objects.create(
+                user=user, selected_as_tester=True, notification_preference=True
+            )
+
+    def _assign_gate_questions(self, membership, now):
+        from crush_lu.models import MemberGateQuestion
+        from crush_lu.services.crush_connect import get_or_create_question_week
+
+        week = get_or_create_question_week()
+        for position, question in enumerate(
+            week.questions.filter(is_active=True)[:3], start=1
+        ):
+            MemberGateQuestion.objects.create(
+                membership=membership,
+                question=question,
+                position=position,
+                owner_answer=(position % 2 == 1),  # alternate Yes/No
+                picked_week=week,
+            )
+
+    # ------------------------------------------------------------------ #
+    # Connect interaction wiring
+    # ------------------------------------------------------------------ #
+
+    def _wire_connect(self, receiver, sender, candidates):
+        from crush_lu.services.crush_connect import get_or_create_daily_drop
+
+        self.stdout.write("\nWiring Connect interactions...")
+
+        # 1) Receiver's Drop = the 3 candidates (deterministic, override the
+        #    weighted sample so the debug view is predictable). Use the service
+        #    so the drop_date matches what the view looks up (06:00 unlock rule).
+        receiver_drop = get_or_create_daily_drop(receiver)
+        receiver_drop.recipients.set(candidates)
+        self.stdout.write(
+            f"  {receiver.email}: Drop -> " + ", ".join(c.email for c in candidates)
+        )
+
+        # 2) Mutual match: receiver x cand_1 (accepted spark). Rows created
+        #    directly (idempotent) to avoid notification side effects.
+        CuriositySpark.objects.get_or_create(
+            sender=receiver,
+            recipient=candidates[0],
+            defaults=dict(
+                drop=receiver_drop,
+                message="Your hiking photos caught my eye — coffee this week?",
+                status="accepted",
+                responded_at=timezone.now(),
+            ),
+        )
+        self.stdout.write(f"  match: {receiver.email} x {candidates[0].email}")
+
+        # 3) Pending spark RECEIVED by the receiver, from the sender. The
+        #    sparks-received view requires the recipient (receiver) to have
+        #    appeared in the sender's Drop, so add it explicitly.
+        sender_drop = get_or_create_daily_drop(sender)
+        sender_drop.recipients.add(receiver)
+        CuriositySpark.objects.get_or_create(
+            sender=sender,
+            recipient=receiver,
+            defaults=dict(
+                drop=sender_drop,
+                message="Loved your story answer — curious to know more!",
+                status="pending",
+            ),
+        )
+        self.stdout.write(f"  pending spark: {sender.email} -> {receiver.email}")
+
+    # ------------------------------------------------------------------ #
+    # Summary
+    # ------------------------------------------------------------------ #
+
+    def _print_summary(self, password):
+        rows = [
+            ("debug_new", "Welcome step", "/en/onboarding/"),
+            ("debug_phone", "Verify-number step", "/en/onboarding/"),
+            ("debug_draft", "Build-profile (step 4)", "/en/onboarding/"),
+            ("debug_pending", "Submitted / pending", "/en/onboarding/"),
+            ("debug_approved", "Dashboard (verified)", "/en/dashboard/"),
+            (
+                "debug_receiver",
+                "Today's Drop (3 cards) + match + spark received",
+                "/en/crush-connect/home/",
+            ),
+            ("debug_cand_1", "Candidate (matched w/ receiver)", "/en/dashboard/"),
+            ("debug_cand_2", "Candidate in the pool", "/en/dashboard/"),
+            ("debug_cand_3", "Candidate in the pool", "/en/dashboard/"),
+            (
+                "debug_sender",
+                "Premium (sent pending spark to receiver)",
+                "/en/crush-connect/home/",
+            ),
+        ]
+        self.stdout.write("\n" + "=" * 78)
+        self.stdout.write(self.style.SUCCESS("  Debug cast ready"))
+        self.stdout.write("=" * 78)
+        self.stdout.write(f"\n  Password for all accounts: {password}\n")
+        self.stdout.write(f"  {'Email':<26}{'What to verify':<48}URL")
+        self.stdout.write(f"  {'-' * 24:<26}{'-' * 46:<48}{'-' * 20}")
+        for name, what, url in rows:
+            self.stdout.write(f"  {name + '@crush.lu':<26}{what:<48}{url}")
+
+        launched = getattr(settings, "CRUSH_CONNECT_LAUNCHED", False)
+        candidate_open = getattr(settings, "CRUSH_CONNECT_CANDIDATE_OPEN", False)
+        self.stdout.write("\n" + "-" * 78)
+        self.stdout.write("Crush Connect phase (from settings):")
+        self.stdout.write(
+            f"  CRUSH_CONNECT_LAUNCHED={launched}   "
+            f"CRUSH_CONNECT_CANDIDATE_OPEN={candidate_open}"
+        )
+        if not launched and not candidate_open:
+            self.stdout.write(
+                self.style.WARNING(
+                    "  Connect surfaces are CLOSED (prelaunch). To debug the beta, add to "
+                    ".env:\n    CRUSH_CONNECT_CANDIDATE_OPEN=true\n"
+                    "  (debug_receiver/debug_sender are seeded beta testers), or "
+                    "CRUSH_CONNECT_LAUNCHED=true to open everything — then restart runserver."
+                )
+            )
+        elif not launched and candidate_open:
+            self.stdout.write(
+                "  Beta phase active — debug_receiver (seeded tester) can reach Today's Drop."
+            )
+        else:
+            self.stdout.write("  Fully launched — all Connect surfaces open.")
+        self.stdout.write("-" * 78 + "\n")

--- a/open_debug_windows.py
+++ b/open_debug_windows.py
@@ -1,0 +1,265 @@
+"""
+Open one *already-logged-in* Chromium window per debug_* account for manual QA.
+
+Why a script (and not just tabs): every tab in one Chrome profile shares a single
+session cookie, so you can only be one user at a time. This script gives each
+account its own **isolated browser context** (separate cookie jar), so all the
+debug accounts stay logged in *simultaneously* in their own windows.
+
+How it logs in: it mints a Django session per account server-side and injects the
+`sessionid` cookie straight into each browser context. This bypasses the login
+form entirely — no cookie-consent banner, no allauth rate limit, no filling
+credentials. (Playwright can set HttpOnly cookies; `document.cookie` cannot.)
+
+Each window opens in a **mobile viewport** (iPhone-sized) by default, gets a pink
+badge (top-left) showing which account it is, and lands on that account's most
+useful page. Windows stay open until you press Enter here. Pass --desktop for
+wide windows.
+
+Prereqs:
+  - Dev server running:      python manage.py runserver   (http://localhost:8000)
+  - Accounts seeded:         python manage.py seed_debug_profiles --reset
+  - Playwright Chromium:     python -m playwright install chromium   (once)
+  - Run with the project venv python (it needs Django + the .env DB settings).
+
+Usage (run in your OWN terminal so you can press Enter to close):
+    python open_debug_windows.py                 # all 10 accounts
+    python open_debug_windows.py receiver cand_1 # only these (by suffix)
+    python open_debug_windows.py --stages        # only the 5 signup-stage accounts
+    python open_debug_windows.py --connect        # only the Connect cast
+    python open_debug_windows.py --desktop        # wide windows instead of mobile
+"""
+
+import math
+import os
+import sys
+
+# --- Django bootstrap (so we can mint sessions) -------------------------------
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, PROJECT_ROOT)
+os.chdir(PROJECT_ROOT)
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv()
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "azureproject.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from importlib import import_module  # noqa: E402
+
+from django.conf import settings  # noqa: E402
+from django.contrib.auth import (  # noqa: E402
+    BACKEND_SESSION_KEY,
+    HASH_SESSION_KEY,
+    SESSION_KEY,
+    get_user_model,
+)
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+BASE = "http://localhost:8000"
+
+# Mobile emulation (iPhone-ish) so each window previews the mobile layout. The
+# real rendering viewport is set, so Tailwind `sm:`/`md:` breakpoints render
+# their MOBILE side (unlike the claude-in-chrome extension, which can't). Pass
+# --desktop for a normal wide window instead.
+MOBILE_CONTEXT = dict(
+    viewport={"width": 390, "height": 844},
+    device_scale_factor=3,
+    is_mobile=True,
+    has_touch=True,
+    user_agent=(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 "
+        "Mobile/15E148 Safari/604.1"
+    ),
+)
+DESKTOP_CONTEXT = dict(viewport={"width": 1280, "height": 900})
+
+# (suffix, badge label, landing path)
+ACCOUNTS = [
+    ("new", "signup: Welcome", "/en/onboarding/"),
+    ("phone", "signup: Verify number", "/en/onboarding/"),
+    ("draft", "signup: Build profile", "/en/onboarding/"),
+    ("pending", "signup: Pending review", "/en/onboarding/"),
+    ("approved", "member: Dashboard", "/en/dashboard/"),
+    ("receiver", "Connect: receiver (drop+match+spark)", "/en/crush-connect/home/"),
+    ("cand_1", "Connect: candidate (matched)", "/en/dashboard/"),
+    ("cand_2", "Connect: candidate", "/en/dashboard/"),
+    ("cand_3", "Connect: candidate", "/en/dashboard/"),
+    ("sender", "Connect: sender (sent spark)", "/en/crush-connect/home/"),
+]
+
+_STAGE_SUFFIXES = {"new", "phone", "draft", "pending", "approved"}
+_CONNECT_SUFFIXES = {"receiver", "cand_1", "cand_2", "cand_3", "sender"}
+
+
+def _select(argv):
+    args = set(argv)
+    if "--stages" in args:
+        return [a for a in ACCOUNTS if a[0] in _STAGE_SUFFIXES]
+    if "--connect" in args:
+        return [a for a in ACCOUNTS if a[0] in _CONNECT_SUFFIXES]
+    wanted = {a for a in args if not a.startswith("--")}
+    return [a for a in ACCOUNTS if not wanted or a[0] in wanted]
+
+
+def _mint_session(user):
+    """Create a logged-in Django session for `user` and return its key."""
+    engine = import_module(settings.SESSION_ENGINE)
+    session = engine.SessionStore()
+    session[SESSION_KEY] = str(user.pk)
+    session[BACKEND_SESSION_KEY] = "django.contrib.auth.backends.ModelBackend"
+    session[HASH_SESSION_KEY] = user.get_session_auth_hash()
+    session.save()
+    return session.session_key
+
+
+def _badge_script(email, label):
+    """Inject a persistent identifying badge on every page in this context."""
+    text = f"{email}  ·  {label}"
+    return (
+        "window.addEventListener('DOMContentLoaded', () => {"
+        "  const b = document.createElement('div');"
+        f"  b.textContent = {text!r};"
+        "  b.style.cssText = 'position:fixed;top:0;left:0;z-index:2147483647;"
+        "background:#e6006e;color:#fff;font:600 12px/1.7 system-ui,sans-serif;"
+        "padding:2px 12px;border-bottom-right-radius:8px;pointer-events:none;"
+        "box-shadow:0 1px 6px rgba(0,0,0,.3);opacity:.94';"
+        "  document.documentElement.appendChild(b);"
+        "});"
+    )
+
+
+def _dismiss_consent(page):
+    """Best-effort: clear the cookie-consent banner so the window looks clean."""
+    try:
+        page.click("#cookie-btn-decline", timeout=1500)
+    except Exception:
+        pass
+
+
+def _screen_size():
+    """Screen work-area in logical pixels (Windows), with a sane fallback."""
+    try:
+        import ctypes
+
+        user32 = ctypes.windll.user32
+        return int(user32.GetSystemMetrics(0)), int(user32.GetSystemMetrics(1))
+    except Exception:
+        return 1920, 1080
+
+
+def _grid(n, win_w, win_h):
+    """Tile n windows edge-to-edge left→right; cascade extra rows to fit height."""
+    screen_w, screen_h = _screen_size()
+    cols = max(1, screen_w // win_w)
+    rows = max(1, math.ceil(n / cols))
+    if rows > 1 and rows * win_h > screen_h:
+        y_step = max(70, (screen_h - win_h) // (rows - 1))
+    else:
+        y_step = win_h
+    return [((i % cols) * win_w, (i // cols) * y_step, win_w, win_h) for i in range(n)]
+
+
+def _position_window(page, x, y, w, h):
+    """Move/size this context's OS window via CDP (Chromium only)."""
+    try:
+        cdp = page.context.new_cdp_session(page)
+        window_id = cdp.send("Browser.getWindowForTarget")["windowId"]
+        cdp.send(
+            "Browser.setWindowBounds",
+            {
+                "windowId": window_id,
+                "bounds": {
+                    "left": x,
+                    "top": y,
+                    "width": w,
+                    "height": h,
+                    "windowState": "normal",
+                },
+            },
+        )
+    except Exception:
+        pass
+
+
+def main():
+    selected = _select(sys.argv[1:])
+    if not selected:
+        print("No matching accounts. Suffixes:", ", ".join(a[0] for a in ACCOUNTS))
+        return
+
+    User = get_user_model()
+    prepared = []
+    for suffix, label, landing in selected:
+        email = f"debug_{suffix}@crush.lu"
+        try:
+            user = User.objects.get(username=f"debug_{suffix}")
+        except User.DoesNotExist:
+            print(
+                f"  MISSING {email} — run: python manage.py seed_debug_profiles --reset"
+            )
+            continue
+        prepared.append((email, label, landing, _mint_session(user)))
+
+    if not prepared:
+        print(
+            "No debug accounts found. Seed them: python manage.py seed_debug_profiles --reset"
+        )
+        return
+
+    mobile = "--desktop" not in sys.argv[1:]
+    ctx_opts = MOBILE_CONTEXT if mobile else DESKTOP_CONTEXT
+    # Chromium enforces a ~515px minimum window width, so tile ≥520 wide even
+    # though the emulated mobile viewport itself is only 390px.
+    win_w, win_h = (520, 860) if mobile else (960, 900)
+    positions = _grid(len(prepared), win_w, win_h)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        view = "mobile" if mobile else "desktop"
+        print(f"Opening {len(prepared)} logged-in windows ({view} view, tiled)...\n")
+        for (email, label, landing, key), (x, y, w, h) in zip(prepared, positions):
+            context = browser.new_context(
+                **ctx_opts,
+                service_workers="block",  # stop the PWA SW hijacking navigations
+            )
+            context.add_cookies(
+                [
+                    {
+                        "name": settings.SESSION_COOKIE_NAME,
+                        "value": key,
+                        "domain": "localhost",
+                        "path": "/",
+                        "httpOnly": True,
+                        "sameSite": "Lax",
+                    }
+                ]
+            )
+            page = context.new_page()
+            _position_window(page, x, y, w, h)
+            page.add_init_script(_badge_script(email, label))
+            try:
+                page.goto(f"{BASE}{landing}", wait_until="commit")
+                page.wait_for_load_state("domcontentloaded", timeout=8000)
+            except Exception:
+                pass  # tolerate redirect chains / SW aborts
+            _dismiss_consent(page)
+            print(f"  OK   {email:<26} @({x},{y}) -> {page.url}")
+
+        print(
+            f"\n{len(prepared)} windows open (each a different logged-in account).\n"
+            "Arrange them as you like. Press Enter here to close them all..."
+        )
+        try:
+            input()
+        except (EOFError, KeyboardInterrupt):
+            pass
+        browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_sqlite_dev_server.py
+++ b/run_sqlite_dev_server.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+def main():
+    # Only for Local Development - Load environment variables from the .env file
+    if 'WEBSITE_HOSTNAME' not in os.environ:
+        from dotenv import load_dotenv
+        load_dotenv('./.env')
+    
+    # Overwrite DBHOST with empty string to force SQLite fallback
+    os.environ['DBHOST'] = ''
+
+    # Ensure DJANGO_SETTINGS_MODULE is set
+    settings_module = "azureproject.settings"
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
+
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django."
+        ) from exc
+
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Why

Three developer-only QA helpers that have been living untracked in the working
tree — landing them so they're versioned and shareable. None touch the running
app.

## What

- **`seed_debug_profiles`** (management command) — seeds ~10 loginable `debug_*`
  accounts with **verified allauth emails** across every signup stage
  (welcome → phone → draft → pending → approved) plus the Crush Connect cast
  (receiver + candidates + sender, with a seeded drop/match/pending spark).
  Safety-guarded: refuses to run on Azure (`WEBSITE_HOSTNAME`) or with
  `DEBUG=False` unless `--force`. Shared password defaults to `debug2025`.
- **`open_debug_windows.py`** — opens one *already-logged-in* Chromium window
  per debug account, each in its own isolated cookie jar, so you can be all the
  accounts at once. Mints Django sessions server-side and injects the
  `sessionid` cookie (skips the login form / consent banner / rate limit).
  Mobile viewport by default; `--desktop`, `--stages`, `--connect` filters.
- **`run_sqlite_dev_server.py`** — `manage.py` wrapper that forces `DBHOST=''`
  to run against the SQLite fallback, for quick work without Postgres/Docker.

## Notes / testing

- `manage.py seed_debug_profiles --help` imports and resolves cleanly against
  current `main`.
- Not collected by pytest (`run_*`/command files don't match `test_*.py`); no
  migrations, no settings changes, zero runtime impact on the deployed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
