### PR TITLE
security: fix photo upload bypass, referral race, N+1 queries, vote logic

### DIFF
--- a/crush_lu/api_views.py
+++ b/crush_lu/api_views.py
@@ -23,14 +23,14 @@ def _require_attended_registration(request, event):
             {'success': False, 'error': _('You are not registered for this event')},
             status=403,
         )
-    if reg.status == 'confirmed':
-        return None, JsonResponse(
-            {'success': False, 'error': _('You must check in at the event before you can vote')},
-            status=403,
-        )
     if reg.status != 'attended':
+        if reg.status == 'confirmed':
+            return None, JsonResponse(
+                {'success': False, 'error': _('You must check in at the event before you can vote')},
+                status=403,
+            )
         return None, JsonResponse(
-            {'success': False, 'error': _('Only confirmed attendees can access voting')},
+            {'success': False, 'error': _('You must be checked in as attended to access voting')},
             status=403,
         )
     return reg, None

--- a/crush_lu/context_processors.py
+++ b/crush_lu/context_processors.py
@@ -140,13 +140,14 @@ def crush_user_context(request):
             )
             if nav_visible:
                 from .models import CuriositySpark
-                from .services.blocking import blocked_user_ids
 
+                # Reuse the already-computed blocked_ids (finding H4 — this was
+                # a duplicate blocked_user_ids query on every authenticated page).
                 connect_pending_sparks_count = (
                     CuriositySpark.objects.filter(
                         recipient=request.user, status="pending"
                     )
-                    .exclude(sender_id__in=blocked_user_ids(request.user))
+                    .exclude(sender_id__in=blocked_ids)
                     .count()
                 )
         except Exception:

--- a/crush_lu/referrals.py
+++ b/crush_lu/referrals.py
@@ -166,12 +166,6 @@ def apply_referral_reward(attribution, reward_type="signup"):
     Returns:
         Tuple of (points_awarded, new_total_points) or (0, 0) if not applicable
     """
-    if attribution.reward_applied:
-        logger.debug(
-            "Reward already applied for attribution %s", attribution.id
-        )
-        return 0, attribution.referrer.referral_points
-
     if attribution.status != ReferralAttribution.Status.CONVERTED:
         logger.debug(
             "Attribution %s not converted yet, skipping reward", attribution.id
@@ -188,6 +182,22 @@ def apply_referral_reward(attribution, reward_type="signup"):
         return 0, 0
 
     with transaction.atomic():
+        # Re-fetch with a row lock to close the double-award race (finding H2).
+        # Multiple callers (coach approval, event check-in, login signals) can
+        # pass the outer status check concurrently; the lock + re-check ensures
+        # only one of them awards the points.
+        attribution = (
+            ReferralAttribution.objects
+            .select_for_update()
+            .get(pk=attribution.pk)
+        )
+        if attribution.reward_applied:
+            logger.debug(
+                "Reward already applied for attribution %s (locked re-check)",
+                attribution.id,
+            )
+            return 0, attribution.referrer.referral_points
+
         # Update attribution
         attribution.reward_applied = True
         attribution.reward_applied_at = timezone.now()

--- a/crush_lu/views_events.py
+++ b/crush_lu/views_events.py
@@ -158,7 +158,8 @@ def event_list(request):
     # timedelta * F() which is not supported on SQLite.
     generous_cutoff = now - timedelta(hours=24)
     upcoming_events = list(
-        MeetupEvent.objects.filter(
+        MeetupEvent.objects.with_registration_counts()
+        .filter(
             is_published=True, is_cancelled=False, date_time__gte=generous_cutoff
         )
         .prefetch_related("coaches__user")
@@ -167,7 +168,8 @@ def event_list(request):
     upcoming_events = [e for e in upcoming_events if e.end_time >= now]
 
     past_events = list(
-        MeetupEvent.objects.filter(
+        MeetupEvent.objects.with_registration_counts()
+        .filter(
             is_published=True, is_cancelled=False, date_time__lt=now
         ).order_by("-date_time")[:50]
     )

--- a/crush_lu/views_profile.py
+++ b/crush_lu/views_profile.py
@@ -523,13 +523,27 @@ def save_profile_step3(request):
     try:
         profile = CrushProfile.objects.get(user=request.user)
 
-        # Handle photos if uploaded (for backward compatibility with form submission)
-        if request.FILES.get("photo_1"):
-            profile.photo_1 = request.FILES["photo_1"]
-        if request.FILES.get("photo_2"):
-            profile.photo_2 = request.FILES["photo_2"]
-        if request.FILES.get("photo_3"):
-            profile.photo_3 = request.FILES["photo_3"]
+        # Handle photos if uploaded (for backward compatibility with form submission).
+        # Route through process_uploaded_image to enforce size limits, EXIF
+        # stripping, and decompression-bomb protection (finding H1 — this path
+        # previously saved raw request.FILES with zero validation).
+        from .utils.image_processing import process_uploaded_image
+        from django.core.exceptions import ValidationError as VE
+
+        for slot_num in (1, 2, 3):
+            photo_key = f"photo_{slot_num}"
+            uploaded = request.FILES.get(photo_key)
+            if not uploaded:
+                continue
+            try:
+                processed = process_uploaded_image(uploaded, filename=uploaded.name)
+                setattr(profile, photo_key, processed)
+            except (VE, Exception) as exc:
+                logger.warning("Photo validation failed in save_profile_step3 for %s: %s", photo_key, exc)
+                return JsonResponse(
+                    {"success": False, "error": "Invalid photo. Please upload a JPEG or PNG under 10MB."},
+                    status=400,
+                )
 
         # Privacy settings
         profile.show_full_name = request.POST.get("show_full_name") == "on"


### PR DESCRIPTION
## Security + performance fixes from archived reviews

Fixes 5 findings from the 2026-06-18 and 2026-07-05 reviews.

### What changed

**H1 — Photo upload bypass** (`views_profile.py`)
`save_profile_step3` saved `request.FILES` directly to the model with zero validation — no MIME check, no size limit, no decompression-bomb guard. A crafted PNG could exhaust memory during thumbnailing. Now routes all three photo slots through `process_uploaded_image` (10MB cap, EXIF strip, resize, format conversion).

**H2 — Referral double-award race** (`referrals.py`)
The `reward_applied` guard was checked outside the `transaction.atomic()` block. Multiple callers (coach approval, event check-in, login signals) could concurrently pass the guard and credit referral points twice (financial: points = € discounts). Now re-fetches with `select_for_update()` inside the atomic block and re-checks under the lock.

**H4 — Context processor duplicate query** (`context_processors.py`)
`blocked_user_ids(request.user)` was called twice on every authenticated page render (line 92 + line 149). Second call now reuses the already-computed `blocked_ids` set.

**H5 — Event list N+1 queries** (`views_events.py`)
`event_list` fetched events without `.with_registration_counts()`, so each event's `is_full`/`spots_remaining` fired a separate COUNT query (30 events → ~90-120 COUNTs on the most SEO-critical public page). Now uses the existing annotated manager method.

**Issue 4 — Vote status logic** (`api_views.py`)
Contradictory error messages in `_require_attended_registration`: "confirmed" was rejected with a check-in message, then `!= attended` with a "confirmed attendees can access" message. Reordered for clarity.

### Test plan
- [x] All modified files compile (py_compile)
- [x] H1: process_uploaded_image already has its own tests (test_image_processing.py)
- [x] H2: referral tests use transactional DB, select_for_update is additive
- [x] H4: no API change — just deduplication
- [x] H5: with_registration_counts is an existing tested manager method
- [ ] CI green
