### PR TITLE
feat(crush_lu): Stage 5 — Premium entitlement = active PremiumMembership

### DIFF
--- a/crush_lu/management/commands/create_connect_test_users.py
+++ b/crush_lu/management/commands/create_connect_test_users.py
@@ -30,7 +30,7 @@ from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
-from crush_lu.models import CrushProfile, ProfileSubmission
+from crush_lu.models import CrushProfile, PremiumMembership, ProfileSubmission
 from crush_lu.models.crush_connect import CrushConnectMembership, SparkPrompt
 from crush_lu.models.profiles import CrushCoach
 
@@ -292,6 +292,17 @@ class Command(BaseCommand):
                 profile_kwargs["assigned_coach_at"] = timezone.now()
 
             profile = CrushProfile.objects.create(**profile_kwargs)
+
+            if is_premium:
+                # The receiver gate keys off an ACTIVE PremiumMembership, not
+                # assigned_coach — give premium seeds the real entitlement.
+                PremiumMembership.objects.create(
+                    user=user,
+                    coach=coach,
+                    status="active",
+                    payment_confirmed=True,
+                    payment_date=timezone.now(),
+                )
 
             if user_data.get("photo_data"):
                 try:

--- a/crush_lu/management/commands/seed_debug_profiles.py
+++ b/crush_lu/management/commands/seed_debug_profiles.py
@@ -39,7 +39,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
-from crush_lu.models import CrushProfile, ProfileSubmission
+from crush_lu.models import CrushProfile, PremiumMembership, ProfileSubmission
 from crush_lu.models.crush_connect import (
     ConnectInterest,
     CrushConnectMembership,
@@ -355,6 +355,15 @@ class Command(BaseCommand):
                 review_call_completed=True,
                 review_call_date=now,
                 reviewed_at=now,
+            )
+            # The receiver gate keys off an ACTIVE PremiumMembership, not
+            # assigned_coach — give receiver/sender seeds the real entitlement.
+            PremiumMembership.objects.create(
+                user=profile.user,
+                coach=profile.assigned_coach,
+                status="active",
+                payment_confirmed=True,
+                payment_date=now,
             )
 
     def _wire_connect_membership(self, user, stage, prompt, now):

--- a/crush_lu/migrations/0184_backfill_tester_premium_memberships.py
+++ b/crush_lu/migrations/0184_backfill_tester_premium_memberships.py
@@ -1,0 +1,47 @@
+# Data migration for the Stage-5 receiver-gate rework.
+#
+# The Premium/receiver gates now key off an ACTIVE PremiumMembership instead
+# of bare CrushProfile.assigned_coach (which the 0150 backfill and the
+# attendance auto-assign signal set without payment). Hand-picked beta
+# testers (CrushConnectWaitlist.selected_as_tester) were comped by assigning
+# a coach directly — give them the membership row the new gate expects so
+# their beta access is uninterrupted. Waitlist.payment_confirmed (the manual
+# €10/month flag) carries over.
+
+from django.db import migrations
+
+
+def backfill_tester_memberships(apps, schema_editor):
+    CrushConnectWaitlist = apps.get_model("crush_lu", "CrushConnectWaitlist")
+    PremiumMembership = apps.get_model("crush_lu", "PremiumMembership")
+
+    testers = CrushConnectWaitlist.objects.filter(
+        selected_as_tester=True,
+        user__crushprofile__assigned_coach__isnull=False,
+    ).select_related("user__crushprofile")
+
+    for entry in testers.iterator():
+        profile = entry.user.crushprofile
+        has_active = PremiumMembership.objects.filter(
+            user_id=entry.user_id, status="active"
+        ).exists()
+        if has_active:
+            continue
+        PremiumMembership.objects.create(
+            user_id=entry.user_id,
+            coach_id=profile.assigned_coach_id,
+            status="active",
+            payment_confirmed=entry.payment_confirmed,
+            payment_date=entry.selected_at,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crush_lu", "0183_cachestation_manual_code"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_tester_memberships, migrations.RunPython.noop),
+    ]

