### PR TITLE
fix(campaign): resolve Alpine CSP error in campaign composer inputs

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -13733,6 +13733,7 @@ document.addEventListener("alpine:init", function () {
             // Schedule section
             get isScheduleMode() { return this.sendMode === "schedule"; },
             get isSendNow() { return this.sendMode === "now"; },
+            get isDraftMode() { return this.sendMode === "draft"; },
             get submitLabel() {
                 if (this.sendMode === "now") return "Launch campaign";
                 if (this.sendMode === "schedule") return "Schedule campaign";
@@ -13756,6 +13757,24 @@ document.addEventListener("alpine:init", function () {
                 if (estimateBtn) htmx.trigger(estimateBtn, "refresh-estimate");
                 if (previewBtn) htmx.trigger(previewBtn, "refresh-preview");
             },
+
+            // Channel checkboxes and send-mode radios are wired with @change +
+            // :checked (bare method/getter refs) instead of x-model, because the
+            // Alpine CSP build cannot evaluate x-model's "channels = __placeholder"
+            // setter expression (see campaign_composer.html). @change fires only on
+            // user interaction, so flipping array membership stays in sync with the
+            // native input state.
+            toggleEmail() { this._toggleChannel("email"); },
+            toggleWhatsapp() { this._toggleChannel("whatsapp"); },
+            togglePush() { this._toggleChannel("push"); },
+            _toggleChannel(name) {
+                var i = this.channels.indexOf(name);
+                if (i === -1) this.channels.push(name);
+                else this.channels.splice(i, 1);
+            },
+            selectDraft() { this.sendMode = "draft"; },
+            selectSendNow() { this.sendMode = "now"; },
+            selectSchedule() { this.sendMode = "schedule"; },
         };
     });
 });

--- a/crush_lu/templates/admin/crush_lu/campaign_composer.html
+++ b/crush_lu/templates/admin/crush_lu/campaign_composer.html
@@ -88,9 +88,9 @@
             <div class="form-field">
                 <label>{% trans "Send via" %}</label>
                 <div class="channel-toggle">
-                    <label><input type="checkbox" name="channels" value="email" x-model="channels"> 📧 {% trans "Email" %}</label>
-                    <label><input type="checkbox" name="channels" value="whatsapp" x-model="channels"> 💬 {% trans "WhatsApp" %}</label>
-                    <label><input type="checkbox" name="channels" value="push" x-model="channels"> 🔔 {% trans "Web Push" %}</label>
+                    <label><input type="checkbox" name="channels" value="email" :checked="emailEnabled" @change="toggleEmail"> 📧 {% trans "Email" %}</label>
+                    <label><input type="checkbox" name="channels" value="whatsapp" :checked="whatsappEnabled" @change="toggleWhatsapp"> 💬 {% trans "WhatsApp" %}</label>
+                    <label><input type="checkbox" name="channels" value="push" :checked="pushEnabled" @change="togglePush"> 🔔 {% trans "Web Push" %}</label>
                 </div>
                 <div class="hint" x-show="noChannels">{% trans "Pick at least one channel." %}</div>
             </div>
@@ -238,9 +238,9 @@
 
             <div class="form-field">
                 <div class="channel-toggle">
-                    <label><input type="radio" name="send_mode" value="draft" x-model="sendMode"> 📝 {% trans "Save as draft" %}</label>
-                    <label><input type="radio" name="send_mode" value="now" x-model="sendMode"> 🚀 {% trans "Send now" %}</label>
-                    <label><input type="radio" name="send_mode" value="schedule" x-model="sendMode"> ⏰ {% trans "Schedule" %}</label>
+                    <label><input type="radio" name="send_mode" value="draft" :checked="isDraftMode" @change="selectDraft"> 📝 {% trans "Save as draft" %}</label>
+                    <label><input type="radio" name="send_mode" value="now" :checked="isSendNow" @change="selectSendNow"> 🚀 {% trans "Send now" %}</label>
+                    <label><input type="radio" name="send_mode" value="schedule" :checked="isScheduleMode" @change="selectSchedule"> ⏰ {% trans "Schedule" %}</label>
                 </div>
                 <div class="hint" x-show="isSendNow">{% trans "Sending starts with the next dispatch tick (within ~5 minutes)." %}</div>
             </div>


### PR DESCRIPTION
## Purpose
The Campaign & Remarketing composer (`/crush-admin/campaigns/new/`) throws a runtime error and its channel/schedule pickers silently fail to update the wizard.

The channel checkboxes and send-mode radios were wired with `x-model`. Under the coach panel's **Alpine CSP build** (`@alpinejs/csp@3.14.9`), `x-model` generates an assignment setter — `channels = __placeholder` — that the CSP-friendly evaluator cannot run. It throws:

```
Alpine Error: Alpine is unable to interpret the following expression using
the CSP-friendly build: "channels = __placeholder"
```

The read side works, so the error only surfaced when a user ticked a channel; the send-mode radios carried the same latent bug. Because the reactive state (`channels` / `sendMode`) never updated, the per-channel content sections and the submit-button label stopped responding.

**Fix:** replace both `x-model` groups with the `@change` + `:checked` pattern already used throughout this template (bare method/getter references only, all logic in the component):
* `campaign_composer.html` — checkboxes → `:checked="emailEnabled" @change="toggleEmail"` (etc.); radios → `:checked="isDraftMode" @change="selectDraft"` (etc.)
* `alpine-components.js` — added the `isDraftMode` getter plus `toggleEmail/Whatsapp/Push`, `_toggleChannel`, and `selectDraft/SendNow/Schedule` methods.

The native `name="channels"` / `name="send_mode"` inputs are unchanged, so form submission and the existing Python tests are unaffected.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Log into the coach panel and open **Campaigns → New** (`/crush-admin/campaigns/new/`).
* Open the browser console. Step to **Channels & content** and tick each channel — no `Alpine Error` should appear, and the Email/WhatsApp/Push content sections should reveal as their boxes are checked.
* Step to **Schedule** and switch between Draft / Send now / Schedule — the submit label and the schedule date field should update accordingly.

## What to Check
* No `Alpine is unable to interpret … "channels = __placeholder"` (or `sendMode = …`) errors in the console during any composer interaction.
* Channel content sections show/hide reactively; the submit button reads "Save draft" / "Launch campaign" / "Schedule campaign" to match the selected mode.
* Submitting the form still posts the selected `channels` and `send_mode` values (native inputs unchanged).

## Other Information
Verified against the real `@alpinejs/csp@3.14.9` build in an isolated harness (not just source review): **0 console errors** after the previously-throwing interactions, channel sections revealed reactively, and the submit label flipped to "Launch campaign" on **Send now**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)