### PR TITLE
fix(android): build-4 hardening — notification delivery, deep links, crash guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ mobile/android/**/app/build/
 build-artifacts/
 *.jks
 project-*.json
+.idea/

--- a/mobile/android/CrushLU/app/build.gradle.kts
+++ b/mobile/android/CrushLU/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
         }
         minSdk = 26
         targetSdk = 35
-        versionCode = 3
+        versionCode = 4
         versionName = "1.0.2"
         buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
         buildConfigField("String", "AUTH_SCHEME", "\"$authScheme\"")

--- a/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
+++ b/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="false"
@@ -15,6 +16,7 @@
             android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:exported="true"
+            android:launchMode="singleTask"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
+++ b/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
@@ -52,5 +52,12 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- Channel the system uses for background (notification-payload) pushes.
+             Must match CHANNEL_ID in MyFirebaseMessagingService, which creates it
+             with IMPORTANCE_HIGH so backgrounded pushes get a heads-up banner. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="crush_notifications" />
     </application>
 </manifest>

--- a/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
+++ b/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
@@ -58,6 +58,6 @@
              with IMPORTANCE_HIGH so backgrounded pushes get a heads-up banner. -->
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
-            android:value="crush_notifications" />
+            android:value="crush_notifications_v2" />
     </application>
 </manifest>

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -232,6 +232,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private boolean shouldStartNativeAuth(Uri uri) {
+        // For local testing, allow login in the WebView to test insets/keyboard
+        if (BuildConfig.BASE_URL.contains("10.0.2.2")) {
+            return false;
+        }
         if (!isInternal(uri)) {
             return false;
         }

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -62,14 +62,17 @@ public class MainActivity extends AppCompatActivity {
 
         ViewCompat.setOnApplyWindowInsetsListener(mainContainer, (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            Insets ime = insets.getInsets(WindowInsetsCompat.Type.ime());
             
             // Set top padding for status bar
             int extraTopPadding = (int) (16 * getResources().getDisplayMetrics().density);
             v.setPadding(0, systemBars.top + extraTopPadding, 0, 0);
 
-            // Set the filler height to match the navigation bar
+            // Set the filler height to match the navigation bar or keyboard
             if (filler != null) {
-                filler.getLayoutParams().height = systemBars.bottom;
+                // Use the maximum of navigation bar and keyboard height to ensure
+                // we don't overlap with either.
+                filler.getLayoutParams().height = Math.max(systemBars.bottom, ime.bottom);
                 filler.requestLayout();
             }
             return WindowInsetsCompat.CONSUMED;
@@ -183,6 +186,13 @@ public class MainActivity extends AppCompatActivity {
                 webView.reload();
             } else {
                 loadInternal(START_URL);
+            }
+        });
+
+        // Disable swipe-to-refresh if the WebView is scrolled down
+        webView.getViewTreeObserver().addOnScrollChangedListener(() -> {
+            if (webView != null) {
+                swipeRefresh.setEnabled(webView.getScrollY() == 0);
             }
         });
     }
@@ -363,9 +373,10 @@ public class MainActivity extends AppCompatActivity {
 
     private void injectTokenRegistrationScript(String token) {
         String deviceId = android.provider.Settings.Secure.getString(getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
-        String deviceName = Build.MANUFACTURER + " " + Build.MODEL;
-        String systemVersion = "Android " + Build.VERSION.RELEASE;
-        String appVersion = BuildConfig.VERSION_NAME;
+        // Escape single quotes to prevent JS injection/syntax errors
+        String deviceName = (Build.MANUFACTURER + " " + Build.MODEL).replace("'", "\\'");
+        String systemVersion = ("Android " + Build.VERSION.RELEASE).replace("'", "\\'");
+        String appVersion = BuildConfig.VERSION_NAME.replace("'", "\\'");
         String appBuild = String.valueOf(BuildConfig.VERSION_CODE);
 
         String js = String.format(
@@ -406,7 +417,7 @@ public class MainActivity extends AppCompatActivity {
             "  }) " +
             "  .catch(function(err) { console.error('FCM registration error', err); }); " +
             "})();",
-            token, deviceId, deviceName, appVersion, appBuild, systemVersion
+            token.replace("'", "\\'"), deviceId.replace("'", "\\'"), deviceName, appVersion, appBuild, systemVersion
         );
 
         webView.evaluateJavascript(js, null);

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -93,6 +93,10 @@ public class MainActivity extends AppCompatActivity {
         configureSwipeRefresh();
         configureBackNavigation();
         maybeRequestNotificationPermission();
+        // Create the high-importance channel up front so background pushes,
+        // which the system renders via the default_notification_channel_id
+        // manifest meta-data, get a heads-up banner instead of a fallback channel.
+        MyFirebaseMessagingService.ensureNotificationChannel(this);
 
         CookieManager.getInstance().setAcceptCookie(true);
         CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true);
@@ -305,8 +309,10 @@ public class MainActivity extends AppCompatActivity {
         intent.addCategory(Intent.CATEGORY_BROWSABLE);
         try {
             startActivity(intent);
-        } catch (ActivityNotFoundException exception) {
-            // No installed app handles this link; dropping it beats crashing.
+        } catch (ActivityNotFoundException | SecurityException exception) {
+            // No installed app handles this link, or a parsed intent: URI asked
+            // for something this app isn't permitted to launch (e.g. an
+            // ACTION_CALL that needs CALL_PHONE). Dropping it beats crashing.
         }
     }
 

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -2,6 +2,7 @@ package lu.crush.app;
 
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
@@ -12,6 +13,7 @@ import android.view.View;
 import android.webkit.CookieManager;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -28,6 +30,7 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -36,6 +39,7 @@ import android.os.Build;
 
 public class MainActivity extends AppCompatActivity {
     private static final int FILE_CHOOSER_REQUEST = 1001;
+    private static final int NOTIFICATION_PERMISSION_REQUEST = 1002;
     private static final String BASE_URL = BuildConfig.BASE_URL;
     private static final String START_URL = BASE_URL + "/en/dashboard/?source=android_app";
     private static final String AUTH_SCHEME = BuildConfig.AUTH_SCHEME;
@@ -88,6 +92,7 @@ public class MainActivity extends AppCompatActivity {
         configureWebView();
         configureSwipeRefresh();
         configureBackNavigation();
+        maybeRequestNotificationPermission();
 
         CookieManager.getInstance().setAcceptCookie(true);
         CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true);
@@ -96,15 +101,8 @@ public class MainActivity extends AppCompatActivity {
         if (launchUri != null) {
             handleUri(launchUri);
         } else {
-            String targetUrl = getIntent().getStringExtra("target_url");
-            if (targetUrl != null && !targetUrl.isEmpty()) {
-                if (targetUrl.startsWith("/")) {
-                    targetUrl = BASE_URL + targetUrl;
-                }
-                loadInternal(targetUrl);
-            } else {
-                loadInternal(START_URL);
-            }
+            String targetUrl = pendingTargetUrl(getIntent());
+            loadInternal(targetUrl != null ? targetUrl : START_URL);
         }
     }
 
@@ -116,13 +114,33 @@ public class MainActivity extends AppCompatActivity {
         if (uri != null) {
             handleUri(uri);
         } else {
-            String targetUrl = intent.getStringExtra("target_url");
-            if (targetUrl != null && !targetUrl.isEmpty()) {
-                if (targetUrl.startsWith("/")) {
-                    targetUrl = BASE_URL + targetUrl;
-                }
+            String targetUrl = pendingTargetUrl(intent);
+            if (targetUrl != null) {
                 loadInternal(targetUrl);
             }
+        }
+    }
+
+    private String pendingTargetUrl(Intent intent) {
+        String targetUrl = intent.getStringExtra("target_url");
+        if (targetUrl == null || targetUrl.isEmpty()) {
+            // Background FCM notifications are rendered by the system; tapping
+            // them delivers the data payload's raw "url" key as an extra.
+            targetUrl = intent.getStringExtra("url");
+        }
+        if (targetUrl == null || targetUrl.isEmpty()) {
+            return null;
+        }
+        return targetUrl.startsWith("/") ? BASE_URL + targetUrl : targetUrl;
+    }
+
+    private void maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
+                        != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(
+                    new String[]{android.Manifest.permission.POST_NOTIFICATIONS},
+                    NOTIFICATION_PERMISSION_REQUEST);
         }
     }
 
@@ -271,9 +289,25 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void openExternal(Uri uri) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        Intent intent;
+        if ("intent".equals(uri.getScheme())) {
+            try {
+                intent = Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME);
+                // A web page must not be able to target internal components.
+                intent.setComponent(null);
+                intent.setSelector(null);
+            } catch (URISyntaxException exception) {
+                return;
+            }
+        } else {
+            intent = new Intent(Intent.ACTION_VIEW, uri);
+        }
         intent.addCategory(Intent.CATEGORY_BROWSABLE);
-        startActivity(intent);
+        try {
+            startActivity(intent);
+        } catch (ActivityNotFoundException exception) {
+            // No installed app handles this link; dropping it beats crashing.
+        }
     }
 
     private void showOffline() {
@@ -327,8 +361,10 @@ public class MainActivity extends AppCompatActivity {
         }
 
         @Override
-        public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            return handleNavigation(Uri.parse(url));
+        public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+            if (request.isForMainFrame()) {
+                showOffline();
+            }
         }
 
         private boolean handleNavigation(Uri uri) {

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -15,6 +15,7 @@ import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -369,6 +370,17 @@ public class MainActivity extends AppCompatActivity {
         @Override
         public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
             if (request.isForMainFrame()) {
+                showOffline();
+            }
+        }
+
+        @Override
+        public void onReceivedHttpError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
+            // onReceivedError only fires for network-level failures; a main-document
+            // 5xx (origin/proxy outage) surfaces here instead. Show the offline view
+            // rather than leaving the raw server error page in the WebView. 4xx pages
+            // (e.g. a 404) carry real content, so they are left to render normally.
+            if (request.isForMainFrame() && errorResponse.getStatusCode() >= 500) {
                 showOffline();
             }
         }

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
@@ -20,7 +20,12 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
     private static final String PREFS_NAME = "CrushPreferences";
     private static final String KEY_FCM_TOKEN = "fcm_token";
     private static final String KEY_TOKEN_SYNCED = "fcm_token_synced";
-    private static final String CHANNEL_ID = "crush_notifications";
+    // Bumped from the original "crush_notifications": that channel shipped in
+    // build 3 at IMPORTANCE_DEFAULT, and a channel's importance is immutable once
+    // created. A fresh id is the only way to give upgrading users the heads-up
+    // (IMPORTANCE_HIGH) channel; the old one is deleted in ensureNotificationChannel.
+    private static final String CHANNEL_ID = "crush_notifications_v2";
+    private static final String LEGACY_CHANNEL_ID = "crush_notifications";
 
     @Override
     public void onNewToken(@NonNull String token) {
@@ -114,6 +119,9 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         if (notificationManager == null) {
             return;
         }
+        // Remove the superseded IMPORTANCE_DEFAULT channel so upgrading users
+        // land on the high-importance one below (no-op on fresh installs).
+        notificationManager.deleteNotificationChannel(LEGACY_CHANNEL_ID);
         NotificationChannel channel = new NotificationChannel(
                 CHANNEL_ID,
                 "Crush Notifications",

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
@@ -60,16 +60,21 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
 
     private void sendNotification(String title, String messageBody, Map<String, String> data) {
         Intent intent = new Intent(this, MainActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         // Pass payload URL data to MainActivity so it can navigate on click
         if (data != null && data.containsKey("url")) {
             intent.putExtra("target_url", data.get("url"));
         }
 
+        // Unique per notification: a fixed id would make every push overwrite
+        // the previous one, and a fixed PendingIntent requestCode would reuse
+        // the first notification's target_url extra for all later ones.
+        int notificationId = (int) (System.currentTimeMillis() & 0x7FFFFFFF);
+
         PendingIntent pendingIntent = PendingIntent.getActivity(
-                this, 0, intent,
-                PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE
+                this, notificationId, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
         );
 
         NotificationManager notificationManager =
@@ -80,7 +85,7 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
             NotificationChannel channel = new NotificationChannel(
                     CHANNEL_ID,
                     "Crush Notifications",
-                    NotificationManager.IMPORTANCE_DEFAULT
+                    NotificationManager.IMPORTANCE_HIGH
             );
             channel.setDescription("Crush push notification updates");
             notificationManager.createNotificationChannel(channel);
@@ -94,6 +99,6 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                         .setAutoCancel(true)
                         .setContentIntent(pendingIntent);
 
-        notificationManager.notify(0, notificationBuilder.build());
+        notificationManager.notify(notificationId, notificationBuilder.build());
     }
 }

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
@@ -80,16 +80,9 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
         NotificationManager notificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-        // Create the NotificationChannel for Android Oreo and above
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(
-                    CHANNEL_ID,
-                    "Crush Notifications",
-                    NotificationManager.IMPORTANCE_HIGH
-            );
-            channel.setDescription("Crush push notification updates");
-            notificationManager.createNotificationChannel(channel);
-        }
+        // Idempotent with the channel created at app startup; keeps the
+        // foreground path working even if onCreate hasn't run this process.
+        ensureNotificationChannel(this);
 
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(this, CHANNEL_ID)
@@ -100,5 +93,33 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
                         .setContentIntent(pendingIntent);
 
         notificationManager.notify(notificationId, notificationBuilder.build());
+    }
+
+    /**
+     * Create (or update) the high-importance notification channel.
+     *
+     * <p>Background FCM "notification" messages are rendered by the system, which
+     * bypasses {@link #onMessageReceived} and looks up the channel named by the
+     * {@code com.google.firebase.messaging.default_notification_channel_id}
+     * manifest meta-data. That channel must already exist, so this is also called
+     * from {@code MainActivity.onCreate()} to guarantee heads-up delivery for
+     * pushes received while the app is backgrounded.
+     */
+    static void ensureNotificationChannel(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        NotificationManager notificationManager =
+                context.getSystemService(NotificationManager.class);
+        if (notificationManager == null) {
+            return;
+        }
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                "Crush Notifications",
+                NotificationManager.IMPORTANCE_HIGH
+        );
+        channel.setDescription("Crush push notification updates");
+        notificationManager.createNotificationChannel(channel);
     }
 }


### PR DESCRIPTION
## Summary

Prepares the Android app for the build-4 Play upload. Recovers the 2026-07-20 review fixes that were stranded in a pre-switch git stash (never committed), and fixes six new findings on top.

### Recovered from the stash (were only on this machine)
- `versionCode` 3 → **4** (required to ship the #650 nav-overlap fix)
- Keyboard handling: bottom filler now uses `max(systemBars.bottom, ime.bottom)` so the IME doesn't cover inputs (edge-to-edge)
- Swipe-to-refresh disabled while the page is scrolled down
- Single-quote escaping in the FCM token-registration script (device names like "Tom's Pixel")
- Ignore `.idea/`

### New fixes
| Finding | Fix |
|---|---|
| Pushes silently dropped on Android 13+ — permission declared (FCM SDK merge) but never *requested* | Runtime `POST_NOTIFICATIONS` prompt on first launch + explicit manifest declaration |
| Background-notification taps lost the deep link (system delivers the data payload's raw `url` key; app only read `target_url`) | `pendingTargetUrl()` reads both extras |
| Every push overwrote the previous one (`notify(0, …)`), and the fixed `PendingIntent` requestCode + `ONE_SHOT` reused stale `target_url` extras | Unique id/requestCode per push, `UPDATE_CURRENT`, `NEW_TASK` |
| No heads-up banner for matches/messages | Channel `IMPORTANCE_HIGH` (existing installs keep the old channel setting unless app data is cleared) |
| Deep links / auth callback stacked a second `MainActivity` (double WebView); `onNewIntent` never fired with the default launchMode | `android:launchMode="singleTask"` |
| `tel:`/`mailto:`/`whatsapp:` links crashed with `ActivityNotFoundException` when no handler app is installed; `intent://` URIs were passed raw to `ACTION_VIEW` | try/catch guard + `Intent.parseUri` with `component`/`selector` stripped |
| Server errors showed the stock WebView error page | `onReceivedError` (main frame) shows the existing offline view |

Also included: keep login inside the WebView for the **local flavor only** (BASE_URL check for `10.0.2.2`) so the login form's inset/keyboard behavior can be tested against the local dev server.

### Verification
- `gradlew :app:assembleDebug` builds clean (local flavor, AGP 8 / compileSdk 35)
- PR CI does not compile Android — reviewer should sanity-build in Android Studio before tagging the release

### Follow-ups (not in this PR)
- Firebase BoM 33.1.2 is ~1 year old — bump separately
- `onActivityResult`/`startActivityForResult` deprecation (file chooser) — works, migrate when convenient
- `fixWebStyles()` CSS injection may be removable once the #650 web-side nav fix is confirmed on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)