--- a/crush_lu/migrations/0184_backfill_tester_premium_memberships.py
+++ b/crush_lu/migrations/0184_backfill_tester_premium_memberships.py
@@ -32,7 +32,11 @@ def backfill_tester_memberships(apps, schema_editor):
             coach_id=profile.assigned_coach_id,
             status="active",
             payment_confirmed=entry.payment_confirmed,
-            payment_date=entry.selected_at,
+            # Use the waitlist's actual payment timestamp when available so
+            # weekly KPI windowing (services/weekly_kpis.py keys on
+            # payment_date) reports these testers in the correct week. Falls
+            # back to selected_at for unpaid/unstamped testers.
+            payment_date=entry.payment_date or entry.selected_at,
         )
 
 

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -380,8 +380,14 @@ class CrushCoach(models.Model):
         )
 
     def get_premium_members_count(self):
-        """Number of members permanently assigned to this coach."""
-        return self.assigned_members.count()
+        """Number of ACTIVE paid/comped premium members with this coach.
+
+        Counts ``PremiumMembership(status='active')`` rows, NOT
+        ``assigned_members`` — coach assignment also happens without payment
+        (0150 backfill, attendance auto-assign), and counting those would
+        wrongly exhaust ``max_premium_members`` capacity.
+        """
+        return self.premium_memberships.filter(status="active").count()
 
     def can_accept_premium(self):
         """Whether this coach is available to be chosen by a new premium member."""
@@ -911,6 +917,19 @@ class CrushProfile(models.Model):
         """
         native, oidc_token = self.luxid_account_querysets(self.user_id)
         return native.exists() or oidc_token.exists()
+
+    @property
+    def has_active_premium(self) -> bool:
+        """True when the user holds an ACTIVE ``PremiumMembership``.
+
+        This — not ``assigned_coach`` — is the Premium entitlement. A coach can
+        be assigned without payment (the 0150 backfill, the attendance
+        auto-assign signal), so ``assigned_coach`` only expresses the service
+        relationship; every Premium/receiver gate must key off this property.
+        """
+        return PremiumMembership.objects.filter(
+            user_id=self.user_id, status="active"
+        ).exists()
 
     def save(self, *args, **kwargs):
         """

--- a/crush_lu/services/crush_connect.py
+++ b/crush_lu/services/crush_connect.py
@@ -78,9 +78,9 @@ def get_eligible_pool(user, candidate_pk=None) -> "QuerySet[User]":
     Return the queryset of users eligible to appear in ``user``'s Crush Connect Drop.
 
     The requester must be eligible to RECEIVE (profile approved, PREMIUM =
-    personal coach assigned, onboarded into Crush Connect, not coach-excluded),
-    otherwise an empty queryset. Candidates don't need Premium — the catalogue
-    requires LuxID + opt-in instead (asymmetric model).
+    active PremiumMembership, onboarded into Crush Connect, not
+    coach-excluded), otherwise an empty queryset. Candidates don't need
+    Premium — the catalogue requires LuxID + opt-in instead (asymmetric model).
 
     ``candidate_pk`` narrows the pool to a single candidate BEFORE the Python
     gender-preference step below — point lookups ("is X in the pool?") must use
@@ -94,8 +94,10 @@ def get_eligible_pool(user, candidate_pk=None) -> "QuerySet[User]":
     if user_profile is None or not user_profile.is_approved:
         return User.objects.none()
 
-    # Premium gate: Crush Connect requires a personal coach (the Premium product).
-    if not user_profile.assigned_coach_id:
+    # Premium gate: receiving Drops requires an ACTIVE PremiumMembership.
+    # assigned_coach alone is NOT the entitlement (backfill / attendance
+    # auto-assign set it without payment).
+    if not user_profile.has_active_premium:
         return User.objects.none()
 
     user_membership = getattr(user, "crush_connect_membership", None)
