### PR TITLE
fix(crush_lu): QR only for QR-unlock stations + honest scan messaging

### DIFF
--- a/crush_lu/admin/crush_cache.py
+++ b/crush_lu/admin/crush_cache.py
@@ -83,6 +83,20 @@ def generate_cache_qr_sheet(modeladmin, request, queryset):
         messages.error(request, _("'%(hunt)s' has no stations yet.") % {"hunt": hunt})
         return None
 
+    # Only stations that actually unlock via QR (qr / gps_qr) need a printed
+    # code — a GPS or 'none' station's QR is a no-op sticker.
+    stations = [s for s in stations if s.requires_qr]
+    if not stations:
+        messages.warning(
+            request,
+            _(
+                "None of '%(hunt)s' stations unlock via QR (they are all GPS or "
+                "none), so there is nothing to print."
+            )
+            % {"hunt": hunt},
+        )
+        return None
+
     if not HAS_REPORTLAB:
         messages.warning(
             request,
@@ -213,6 +227,10 @@ class CacheStationAdmin(AutoTranslateMixin, TranslationAdmin):
         """Inline QR image — right-click to save as PNG when no reportlab."""
         if not obj.pk:
             return _("Save the station first to get its QR code.")
+        if not obj.requires_qr:
+            return _(
+                "No QR needed — this station unlocks by “%(mode)s”."
+            ) % {"mode": obj.get_unlock_mode_display()}
         from crush_lu.qr_utils import generate_cache_qr_url, generate_qr_code_base64
 
         url = generate_cache_qr_url(obj.qr_token)

--- a/crush_lu/tests/test_crush_cache.py
+++ b/crush_lu/tests/test_crush_cache.py
@@ -1045,3 +1045,36 @@ class TestCodexReviewFixes:
         assert not CacheTeamMember.objects.filter(
             hunt=hunt, registration__user=teammate
         ).exists()
+
+
+@pytest.mark.django_db
+class TestQrUnlockMessaging:
+    def test_scan_before_arrival_does_not_claim_unlocked(
+        self, client, hunt, team, player
+    ):
+        """Scanning a gps_qr station before arriving records the scan but must
+        NOT claim the station is unlocked — GPS arrival is still required."""
+        station = CacheStation.objects.create(
+            hunt=hunt,
+            order=1,
+            name="Grand Ducal Palace",
+            unlock_mode="gps_qr",
+            latitude="49.610600",
+            longitude="6.131900",
+            radius_meters=40,
+        )
+        _start_hunt(hunt)  # hunt live + progress parked at this first station
+        client.force_login(player)
+
+        url = reverse("crush_lu:cache_qr_scan", args=[station.qr_token])
+        response = client.get(url, follow=True)
+
+        attempt = CacheStationAttempt.objects.get(team=team, station=station)
+        assert attempt.scanned_at is not None  # the scan is recorded
+        assert attempt.is_unlocked is False  # ...but still locked (not arrived)
+
+        from django.contrib.messages import constants as msg_constants
+
+        levels = [m.level for m in response.context["messages"]]
+        assert msg_constants.SUCCESS not in levels  # must not say "unlocked!"
+        assert msg_constants.INFO in levels  # nudge to reach the location

--- a/crush_lu/views_crush_cache.py
+++ b/crush_lu/views_crush_cache.py
@@ -459,13 +459,25 @@ def cache_qr_scan(request, token):
         team=membership.team, station=station
     )
     if attempt.scanned_at is None:
+        now = timezone.now()
         CacheStationAttempt.objects.filter(
             pk=attempt.pk, scanned_at__isnull=True
-        ).update(scanned_at=timezone.now())
-        messages.success(
-            request,
-            _("Code scanned — %(station)s unlocked!") % {"station": station.name},
-        )
+        ).update(scanned_at=now)
+        attempt.scanned_at = now  # reflect the write for the is_unlocked check
+        if attempt.is_unlocked:
+            messages.success(
+                request,
+                _("Code scanned — %(station)s unlocked!") % {"station": station.name},
+            )
+        else:
+            # A gps_qr station scanned before the team has arrived: the scan is
+            # recorded, but GPS arrival is still required — don't claim it's
+            # unlocked when it isn't.
+            messages.info(
+                request,
+                _("Code scanned — now reach the location to unlock %(station)s.")
+                % {"station": station.name},
+            )
     return redirect("crush_lu:cache_play", event_id=event_id)
 
 


### PR DESCRIPTION
Two small Crush Cache cleanups found during staging QA:

1. **QR codes only where they're used.** The printable QR sheet (admin action) and the per-station QR preview generated a code for *every* station regardless of `unlock_mode` — so a `gps`/`none` station got a no-op sticker. Both are now gated on `requires_qr` (`qr` / `gps_qr`): the sheet action warns when a hunt has no QR stations, and the admin preview shows the unlock mode instead of a pointless code.
2. **Honest scan copy.** `cache_qr_scan` always flashed *"Code scanned — unlocked!"*, even when scanning a `gps_qr` station *before* arriving (which leaves it locked). It now only claims "unlocked" when the station actually is, otherwise nudges the team to reach the location.

Regression test added for the scan-before-arrival messaging. `pytest crush_lu/tests/test_crush_cache.py` → 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)