### PR TITLE
chore(crush_lu): add seed_crush_cache debug hunt seeder (missed in #617)

### DIFF
--- a/crush_lu/management/commands/seed_crush_cache.py
+++ b/crush_lu/management/commands/seed_crush_cache.py
@@ -1,0 +1,326 @@
+"""
+Seed a ready-to-play **Crush Cache** scavenger hunt through Luxembourg City,
+for manual QA of the GPS + QR gameplay.
+
+Creates one `crush_cache` MeetupEvent + a CacheHunt with a walking loop of real
+Luxembourg City landmarks (GPS coords + a QR station), each with a challenge,
+plus a demo team. Every existing `debug_*` account (from
+`seed_debug_profiles`) is registered as a confirmed attendee so you can log in
+and play immediately; if none exist it creates a couple of players.
+
+LOCAL-ONLY: refuses to run on Azure (WEBSITE_HOSTNAME set) or when DEBUG is
+False, unless --force. Also needs the feature flag: CRUSH_CACHE_ENABLED=true
+(in your .env), or the gameplay URLs 404.
+
+Usage:
+    python manage.py seed_crush_cache --reset
+    python manage.py seed_crush_cache --reset --live   # start the hunt now
+
+Testing GPS without being in Luxembourg: open the play page in Chrome, then
+DevTools → ⋮ → More tools → Sensors → Location → "Other…" and paste a
+station's lat/lng (printed below). The arrival check will pass.
+"""
+
+import os
+from datetime import timedelta
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from crush_lu.models import EventRegistration, MeetupEvent
+from crush_lu.models.crush_cache import (
+    CacheChallenge,
+    CacheHunt,
+    CacheStation,
+    CacheTeam,
+)
+from crush_lu.models.profiles import CrushCoach
+
+EVENT_TITLE = "🧭 [DEBUG] Luxembourg City Crush Cache"
+
+# Real Luxembourg City landmarks — a compact walking loop in the Ville Haute /
+# Pétrusse. Coordinates are approximate to the landmark; tweak per station in
+# the admin (📍 Cache Stations) if you want tighter/looser arrival radii.
+STATIONS = [
+    {
+        "order": 1,
+        "name": "Gëlle Fra (Monument of Remembrance)",
+        "lat": "49.609720",
+        "lng": "6.129170",
+        "unlock_mode": "gps",
+        "intro": "Head to the golden lady watching over Place de la Constitution.",
+        "challenge_type": "riddle",
+        "question": "What is the popular Luxembourgish name of this golden statue?",
+        "answer": "Gëlle Fra",
+        "alternatives": ["Gelle Fra", "Golden Lady", "Golden Fra"],
+        "hint_1": "It means 'Golden Lady' in Luxembourgish.",
+        "points": 100,
+    },
+    {
+        "order": 2,
+        "name": "Pont Adolphe",
+        "lat": "49.607500",
+        "lng": "6.127220",
+        "unlock_mode": "gps",
+        "intro": "Cross to the great arched bridge over the Pétrusse valley.",
+        "challenge_type": "open_text",
+        "question": "Which valley does the Pont Adolphe span?",
+        "answer": "Petrusse",
+        "alternatives": ["Pétrusse", "Petrusse valley", "Vallée de la Pétrusse"],
+        "hint_1": "A small river gorge below the Ville Haute.",
+        "points": 80,
+    },
+    {
+        "order": 3,
+        "name": "Place Guillaume II (Knuedler)",
+        "lat": "49.610830",
+        "lng": "6.130000",
+        "unlock_mode": "gps",
+        "intro": "Walk to the big square with the equestrian statue and the Town Hall.",
+        "challenge_type": "riddle",
+        "question": "By what nickname do locals call this square?",
+        "answer": "Knuedler",
+        "alternatives": ["Knudler"],
+        "hint_1": "It refers to the knot in a monk's belt (Knued).",
+        "points": 100,
+    },
+    {
+        "order": 4,
+        "name": "Grand Ducal Palace",
+        "lat": "49.610600",
+        "lng": "6.131900",
+        "unlock_mode": "gps_qr",
+        "intro": "Reach the palace, then scan the sticker by the guard's post.",
+        "challenge_type": "open_text",
+        "question": "Who officially resides at this palace (title, not name)?",
+        "answer": "Grand Duke",
+        "alternatives": ["The Grand Duke", "Grand-Duke", "Grand Duke of Luxembourg"],
+        "hint_1": "The head of state of the Grand Duchy.",
+        "points": 120,
+    },
+    {
+        "order": 5,
+        "name": "Casemates du Bock",
+        "lat": "49.611500",
+        "lng": "6.134800",
+        "unlock_mode": "gps",
+        "intro": "Finish at the cliffside fortifications carved into the Bock promontory.",
+        "challenge_type": "open_text",
+        "question": "These underground tunnels are famously called the Bock ______?",
+        "answer": "Casemates",
+        "alternatives": ["Casemates du Bock", "the Casemates"],
+        "hint_1": "A French word for fortified galleries.",
+        "points": 100,
+    },
+]
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed a playable Crush Cache hunt through Luxembourg City (GPS + QR) "
+        "for manual QA. Local-only."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Delete the existing debug hunt/event first, then reseed.",
+        )
+        parser.add_argument(
+            "--live",
+            action="store_true",
+            help="Start the hunt immediately (status=live) instead of draft.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Override the local-only safety guard (NOT for production).",
+        )
+
+    def handle(self, *args, **options):
+        force = options["force"]
+        if not force:
+            if "WEBSITE_HOSTNAME" in os.environ:
+                raise CommandError(
+                    "Refusing to run on Azure. Use --force only if you are sure."
+                )
+            if not settings.DEBUG:
+                raise CommandError(
+                    "Refusing to run with DEBUG=False. Use --force to override."
+                )
+
+        if not getattr(settings, "CRUSH_CACHE_ENABLED", False):
+            self.stdout.write(
+                self.style.WARNING(
+                    "⚠ CRUSH_CACHE_ENABLED is not true — seeding anyway, but the "
+                    "gameplay URLs will 404 until you set CRUSH_CACHE_ENABLED=true "
+                    "in your .env and restart runserver."
+                )
+            )
+
+        existing = MeetupEvent.objects.filter(
+            title=EVENT_TITLE, event_type="crush_cache"
+        ).first()
+        if existing:
+            if not options["reset"]:
+                raise CommandError(
+                    "The debug Crush Cache event already exists. Re-run with "
+                    "--reset to delete and recreate it."
+                )
+            # Cascades to hunt, stations, challenges, teams, registrations.
+            existing.delete()
+            self.stdout.write("Deleted the previous debug Crush Cache event.")
+
+        coach = self._ensure_coach()
+        event = self._create_event()
+        hunt = self._create_hunt(event, coach)
+        self._create_stations(hunt)
+        team = self._create_demo_team(hunt)
+        players = self._register_players(event)
+
+        if options["live"]:
+            hunt.status = "live"
+            hunt.started_at = timezone.now()
+            hunt.save(update_fields=["status", "started_at"])
+
+        self._report(hunt, team, players)
+
+    # ------------------------------------------------------------------ #
+
+    def _ensure_coach(self):
+        from allauth.account.models import EmailAddress
+
+        coach_user, _ = User.objects.get_or_create(
+            username="debug_cache_coach@crush.lu",
+            defaults={"email": "debug_cache_coach@crush.lu"},
+        )
+        # Loginable (password + verified email under mandatory verification) so
+        # you can reach the coach dashboard to start/finish the hunt.
+        coach_user.is_staff = True
+        coach_user.set_password("debug2025")
+        coach_user.save()
+        EmailAddress.objects.update_or_create(
+            user=coach_user,
+            email=coach_user.email,
+            defaults={"verified": True, "primary": True},
+        )
+        CrushCoach.objects.get_or_create(
+            user=coach_user,
+            defaults={
+                "bio": "Crush Cache debug host",
+                "specializations": "Scavenger hunts",
+                "is_active": True,
+            },
+        )
+        return coach_user
+
+    def _create_event(self):
+        now = timezone.now()
+        return MeetupEvent.objects.create(
+            title=EVENT_TITLE,
+            description="Debug scavenger hunt through Luxembourg City for QA.",
+            event_type="crush_cache",
+            date_time=now + timedelta(hours=2),
+            registration_deadline=now + timedelta(hours=1),
+            location="Luxembourg City",
+            address="Place de la Constitution, Luxembourg",
+            max_participants=30,
+            is_published=True,
+        )
+
+    def _create_hunt(self, event, coach):
+        return CacheHunt.objects.create(
+            event=event,
+            title="Old Town GPS Hunt",
+            description="Follow the pins around the Ville Haute. First team home wins!",
+            status="draft",
+            navigation_mode="map",  # target pin shown — easiest to test GPS with
+            team_size_max=4,
+            allow_self_join=True,
+            created_by=coach,
+        )
+
+    def _create_stations(self, hunt):
+        for s in STATIONS:
+            station = CacheStation.objects.create(
+                hunt=hunt,
+                order=s["order"],
+                name=s["name"],
+                intro_text=s["intro"],
+                latitude=s["lat"],
+                longitude=s["lng"],
+                radius_meters=40,
+                unlock_mode=s["unlock_mode"],
+                completion_message="Nice — on to the next one!",
+            )
+            CacheChallenge.objects.create(
+                station=station,
+                challenge_order=1,
+                challenge_type=s["challenge_type"],
+                question=s["question"],
+                correct_answer=s["answer"],
+                alternative_answers=s["alternatives"],
+                hint_1=s["hint_1"],
+                points_awarded=s["points"],
+                success_message="Correct!",
+            )
+
+    def _create_demo_team(self, hunt):
+        return CacheTeam.objects.create(
+            hunt=hunt, name="Explorers", color="#3b82f6"
+        )
+
+    def _register_players(self, event):
+        debug_users = list(User.objects.filter(username__startswith="debug_"))
+        if not debug_users:
+            debug_users = []
+            for i in (1, 2):
+                u, _ = User.objects.get_or_create(
+                    username=f"debug_cache_player{i}@crush.lu",
+                    defaults={"email": f"debug_cache_player{i}@crush.lu"},
+                )
+                debug_users.append(u)
+
+        registered = []
+        for user in debug_users:
+            reg, _ = EventRegistration.objects.get_or_create(
+                event=event, user=user, defaults={"status": "confirmed"}
+            )
+            if reg.status not in ("confirmed", "attended"):
+                reg.status = "confirmed"
+                reg.save(update_fields=["status"])
+            registered.append(user)
+        return registered
+
+    def _report(self, hunt, team, players):
+        out = self.stdout
+        style = self.style
+        out.write(style.SUCCESS(f"\n✅ Seeded '{hunt.title}' ({hunt.status})."))
+        out.write(
+            f"   Event id: {hunt.event_id}   "
+            f"Coach login: {hunt.created_by.username} / debug2025"
+        )
+        out.write(f"   Demo team: {team.name} — join code: {team.join_code}")
+        out.write(f"   Registered players ({len(players)}):")
+        for u in players[:12]:
+            out.write(f"     - {u.username}")
+        out.write("\n   Play URL (log in as a registered player first):")
+        out.write(f"     http://localhost:8000/en/events/{hunt.event_id}/cache/")
+        out.write("\n   Station coordinates (for the DevTools → Sensors override):")
+        for s in STATIONS:
+            out.write(
+                f"     {s['order']}. {s['name']}: {s['lat']}, {s['lng']} "
+                f"({s['unlock_mode']})"
+            )
+        if hunt.status == "draft":
+            out.write(
+                style.WARNING(
+                    "\n   Hunt is DRAFT. Log in as the coach and press Start on the "
+                    "coach dashboard (or reseed with --live) before GPS positions "
+                    "are accepted."
+                )
+            )
+        out.write("")


### PR DESCRIPTION
The `seed_crush_cache` management command was authored on the #617 branch but landed *after* #617 merged, so it never reached `main` (only `seed_debug_profiles` did). This lands it.

Seeds a playable Crush Cache hunt through Luxembourg City — 5 GPS/QR stations at real landmarks, each with a challenge, a demo team, and a loginable coach (`debug_cache_coach@crush.lu` / `debug2025`). Registers existing `debug_*` accounts as attendees and prints the play URL, join code, and per-station coordinates for the DevTools Sensors geolocation override. Local-only guard (Azure / DEBUG=False); flags: --reset, --live, --force.

Verified locally (ruff clean, seeds + re-seeds idempotently against the dev DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)