@@ -498,8 +500,8 @@ def is_catalogue_eligible(user) -> bool:
 def is_sender_eligible(user) -> bool:
     """
     Whether ``user`` currently qualifies to SEND Sparks (the receiver track):
-    approved profile + Premium coach assigned + onboarded (not excluded) + has
-    given photo-share consent.
+    approved profile + active PremiumMembership + onboarded (not excluded) +
+    has given photo-share consent.
 
     Consent matters on the SEND side too now: reading a candidate exposes the
     sender's clear photo to that candidate on the answer-back surface, so a
@@ -516,7 +518,7 @@ def is_sender_eligible(user) -> bool:
     return bool(
         profile is not None
         and profile.is_approved
-        and profile.assigned_coach_id
+        and profile.has_active_premium
         and membership is not None
         and membership.is_onboarded
         and membership.photo_share_consent

--- a/crush_lu/tests/test_crush_connect.py
+++ b/crush_lu/tests/test_crush_connect.py
@@ -23,6 +23,7 @@ from crush_lu.models import (
     EventConnection,
     EventRegistration,
     MeetupEvent,
+    PremiumMembership,
     SparkPrompt,
 )
 from crush_lu.services.crush_connect import (
@@ -124,6 +125,15 @@ def _make_user(
         profile.assigned_coach = _get_coach()
         profile.assigned_coach_at = timezone.now()
         profile.save(update_fields=["assigned_coach", "assigned_coach_at"])
+        # Premium entitlement = ACTIVE PremiumMembership (the receiver gates
+        # key off it); assigned_coach alone is just the service relationship.
+        PremiumMembership.objects.create(
+            user=user,
+            coach=profile.assigned_coach,
+            status="active",
+            payment_confirmed=True,
+            payment_date=timezone.now(),
+        )
     if has_luxid:
         SocialAccount.objects.create(user=user, provider="luxid", uid=username)
 
@@ -241,6 +251,35 @@ def test_pool_includes_non_premium_luxid_targets():
     me = _make_user(username="me", preferred_genders=["F", "M"])
     non_premium = _make_user(username="nonprem", premium=False, has_luxid=True)
     assert non_premium in get_eligible_pool(me)
+
+
+@pytest.mark.django_db
+def test_pool_empty_for_coach_assigned_member_without_membership(settings):
+    """Stage-5 receiver gate: a coach assigned WITHOUT an active
+    PremiumMembership (the 0150 backfill, the attendance auto-assign signal)
+    must not unlock the receiver track at full launch."""
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    me = _make_user(username="me", preferred_genders=["F"])
+    _make_user(username="cand", gender="F", premium=False)
+    PremiumMembership.objects.filter(user=me).delete()
+    me.crushprofile.refresh_from_db()
+    assert me.crushprofile.assigned_coach_id is not None  # coach stays
+    assert not get_eligible_pool(me).exists()
+
+
+@pytest.mark.django_db
+def test_receiver_eligibility_requires_active_membership():
+    """The view-layer receiver gate keys off PremiumMembership status, not
+    assigned_coach — cancelling the membership revokes receiving even while
+    the coach relationship remains."""
+    from crush_lu.views_crush_connect import _user_is_connect_receiver_eligible
+
+    me = _make_user(username="me")
+    assert _user_is_connect_receiver_eligible(me)
+
+    PremiumMembership.objects.filter(user=me).update(status="cancelled")
+    assert not _user_is_connect_receiver_eligible(me)
+    assert me.crushprofile.assigned_coach_id is not None
 
 
 @pytest.mark.django_db
@@ -1820,8 +1859,7 @@ def test_respond_accept_blocked_when_sender_lost_eligibility():
     _surface_in_drop(me, her)
     spark = send_spark(me, her)
 
-    me.crushprofile.assigned_coach = None
-    me.crushprofile.save(update_fields=["assigned_coach"])
+    PremiumMembership.objects.filter(user=me).update(status="cancelled")
 
     respond_to_spark(spark, accept=True)
     spark.refresh_from_db()
@@ -1839,8 +1877,7 @@ def test_sparks_received_hides_sparks_from_ineligible_sender(client, settings):
     _surface_in_drop(me, her)
     send_spark(me, her, message="Hello there")
 
-    me.crushprofile.assigned_coach = None
-    me.crushprofile.save(update_fields=["assigned_coach"])
+    PremiumMembership.objects.filter(user=me).update(status="cancelled")
 
     _login_eligible(client, her)
     resp = client.get(SPARKS_RECEIVED_URL)

--- a/crush_lu/tests/test_dashboard_connect_status.py
+++ b/crush_lu/tests/test_dashboard_connect_status.py
@@ -166,10 +166,16 @@ class DashboardConnectStatusStripTests(TestCase):
 
     @override_settings(CRUSH_CONNECT_LAUNCHED=True)
     def test_premium_member_gets_no_strip(self):
+        from crush_lu.models import PremiumMembership
+
         coach = _make_coach("coach_p", "+352999999")
         profile = self.user.crushprofile
-        profile.assigned_coach = coach  # premium
+        profile.assigned_coach = coach
         profile.save()
+        # Premium = active membership, not the coach assignment alone.
+        PremiumMembership.objects.create(
+            user=self.user, coach=coach, status="active", payment_confirmed=True
+        )
         _link_luxid(self.user)
         response = self._get()
         self.assertEqual(response.status_code, 200)

--- a/crush_lu/tests/test_premium_membership.py
+++ b/crush_lu/tests/test_premium_membership.py
@@ -35,12 +35,13 @@ class SiteTestMixin:
 @override_settings(**CRUSH_LU_URL_SETTINGS, PREMIUM_REDIRECTS_TO_BETA=False)
 class PremiumMembershipTests(SiteTestMixin, TestCase):
     def setUp(self):
-        from crush_lu.models import CrushCoach, CrushProfile
+        from crush_lu.models import CrushCoach, CrushProfile, PremiumMembership
         from crush_lu.models.profiles import UserDataConsent
 
         self.client = Client()
         self.CrushCoach = CrushCoach
         self.CrushProfile = CrushProfile
+        self.PremiumMembership = PremiumMembership
 
         self.member = User.objects.create_user(
             username="m@example.com", email="m@example.com", password="pass12345"
@@ -69,7 +70,7 @@ class PremiumMembershipTests(SiteTestMixin, TestCase):
         self._make_coach("notpremium", accepting_premium=False)
         self._make_coach("away", is_away=True)
         full = self._make_coach("full", max_premium_members=1)
-        # Fill the "full" coach to capacity.
+        # Fill the "full" coach to capacity with an ACTIVE membership.
         other = User.objects.create_user(
             username="taken@example.com", email="taken@example.com", password="x"
         )
@@ -77,6 +78,20 @@ class PremiumMembershipTests(SiteTestMixin, TestCase):
         p.assigned_coach = full
         p.assigned_coach_at = timezone.now()
         p.save()
+        self.PremiumMembership.objects.create(
+            user=other, coach=full, status="active", payment_confirmed=True
+        )
+        # A bare coach assignment (backfill / attendance auto-assign) must NOT
+        # consume premium capacity — only active memberships do.
+        freeloader = User.objects.create_user(
+            username="freeload@example.com",
+            email="freeload@example.com",
+            password="x",
+        )
+        fp = self.CrushProfile.objects.create(user=freeloader, gender="M")
+        fp.assigned_coach = available
+        fp.assigned_coach_at = timezone.now()
+        fp.save()
 
         self.client.force_login(self.member)
         resp = self.client.get(reverse("crush_lu:premium_choose_coach"))
@@ -112,6 +127,9 @@ class PremiumMembershipTests(SiteTestMixin, TestCase):
         p.assigned_coach = coach
         p.assigned_coach_at = timezone.now()
         p.save()
+        self.PremiumMembership.objects.create(
+            user=other, coach=coach, status="active", payment_confirmed=True
+        )
 
         self.client.force_login(self.member)
         resp = self.client.post(
@@ -142,7 +160,8 @@ class PremiumMembershipTests(SiteTestMixin, TestCase):
         from crush_lu.models import PremiumMembership
 
         coach = self._make_coach("solo", max_premium_members=1)
-        # Fill the only seat.
+        # Fill the only seat with an ACTIVE membership (bare assigned_coach no
+        # longer counts against capacity).
         other = User.objects.create_user(
             username="t3@example.com", email="t3@example.com", password="x"
         )
@@ -150,6 +169,9 @@ class PremiumMembershipTests(SiteTestMixin, TestCase):
         p.assigned_coach = coach
         p.assigned_coach_at = timezone.now()
         p.save()
+        self.PremiumMembership.objects.create(
+            user=other, coach=coach, status="active", payment_confirmed=True
+        )
 
         membership = PremiumMembership.objects.create(
             user=self.member, coach=coach, status="pending"
@@ -164,10 +186,25 @@ class PremiumMembershipTests(SiteTestMixin, TestCase):
         self.profile.assigned_coach = coach
         self.profile.assigned_coach_at = timezone.now()
         self.profile.save()
+        self.PremiumMembership.objects.create(
+            user=self.member, coach=coach, status="active", payment_confirmed=True
+        )
 
         self.client.force_login(self.member)
         resp = self.client.get(reverse("crush_lu:premium_choose_coach"))
         self.assertEqual(resp.status_code, 302)
+
+    def test_coach_without_membership_can_still_buy_premium(self):
+        """A coach assigned without payment (0150 backfill, attendance
+        auto-assign) must NOT lock the member out of the directory."""
+        coach = self._make_coach("gift")
+        self.profile.assigned_coach = coach
+        self.profile.assigned_coach_at = timezone.now()
+        self.profile.save()
+
+        self.client.force_login(self.member)
+        resp = self.client.get(reverse("crush_lu:premium_choose_coach"))
+        self.assertEqual(resp.status_code, 200)
 
     @override_settings(PREMIUM_REDIRECTS_TO_BETA=True)
     def test_premium_seeker_redirected_to_beta(self):

--- a/crush_lu/tests/test_profile_edit_connect_card.py
+++ b/crush_lu/tests/test_profile_edit_connect_card.py
@@ -141,11 +141,17 @@ class EditProfileConnectCardTests(TestCase):
 @override_settings(ROOT_URLCONF="azureproject.urls_crush")
 class DashboardVerifierDedupeTests(TestCase):
     def setUp(self):
+        from crush_lu.models import PremiumMembership
+
         self.user = _make_member("dash@example.com")
         self.coach = _make_coach("coach_a", "+352111111")
         profile = self.user.crushprofile
-        profile.assigned_coach = self.coach  # premium
+        profile.assigned_coach = self.coach
         profile.save()
+        # Premium = active membership, not the coach assignment alone.
+        PremiumMembership.objects.create(
+            user=self.user, coach=self.coach, status="active", payment_confirmed=True
+        )
         self.client.login(username="dash@example.com", password="testpass123")
 
     def _get(self):

--- a/crush_lu/views.py
+++ b/crush_lu/views.py
@@ -372,9 +372,11 @@ def dashboard(request):
             user=request.user, status="attended"
         ).exists()
 
-        # Premium = personal coach assigned. Premium unlocks RECEIVING
-        # Crush Connect Drops; LuxID unlocks APPEARING in the catalogue.
-        is_premium = bool(profile.assigned_coach_id)
+        # Premium = active PremiumMembership (paid or comped). Premium unlocks
+        # RECEIVING Crush Connect Drops; LuxID unlocks APPEARING in the
+        # catalogue. A coach assigned without a membership (backfill,
+        # attendance auto-assign) is a service relationship, not Premium.
+        is_premium = profile.has_active_premium
 
         # LuxID upgrade prompt: verified members without LuxID can link it
         # to enter the Crush Connect catalogue (asymmetric model).

--- a/crush_lu/views_crush_connect.py
+++ b/crush_lu/views_crush_connect.py
@@ -61,15 +61,18 @@ def dev_connect_card_preview(request, user_id: int):
 
 
 def _user_is_connect_receiver_eligible(user) -> bool:
-    """Verified profile + PREMIUM (personal coach assigned).
+    """Verified profile + PREMIUM (active ``PremiumMembership``).
 
-    Receiving Drops is the Premium product: it unlocks when a coach is
-    assigned, not on plain event attendance or LuxID alone.
+    Receiving Drops is the Premium product: it unlocks with an ACTIVE
+    membership (paid or admin-comped via ``PremiumMembership.confirm()``),
+    NOT with ``assigned_coach`` alone — coaches are also assigned without
+    payment (0150 backfill, attendance auto-assign), and those members must
+    not become free receivers at full launch.
     """
     profile = getattr(user, "crushprofile", None)
     if profile is None or not profile.is_approved:
         return False
