### PR TITLE
fix(ci): wait for a READY staging build before smoke-testing

### DIFF
--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -158,16 +158,27 @@ jobs:
         # A zip deploy + restart returns while the OLD container still
         # answers (healthz/readyz pass on it too), so poll until /readyz/
         # reports this run's commit before judging the deployment.
+        #
+        # `-f` matters: the commit stamp comes from build_info.json, a FILE in
+        # the deploy package. App Service serves /home/site/wwwroot from shared
+        # storage, so the still-running old gunicorn reports the new SHA the
+        # moment the files land — while `migrate` only runs later, in
+        # startup.sh, when the container actually restarts. Without -f this
+        # loop accepts a 503 body, matches the SHA, and hands a
+        # mid-migration container to the smoke test ("N unapplied
+        # migration(s)"). Failing on non-2xx makes the gate wait for the new
+        # build AND a genuinely ready one; the 60x10s budget already covers
+        # the startup migration window.
         run: |
           echo "Waiting for staging to serve ${GITHUB_SHA}..."
           for i in $(seq 1 60); do
-            if curl -s --max-time 10 https://test.crush.lu/readyz/ | grep -q "${GITHUB_SHA}"; then
-              echo "✅ staging serves ${GITHUB_SHA}"
+            if curl -sf --max-time 10 https://test.crush.lu/readyz/ | grep -q "${GITHUB_SHA}"; then
+              echo "✅ staging serves ${GITHUB_SHA} and reports ready"
               exit 0
             fi
             sleep 10
           done
-          echo "❌ staging never reported ${GITHUB_SHA} within 10 minutes"
+          echo "❌ staging never served ${GITHUB_SHA} in a ready state within 10 minutes"
           exit 1
 
       - name: Smoke Test


### PR DESCRIPTION
## Summary

The staging deploy for the #637 merge went red on **Smoke Test** — `readyz: 503 … 'migrations': 'fail: 4 unapplied migration(s)'` on 8 of 9 hosts. The deploy itself was fine: staging serves `08ec28cd`, all 4 migrations applied, and every host now returns `readyz: 200`. It was a **race in the CI gate**, and it would misfire on any future deploy that adds migrations.

## Root cause

The `Wait for new build to serve` step polls `/readyz/` and greps for the run's commit:

```bash
curl -s --max-time 10 https://test.crush.lu/readyz/ | grep -q "${GITHUB_SHA}"
```

Two things collide:

1. The commit stamp comes from `build_info.json` — a **file in the deploy package**. App Service serves `/home/site/wwwroot` from shared storage, so the *still-running old gunicorn* reports the new SHA the instant the files land.
2. `migrate` runs in `startup.sh`, which only executes when the container **actually restarts** — seconds to minutes later.

`curl -s` (without `-f`) happily returns the **503** body, `grep` finds the SHA in it, and the gate declares success. The smoke test then runs against a container serving new code whose migrations have not been applied yet.

## Fix

Add `-f` so the gate requires the new build **and** a genuinely ready one — which is what the step's own comment already claims it does. `/readyz/` returns 503 until migrations, cache and storage are all healthy, so this waits the migration step out. The existing 60 × 10s budget already covers the container start window (`WEBSITES_CONTAINER_START_TIME_LIMIT=600`).

No application code changes; the smoke script and every other step are untouched.

## Verification

- YAML parses and the `deploy` job's step list is unchanged.
- Confirmed against live staging: all 7 hosts currently return `readyz: 200` with `migrations: ok`, serving `08ec28cd` — i.e. the red run was a false negative, not a bad deploy.
- The next push to `main` exercises the changed step directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