-    return profile.assigned_coach_id is not None
+    return profile.has_active_premium
 
 
 def _user_can_receive_now(user) -> bool:
@@ -1114,9 +1117,15 @@ def coach_connect_members(request):
 
     coach = request.coach
     members = (
-        User.objects.filter(crushprofile__assigned_coach=coach)
+        # Active premium members only — coach assignment alone (backfill,
+        # attendance auto-assign) doesn't put a member in the curation hub.
+        User.objects.filter(
+            crushprofile__assigned_coach=coach,
+            premium_memberships__status="active",
+        )
         .select_related("crushprofile", "crush_connect_membership")
         .order_by("first_name", "pk")
+        .distinct()
     )
     # Iterate oldest-first so the NEWEST row wins the per-member map —
     # default model ordering is newest-first, which would let an older
@@ -1165,9 +1174,12 @@ def coach_connect_member(request, user_id: int):
 
     coach = request.coach
     member = get_object_or_404(
-        User.objects.select_related("crushprofile", "crush_connect_membership"),
+        User.objects.select_related(
+            "crushprofile", "crush_connect_membership"
+        ).distinct(),
         pk=user_id,
         crushprofile__assigned_coach=coach,
+        premium_memberships__status="active",
     )
 
     if request.method == "POST":

--- a/crush_lu/views_premium.py
+++ b/crush_lu/views_premium.py
@@ -11,7 +11,7 @@ import logging
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.db.models import Count, F
+from django.db.models import Count, F, Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
@@ -23,10 +23,20 @@ logger = logging.getLogger(__name__)
 
 
 def _available_coaches():
-    """Coaches open to new premium members and not yet at capacity."""
+    """Coaches open to new premium members and not yet at capacity.
+
+    Capacity counts ACTIVE PremiumMemberships, not assigned_members — coach
+    assignment also happens without payment (backfill, attendance
+    auto-assign) and must not exhaust premium capacity.
+    """
     return (
         CrushCoach.objects.filter(is_active=True, accepting_premium=True, is_away=False)
-        .annotate(member_count=Count("assigned_members"))
+        .annotate(
+            member_count=Count(
+                "premium_memberships",
+                filter=Q(premium_memberships__status="active"),
+            )
+        )
         .filter(member_count__lt=F("max_premium_members"))
         .select_related("user")
         .order_by("user__first_name")
@@ -60,8 +70,10 @@ def premium_choose_coach(request):
         messages.info(request, _("Create your profile first to go premium."))
         return redirect("crush_lu:dashboard")
 
-    # Already premium — nothing to choose.
-    if profile.assigned_coach_id:
+    # Already premium — nothing to choose. Checks the membership, not
+    # assigned_coach: a coach assigned without payment (backfill, attendance
+    # auto-assign) must not lock the member out of actually buying Premium.
+    if profile.has_active_premium:
         messages.info(request, _("You already have a personal coach."))
         return redirect("crush_lu:dashboard")
 
@@ -101,7 +113,7 @@ def premium_select_coach(request, coach_id):
         messages.info(request, _("Create your profile first to go premium."))
         return redirect("crush_lu:dashboard")
 
-    if profile.assigned_coach_id:
+    if profile.has_active_premium:
         messages.info(request, _("You already have a personal coach."))
         return redirect("crush_lu:dashboard")
 

--- a/crush_lu/views_static.py
+++ b/crush_lu/views_static.py
@@ -50,7 +50,11 @@ def membership_concept_preview(request):
 
     # Community + premium unlocks
     n_community = verified.filter(_has_attended=True).count()
-    n_premium = verified.filter(assigned_coach__isnull=False).count()
+    n_premium = (
+        verified.filter(user__premium_memberships__status="active")
+        .distinct()
+        .count()
+    )
 
     def pct(n):
         return round(n / total_active * 100, 1) if total_active else 0
@@ -199,7 +203,7 @@ def crush_connect_teaser(request):
                 onboarded = bool(membership and membership.is_onboarded)
                 if (
                     onboarded
-                    and profile.assigned_coach_id
+                    and profile.has_active_premium
                     and receiver_access_open(request.user)
                 ):
                     # Onboarded Premium receiver → their Drop (grandfathered;
@@ -244,7 +248,7 @@ def crush_connect_teaser(request):
 
         _profile = getattr(request.user, "crushprofile", None)
         context["profile_approved"] = bool(_profile and _profile.is_approved)
-        context["is_premium"] = bool(_profile and _profile.assigned_coach_id)
+        context["is_premium"] = bool(_profile and _profile.has_active_premium)
         context["has_luxid_connected"] = bool(
             _profile and _profile.has_luxid_connected
         )


### PR DESCRIPTION
## Why (the Stage-5 launch blocker)

At `CRUSH_CONNECT_LAUNCHED=true` the receiver phase-gate opens for everyone, leaving **"has an assigned coach"** as the only Premium check. Migration 0150 backfilled coaches onto **464/496 approved members**, and the attendance signal keeps auto-assigning coaches at every event — so at full launch they would all become free Premium receivers (Drops, Sparks-send, weekly coach picks).

`PremiumMembership` already models the entitlement (`pending payment → active`; `confirm()` is documented as the sole legitimate writer of `assigned_coach` — the backfill bypassed it). This PR makes the entitlement real everywhere.

## What changes

- **Receiver/sender gates** key off an active membership: `_user_is_connect_receiver_eligible`, `get_eligible_pool` requester gate, `is_sender_eligible`, teaser routing, dashboard/teaser `is_premium`.
- **Coach curation hub** lists only active-premium members.
- **Capacity accounting fixed**: `get_premium_members_count` and the premium coach directory count active memberships. Bare assignments were silently exhausting `max_premium_members` — the paid flow was likely already blocked on prod.
- **Purchase flow unblocked**: a backfilled/attendance coach no longer locks a member out of buying Premium.
- **Migration 0184** (data-only, additive): selected beta testers with an assigned coach get an active membership so beta access is uninterrupted (waitlist `payment_confirmed` carries over).
- Seed commands create memberships for premium seeds.

## What deliberately does NOT change

- `assigned_coach` keeps all service-relationship meanings: dashboard "Your Crush Coach" section (the 464 keep their coach card), coach review/verification, coach-pick coach-must-match checks, attendance auto-assign.
- **Event reserved seats** still key on `assigned_coach` — flagged as a separate product decision, out of scope here.
- Comping Premium for the GTM plan = admin creates + confirms a membership (no new tooling in this PR).

## Test plan

- [x] Full suite green (exit 0), including `--create-db` to exercise migration 0184
- [x] New regression tests: coach-without-membership ≠ receiver at launch; cancelled membership revokes receiving; bare assignment doesn't consume capacity; backfilled member can still buy Premium
- [x] No new ruff findings vs main in any touched file
- [ ] After merge: staging spot-check (teaser routing for a coach-assigned non-member; coach hub list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)