### PR TITLE
feat(crush): add How It Works ghost-story animation (live-lobby)

### DIFF
--- a/crush_lu/static/crush_lu/animations/live-lobby.html
+++ b/crush_lu/static/crush_lu/animations/live-lobby.html
@@ -1,0 +1,2944 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Crush.lu — How It Works</title>
+<meta name="description" content="Crush.lu cinematic 'How It Works' ghost-story loop: come to a real event, meet people live, match and stay in touch.">
+<style>
+/* ============================================================================
+   Crush.lu Design System — Tokens
+   Drop into any HTML file:
+     <link rel="stylesheet" href="colors_and_type.css">
+   All values derived from tailwind-src/crush_lu/tailwind-input.css in the
+   EuphoriaLux/Multi-Domain-Django-Platform repo.
+   ============================================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&display=swap');
+
+:root {
+  /* ── Brand — Purple ─────────────────────────────────────────────── */
+  --color-purple-50:  #f5ebf8;
+  --color-purple-100: #ead6f0;
+  --color-purple-200: #d5ade1;
+  --color-purple-300: #c085d2;
+  --color-purple-400: #ab5cc3;
+  --color-purple-500: #9b59b6;
+  --color-purple-600: #8e44ad;
+  --color-purple-700: #7d3c9b;
+  --color-purple-800: #6c3589;
+  --color-purple-900: #5b2d77;
+
+  /* ── Brand — Pink ───────────────────────────────────────────────── */
+  --color-pink-50:  #fff0f5;
+  --color-pink-100: #ffe0eb;
+  --color-pink-200: #ffc1d7;
+  --color-pink-300: #ffa1c3;
+  --color-pink-400: #ff82af;
+  --color-pink-500: #ff6b9d;
+  --color-pink-600: #d94d7b;
+  --color-pink-700: #b33d63;
+  --color-pink-800: #8c304d;
+  --color-pink-900: #662438;
+
+  /* ── Brand aliases (use these in product) ──────────────────────── */
+  --crush-purple:       #9b59b6;
+  --crush-purple-light: #af7ac5;
+  --crush-purple-dark:  #8e44ad;
+  --crush-pink:         #ff6b9d;
+  --crush-pink-light:   #ff8fb3;
+  --crush-pink-dark:    #d94d7b;
+
+  /* ── Logo indigo — the deep ground of the mark ─────────────────── */
+  /* Pulled directly from assets/logos/crush-logo.png background.
+     Use for logo lockup backdrops, the "night" surface on dark
+     onboarding (distinct from journey-dark), and ghost facial features. */
+  --crush-indigo:       #280d49;
+  --crush-indigo-deep:  #1c0836;   /* 1-stop darker — edge vignette */
+  --crush-indigo-soft:  #3a1668;   /* 1-stop lighter — hover / raised */
+
+  /* ── Neutrals ─────────────────────────────────────────────────── */
+  --crush-dark:       #2c3e50;
+  --crush-light:      #f8f9fa;
+  --crush-white:      #F0ECF5;  /* lavender-tinted warm white (light mode) */
+  --crush-gray:       #6c757d;
+  --crush-gray-dark:  #4b5563;
+
+  /* ── Semantic ─────────────────────────────────────────────────── */
+  --crush-success: #28a745;
+  --crush-warning: #f39c12;
+  --crush-danger:  #dc3545;
+  --crush-info:    #17a2b8;
+
+  /* ── Foreground / background helpers ──────────────────────────── */
+  --fg-1: var(--crush-dark);       /* primary text */
+  --fg-2: #4b5563;                 /* gray-600 — body / secondary text */
+  --fg-3: #6b7280;                 /* gray-500 — muted / meta text */
+  --fg-brand: var(--crush-purple);
+  --bg-1: var(--crush-white);      /* page bg */
+  --bg-2: #ffffff;                 /* card bg */
+  --bg-3: #f3f4f6;                 /* subtle contrast surface */
+  --border-soft: #f3f4f6;          /* gray-100 */
+  --border-medium: #e5e7eb;        /* gray-200 */
+
+  /* ── Journey (dark onboarding) ────────────────────────────────── */
+  --journey-dark:       #1a1a2e;
+  --journey-dark-mid:   #16213e;
+  --journey-dark-light: #0f3460;
+  --journey-success:    #2ecc71;
+  --journey-warning:    #f39c12;
+
+  /* ── Gradients ────────────────────────────────────────────────── */
+  --gradient-crush-primary:   linear-gradient(135deg, #9b59b6, #ff6b9d);
+  --gradient-crush-hover:     linear-gradient(135deg, #8e44ad, #d94d7b);
+  --gradient-crush-vertical:  linear-gradient(180deg, #9b59b6, #ff6b9d);
+  --gradient-journey-bg:      linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  --gradient-journey-title:   linear-gradient(135deg, #ff6b9d, #c850c0, #9b59b6);
+
+  /* ── Radii ────────────────────────────────────────────────────── */
+  --radius-sm:   8px;
+  --radius-md:   12px;
+  --radius-lg:   15px;
+  --radius-xl:   20px;
+  --radius-2xl:  25px;
+  --radius-pill: 9999px;
+
+  /* ── Shadows ─────────────────────────────────────────────────── */
+  --shadow-sm:     0 2px 10px rgba(0,0,0,0.08);
+  --shadow-md:     0 4px 20px rgba(0,0,0,0.10);
+  --shadow-lg:     0 10px 30px rgba(0,0,0,0.15);
+  --shadow-purple: 0 5px 15px rgba(155, 89, 182, 0.4);
+  --shadow-pink:   0 5px 15px rgba(255, 107, 157, 0.4);
+  --shadow-journey-card:  0 10px 40px rgba(0,0,0,0.3);
+  --shadow-journey-glow-purple:  0 0 30px rgba(155, 89, 182, 0.6);
+  --shadow-journey-glow-pink:    0 0 40px rgba(255, 107, 157, 0.9);
+
+  /* ── Spacing scale (tailwind-equivalent) ─────────────────────── */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ── Container widths ────────────────────────────────────────── */
+  --container-wide:    1280px;  /* max-w-7xl */
+  --container-content: 896px;   /* max-w-4xl */
+  --container-narrow:  672px;   /* max-w-2xl */
+
+  /* ── Typography ──────────────────────────────────────────────── */
+  --font-sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-display: "Fraunces", "Georgia", "Times New Roman", serif;
+  --font-mono: ui-monospace, SFMono-Regular, "Menlo", "Monaco", Consolas, monospace;
+
+  /* Sizes */
+  --text-xs:   12px;  --lh-xs:   16px;
+  --text-sm:   14px;  --lh-sm:   20px;
+  --text-base: 16px;  --lh-base: 24px;
+  --text-lg:   18px;  --lh-lg:   28px;
+  --text-xl:   20px;  --lh-xl:   28px;
+  --text-2xl:  24px;  --lh-2xl:  32px;
+  --text-3xl:  30px;  --lh-3xl:  36px;
+  --text-4xl:  36px;  --lh-4xl:  40px;
+  --text-5xl:  48px;  --lh-5xl:  1;
+  --text-6xl:  60px;  --lh-6xl:  1;
+}
+
+/* ── Dark mode ─────────────────────────────────────────────────── */
+.dark {
+  --fg-1: #ffffff;
+  --fg-2: #d1d5db;  /* gray-300 */
+  --fg-3: #9ca3af;  /* gray-400 */
+  --bg-1: #111827;  /* gray-900 */
+  --bg-2: #1f2937;  /* gray-800 */
+  --bg-3: #374151;  /* gray-700 */
+  --border-soft:  #374151;  /* gray-700 */
+  --border-medium:#4b5563;  /* gray-600 */
+}
+
+/* ============================================================================
+   Semantic element styles — drop-in typography defaults.
+   Use these directly, or mirror them with your own classes.
+   ============================================================================ */
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--lh-base);
+  color: var(--fg-1);
+  background: var(--bg-1);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, .h1 { font-size: var(--text-4xl); line-height: var(--lh-4xl); font-weight: 700; letter-spacing: -0.02em; }
+h2, .h2 { font-size: var(--text-3xl); line-height: var(--lh-3xl); font-weight: 700; letter-spacing: -0.015em; }
+h3, .h3 { font-size: var(--text-2xl); line-height: var(--lh-2xl); font-weight: 600; }
+h4, .h4 { font-size: var(--text-xl);  line-height: var(--lh-xl);  font-weight: 600; }
+h5, .h5 { font-size: var(--text-lg);  line-height: var(--lh-lg);  font-weight: 500; }
+h6, .h6 { font-size: var(--text-base);line-height: var(--lh-base);font-weight: 500; }
+
+.display-xl {
+  font-family: var(--font-display);
+  font-size: clamp(40px, 6vw, 72px);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+}
+.display-lg {
+  font-family: var(--font-display);
+  font-size: clamp(32px, 5vw, 56px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+p { color: var(--fg-2); }
+.lead { font-size: var(--text-xl); line-height: 1.5; color: var(--fg-2); }
+small, .text-small { font-size: var(--text-sm); line-height: var(--lh-sm); }
+.text-muted { color: var(--fg-3); }
+.text-gradient {
+  background: var(--gradient-crush-primary);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+a {
+  color: var(--crush-purple);
+  text-decoration: none;
+  transition: color 200ms ease;
+}
+a:hover { color: var(--crush-purple-dark); }
+
+code, kbd, samp, pre { font-family: var(--font-mono); font-size: 0.9em; }
+
+</style>
+<style>
+  html, body { margin: 0; height: 100%; background: #0a0a0a; overflow: hidden; }
+  #root { position: fixed; inset: 0; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<!-- React + ReactDOM (UMD, production) inlined -->
+<script>/**
+ * @license React
+ * react.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+(function(){'use strict';(function(c,x){"object"===typeof exports&&"undefined"!==typeof module?x(exports):"function"===typeof define&&define.amd?define(["exports"],x):(c=c||self,x(c.React={}))})(this,function(c){function x(a){if(null===a||"object"!==typeof a)return null;a=V&&a[V]||a["@@iterator"];return"function"===typeof a?a:null}function w(a,b,e){this.props=a;this.context=b;this.refs=W;this.updater=e||X}function Y(){}function K(a,b,e){this.props=a;this.context=b;this.refs=W;this.updater=e||X}function Z(a,b,
+e){var m,d={},c=null,h=null;if(null!=b)for(m in void 0!==b.ref&&(h=b.ref),void 0!==b.key&&(c=""+b.key),b)aa.call(b,m)&&!ba.hasOwnProperty(m)&&(d[m]=b[m]);var l=arguments.length-2;if(1===l)d.children=e;else if(1<l){for(var f=Array(l),k=0;k<l;k++)f[k]=arguments[k+2];d.children=f}if(a&&a.defaultProps)for(m in l=a.defaultProps,l)void 0===d[m]&&(d[m]=l[m]);return{$$typeof:y,type:a,key:c,ref:h,props:d,_owner:L.current}}function oa(a,b){return{$$typeof:y,type:a.type,key:b,ref:a.ref,props:a.props,_owner:a._owner}}
+function M(a){return"object"===typeof a&&null!==a&&a.$$typeof===y}function pa(a){var b={"=":"=0",":":"=2"};return"$"+a.replace(/[=:]/g,function(a){return b[a]})}function N(a,b){return"object"===typeof a&&null!==a&&null!=a.key?pa(""+a.key):b.toString(36)}function B(a,b,e,m,d){var c=typeof a;if("undefined"===c||"boolean"===c)a=null;var h=!1;if(null===a)h=!0;else switch(c){case "string":case "number":h=!0;break;case "object":switch(a.$$typeof){case y:case qa:h=!0}}if(h)return h=a,d=d(h),a=""===m?"."+
+N(h,0):m,ca(d)?(e="",null!=a&&(e=a.replace(da,"$&/")+"/"),B(d,b,e,"",function(a){return a})):null!=d&&(M(d)&&(d=oa(d,e+(!d.key||h&&h.key===d.key?"":(""+d.key).replace(da,"$&/")+"/")+a)),b.push(d)),1;h=0;m=""===m?".":m+":";if(ca(a))for(var l=0;l<a.length;l++){c=a[l];var f=m+N(c,l);h+=B(c,b,e,f,d)}else if(f=x(a),"function"===typeof f)for(a=f.call(a),l=0;!(c=a.next()).done;)c=c.value,f=m+N(c,l++),h+=B(c,b,e,f,d);else if("object"===c)throw b=String(a),Error("Objects are not valid as a React child (found: "+
+("[object Object]"===b?"object with keys {"+Object.keys(a).join(", ")+"}":b)+"). If you meant to render a collection of children, use an array instead.");return h}function C(a,b,e){if(null==a)return a;var c=[],d=0;B(a,c,"","",function(a){return b.call(e,a,d++)});return c}function ra(a){if(-1===a._status){var b=a._result;b=b();b.then(function(b){if(0===a._status||-1===a._status)a._status=1,a._result=b},function(b){if(0===a._status||-1===a._status)a._status=2,a._result=b});-1===a._status&&(a._status=
+0,a._result=b)}if(1===a._status)return a._result.default;throw a._result;}function O(a,b){var e=a.length;a.push(b);a:for(;0<e;){var c=e-1>>>1,d=a[c];if(0<D(d,b))a[c]=b,a[e]=d,e=c;else break a}}function p(a){return 0===a.length?null:a[0]}function E(a){if(0===a.length)return null;var b=a[0],e=a.pop();if(e!==b){a[0]=e;a:for(var c=0,d=a.length,k=d>>>1;c<k;){var h=2*(c+1)-1,l=a[h],f=h+1,g=a[f];if(0>D(l,e))f<d&&0>D(g,l)?(a[c]=g,a[f]=e,c=f):(a[c]=l,a[h]=e,c=h);else if(f<d&&0>D(g,e))a[c]=g,a[f]=e,c=f;else break a}}return b}
+function D(a,b){var c=a.sortIndex-b.sortIndex;return 0!==c?c:a.id-b.id}function P(a){for(var b=p(r);null!==b;){if(null===b.callback)E(r);else if(b.startTime<=a)E(r),b.sortIndex=b.expirationTime,O(q,b);else break;b=p(r)}}function Q(a){z=!1;P(a);if(!u)if(null!==p(q))u=!0,R(S);else{var b=p(r);null!==b&&T(Q,b.startTime-a)}}function S(a,b){u=!1;z&&(z=!1,ea(A),A=-1);F=!0;var c=k;try{P(b);for(n=p(q);null!==n&&(!(n.expirationTime>b)||a&&!fa());){var m=n.callback;if("function"===typeof m){n.callback=null;
+k=n.priorityLevel;var d=m(n.expirationTime<=b);b=v();"function"===typeof d?n.callback=d:n===p(q)&&E(q);P(b)}else E(q);n=p(q)}if(null!==n)var g=!0;else{var h=p(r);null!==h&&T(Q,h.startTime-b);g=!1}return g}finally{n=null,k=c,F=!1}}function fa(){return v()-ha<ia?!1:!0}function R(a){G=a;H||(H=!0,I())}function T(a,b){A=ja(function(){a(v())},b)}function ka(a){throw Error("act(...) is not supported in production builds of React.");}var y=Symbol.for("react.element"),qa=Symbol.for("react.portal"),sa=Symbol.for("react.fragment"),
+ta=Symbol.for("react.strict_mode"),ua=Symbol.for("react.profiler"),va=Symbol.for("react.provider"),wa=Symbol.for("react.context"),xa=Symbol.for("react.forward_ref"),ya=Symbol.for("react.suspense"),za=Symbol.for("react.memo"),Aa=Symbol.for("react.lazy"),V=Symbol.iterator,X={isMounted:function(a){return!1},enqueueForceUpdate:function(a,b,c){},enqueueReplaceState:function(a,b,c,m){},enqueueSetState:function(a,b,c,m){}},la=Object.assign,W={};w.prototype.isReactComponent={};w.prototype.setState=function(a,
+b){if("object"!==typeof a&&"function"!==typeof a&&null!=a)throw Error("setState(...): takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,a,b,"setState")};w.prototype.forceUpdate=function(a){this.updater.enqueueForceUpdate(this,a,"forceUpdate")};Y.prototype=w.prototype;var t=K.prototype=new Y;t.constructor=K;la(t,w.prototype);t.isPureReactComponent=!0;var ca=Array.isArray,aa=Object.prototype.hasOwnProperty,L={current:null},
+ba={key:!0,ref:!0,__self:!0,__source:!0},da=/\/+/g,g={current:null},J={transition:null};if("object"===typeof performance&&"function"===typeof performance.now){var Ba=performance;var v=function(){return Ba.now()}}else{var ma=Date,Ca=ma.now();v=function(){return ma.now()-Ca}}var q=[],r=[],Da=1,n=null,k=3,F=!1,u=!1,z=!1,ja="function"===typeof setTimeout?setTimeout:null,ea="function"===typeof clearTimeout?clearTimeout:null,na="undefined"!==typeof setImmediate?setImmediate:null;"undefined"!==typeof navigator&&
+void 0!==navigator.scheduling&&void 0!==navigator.scheduling.isInputPending&&navigator.scheduling.isInputPending.bind(navigator.scheduling);var H=!1,G=null,A=-1,ia=5,ha=-1,U=function(){if(null!==G){var a=v();ha=a;var b=!0;try{b=G(!0,a)}finally{b?I():(H=!1,G=null)}}else H=!1};if("function"===typeof na)var I=function(){na(U)};else if("undefined"!==typeof MessageChannel){t=new MessageChannel;var Ea=t.port2;t.port1.onmessage=U;I=function(){Ea.postMessage(null)}}else I=function(){ja(U,0)};t={ReactCurrentDispatcher:g,
+ReactCurrentOwner:L,ReactCurrentBatchConfig:J,Scheduler:{__proto__:null,unstable_ImmediatePriority:1,unstable_UserBlockingPriority:2,unstable_NormalPriority:3,unstable_IdlePriority:5,unstable_LowPriority:4,unstable_runWithPriority:function(a,b){switch(a){case 1:case 2:case 3:case 4:case 5:break;default:a=3}var c=k;k=a;try{return b()}finally{k=c}},unstable_next:function(a){switch(k){case 1:case 2:case 3:var b=3;break;default:b=k}var c=k;k=b;try{return a()}finally{k=c}},unstable_scheduleCallback:function(a,
+b,c){var e=v();"object"===typeof c&&null!==c?(c=c.delay,c="number"===typeof c&&0<c?e+c:e):c=e;switch(a){case 1:var d=-1;break;case 2:d=250;break;case 5:d=1073741823;break;case 4:d=1E4;break;default:d=5E3}d=c+d;a={id:Da++,callback:b,priorityLevel:a,startTime:c,expirationTime:d,sortIndex:-1};c>e?(a.sortIndex=c,O(r,a),null===p(q)&&a===p(r)&&(z?(ea(A),A=-1):z=!0,T(Q,c-e))):(a.sortIndex=d,O(q,a),u||F||(u=!0,R(S)));return a},unstable_cancelCallback:function(a){a.callback=null},unstable_wrapCallback:function(a){var b=
+k;return function(){var c=k;k=b;try{return a.apply(this,arguments)}finally{k=c}}},unstable_getCurrentPriorityLevel:function(){return k},unstable_shouldYield:fa,unstable_requestPaint:function(){},unstable_continueExecution:function(){u||F||(u=!0,R(S))},unstable_pauseExecution:function(){},unstable_getFirstCallbackNode:function(){return p(q)},get unstable_now(){return v},unstable_forceFrameRate:function(a){0>a||125<a?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):
+ia=0<a?Math.floor(1E3/a):5},unstable_Profiling:null}};c.Children={map:C,forEach:function(a,b,c){C(a,function(){b.apply(this,arguments)},c)},count:function(a){var b=0;C(a,function(){b++});return b},toArray:function(a){return C(a,function(a){return a})||[]},only:function(a){if(!M(a))throw Error("React.Children.only expected to receive a single React element child.");return a}};c.Component=w;c.Fragment=sa;c.Profiler=ua;c.PureComponent=K;c.StrictMode=ta;c.Suspense=ya;c.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED=
+t;c.act=ka;c.cloneElement=function(a,b,c){if(null===a||void 0===a)throw Error("React.cloneElement(...): The argument must be a React element, but you passed "+a+".");var e=la({},a.props),d=a.key,k=a.ref,h=a._owner;if(null!=b){void 0!==b.ref&&(k=b.ref,h=L.current);void 0!==b.key&&(d=""+b.key);if(a.type&&a.type.defaultProps)var l=a.type.defaultProps;for(f in b)aa.call(b,f)&&!ba.hasOwnProperty(f)&&(e[f]=void 0===b[f]&&void 0!==l?l[f]:b[f])}var f=arguments.length-2;if(1===f)e.children=c;else if(1<f){l=
+Array(f);for(var g=0;g<f;g++)l[g]=arguments[g+2];e.children=l}return{$$typeof:y,type:a.type,key:d,ref:k,props:e,_owner:h}};c.createContext=function(a){a={$$typeof:wa,_currentValue:a,_currentValue2:a,_threadCount:0,Provider:null,Consumer:null,_defaultValue:null,_globalName:null};a.Provider={$$typeof:va,_context:a};return a.Consumer=a};c.createElement=Z;c.createFactory=function(a){var b=Z.bind(null,a);b.type=a;return b};c.createRef=function(){return{current:null}};c.forwardRef=function(a){return{$$typeof:xa,
+render:a}};c.isValidElement=M;c.lazy=function(a){return{$$typeof:Aa,_payload:{_status:-1,_result:a},_init:ra}};c.memo=function(a,b){return{$$typeof:za,type:a,compare:void 0===b?null:b}};c.startTransition=function(a,b){b=J.transition;J.transition={};try{a()}finally{J.transition=b}};c.unstable_act=ka;c.useCallback=function(a,b){return g.current.useCallback(a,b)};c.useContext=function(a){return g.current.useContext(a)};c.useDebugValue=function(a,b){};c.useDeferredValue=function(a){return g.current.useDeferredValue(a)};
+c.useEffect=function(a,b){return g.current.useEffect(a,b)};c.useId=function(){return g.current.useId()};c.useImperativeHandle=function(a,b,c){return g.current.useImperativeHandle(a,b,c)};c.useInsertionEffect=function(a,b){return g.current.useInsertionEffect(a,b)};c.useLayoutEffect=function(a,b){return g.current.useLayoutEffect(a,b)};c.useMemo=function(a,b){return g.current.useMemo(a,b)};c.useReducer=function(a,b,c){return g.current.useReducer(a,b,c)};c.useRef=function(a){return g.current.useRef(a)};
+c.useState=function(a){return g.current.useState(a)};c.useSyncExternalStore=function(a,b,c){return g.current.useSyncExternalStore(a,b,c)};c.useTransition=function(){return g.current.useTransition()};c.version="18.3.1"});
+})();
+</script>
+<script>/**
+ * @license React
+ * react-dom.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+(function(){/*
+ Modernizr 3.0.0pre (Custom Build) | MIT
+*/
+'use strict';(function(Q,zb){"object"===typeof exports&&"undefined"!==typeof module?zb(exports,require("react")):"function"===typeof define&&define.amd?define(["exports","react"],zb):(Q=Q||self,zb(Q.ReactDOM={},Q.React))})(this,function(Q,zb){function m(a){for(var b="https://reactjs.org/docs/error-decoder.html?invariant="+a,c=1;c<arguments.length;c++)b+="&args[]="+encodeURIComponent(arguments[c]);return"Minified React error #"+a+"; visit "+b+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}
+function mb(a,b){Ab(a,b);Ab(a+"Capture",b)}function Ab(a,b){$b[a]=b;for(a=0;a<b.length;a++)cg.add(b[a])}function bj(a){if(Zd.call(dg,a))return!0;if(Zd.call(eg,a))return!1;if(cj.test(a))return dg[a]=!0;eg[a]=!0;return!1}function dj(a,b,c,d){if(null!==c&&0===c.type)return!1;switch(typeof b){case "function":case "symbol":return!0;case "boolean":if(d)return!1;if(null!==c)return!c.acceptsBooleans;a=a.toLowerCase().slice(0,5);return"data-"!==a&&"aria-"!==a;default:return!1}}function ej(a,b,c,d){if(null===
+b||"undefined"===typeof b||dj(a,b,c,d))return!0;if(d)return!1;if(null!==c)switch(c.type){case 3:return!b;case 4:return!1===b;case 5:return isNaN(b);case 6:return isNaN(b)||1>b}return!1}function Y(a,b,c,d,e,f,g){this.acceptsBooleans=2===b||3===b||4===b;this.attributeName=d;this.attributeNamespace=e;this.mustUseProperty=c;this.propertyName=a;this.type=b;this.sanitizeURL=f;this.removeEmptyString=g}function $d(a,b,c,d){var e=R.hasOwnProperty(b)?R[b]:null;if(null!==e?0!==e.type:d||!(2<b.length)||"o"!==
+b[0]&&"O"!==b[0]||"n"!==b[1]&&"N"!==b[1])ej(b,c,e,d)&&(c=null),d||null===e?bj(b)&&(null===c?a.removeAttribute(b):a.setAttribute(b,""+c)):e.mustUseProperty?a[e.propertyName]=null===c?3===e.type?!1:"":c:(b=e.attributeName,d=e.attributeNamespace,null===c?a.removeAttribute(b):(e=e.type,c=3===e||4===e&&!0===c?"":""+c,d?a.setAttributeNS(d,b,c):a.setAttribute(b,c)))}function ac(a){if(null===a||"object"!==typeof a)return null;a=fg&&a[fg]||a["@@iterator"];return"function"===typeof a?a:null}function bc(a,b,
+c){if(void 0===ae)try{throw Error();}catch(d){ae=(b=d.stack.trim().match(/\n( *(at )?)/))&&b[1]||""}return"\n"+ae+a}function be(a,b){if(!a||ce)return"";ce=!0;var c=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{if(b)if(b=function(){throw Error();},Object.defineProperty(b.prototype,"props",{set:function(){throw Error();}}),"object"===typeof Reflect&&Reflect.construct){try{Reflect.construct(b,[])}catch(n){var d=n}Reflect.construct(a,[],b)}else{try{b.call()}catch(n){d=n}a.call(b.prototype)}else{try{throw Error();
+}catch(n){d=n}a()}}catch(n){if(n&&d&&"string"===typeof n.stack){for(var e=n.stack.split("\n"),f=d.stack.split("\n"),g=e.length-1,h=f.length-1;1<=g&&0<=h&&e[g]!==f[h];)h--;for(;1<=g&&0<=h;g--,h--)if(e[g]!==f[h]){if(1!==g||1!==h){do if(g--,h--,0>h||e[g]!==f[h]){var k="\n"+e[g].replace(" at new "," at ");a.displayName&&k.includes("<anonymous>")&&(k=k.replace("<anonymous>",a.displayName));return k}while(1<=g&&0<=h)}break}}}finally{ce=!1,Error.prepareStackTrace=c}return(a=a?a.displayName||a.name:"")?bc(a):
+""}function fj(a){switch(a.tag){case 5:return bc(a.type);case 16:return bc("Lazy");case 13:return bc("Suspense");case 19:return bc("SuspenseList");case 0:case 2:case 15:return a=be(a.type,!1),a;case 11:return a=be(a.type.render,!1),a;case 1:return a=be(a.type,!0),a;default:return""}}function de(a){if(null==a)return null;if("function"===typeof a)return a.displayName||a.name||null;if("string"===typeof a)return a;switch(a){case Bb:return"Fragment";case Cb:return"Portal";case ee:return"Profiler";case fe:return"StrictMode";
+case ge:return"Suspense";case he:return"SuspenseList"}if("object"===typeof a)switch(a.$$typeof){case gg:return(a.displayName||"Context")+".Consumer";case hg:return(a._context.displayName||"Context")+".Provider";case ie:var b=a.render;a=a.displayName;a||(a=b.displayName||b.name||"",a=""!==a?"ForwardRef("+a+")":"ForwardRef");return a;case je:return b=a.displayName||null,null!==b?b:de(a.type)||"Memo";case Ta:b=a._payload;a=a._init;try{return de(a(b))}catch(c){}}return null}function gj(a){var b=a.type;
+switch(a.tag){case 24:return"Cache";case 9:return(b.displayName||"Context")+".Consumer";case 10:return(b._context.displayName||"Context")+".Provider";case 18:return"DehydratedFragment";case 11:return a=b.render,a=a.displayName||a.name||"",b.displayName||(""!==a?"ForwardRef("+a+")":"ForwardRef");case 7:return"Fragment";case 5:return b;case 4:return"Portal";case 3:return"Root";case 6:return"Text";case 16:return de(b);case 8:return b===fe?"StrictMode":"Mode";case 22:return"Offscreen";case 12:return"Profiler";
+case 21:return"Scope";case 13:return"Suspense";case 19:return"SuspenseList";case 25:return"TracingMarker";case 1:case 0:case 17:case 2:case 14:case 15:if("function"===typeof b)return b.displayName||b.name||null;if("string"===typeof b)return b}return null}function Ua(a){switch(typeof a){case "boolean":case "number":case "string":case "undefined":return a;case "object":return a;default:return""}}function ig(a){var b=a.type;return(a=a.nodeName)&&"input"===a.toLowerCase()&&("checkbox"===b||"radio"===
+b)}function hj(a){var b=ig(a)?"checked":"value",c=Object.getOwnPropertyDescriptor(a.constructor.prototype,b),d=""+a[b];if(!a.hasOwnProperty(b)&&"undefined"!==typeof c&&"function"===typeof c.get&&"function"===typeof c.set){var e=c.get,f=c.set;Object.defineProperty(a,b,{configurable:!0,get:function(){return e.call(this)},set:function(a){d=""+a;f.call(this,a)}});Object.defineProperty(a,b,{enumerable:c.enumerable});return{getValue:function(){return d},setValue:function(a){d=""+a},stopTracking:function(){a._valueTracker=
+null;delete a[b]}}}}function Pc(a){a._valueTracker||(a._valueTracker=hj(a))}function jg(a){if(!a)return!1;var b=a._valueTracker;if(!b)return!0;var c=b.getValue();var d="";a&&(d=ig(a)?a.checked?"true":"false":a.value);a=d;return a!==c?(b.setValue(a),!0):!1}function Qc(a){a=a||("undefined"!==typeof document?document:void 0);if("undefined"===typeof a)return null;try{return a.activeElement||a.body}catch(b){return a.body}}function ke(a,b){var c=b.checked;return E({},b,{defaultChecked:void 0,defaultValue:void 0,
+value:void 0,checked:null!=c?c:a._wrapperState.initialChecked})}function kg(a,b){var c=null==b.defaultValue?"":b.defaultValue,d=null!=b.checked?b.checked:b.defaultChecked;c=Ua(null!=b.value?b.value:c);a._wrapperState={initialChecked:d,initialValue:c,controlled:"checkbox"===b.type||"radio"===b.type?null!=b.checked:null!=b.value}}function lg(a,b){b=b.checked;null!=b&&$d(a,"checked",b,!1)}function le(a,b){lg(a,b);var c=Ua(b.value),d=b.type;if(null!=c)if("number"===d){if(0===c&&""===a.value||a.value!=
+c)a.value=""+c}else a.value!==""+c&&(a.value=""+c);else if("submit"===d||"reset"===d){a.removeAttribute("value");return}b.hasOwnProperty("value")?me(a,b.type,c):b.hasOwnProperty("defaultValue")&&me(a,b.type,Ua(b.defaultValue));null==b.checked&&null!=b.defaultChecked&&(a.defaultChecked=!!b.defaultChecked)}function mg(a,b,c){if(b.hasOwnProperty("value")||b.hasOwnProperty("defaultValue")){var d=b.type;if(!("submit"!==d&&"reset"!==d||void 0!==b.value&&null!==b.value))return;b=""+a._wrapperState.initialValue;
+c||b===a.value||(a.value=b);a.defaultValue=b}c=a.name;""!==c&&(a.name="");a.defaultChecked=!!a._wrapperState.initialChecked;""!==c&&(a.name=c)}function me(a,b,c){if("number"!==b||Qc(a.ownerDocument)!==a)null==c?a.defaultValue=""+a._wrapperState.initialValue:a.defaultValue!==""+c&&(a.defaultValue=""+c)}function Db(a,b,c,d){a=a.options;if(b){b={};for(var e=0;e<c.length;e++)b["$"+c[e]]=!0;for(c=0;c<a.length;c++)e=b.hasOwnProperty("$"+a[c].value),a[c].selected!==e&&(a[c].selected=e),e&&d&&(a[c].defaultSelected=
+!0)}else{c=""+Ua(c);b=null;for(e=0;e<a.length;e++){if(a[e].value===c){a[e].selected=!0;d&&(a[e].defaultSelected=!0);return}null!==b||a[e].disabled||(b=a[e])}null!==b&&(b.selected=!0)}}function ne(a,b){if(null!=b.dangerouslySetInnerHTML)throw Error(m(91));return E({},b,{value:void 0,defaultValue:void 0,children:""+a._wrapperState.initialValue})}function ng(a,b){var c=b.value;if(null==c){c=b.children;b=b.defaultValue;if(null!=c){if(null!=b)throw Error(m(92));if(cc(c)){if(1<c.length)throw Error(m(93));
+c=c[0]}b=c}null==b&&(b="");c=b}a._wrapperState={initialValue:Ua(c)}}function og(a,b){var c=Ua(b.value),d=Ua(b.defaultValue);null!=c&&(c=""+c,c!==a.value&&(a.value=c),null==b.defaultValue&&a.defaultValue!==c&&(a.defaultValue=c));null!=d&&(a.defaultValue=""+d)}function pg(a,b){b=a.textContent;b===a._wrapperState.initialValue&&""!==b&&null!==b&&(a.value=b)}function qg(a){switch(a){case "svg":return"http://www.w3.org/2000/svg";case "math":return"http://www.w3.org/1998/Math/MathML";default:return"http://www.w3.org/1999/xhtml"}}
+function oe(a,b){return null==a||"http://www.w3.org/1999/xhtml"===a?qg(b):"http://www.w3.org/2000/svg"===a&&"foreignObject"===b?"http://www.w3.org/1999/xhtml":a}function rg(a,b,c){return null==b||"boolean"===typeof b||""===b?"":c||"number"!==typeof b||0===b||dc.hasOwnProperty(a)&&dc[a]?(""+b).trim():b+"px"}function sg(a,b){a=a.style;for(var c in b)if(b.hasOwnProperty(c)){var d=0===c.indexOf("--"),e=rg(c,b[c],d);"float"===c&&(c="cssFloat");d?a.setProperty(c,e):a[c]=e}}function pe(a,b){if(b){if(ij[a]&&
+(null!=b.children||null!=b.dangerouslySetInnerHTML))throw Error(m(137,a));if(null!=b.dangerouslySetInnerHTML){if(null!=b.children)throw Error(m(60));if("object"!==typeof b.dangerouslySetInnerHTML||!("__html"in b.dangerouslySetInnerHTML))throw Error(m(61));}if(null!=b.style&&"object"!==typeof b.style)throw Error(m(62));}}function qe(a,b){if(-1===a.indexOf("-"))return"string"===typeof b.is;switch(a){case "annotation-xml":case "color-profile":case "font-face":case "font-face-src":case "font-face-uri":case "font-face-format":case "font-face-name":case "missing-glyph":return!1;
+default:return!0}}function re(a){a=a.target||a.srcElement||window;a.correspondingUseElement&&(a=a.correspondingUseElement);return 3===a.nodeType?a.parentNode:a}function tg(a){if(a=ec(a)){if("function"!==typeof se)throw Error(m(280));var b=a.stateNode;b&&(b=Rc(b),se(a.stateNode,a.type,b))}}function ug(a){Eb?Fb?Fb.push(a):Fb=[a]:Eb=a}function vg(){if(Eb){var a=Eb,b=Fb;Fb=Eb=null;tg(a);if(b)for(a=0;a<b.length;a++)tg(b[a])}}function wg(a,b,c){if(te)return a(b,c);te=!0;try{return xg(a,b,c)}finally{if(te=
+!1,null!==Eb||null!==Fb)yg(),vg()}}function fc(a,b){var c=a.stateNode;if(null===c)return null;var d=Rc(c);if(null===d)return null;c=d[b];a:switch(b){case "onClick":case "onClickCapture":case "onDoubleClick":case "onDoubleClickCapture":case "onMouseDown":case "onMouseDownCapture":case "onMouseMove":case "onMouseMoveCapture":case "onMouseUp":case "onMouseUpCapture":case "onMouseEnter":(d=!d.disabled)||(a=a.type,d=!("button"===a||"input"===a||"select"===a||"textarea"===a));a=!d;break a;default:a=!1}if(a)return null;
+if(c&&"function"!==typeof c)throw Error(m(231,b,typeof c));return c}function jj(a,b,c,d,e,f,g,h,k){gc=!1;Sc=null;kj.apply(lj,arguments)}function mj(a,b,c,d,e,f,g,h,k){jj.apply(this,arguments);if(gc){if(gc){var n=Sc;gc=!1;Sc=null}else throw Error(m(198));Tc||(Tc=!0,ue=n)}}function nb(a){var b=a,c=a;if(a.alternate)for(;b.return;)b=b.return;else{a=b;do b=a,0!==(b.flags&4098)&&(c=b.return),a=b.return;while(a)}return 3===b.tag?c:null}function zg(a){if(13===a.tag){var b=a.memoizedState;null===b&&(a=a.alternate,
+null!==a&&(b=a.memoizedState));if(null!==b)return b.dehydrated}return null}function Ag(a){if(nb(a)!==a)throw Error(m(188));}function nj(a){var b=a.alternate;if(!b){b=nb(a);if(null===b)throw Error(m(188));return b!==a?null:a}for(var c=a,d=b;;){var e=c.return;if(null===e)break;var f=e.alternate;if(null===f){d=e.return;if(null!==d){c=d;continue}break}if(e.child===f.child){for(f=e.child;f;){if(f===c)return Ag(e),a;if(f===d)return Ag(e),b;f=f.sibling}throw Error(m(188));}if(c.return!==d.return)c=e,d=f;
+else{for(var g=!1,h=e.child;h;){if(h===c){g=!0;c=e;d=f;break}if(h===d){g=!0;d=e;c=f;break}h=h.sibling}if(!g){for(h=f.child;h;){if(h===c){g=!0;c=f;d=e;break}if(h===d){g=!0;d=f;c=e;break}h=h.sibling}if(!g)throw Error(m(189));}}if(c.alternate!==d)throw Error(m(190));}if(3!==c.tag)throw Error(m(188));return c.stateNode.current===c?a:b}function Bg(a){a=nj(a);return null!==a?Cg(a):null}function Cg(a){if(5===a.tag||6===a.tag)return a;for(a=a.child;null!==a;){var b=Cg(a);if(null!==b)return b;a=a.sibling}return null}
+function oj(a,b){if(Ca&&"function"===typeof Ca.onCommitFiberRoot)try{Ca.onCommitFiberRoot(Uc,a,void 0,128===(a.current.flags&128))}catch(c){}}function pj(a){a>>>=0;return 0===a?32:31-(qj(a)/rj|0)|0}function hc(a){switch(a&-a){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return a&
+4194240;case 4194304:case 8388608:case 16777216:case 33554432:case 67108864:return a&130023424;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 1073741824;default:return a}}function Vc(a,b){var c=a.pendingLanes;if(0===c)return 0;var d=0,e=a.suspendedLanes,f=a.pingedLanes,g=c&268435455;if(0!==g){var h=g&~e;0!==h?d=hc(h):(f&=g,0!==f&&(d=hc(f)))}else g=c&~e,0!==g?d=hc(g):0!==f&&(d=hc(f));if(0===d)return 0;if(0!==b&&b!==d&&0===(b&e)&&
+(e=d&-d,f=b&-b,e>=f||16===e&&0!==(f&4194240)))return b;0!==(d&4)&&(d|=c&16);b=a.entangledLanes;if(0!==b)for(a=a.entanglements,b&=d;0<b;)c=31-ta(b),e=1<<c,d|=a[c],b&=~e;return d}function sj(a,b){switch(a){case 1:case 2:case 4:return b+250;case 8:case 16:case 32:case 64:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return b+5E3;case 4194304:case 8388608:case 16777216:case 33554432:case 67108864:return-1;
+case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function tj(a,b){for(var c=a.suspendedLanes,d=a.pingedLanes,e=a.expirationTimes,f=a.pendingLanes;0<f;){var g=31-ta(f),h=1<<g,k=e[g];if(-1===k){if(0===(h&c)||0!==(h&d))e[g]=sj(h,b)}else k<=b&&(a.expiredLanes|=h);f&=~h}}function ve(a){a=a.pendingLanes&-1073741825;return 0!==a?a:a&1073741824?1073741824:0}function Dg(){var a=Wc;Wc<<=1;0===(Wc&4194240)&&(Wc=64);return a}function we(a){for(var b=[],c=0;31>c;c++)b.push(a);
+return b}function ic(a,b,c){a.pendingLanes|=b;536870912!==b&&(a.suspendedLanes=0,a.pingedLanes=0);a=a.eventTimes;b=31-ta(b);a[b]=c}function uj(a,b){var c=a.pendingLanes&~b;a.pendingLanes=b;a.suspendedLanes=0;a.pingedLanes=0;a.expiredLanes&=b;a.mutableReadLanes&=b;a.entangledLanes&=b;b=a.entanglements;var d=a.eventTimes;for(a=a.expirationTimes;0<c;){var e=31-ta(c),f=1<<e;b[e]=0;d[e]=-1;a[e]=-1;c&=~f}}function xe(a,b){var c=a.entangledLanes|=b;for(a=a.entanglements;c;){var d=31-ta(c),e=1<<d;e&b|a[d]&
+b&&(a[d]|=b);c&=~e}}function Eg(a){a&=-a;return 1<a?4<a?0!==(a&268435455)?16:536870912:4:1}function Fg(a,b){switch(a){case "focusin":case "focusout":Va=null;break;case "dragenter":case "dragleave":Wa=null;break;case "mouseover":case "mouseout":Xa=null;break;case "pointerover":case "pointerout":jc.delete(b.pointerId);break;case "gotpointercapture":case "lostpointercapture":kc.delete(b.pointerId)}}function lc(a,b,c,d,e,f){if(null===a||a.nativeEvent!==f)return a={blockedOn:b,domEventName:c,eventSystemFlags:d,
+nativeEvent:f,targetContainers:[e]},null!==b&&(b=ec(b),null!==b&&Gg(b)),a;a.eventSystemFlags|=d;b=a.targetContainers;null!==e&&-1===b.indexOf(e)&&b.push(e);return a}function vj(a,b,c,d,e){switch(b){case "focusin":return Va=lc(Va,a,b,c,d,e),!0;case "dragenter":return Wa=lc(Wa,a,b,c,d,e),!0;case "mouseover":return Xa=lc(Xa,a,b,c,d,e),!0;case "pointerover":var f=e.pointerId;jc.set(f,lc(jc.get(f)||null,a,b,c,d,e));return!0;case "gotpointercapture":return f=e.pointerId,kc.set(f,lc(kc.get(f)||null,a,b,
+c,d,e)),!0}return!1}function Hg(a){var b=ob(a.target);if(null!==b){var c=nb(b);if(null!==c)if(b=c.tag,13===b){if(b=zg(c),null!==b){a.blockedOn=b;wj(a.priority,function(){xj(c)});return}}else if(3===b&&c.stateNode.current.memoizedState.isDehydrated){a.blockedOn=3===c.tag?c.stateNode.containerInfo:null;return}}a.blockedOn=null}function Xc(a){if(null!==a.blockedOn)return!1;for(var b=a.targetContainers;0<b.length;){var c=ye(a.domEventName,a.eventSystemFlags,b[0],a.nativeEvent);if(null===c){c=a.nativeEvent;
+var d=new c.constructor(c.type,c);ze=d;c.target.dispatchEvent(d);ze=null}else return b=ec(c),null!==b&&Gg(b),a.blockedOn=c,!1;b.shift()}return!0}function Ig(a,b,c){Xc(a)&&c.delete(b)}function yj(){Ae=!1;null!==Va&&Xc(Va)&&(Va=null);null!==Wa&&Xc(Wa)&&(Wa=null);null!==Xa&&Xc(Xa)&&(Xa=null);jc.forEach(Ig);kc.forEach(Ig)}function mc(a,b){a.blockedOn===b&&(a.blockedOn=null,Ae||(Ae=!0,Jg(Kg,yj)))}function nc(a){if(0<Yc.length){mc(Yc[0],a);for(var b=1;b<Yc.length;b++){var c=Yc[b];c.blockedOn===a&&(c.blockedOn=
+null)}}null!==Va&&mc(Va,a);null!==Wa&&mc(Wa,a);null!==Xa&&mc(Xa,a);b=function(b){return mc(b,a)};jc.forEach(b);kc.forEach(b);for(b=0;b<Ya.length;b++)c=Ya[b],c.blockedOn===a&&(c.blockedOn=null);for(;0<Ya.length&&(b=Ya[0],null===b.blockedOn);)Hg(b),null===b.blockedOn&&Ya.shift()}function zj(a,b,c,d){var e=z,f=Gb.transition;Gb.transition=null;try{z=1,Be(a,b,c,d)}finally{z=e,Gb.transition=f}}function Aj(a,b,c,d){var e=z,f=Gb.transition;Gb.transition=null;try{z=4,Be(a,b,c,d)}finally{z=e,Gb.transition=
+f}}function Be(a,b,c,d){if(Zc){var e=ye(a,b,c,d);if(null===e)Ce(a,b,d,$c,c),Fg(a,d);else if(vj(e,a,b,c,d))d.stopPropagation();else if(Fg(a,d),b&4&&-1<Bj.indexOf(a)){for(;null!==e;){var f=ec(e);null!==f&&Cj(f);f=ye(a,b,c,d);null===f&&Ce(a,b,d,$c,c);if(f===e)break;e=f}null!==e&&d.stopPropagation()}else Ce(a,b,d,null,c)}}function ye(a,b,c,d){$c=null;a=re(d);a=ob(a);if(null!==a)if(b=nb(a),null===b)a=null;else if(c=b.tag,13===c){a=zg(b);if(null!==a)return a;a=null}else if(3===c){if(b.stateNode.current.memoizedState.isDehydrated)return 3===
+b.tag?b.stateNode.containerInfo:null;a=null}else b!==a&&(a=null);$c=a;return null}function Lg(a){switch(a){case "cancel":case "click":case "close":case "contextmenu":case "copy":case "cut":case "auxclick":case "dblclick":case "dragend":case "dragstart":case "drop":case "focusin":case "focusout":case "input":case "invalid":case "keydown":case "keypress":case "keyup":case "mousedown":case "mouseup":case "paste":case "pause":case "play":case "pointercancel":case "pointerdown":case "pointerup":case "ratechange":case "reset":case "resize":case "seeked":case "submit":case "touchcancel":case "touchend":case "touchstart":case "volumechange":case "change":case "selectionchange":case "textInput":case "compositionstart":case "compositionend":case "compositionupdate":case "beforeblur":case "afterblur":case "beforeinput":case "blur":case "fullscreenchange":case "focus":case "hashchange":case "popstate":case "select":case "selectstart":return 1;
+case "drag":case "dragenter":case "dragexit":case "dragleave":case "dragover":case "mousemove":case "mouseout":case "mouseover":case "pointermove":case "pointerout":case "pointerover":case "scroll":case "toggle":case "touchmove":case "wheel":case "mouseenter":case "mouseleave":case "pointerenter":case "pointerleave":return 4;case "message":switch(Dj()){case De:return 1;case Mg:return 4;case ad:case Ej:return 16;case Ng:return 536870912;default:return 16}default:return 16}}function Og(){if(bd)return bd;
+var a,b=Ee,c=b.length,d,e="value"in Za?Za.value:Za.textContent,f=e.length;for(a=0;a<c&&b[a]===e[a];a++);var g=c-a;for(d=1;d<=g&&b[c-d]===e[f-d];d++);return bd=e.slice(a,1<d?1-d:void 0)}function cd(a){var b=a.keyCode;"charCode"in a?(a=a.charCode,0===a&&13===b&&(a=13)):a=b;10===a&&(a=13);return 32<=a||13===a?a:0}function dd(){return!0}function Pg(){return!1}function ka(a){function b(b,d,e,f,g){this._reactName=b;this._targetInst=e;this.type=d;this.nativeEvent=f;this.target=g;this.currentTarget=null;
+for(var c in a)a.hasOwnProperty(c)&&(b=a[c],this[c]=b?b(f):f[c]);this.isDefaultPrevented=(null!=f.defaultPrevented?f.defaultPrevented:!1===f.returnValue)?dd:Pg;this.isPropagationStopped=Pg;return this}E(b.prototype,{preventDefault:function(){this.defaultPrevented=!0;var a=this.nativeEvent;a&&(a.preventDefault?a.preventDefault():"unknown"!==typeof a.returnValue&&(a.returnValue=!1),this.isDefaultPrevented=dd)},stopPropagation:function(){var a=this.nativeEvent;a&&(a.stopPropagation?a.stopPropagation():
+"unknown"!==typeof a.cancelBubble&&(a.cancelBubble=!0),this.isPropagationStopped=dd)},persist:function(){},isPersistent:dd});return b}function Fj(a){var b=this.nativeEvent;return b.getModifierState?b.getModifierState(a):(a=Gj[a])?!!b[a]:!1}function Fe(a){return Fj}function Qg(a,b){switch(a){case "keyup":return-1!==Hj.indexOf(b.keyCode);case "keydown":return 229!==b.keyCode;case "keypress":case "mousedown":case "focusout":return!0;default:return!1}}function Rg(a){a=a.detail;return"object"===typeof a&&
+"data"in a?a.data:null}function Ij(a,b){switch(a){case "compositionend":return Rg(b);case "keypress":if(32!==b.which)return null;Sg=!0;return Tg;case "textInput":return a=b.data,a===Tg&&Sg?null:a;default:return null}}function Jj(a,b){if(Hb)return"compositionend"===a||!Ge&&Qg(a,b)?(a=Og(),bd=Ee=Za=null,Hb=!1,a):null;switch(a){case "paste":return null;case "keypress":if(!(b.ctrlKey||b.altKey||b.metaKey)||b.ctrlKey&&b.altKey){if(b.char&&1<b.char.length)return b.char;if(b.which)return String.fromCharCode(b.which)}return null;
+case "compositionend":return Ug&&"ko"!==b.locale?null:b.data;default:return null}}function Vg(a){var b=a&&a.nodeName&&a.nodeName.toLowerCase();return"input"===b?!!Kj[a.type]:"textarea"===b?!0:!1}function Lj(a){if(!Ia)return!1;a="on"+a;var b=a in document;b||(b=document.createElement("div"),b.setAttribute(a,"return;"),b="function"===typeof b[a]);return b}function Wg(a,b,c,d){ug(d);b=ed(b,"onChange");0<b.length&&(c=new He("onChange","change",null,c,d),a.push({event:c,listeners:b}))}function Mj(a){Xg(a,
+0)}function fd(a){var b=Ib(a);if(jg(b))return a}function Nj(a,b){if("change"===a)return b}function Yg(){oc&&(oc.detachEvent("onpropertychange",Zg),pc=oc=null)}function Zg(a){if("value"===a.propertyName&&fd(pc)){var b=[];Wg(b,pc,a,re(a));wg(Mj,b)}}function Oj(a,b,c){"focusin"===a?(Yg(),oc=b,pc=c,oc.attachEvent("onpropertychange",Zg)):"focusout"===a&&Yg()}function Pj(a,b){if("selectionchange"===a||"keyup"===a||"keydown"===a)return fd(pc)}function Qj(a,b){if("click"===a)return fd(b)}function Rj(a,b){if("input"===
+a||"change"===a)return fd(b)}function Sj(a,b){return a===b&&(0!==a||1/a===1/b)||a!==a&&b!==b}function qc(a,b){if(ua(a,b))return!0;if("object"!==typeof a||null===a||"object"!==typeof b||null===b)return!1;var c=Object.keys(a),d=Object.keys(b);if(c.length!==d.length)return!1;for(d=0;d<c.length;d++){var e=c[d];if(!Zd.call(b,e)||!ua(a[e],b[e]))return!1}return!0}function $g(a){for(;a&&a.firstChild;)a=a.firstChild;return a}function ah(a,b){var c=$g(a);a=0;for(var d;c;){if(3===c.nodeType){d=a+c.textContent.length;
+if(a<=b&&d>=b)return{node:c,offset:b-a};a=d}a:{for(;c;){if(c.nextSibling){c=c.nextSibling;break a}c=c.parentNode}c=void 0}c=$g(c)}}function bh(a,b){return a&&b?a===b?!0:a&&3===a.nodeType?!1:b&&3===b.nodeType?bh(a,b.parentNode):"contains"in a?a.contains(b):a.compareDocumentPosition?!!(a.compareDocumentPosition(b)&16):!1:!1}function ch(){for(var a=window,b=Qc();b instanceof a.HTMLIFrameElement;){try{var c="string"===typeof b.contentWindow.location.href}catch(d){c=!1}if(c)a=b.contentWindow;else break;
+b=Qc(a.document)}return b}function Ie(a){var b=a&&a.nodeName&&a.nodeName.toLowerCase();return b&&("input"===b&&("text"===a.type||"search"===a.type||"tel"===a.type||"url"===a.type||"password"===a.type)||"textarea"===b||"true"===a.contentEditable)}function Tj(a){var b=ch(),c=a.focusedElem,d=a.selectionRange;if(b!==c&&c&&c.ownerDocument&&bh(c.ownerDocument.documentElement,c)){if(null!==d&&Ie(c))if(b=d.start,a=d.end,void 0===a&&(a=b),"selectionStart"in c)c.selectionStart=b,c.selectionEnd=Math.min(a,c.value.length);
+else if(a=(b=c.ownerDocument||document)&&b.defaultView||window,a.getSelection){a=a.getSelection();var e=c.textContent.length,f=Math.min(d.start,e);d=void 0===d.end?f:Math.min(d.end,e);!a.extend&&f>d&&(e=d,d=f,f=e);e=ah(c,f);var g=ah(c,d);e&&g&&(1!==a.rangeCount||a.anchorNode!==e.node||a.anchorOffset!==e.offset||a.focusNode!==g.node||a.focusOffset!==g.offset)&&(b=b.createRange(),b.setStart(e.node,e.offset),a.removeAllRanges(),f>d?(a.addRange(b),a.extend(g.node,g.offset)):(b.setEnd(g.node,g.offset),
+a.addRange(b)))}b=[];for(a=c;a=a.parentNode;)1===a.nodeType&&b.push({element:a,left:a.scrollLeft,top:a.scrollTop});"function"===typeof c.focus&&c.focus();for(c=0;c<b.length;c++)a=b[c],a.element.scrollLeft=a.left,a.element.scrollTop=a.top}}function dh(a,b,c){var d=c.window===c?c.document:9===c.nodeType?c:c.ownerDocument;Je||null==Jb||Jb!==Qc(d)||(d=Jb,"selectionStart"in d&&Ie(d)?d={start:d.selectionStart,end:d.selectionEnd}:(d=(d.ownerDocument&&d.ownerDocument.defaultView||window).getSelection(),d=
+{anchorNode:d.anchorNode,anchorOffset:d.anchorOffset,focusNode:d.focusNode,focusOffset:d.focusOffset}),rc&&qc(rc,d)||(rc=d,d=ed(Ke,"onSelect"),0<d.length&&(b=new He("onSelect","select",null,b,c),a.push({event:b,listeners:d}),b.target=Jb)))}function gd(a,b){var c={};c[a.toLowerCase()]=b.toLowerCase();c["Webkit"+a]="webkit"+b;c["Moz"+a]="moz"+b;return c}function hd(a){if(Le[a])return Le[a];if(!Kb[a])return a;var b=Kb[a],c;for(c in b)if(b.hasOwnProperty(c)&&c in eh)return Le[a]=b[c];return a}function $a(a,
+b){fh.set(a,b);mb(b,[a])}function gh(a,b,c){var d=a.type||"unknown-event";a.currentTarget=c;mj(d,b,void 0,a);a.currentTarget=null}function Xg(a,b){b=0!==(b&4);for(var c=0;c<a.length;c++){var d=a[c],e=d.event;d=d.listeners;a:{var f=void 0;if(b)for(var g=d.length-1;0<=g;g--){var h=d[g],k=h.instance,n=h.currentTarget;h=h.listener;if(k!==f&&e.isPropagationStopped())break a;gh(e,h,n);f=k}else for(g=0;g<d.length;g++){h=d[g];k=h.instance;n=h.currentTarget;h=h.listener;if(k!==f&&e.isPropagationStopped())break a;
+gh(e,h,n);f=k}}}if(Tc)throw a=ue,Tc=!1,ue=null,a;}function B(a,b){var c=b[Me];void 0===c&&(c=b[Me]=new Set);var d=a+"__bubble";c.has(d)||(hh(b,a,2,!1),c.add(d))}function Ne(a,b,c){var d=0;b&&(d|=4);hh(c,a,d,b)}function sc(a){if(!a[id]){a[id]=!0;cg.forEach(function(b){"selectionchange"!==b&&(Uj.has(b)||Ne(b,!1,a),Ne(b,!0,a))});var b=9===a.nodeType?a:a.ownerDocument;null===b||b[id]||(b[id]=!0,Ne("selectionchange",!1,b))}}function hh(a,b,c,d,e){switch(Lg(b)){case 1:e=zj;break;case 4:e=Aj;break;default:e=
+Be}c=e.bind(null,b,c,a);e=void 0;!Oe||"touchstart"!==b&&"touchmove"!==b&&"wheel"!==b||(e=!0);d?void 0!==e?a.addEventListener(b,c,{capture:!0,passive:e}):a.addEventListener(b,c,!0):void 0!==e?a.addEventListener(b,c,{passive:e}):a.addEventListener(b,c,!1)}function Ce(a,b,c,d,e){var f=d;if(0===(b&1)&&0===(b&2)&&null!==d)a:for(;;){if(null===d)return;var g=d.tag;if(3===g||4===g){var h=d.stateNode.containerInfo;if(h===e||8===h.nodeType&&h.parentNode===e)break;if(4===g)for(g=d.return;null!==g;){var k=g.tag;
+if(3===k||4===k)if(k=g.stateNode.containerInfo,k===e||8===k.nodeType&&k.parentNode===e)return;g=g.return}for(;null!==h;){g=ob(h);if(null===g)return;k=g.tag;if(5===k||6===k){d=f=g;continue a}h=h.parentNode}}d=d.return}wg(function(){var d=f,e=re(c),g=[];a:{var h=fh.get(a);if(void 0!==h){var k=He,m=a;switch(a){case "keypress":if(0===cd(c))break a;case "keydown":case "keyup":k=Vj;break;case "focusin":m="focus";k=Pe;break;case "focusout":m="blur";k=Pe;break;case "beforeblur":case "afterblur":k=Pe;break;
+case "click":if(2===c.button)break a;case "auxclick":case "dblclick":case "mousedown":case "mousemove":case "mouseup":case "mouseout":case "mouseover":case "contextmenu":k=ih;break;case "drag":case "dragend":case "dragenter":case "dragexit":case "dragleave":case "dragover":case "dragstart":case "drop":k=Wj;break;case "touchcancel":case "touchend":case "touchmove":case "touchstart":k=Xj;break;case jh:case kh:case lh:k=Yj;break;case mh:k=Zj;break;case "scroll":k=ak;break;case "wheel":k=bk;break;case "copy":case "cut":case "paste":k=
+ck;break;case "gotpointercapture":case "lostpointercapture":case "pointercancel":case "pointerdown":case "pointermove":case "pointerout":case "pointerover":case "pointerup":k=nh}var l=0!==(b&4),p=!l&&"scroll"===a,w=l?null!==h?h+"Capture":null:h;l=[];for(var A=d,t;null!==A;){t=A;var M=t.stateNode;5===t.tag&&null!==M&&(t=M,null!==w&&(M=fc(A,w),null!=M&&l.push(tc(A,M,t))));if(p)break;A=A.return}0<l.length&&(h=new k(h,m,null,c,e),g.push({event:h,listeners:l}))}}if(0===(b&7)){a:{h="mouseover"===a||"pointerover"===
+a;k="mouseout"===a||"pointerout"===a;if(h&&c!==ze&&(m=c.relatedTarget||c.fromElement)&&(ob(m)||m[Ja]))break a;if(k||h){h=e.window===e?e:(h=e.ownerDocument)?h.defaultView||h.parentWindow:window;if(k){if(m=c.relatedTarget||c.toElement,k=d,m=m?ob(m):null,null!==m&&(p=nb(m),m!==p||5!==m.tag&&6!==m.tag))m=null}else k=null,m=d;if(k!==m){l=ih;M="onMouseLeave";w="onMouseEnter";A="mouse";if("pointerout"===a||"pointerover"===a)l=nh,M="onPointerLeave",w="onPointerEnter",A="pointer";p=null==k?h:Ib(k);t=null==
+m?h:Ib(m);h=new l(M,A+"leave",k,c,e);h.target=p;h.relatedTarget=t;M=null;ob(e)===d&&(l=new l(w,A+"enter",m,c,e),l.target=t,l.relatedTarget=p,M=l);p=M;if(k&&m)b:{l=k;w=m;A=0;for(t=l;t;t=Lb(t))A++;t=0;for(M=w;M;M=Lb(M))t++;for(;0<A-t;)l=Lb(l),A--;for(;0<t-A;)w=Lb(w),t--;for(;A--;){if(l===w||null!==w&&l===w.alternate)break b;l=Lb(l);w=Lb(w)}l=null}else l=null;null!==k&&oh(g,h,k,l,!1);null!==m&&null!==p&&oh(g,p,m,l,!0)}}}a:{h=d?Ib(d):window;k=h.nodeName&&h.nodeName.toLowerCase();if("select"===k||"input"===
+k&&"file"===h.type)var ma=Nj;else if(Vg(h))if(ph)ma=Rj;else{ma=Pj;var va=Oj}else(k=h.nodeName)&&"input"===k.toLowerCase()&&("checkbox"===h.type||"radio"===h.type)&&(ma=Qj);if(ma&&(ma=ma(a,d))){Wg(g,ma,c,e);break a}va&&va(a,h,d);"focusout"===a&&(va=h._wrapperState)&&va.controlled&&"number"===h.type&&me(h,"number",h.value)}va=d?Ib(d):window;switch(a){case "focusin":if(Vg(va)||"true"===va.contentEditable)Jb=va,Ke=d,rc=null;break;case "focusout":rc=Ke=Jb=null;break;case "mousedown":Je=!0;break;case "contextmenu":case "mouseup":case "dragend":Je=
+!1;dh(g,c,e);break;case "selectionchange":if(dk)break;case "keydown":case "keyup":dh(g,c,e)}var ab;if(Ge)b:{switch(a){case "compositionstart":var da="onCompositionStart";break b;case "compositionend":da="onCompositionEnd";break b;case "compositionupdate":da="onCompositionUpdate";break b}da=void 0}else Hb?Qg(a,c)&&(da="onCompositionEnd"):"keydown"===a&&229===c.keyCode&&(da="onCompositionStart");da&&(Ug&&"ko"!==c.locale&&(Hb||"onCompositionStart"!==da?"onCompositionEnd"===da&&Hb&&(ab=Og()):(Za=e,Ee=
+"value"in Za?Za.value:Za.textContent,Hb=!0)),va=ed(d,da),0<va.length&&(da=new qh(da,a,null,c,e),g.push({event:da,listeners:va}),ab?da.data=ab:(ab=Rg(c),null!==ab&&(da.data=ab))));if(ab=ek?Ij(a,c):Jj(a,c))d=ed(d,"onBeforeInput"),0<d.length&&(e=new fk("onBeforeInput","beforeinput",null,c,e),g.push({event:e,listeners:d}),e.data=ab)}Xg(g,b)})}function tc(a,b,c){return{instance:a,listener:b,currentTarget:c}}function ed(a,b){for(var c=b+"Capture",d=[];null!==a;){var e=a,f=e.stateNode;5===e.tag&&null!==
+f&&(e=f,f=fc(a,c),null!=f&&d.unshift(tc(a,f,e)),f=fc(a,b),null!=f&&d.push(tc(a,f,e)));a=a.return}return d}function Lb(a){if(null===a)return null;do a=a.return;while(a&&5!==a.tag);return a?a:null}function oh(a,b,c,d,e){for(var f=b._reactName,g=[];null!==c&&c!==d;){var h=c,k=h.alternate,n=h.stateNode;if(null!==k&&k===d)break;5===h.tag&&null!==n&&(h=n,e?(k=fc(c,f),null!=k&&g.unshift(tc(c,k,h))):e||(k=fc(c,f),null!=k&&g.push(tc(c,k,h))));c=c.return}0!==g.length&&a.push({event:b,listeners:g})}function rh(a){return("string"===
+typeof a?a:""+a).replace(gk,"\n").replace(hk,"")}function jd(a,b,c,d){b=rh(b);if(rh(a)!==b&&c)throw Error(m(425));}function kd(){}function Qe(a,b){return"textarea"===a||"noscript"===a||"string"===typeof b.children||"number"===typeof b.children||"object"===typeof b.dangerouslySetInnerHTML&&null!==b.dangerouslySetInnerHTML&&null!=b.dangerouslySetInnerHTML.__html}function ik(a){setTimeout(function(){throw a;})}function Re(a,b){var c=b,d=0;do{var e=c.nextSibling;a.removeChild(c);if(e&&8===e.nodeType)if(c=
+e.data,"/$"===c){if(0===d){a.removeChild(e);nc(b);return}d--}else"$"!==c&&"$?"!==c&&"$!"!==c||d++;c=e}while(c);nc(b)}function Ka(a){for(;null!=a;a=a.nextSibling){var b=a.nodeType;if(1===b||3===b)break;if(8===b){b=a.data;if("$"===b||"$!"===b||"$?"===b)break;if("/$"===b)return null}}return a}function sh(a){a=a.previousSibling;for(var b=0;a;){if(8===a.nodeType){var c=a.data;if("$"===c||"$!"===c||"$?"===c){if(0===b)return a;b--}else"/$"===c&&b++}a=a.previousSibling}return null}function ob(a){var b=a[Da];
+if(b)return b;for(var c=a.parentNode;c;){if(b=c[Ja]||c[Da]){c=b.alternate;if(null!==b.child||null!==c&&null!==c.child)for(a=sh(a);null!==a;){if(c=a[Da])return c;a=sh(a)}return b}a=c;c=a.parentNode}return null}function ec(a){a=a[Da]||a[Ja];return!a||5!==a.tag&&6!==a.tag&&13!==a.tag&&3!==a.tag?null:a}function Ib(a){if(5===a.tag||6===a.tag)return a.stateNode;throw Error(m(33));}function Rc(a){return a[uc]||null}function bb(a){return{current:a}}function v(a,b){0>Mb||(a.current=Se[Mb],Se[Mb]=null,Mb--)}
+function y(a,b,c){Mb++;Se[Mb]=a.current;a.current=b}function Nb(a,b){var c=a.type.contextTypes;if(!c)return cb;var d=a.stateNode;if(d&&d.__reactInternalMemoizedUnmaskedChildContext===b)return d.__reactInternalMemoizedMaskedChildContext;var e={},f;for(f in c)e[f]=b[f];d&&(a=a.stateNode,a.__reactInternalMemoizedUnmaskedChildContext=b,a.__reactInternalMemoizedMaskedChildContext=e);return e}function ea(a){a=a.childContextTypes;return null!==a&&void 0!==a}function th(a,b,c){if(J.current!==cb)throw Error(m(168));
+y(J,b);y(S,c)}function uh(a,b,c){var d=a.stateNode;b=b.childContextTypes;if("function"!==typeof d.getChildContext)return c;d=d.getChildContext();for(var e in d)if(!(e in b))throw Error(m(108,gj(a)||"Unknown",e));return E({},c,d)}function ld(a){a=(a=a.stateNode)&&a.__reactInternalMemoizedMergedChildContext||cb;pb=J.current;y(J,a);y(S,S.current);return!0}function vh(a,b,c){var d=a.stateNode;if(!d)throw Error(m(169));c?(a=uh(a,b,pb),d.__reactInternalMemoizedMergedChildContext=a,v(S),v(J),y(J,a)):v(S);
+y(S,c)}function wh(a){null===La?La=[a]:La.push(a)}function jk(a){md=!0;wh(a)}function db(){if(!Te&&null!==La){Te=!0;var a=0,b=z;try{var c=La;for(z=1;a<c.length;a++){var d=c[a];do d=d(!0);while(null!==d)}La=null;md=!1}catch(e){throw null!==La&&(La=La.slice(a+1)),xh(De,db),e;}finally{z=b,Te=!1}}return null}function qb(a,b){Ob[Pb++]=nd;Ob[Pb++]=od;od=a;nd=b}function yh(a,b,c){na[oa++]=Ma;na[oa++]=Na;na[oa++]=rb;rb=a;var d=Ma;a=Na;var e=32-ta(d)-1;d&=~(1<<e);c+=1;var f=32-ta(b)+e;if(30<f){var g=e-e%5;
+f=(d&(1<<g)-1).toString(32);d>>=g;e-=g;Ma=1<<32-ta(b)+e|c<<e|d;Na=f+a}else Ma=1<<f|c<<e|d,Na=a}function Ue(a){null!==a.return&&(qb(a,1),yh(a,1,0))}function Ve(a){for(;a===od;)od=Ob[--Pb],Ob[Pb]=null,nd=Ob[--Pb],Ob[Pb]=null;for(;a===rb;)rb=na[--oa],na[oa]=null,Na=na[--oa],na[oa]=null,Ma=na[--oa],na[oa]=null}function zh(a,b){var c=pa(5,null,null,0);c.elementType="DELETED";c.stateNode=b;c.return=a;b=a.deletions;null===b?(a.deletions=[c],a.flags|=16):b.push(c)}function Ah(a,b){switch(a.tag){case 5:var c=
+a.type;b=1!==b.nodeType||c.toLowerCase()!==b.nodeName.toLowerCase()?null:b;return null!==b?(a.stateNode=b,la=a,fa=Ka(b.firstChild),!0):!1;case 6:return b=""===a.pendingProps||3!==b.nodeType?null:b,null!==b?(a.stateNode=b,la=a,fa=null,!0):!1;case 13:return b=8!==b.nodeType?null:b,null!==b?(c=null!==rb?{id:Ma,overflow:Na}:null,a.memoizedState={dehydrated:b,treeContext:c,retryLane:1073741824},c=pa(18,null,null,0),c.stateNode=b,c.return=a,a.child=c,la=a,fa=null,!0):!1;default:return!1}}function We(a){return 0!==
+(a.mode&1)&&0===(a.flags&128)}function Xe(a){if(D){var b=fa;if(b){var c=b;if(!Ah(a,b)){if(We(a))throw Error(m(418));b=Ka(c.nextSibling);var d=la;b&&Ah(a,b)?zh(d,c):(a.flags=a.flags&-4097|2,D=!1,la=a)}}else{if(We(a))throw Error(m(418));a.flags=a.flags&-4097|2;D=!1;la=a}}}function Bh(a){for(a=a.return;null!==a&&5!==a.tag&&3!==a.tag&&13!==a.tag;)a=a.return;la=a}function pd(a){if(a!==la)return!1;if(!D)return Bh(a),D=!0,!1;var b;(b=3!==a.tag)&&!(b=5!==a.tag)&&(b=a.type,b="head"!==b&&"body"!==b&&!Qe(a.type,
+a.memoizedProps));if(b&&(b=fa)){if(We(a)){for(a=fa;a;)a=Ka(a.nextSibling);throw Error(m(418));}for(;b;)zh(a,b),b=Ka(b.nextSibling)}Bh(a);if(13===a.tag){a=a.memoizedState;a=null!==a?a.dehydrated:null;if(!a)throw Error(m(317));a:{a=a.nextSibling;for(b=0;a;){if(8===a.nodeType){var c=a.data;if("/$"===c){if(0===b){fa=Ka(a.nextSibling);break a}b--}else"$"!==c&&"$!"!==c&&"$?"!==c||b++}a=a.nextSibling}fa=null}}else fa=la?Ka(a.stateNode.nextSibling):null;return!0}function Qb(){fa=la=null;D=!1}function Ye(a){null===
+wa?wa=[a]:wa.push(a)}function vc(a,b,c){a=c.ref;if(null!==a&&"function"!==typeof a&&"object"!==typeof a){if(c._owner){c=c._owner;if(c){if(1!==c.tag)throw Error(m(309));var d=c.stateNode}if(!d)throw Error(m(147,a));var e=d,f=""+a;if(null!==b&&null!==b.ref&&"function"===typeof b.ref&&b.ref._stringRef===f)return b.ref;b=function(a){var b=e.refs;null===a?delete b[f]:b[f]=a};b._stringRef=f;return b}if("string"!==typeof a)throw Error(m(284));if(!c._owner)throw Error(m(290,a));}return a}function qd(a,b){a=
+Object.prototype.toString.call(b);throw Error(m(31,"[object Object]"===a?"object with keys {"+Object.keys(b).join(", ")+"}":a));}function Ch(a){var b=a._init;return b(a._payload)}function Dh(a){function b(b,c){if(a){var d=b.deletions;null===d?(b.deletions=[c],b.flags|=16):d.push(c)}}function c(c,d){if(!a)return null;for(;null!==d;)b(c,d),d=d.sibling;return null}function d(a,b){for(a=new Map;null!==b;)null!==b.key?a.set(b.key,b):a.set(b.index,b),b=b.sibling;return a}function e(a,b){a=eb(a,b);a.index=
+0;a.sibling=null;return a}function f(b,c,d){b.index=d;if(!a)return b.flags|=1048576,c;d=b.alternate;if(null!==d)return d=d.index,d<c?(b.flags|=2,c):d;b.flags|=2;return c}function g(b){a&&null===b.alternate&&(b.flags|=2);return b}function h(a,b,c,d){if(null===b||6!==b.tag)return b=Ze(c,a.mode,d),b.return=a,b;b=e(b,c);b.return=a;return b}function k(a,b,c,d){var f=c.type;if(f===Bb)return l(a,b,c.props.children,d,c.key);if(null!==b&&(b.elementType===f||"object"===typeof f&&null!==f&&f.$$typeof===Ta&&
+Ch(f)===b.type))return d=e(b,c.props),d.ref=vc(a,b,c),d.return=a,d;d=rd(c.type,c.key,c.props,null,a.mode,d);d.ref=vc(a,b,c);d.return=a;return d}function n(a,b,c,d){if(null===b||4!==b.tag||b.stateNode.containerInfo!==c.containerInfo||b.stateNode.implementation!==c.implementation)return b=$e(c,a.mode,d),b.return=a,b;b=e(b,c.children||[]);b.return=a;return b}function l(a,b,c,d,f){if(null===b||7!==b.tag)return b=sb(c,a.mode,d,f),b.return=a,b;b=e(b,c);b.return=a;return b}function u(a,b,c){if("string"===
+typeof b&&""!==b||"number"===typeof b)return b=Ze(""+b,a.mode,c),b.return=a,b;if("object"===typeof b&&null!==b){switch(b.$$typeof){case sd:return c=rd(b.type,b.key,b.props,null,a.mode,c),c.ref=vc(a,null,b),c.return=a,c;case Cb:return b=$e(b,a.mode,c),b.return=a,b;case Ta:var d=b._init;return u(a,d(b._payload),c)}if(cc(b)||ac(b))return b=sb(b,a.mode,c,null),b.return=a,b;qd(a,b)}return null}function r(a,b,c,d){var e=null!==b?b.key:null;if("string"===typeof c&&""!==c||"number"===typeof c)return null!==
+e?null:h(a,b,""+c,d);if("object"===typeof c&&null!==c){switch(c.$$typeof){case sd:return c.key===e?k(a,b,c,d):null;case Cb:return c.key===e?n(a,b,c,d):null;case Ta:return e=c._init,r(a,b,e(c._payload),d)}if(cc(c)||ac(c))return null!==e?null:l(a,b,c,d,null);qd(a,c)}return null}function p(a,b,c,d,e){if("string"===typeof d&&""!==d||"number"===typeof d)return a=a.get(c)||null,h(b,a,""+d,e);if("object"===typeof d&&null!==d){switch(d.$$typeof){case sd:return a=a.get(null===d.key?c:d.key)||null,k(b,a,d,
+e);case Cb:return a=a.get(null===d.key?c:d.key)||null,n(b,a,d,e);case Ta:var f=d._init;return p(a,b,c,f(d._payload),e)}if(cc(d)||ac(d))return a=a.get(c)||null,l(b,a,d,e,null);qd(b,d)}return null}function x(e,g,h,k){for(var n=null,m=null,l=g,t=g=0,q=null;null!==l&&t<h.length;t++){l.index>t?(q=l,l=null):q=l.sibling;var A=r(e,l,h[t],k);if(null===A){null===l&&(l=q);break}a&&l&&null===A.alternate&&b(e,l);g=f(A,g,t);null===m?n=A:m.sibling=A;m=A;l=q}if(t===h.length)return c(e,l),D&&qb(e,t),n;if(null===l){for(;t<
+h.length;t++)l=u(e,h[t],k),null!==l&&(g=f(l,g,t),null===m?n=l:m.sibling=l,m=l);D&&qb(e,t);return n}for(l=d(e,l);t<h.length;t++)q=p(l,e,t,h[t],k),null!==q&&(a&&null!==q.alternate&&l.delete(null===q.key?t:q.key),g=f(q,g,t),null===m?n=q:m.sibling=q,m=q);a&&l.forEach(function(a){return b(e,a)});D&&qb(e,t);return n}function I(e,g,h,k){var n=ac(h);if("function"!==typeof n)throw Error(m(150));h=n.call(h);if(null==h)throw Error(m(151));for(var l=n=null,q=g,t=g=0,A=null,w=h.next();null!==q&&!w.done;t++,w=
+h.next()){q.index>t?(A=q,q=null):A=q.sibling;var x=r(e,q,w.value,k);if(null===x){null===q&&(q=A);break}a&&q&&null===x.alternate&&b(e,q);g=f(x,g,t);null===l?n=x:l.sibling=x;l=x;q=A}if(w.done)return c(e,q),D&&qb(e,t),n;if(null===q){for(;!w.done;t++,w=h.next())w=u(e,w.value,k),null!==w&&(g=f(w,g,t),null===l?n=w:l.sibling=w,l=w);D&&qb(e,t);return n}for(q=d(e,q);!w.done;t++,w=h.next())w=p(q,e,t,w.value,k),null!==w&&(a&&null!==w.alternate&&q.delete(null===w.key?t:w.key),g=f(w,g,t),null===l?n=w:l.sibling=
+w,l=w);a&&q.forEach(function(a){return b(e,a)});D&&qb(e,t);return n}function v(a,d,f,h){"object"===typeof f&&null!==f&&f.type===Bb&&null===f.key&&(f=f.props.children);if("object"===typeof f&&null!==f){switch(f.$$typeof){case sd:a:{for(var k=f.key,n=d;null!==n;){if(n.key===k){k=f.type;if(k===Bb){if(7===n.tag){c(a,n.sibling);d=e(n,f.props.children);d.return=a;a=d;break a}}else if(n.elementType===k||"object"===typeof k&&null!==k&&k.$$typeof===Ta&&Ch(k)===n.type){c(a,n.sibling);d=e(n,f.props);d.ref=vc(a,
+n,f);d.return=a;a=d;break a}c(a,n);break}else b(a,n);n=n.sibling}f.type===Bb?(d=sb(f.props.children,a.mode,h,f.key),d.return=a,a=d):(h=rd(f.type,f.key,f.props,null,a.mode,h),h.ref=vc(a,d,f),h.return=a,a=h)}return g(a);case Cb:a:{for(n=f.key;null!==d;){if(d.key===n)if(4===d.tag&&d.stateNode.containerInfo===f.containerInfo&&d.stateNode.implementation===f.implementation){c(a,d.sibling);d=e(d,f.children||[]);d.return=a;a=d;break a}else{c(a,d);break}else b(a,d);d=d.sibling}d=$e(f,a.mode,h);d.return=a;
+a=d}return g(a);case Ta:return n=f._init,v(a,d,n(f._payload),h)}if(cc(f))return x(a,d,f,h);if(ac(f))return I(a,d,f,h);qd(a,f)}return"string"===typeof f&&""!==f||"number"===typeof f?(f=""+f,null!==d&&6===d.tag?(c(a,d.sibling),d=e(d,f),d.return=a,a=d):(c(a,d),d=Ze(f,a.mode,h),d.return=a,a=d),g(a)):c(a,d)}return v}function af(){bf=Rb=td=null}function cf(a,b){b=ud.current;v(ud);a._currentValue=b}function df(a,b,c){for(;null!==a;){var d=a.alternate;(a.childLanes&b)!==b?(a.childLanes|=b,null!==d&&(d.childLanes|=
+b)):null!==d&&(d.childLanes&b)!==b&&(d.childLanes|=b);if(a===c)break;a=a.return}}function Sb(a,b){td=a;bf=Rb=null;a=a.dependencies;null!==a&&null!==a.firstContext&&(0!==(a.lanes&b)&&(ha=!0),a.firstContext=null)}function qa(a){var b=a._currentValue;if(bf!==a)if(a={context:a,memoizedValue:b,next:null},null===Rb){if(null===td)throw Error(m(308));Rb=a;td.dependencies={lanes:0,firstContext:a}}else Rb=Rb.next=a;return b}function ef(a){null===tb?tb=[a]:tb.push(a)}function Eh(a,b,c,d){var e=b.interleaved;
+null===e?(c.next=c,ef(b)):(c.next=e.next,e.next=c);b.interleaved=c;return Oa(a,d)}function Oa(a,b){a.lanes|=b;var c=a.alternate;null!==c&&(c.lanes|=b);c=a;for(a=a.return;null!==a;)a.childLanes|=b,c=a.alternate,null!==c&&(c.childLanes|=b),c=a,a=a.return;return 3===c.tag?c.stateNode:null}function ff(a){a.updateQueue={baseState:a.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,interleaved:null,lanes:0},effects:null}}function Fh(a,b){a=a.updateQueue;b.updateQueue===a&&(b.updateQueue=
+{baseState:a.baseState,firstBaseUpdate:a.firstBaseUpdate,lastBaseUpdate:a.lastBaseUpdate,shared:a.shared,effects:a.effects})}function Pa(a,b){return{eventTime:a,lane:b,tag:0,payload:null,callback:null,next:null}}function fb(a,b,c){var d=a.updateQueue;if(null===d)return null;d=d.shared;if(0!==(p&2)){var e=d.pending;null===e?b.next=b:(b.next=e.next,e.next=b);d.pending=b;return kk(a,c)}e=d.interleaved;null===e?(b.next=b,ef(d)):(b.next=e.next,e.next=b);d.interleaved=b;return Oa(a,c)}function vd(a,b,c){b=
+b.updateQueue;if(null!==b&&(b=b.shared,0!==(c&4194240))){var d=b.lanes;d&=a.pendingLanes;c|=d;b.lanes=c;xe(a,c)}}function Gh(a,b){var c=a.updateQueue,d=a.alternate;if(null!==d&&(d=d.updateQueue,c===d)){var e=null,f=null;c=c.firstBaseUpdate;if(null!==c){do{var g={eventTime:c.eventTime,lane:c.lane,tag:c.tag,payload:c.payload,callback:c.callback,next:null};null===f?e=f=g:f=f.next=g;c=c.next}while(null!==c);null===f?e=f=b:f=f.next=b}else e=f=b;c={baseState:d.baseState,firstBaseUpdate:e,lastBaseUpdate:f,
+shared:d.shared,effects:d.effects};a.updateQueue=c;return}a=c.lastBaseUpdate;null===a?c.firstBaseUpdate=b:a.next=b;c.lastBaseUpdate=b}function wd(a,b,c,d){var e=a.updateQueue;gb=!1;var f=e.firstBaseUpdate,g=e.lastBaseUpdate,h=e.shared.pending;if(null!==h){e.shared.pending=null;var k=h,n=k.next;k.next=null;null===g?f=n:g.next=n;g=k;var l=a.alternate;null!==l&&(l=l.updateQueue,h=l.lastBaseUpdate,h!==g&&(null===h?l.firstBaseUpdate=n:h.next=n,l.lastBaseUpdate=k))}if(null!==f){var m=e.baseState;g=0;l=
+n=k=null;h=f;do{var r=h.lane,p=h.eventTime;if((d&r)===r){null!==l&&(l=l.next={eventTime:p,lane:0,tag:h.tag,payload:h.payload,callback:h.callback,next:null});a:{var x=a,v=h;r=b;p=c;switch(v.tag){case 1:x=v.payload;if("function"===typeof x){m=x.call(p,m,r);break a}m=x;break a;case 3:x.flags=x.flags&-65537|128;case 0:x=v.payload;r="function"===typeof x?x.call(p,m,r):x;if(null===r||void 0===r)break a;m=E({},m,r);break a;case 2:gb=!0}}null!==h.callback&&0!==h.lane&&(a.flags|=64,r=e.effects,null===r?e.effects=
+[h]:r.push(h))}else p={eventTime:p,lane:r,tag:h.tag,payload:h.payload,callback:h.callback,next:null},null===l?(n=l=p,k=m):l=l.next=p,g|=r;h=h.next;if(null===h)if(h=e.shared.pending,null===h)break;else r=h,h=r.next,r.next=null,e.lastBaseUpdate=r,e.shared.pending=null}while(1);null===l&&(k=m);e.baseState=k;e.firstBaseUpdate=n;e.lastBaseUpdate=l;b=e.shared.interleaved;if(null!==b){e=b;do g|=e.lane,e=e.next;while(e!==b)}else null===f&&(e.shared.lanes=0);ra|=g;a.lanes=g;a.memoizedState=m}}function Hh(a,
+b,c){a=b.effects;b.effects=null;if(null!==a)for(b=0;b<a.length;b++){var d=a[b],e=d.callback;if(null!==e){d.callback=null;d=c;if("function"!==typeof e)throw Error(m(191,e));e.call(d)}}}function ub(a){if(a===wc)throw Error(m(174));return a}function gf(a,b){y(xc,b);y(yc,a);y(Ea,wc);a=b.nodeType;switch(a){case 9:case 11:b=(b=b.documentElement)?b.namespaceURI:oe(null,"");break;default:a=8===a?b.parentNode:b,b=a.namespaceURI||null,a=a.tagName,b=oe(b,a)}v(Ea);y(Ea,b)}function Tb(a){v(Ea);v(yc);v(xc)}function Ih(a){ub(xc.current);
+var b=ub(Ea.current);var c=oe(b,a.type);b!==c&&(y(yc,a),y(Ea,c))}function hf(a){yc.current===a&&(v(Ea),v(yc))}function xd(a){for(var b=a;null!==b;){if(13===b.tag){var c=b.memoizedState;if(null!==c&&(c=c.dehydrated,null===c||"$?"===c.data||"$!"===c.data))return b}else if(19===b.tag&&void 0!==b.memoizedProps.revealOrder){if(0!==(b.flags&128))return b}else if(null!==b.child){b.child.return=b;b=b.child;continue}if(b===a)break;for(;null===b.sibling;){if(null===b.return||b.return===a)return null;b=b.return}b.sibling.return=
+b.return;b=b.sibling}return null}function jf(){for(var a=0;a<kf.length;a++)kf[a]._workInProgressVersionPrimary=null;kf.length=0}function V(){throw Error(m(321));}function lf(a,b){if(null===b)return!1;for(var c=0;c<b.length&&c<a.length;c++)if(!ua(a[c],b[c]))return!1;return!0}function mf(a,b,c,d,e,f){vb=f;C=b;b.memoizedState=null;b.updateQueue=null;b.lanes=0;yd.current=null===a||null===a.memoizedState?lk:mk;a=c(d,e);if(zc){f=0;do{zc=!1;Ac=0;if(25<=f)throw Error(m(301));f+=1;N=K=null;b.updateQueue=null;
+yd.current=nk;a=c(d,e)}while(zc)}yd.current=zd;b=null!==K&&null!==K.next;vb=0;N=K=C=null;Ad=!1;if(b)throw Error(m(300));return a}function nf(){var a=0!==Ac;Ac=0;return a}function Fa(){var a={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};null===N?C.memoizedState=N=a:N=N.next=a;return N}function sa(){if(null===K){var a=C.alternate;a=null!==a?a.memoizedState:null}else a=K.next;var b=null===N?C.memoizedState:N.next;if(null!==b)N=b,K=a;else{if(null===a)throw Error(m(310));K=a;
+a={memoizedState:K.memoizedState,baseState:K.baseState,baseQueue:K.baseQueue,queue:K.queue,next:null};null===N?C.memoizedState=N=a:N=N.next=a}return N}function Bc(a,b){return"function"===typeof b?b(a):b}function of(a,b,c){b=sa();c=b.queue;if(null===c)throw Error(m(311));c.lastRenderedReducer=a;var d=K,e=d.baseQueue,f=c.pending;if(null!==f){if(null!==e){var g=e.next;e.next=f.next;f.next=g}d.baseQueue=e=f;c.pending=null}if(null!==e){f=e.next;d=d.baseState;var h=g=null,k=null,n=f;do{var l=n.lane;if((vb&
+l)===l)null!==k&&(k=k.next={lane:0,action:n.action,hasEagerState:n.hasEagerState,eagerState:n.eagerState,next:null}),d=n.hasEagerState?n.eagerState:a(d,n.action);else{var u={lane:l,action:n.action,hasEagerState:n.hasEagerState,eagerState:n.eagerState,next:null};null===k?(h=k=u,g=d):k=k.next=u;C.lanes|=l;ra|=l}n=n.next}while(null!==n&&n!==f);null===k?g=d:k.next=h;ua(d,b.memoizedState)||(ha=!0);b.memoizedState=d;b.baseState=g;b.baseQueue=k;c.lastRenderedState=d}a=c.interleaved;if(null!==a){e=a;do f=
+e.lane,C.lanes|=f,ra|=f,e=e.next;while(e!==a)}else null===e&&(c.lanes=0);return[b.memoizedState,c.dispatch]}function pf(a,b,c){b=sa();c=b.queue;if(null===c)throw Error(m(311));c.lastRenderedReducer=a;var d=c.dispatch,e=c.pending,f=b.memoizedState;if(null!==e){c.pending=null;var g=e=e.next;do f=a(f,g.action),g=g.next;while(g!==e);ua(f,b.memoizedState)||(ha=!0);b.memoizedState=f;null===b.baseQueue&&(b.baseState=f);c.lastRenderedState=f}return[f,d]}function Jh(a,b,c){}function Kh(a,b,c){c=C;var d=sa(),
+e=b(),f=!ua(d.memoizedState,e);f&&(d.memoizedState=e,ha=!0);d=d.queue;qf(Lh.bind(null,c,d,a),[a]);if(d.getSnapshot!==b||f||null!==N&&N.memoizedState.tag&1){c.flags|=2048;Cc(9,Mh.bind(null,c,d,e,b),void 0,null);if(null===O)throw Error(m(349));0!==(vb&30)||Nh(c,b,e)}return e}function Nh(a,b,c){a.flags|=16384;a={getSnapshot:b,value:c};b=C.updateQueue;null===b?(b={lastEffect:null,stores:null},C.updateQueue=b,b.stores=[a]):(c=b.stores,null===c?b.stores=[a]:c.push(a))}function Mh(a,b,c,d){b.value=c;b.getSnapshot=
+d;Oh(b)&&Ph(a)}function Lh(a,b,c){return c(function(){Oh(b)&&Ph(a)})}function Oh(a){var b=a.getSnapshot;a=a.value;try{var c=b();return!ua(a,c)}catch(d){return!0}}function Ph(a){var b=Oa(a,1);null!==b&&xa(b,a,1,-1)}function Qh(a){var b=Fa();"function"===typeof a&&(a=a());b.memoizedState=b.baseState=a;a={pending:null,interleaved:null,lanes:0,dispatch:null,lastRenderedReducer:Bc,lastRenderedState:a};b.queue=a;a=a.dispatch=ok.bind(null,C,a);return[b.memoizedState,a]}function Cc(a,b,c,d){a={tag:a,create:b,
+destroy:c,deps:d,next:null};b=C.updateQueue;null===b?(b={lastEffect:null,stores:null},C.updateQueue=b,b.lastEffect=a.next=a):(c=b.lastEffect,null===c?b.lastEffect=a.next=a:(d=c.next,c.next=a,a.next=d,b.lastEffect=a));return a}function Rh(a){return sa().memoizedState}function Bd(a,b,c,d){var e=Fa();C.flags|=a;e.memoizedState=Cc(1|b,c,void 0,void 0===d?null:d)}function Cd(a,b,c,d){var e=sa();d=void 0===d?null:d;var f=void 0;if(null!==K){var g=K.memoizedState;f=g.destroy;if(null!==d&&lf(d,g.deps)){e.memoizedState=
+Cc(b,c,f,d);return}}C.flags|=a;e.memoizedState=Cc(1|b,c,f,d)}function Sh(a,b){return Bd(8390656,8,a,b)}function qf(a,b){return Cd(2048,8,a,b)}function Th(a,b){return Cd(4,2,a,b)}function Uh(a,b){return Cd(4,4,a,b)}function Vh(a,b){if("function"===typeof b)return a=a(),b(a),function(){b(null)};if(null!==b&&void 0!==b)return a=a(),b.current=a,function(){b.current=null}}function Wh(a,b,c){c=null!==c&&void 0!==c?c.concat([a]):null;return Cd(4,4,Vh.bind(null,b,a),c)}function rf(a,b){}function Xh(a,b){var c=
+sa();b=void 0===b?null:b;var d=c.memoizedState;if(null!==d&&null!==b&&lf(b,d[1]))return d[0];c.memoizedState=[a,b];return a}function Yh(a,b){var c=sa();b=void 0===b?null:b;var d=c.memoizedState;if(null!==d&&null!==b&&lf(b,d[1]))return d[0];a=a();c.memoizedState=[a,b];return a}function Zh(a,b,c){if(0===(vb&21))return a.baseState&&(a.baseState=!1,ha=!0),a.memoizedState=c;ua(c,b)||(c=Dg(),C.lanes|=c,ra|=c,a.baseState=!0);return b}function pk(a,b,c){c=z;z=0!==c&&4>c?c:4;a(!0);var d=sf.transition;sf.transition=
+{};try{a(!1),b()}finally{z=c,sf.transition=d}}function $h(){return sa().memoizedState}function qk(a,b,c){var d=hb(a);c={lane:d,action:c,hasEagerState:!1,eagerState:null,next:null};if(ai(a))bi(b,c);else if(c=Eh(a,b,c,d),null!==c){var e=Z();xa(c,a,d,e);ci(c,b,d)}}function ok(a,b,c){var d=hb(a),e={lane:d,action:c,hasEagerState:!1,eagerState:null,next:null};if(ai(a))bi(b,e);else{var f=a.alternate;if(0===a.lanes&&(null===f||0===f.lanes)&&(f=b.lastRenderedReducer,null!==f))try{var g=b.lastRenderedState,
+h=f(g,c);e.hasEagerState=!0;e.eagerState=h;if(ua(h,g)){var k=b.interleaved;null===k?(e.next=e,ef(b)):(e.next=k.next,k.next=e);b.interleaved=e;return}}catch(n){}finally{}c=Eh(a,b,e,d);null!==c&&(e=Z(),xa(c,a,d,e),ci(c,b,d))}}function ai(a){var b=a.alternate;return a===C||null!==b&&b===C}function bi(a,b){zc=Ad=!0;var c=a.pending;null===c?b.next=b:(b.next=c.next,c.next=b);a.pending=b}function ci(a,b,c){if(0!==(c&4194240)){var d=b.lanes;d&=a.pendingLanes;c|=d;b.lanes=c;xe(a,c)}}function ya(a,b){if(a&&
+a.defaultProps){b=E({},b);a=a.defaultProps;for(var c in a)void 0===b[c]&&(b[c]=a[c]);return b}return b}function tf(a,b,c,d){b=a.memoizedState;c=c(d,b);c=null===c||void 0===c?b:E({},b,c);a.memoizedState=c;0===a.lanes&&(a.updateQueue.baseState=c)}function di(a,b,c,d,e,f,g){a=a.stateNode;return"function"===typeof a.shouldComponentUpdate?a.shouldComponentUpdate(d,f,g):b.prototype&&b.prototype.isPureReactComponent?!qc(c,d)||!qc(e,f):!0}function ei(a,b,c){var d=!1,e=cb;var f=b.contextType;"object"===typeof f&&
+null!==f?f=qa(f):(e=ea(b)?pb:J.current,d=b.contextTypes,f=(d=null!==d&&void 0!==d)?Nb(a,e):cb);b=new b(c,f);a.memoizedState=null!==b.state&&void 0!==b.state?b.state:null;b.updater=Dd;a.stateNode=b;b._reactInternals=a;d&&(a=a.stateNode,a.__reactInternalMemoizedUnmaskedChildContext=e,a.__reactInternalMemoizedMaskedChildContext=f);return b}function fi(a,b,c,d){a=b.state;"function"===typeof b.componentWillReceiveProps&&b.componentWillReceiveProps(c,d);"function"===typeof b.UNSAFE_componentWillReceiveProps&&
+b.UNSAFE_componentWillReceiveProps(c,d);b.state!==a&&Dd.enqueueReplaceState(b,b.state,null)}function uf(a,b,c,d){var e=a.stateNode;e.props=c;e.state=a.memoizedState;e.refs={};ff(a);var f=b.contextType;"object"===typeof f&&null!==f?e.context=qa(f):(f=ea(b)?pb:J.current,e.context=Nb(a,f));e.state=a.memoizedState;f=b.getDerivedStateFromProps;"function"===typeof f&&(tf(a,b,f,c),e.state=a.memoizedState);"function"===typeof b.getDerivedStateFromProps||"function"===typeof e.getSnapshotBeforeUpdate||"function"!==
+typeof e.UNSAFE_componentWillMount&&"function"!==typeof e.componentWillMount||(b=e.state,"function"===typeof e.componentWillMount&&e.componentWillMount(),"function"===typeof e.UNSAFE_componentWillMount&&e.UNSAFE_componentWillMount(),b!==e.state&&Dd.enqueueReplaceState(e,e.state,null),wd(a,c,e,d),e.state=a.memoizedState);"function"===typeof e.componentDidMount&&(a.flags|=4194308)}function Ub(a,b){try{var c="",d=b;do c+=fj(d),d=d.return;while(d);var e=c}catch(f){e="\nError generating stack: "+f.message+
+"\n"+f.stack}return{value:a,source:b,stack:e,digest:null}}function vf(a,b,c){return{value:a,source:null,stack:null!=c?c:null,digest:null!=b?b:null}}function wf(a,b){try{console.error(b.value)}catch(c){setTimeout(function(){throw c;})}}function gi(a,b,c){c=Pa(-1,c);c.tag=3;c.payload={element:null};var d=b.value;c.callback=function(){Ed||(Ed=!0,xf=d);wf(a,b)};return c}function hi(a,b,c){c=Pa(-1,c);c.tag=3;var d=a.type.getDerivedStateFromError;if("function"===typeof d){var e=b.value;c.payload=function(){return d(e)};
+c.callback=function(){wf(a,b)}}var f=a.stateNode;null!==f&&"function"===typeof f.componentDidCatch&&(c.callback=function(){wf(a,b);"function"!==typeof d&&(null===ib?ib=new Set([this]):ib.add(this));var c=b.stack;this.componentDidCatch(b.value,{componentStack:null!==c?c:""})});return c}function ii(a,b,c){var d=a.pingCache;if(null===d){d=a.pingCache=new rk;var e=new Set;d.set(b,e)}else e=d.get(b),void 0===e&&(e=new Set,d.set(b,e));e.has(c)||(e.add(c),a=sk.bind(null,a,b,c),b.then(a,a))}function ji(a){do{var b;
+if(b=13===a.tag)b=a.memoizedState,b=null!==b?null!==b.dehydrated?!0:!1:!0;if(b)return a;a=a.return}while(null!==a);return null}function ki(a,b,c,d,e){if(0===(a.mode&1))return a===b?a.flags|=65536:(a.flags|=128,c.flags|=131072,c.flags&=-52805,1===c.tag&&(null===c.alternate?c.tag=17:(b=Pa(-1,1),b.tag=2,fb(c,b,1))),c.lanes|=1),a;a.flags|=65536;a.lanes=e;return a}function aa(a,b,c,d){b.child=null===a?li(b,null,c,d):Vb(b,a.child,c,d)}function mi(a,b,c,d,e){c=c.render;var f=b.ref;Sb(b,e);d=mf(a,b,c,d,f,
+e);c=nf();if(null!==a&&!ha)return b.updateQueue=a.updateQueue,b.flags&=-2053,a.lanes&=~e,Qa(a,b,e);D&&c&&Ue(b);b.flags|=1;aa(a,b,d,e);return b.child}function ni(a,b,c,d,e){if(null===a){var f=c.type;if("function"===typeof f&&!yf(f)&&void 0===f.defaultProps&&null===c.compare&&void 0===c.defaultProps)return b.tag=15,b.type=f,oi(a,b,f,d,e);a=rd(c.type,null,d,b,b.mode,e);a.ref=b.ref;a.return=b;return b.child=a}f=a.child;if(0===(a.lanes&e)){var g=f.memoizedProps;c=c.compare;c=null!==c?c:qc;if(c(g,d)&&a.ref===
+b.ref)return Qa(a,b,e)}b.flags|=1;a=eb(f,d);a.ref=b.ref;a.return=b;return b.child=a}function oi(a,b,c,d,e){if(null!==a){var f=a.memoizedProps;if(qc(f,d)&&a.ref===b.ref)if(ha=!1,b.pendingProps=d=f,0!==(a.lanes&e))0!==(a.flags&131072)&&(ha=!0);else return b.lanes=a.lanes,Qa(a,b,e)}return zf(a,b,c,d,e)}function pi(a,b,c){var d=b.pendingProps,e=d.children,f=null!==a?a.memoizedState:null;if("hidden"===d.mode)if(0===(b.mode&1))b.memoizedState={baseLanes:0,cachePool:null,transitions:null},y(Ga,ba),ba|=c;
+else{if(0===(c&1073741824))return a=null!==f?f.baseLanes|c:c,b.lanes=b.childLanes=1073741824,b.memoizedState={baseLanes:a,cachePool:null,transitions:null},b.updateQueue=null,y(Ga,ba),ba|=a,null;b.memoizedState={baseLanes:0,cachePool:null,transitions:null};d=null!==f?f.baseLanes:c;y(Ga,ba);ba|=d}else null!==f?(d=f.baseLanes|c,b.memoizedState=null):d=c,y(Ga,ba),ba|=d;aa(a,b,e,c);return b.child}function qi(a,b){var c=b.ref;if(null===a&&null!==c||null!==a&&a.ref!==c)b.flags|=512,b.flags|=2097152}function zf(a,
+b,c,d,e){var f=ea(c)?pb:J.current;f=Nb(b,f);Sb(b,e);c=mf(a,b,c,d,f,e);d=nf();if(null!==a&&!ha)return b.updateQueue=a.updateQueue,b.flags&=-2053,a.lanes&=~e,Qa(a,b,e);D&&d&&Ue(b);b.flags|=1;aa(a,b,c,e);return b.child}function ri(a,b,c,d,e){if(ea(c)){var f=!0;ld(b)}else f=!1;Sb(b,e);if(null===b.stateNode)Fd(a,b),ei(b,c,d),uf(b,c,d,e),d=!0;else if(null===a){var g=b.stateNode,h=b.memoizedProps;g.props=h;var k=g.context,n=c.contextType;"object"===typeof n&&null!==n?n=qa(n):(n=ea(c)?pb:J.current,n=Nb(b,
+n));var l=c.getDerivedStateFromProps,m="function"===typeof l||"function"===typeof g.getSnapshotBeforeUpdate;m||"function"!==typeof g.UNSAFE_componentWillReceiveProps&&"function"!==typeof g.componentWillReceiveProps||(h!==d||k!==n)&&fi(b,g,d,n);gb=!1;var r=b.memoizedState;g.state=r;wd(b,d,g,e);k=b.memoizedState;h!==d||r!==k||S.current||gb?("function"===typeof l&&(tf(b,c,l,d),k=b.memoizedState),(h=gb||di(b,c,h,d,r,k,n))?(m||"function"!==typeof g.UNSAFE_componentWillMount&&"function"!==typeof g.componentWillMount||
+("function"===typeof g.componentWillMount&&g.componentWillMount(),"function"===typeof g.UNSAFE_componentWillMount&&g.UNSAFE_componentWillMount()),"function"===typeof g.componentDidMount&&(b.flags|=4194308)):("function"===typeof g.componentDidMount&&(b.flags|=4194308),b.memoizedProps=d,b.memoizedState=k),g.props=d,g.state=k,g.context=n,d=h):("function"===typeof g.componentDidMount&&(b.flags|=4194308),d=!1)}else{g=b.stateNode;Fh(a,b);h=b.memoizedProps;n=b.type===b.elementType?h:ya(b.type,h);g.props=
+n;m=b.pendingProps;r=g.context;k=c.contextType;"object"===typeof k&&null!==k?k=qa(k):(k=ea(c)?pb:J.current,k=Nb(b,k));var p=c.getDerivedStateFromProps;(l="function"===typeof p||"function"===typeof g.getSnapshotBeforeUpdate)||"function"!==typeof g.UNSAFE_componentWillReceiveProps&&"function"!==typeof g.componentWillReceiveProps||(h!==m||r!==k)&&fi(b,g,d,k);gb=!1;r=b.memoizedState;g.state=r;wd(b,d,g,e);var x=b.memoizedState;h!==m||r!==x||S.current||gb?("function"===typeof p&&(tf(b,c,p,d),x=b.memoizedState),
+(n=gb||di(b,c,n,d,r,x,k)||!1)?(l||"function"!==typeof g.UNSAFE_componentWillUpdate&&"function"!==typeof g.componentWillUpdate||("function"===typeof g.componentWillUpdate&&g.componentWillUpdate(d,x,k),"function"===typeof g.UNSAFE_componentWillUpdate&&g.UNSAFE_componentWillUpdate(d,x,k)),"function"===typeof g.componentDidUpdate&&(b.flags|=4),"function"===typeof g.getSnapshotBeforeUpdate&&(b.flags|=1024)):("function"!==typeof g.componentDidUpdate||h===a.memoizedProps&&r===a.memoizedState||(b.flags|=
+4),"function"!==typeof g.getSnapshotBeforeUpdate||h===a.memoizedProps&&r===a.memoizedState||(b.flags|=1024),b.memoizedProps=d,b.memoizedState=x),g.props=d,g.state=x,g.context=k,d=n):("function"!==typeof g.componentDidUpdate||h===a.memoizedProps&&r===a.memoizedState||(b.flags|=4),"function"!==typeof g.getSnapshotBeforeUpdate||h===a.memoizedProps&&r===a.memoizedState||(b.flags|=1024),d=!1)}return Af(a,b,c,d,f,e)}function Af(a,b,c,d,e,f){qi(a,b);var g=0!==(b.flags&128);if(!d&&!g)return e&&vh(b,c,!1),
+Qa(a,b,f);d=b.stateNode;tk.current=b;var h=g&&"function"!==typeof c.getDerivedStateFromError?null:d.render();b.flags|=1;null!==a&&g?(b.child=Vb(b,a.child,null,f),b.child=Vb(b,null,h,f)):aa(a,b,h,f);b.memoizedState=d.state;e&&vh(b,c,!0);return b.child}function si(a){var b=a.stateNode;b.pendingContext?th(a,b.pendingContext,b.pendingContext!==b.context):b.context&&th(a,b.context,!1);gf(a,b.containerInfo)}function ti(a,b,c,d,e){Qb();Ye(e);b.flags|=256;aa(a,b,c,d);return b.child}function Bf(a){return{baseLanes:a,
+cachePool:null,transitions:null}}function ui(a,b,c){var d=b.pendingProps,e=F.current,f=!1,g=0!==(b.flags&128),h;(h=g)||(h=null!==a&&null===a.memoizedState?!1:0!==(e&2));if(h)f=!0,b.flags&=-129;else if(null===a||null!==a.memoizedState)e|=1;y(F,e&1);if(null===a){Xe(b);a=b.memoizedState;if(null!==a&&(a=a.dehydrated,null!==a))return 0===(b.mode&1)?b.lanes=1:"$!"===a.data?b.lanes=8:b.lanes=1073741824,null;g=d.children;a=d.fallback;return f?(d=b.mode,f=b.child,g={mode:"hidden",children:g},0===(d&1)&&null!==
+f?(f.childLanes=0,f.pendingProps=g):f=Gd(g,d,0,null),a=sb(a,d,c,null),f.return=b,a.return=b,f.sibling=a,b.child=f,b.child.memoizedState=Bf(c),b.memoizedState=Cf,a):Df(b,g)}e=a.memoizedState;if(null!==e&&(h=e.dehydrated,null!==h))return uk(a,b,g,d,h,e,c);if(f){f=d.fallback;g=b.mode;e=a.child;h=e.sibling;var k={mode:"hidden",children:d.children};0===(g&1)&&b.child!==e?(d=b.child,d.childLanes=0,d.pendingProps=k,b.deletions=null):(d=eb(e,k),d.subtreeFlags=e.subtreeFlags&14680064);null!==h?f=eb(h,f):(f=
+sb(f,g,c,null),f.flags|=2);f.return=b;d.return=b;d.sibling=f;b.child=d;d=f;f=b.child;g=a.child.memoizedState;g=null===g?Bf(c):{baseLanes:g.baseLanes|c,cachePool:null,transitions:g.transitions};f.memoizedState=g;f.childLanes=a.childLanes&~c;b.memoizedState=Cf;return d}f=a.child;a=f.sibling;d=eb(f,{mode:"visible",children:d.children});0===(b.mode&1)&&(d.lanes=c);d.return=b;d.sibling=null;null!==a&&(c=b.deletions,null===c?(b.deletions=[a],b.flags|=16):c.push(a));b.child=d;b.memoizedState=null;return d}
+function Df(a,b,c){b=Gd({mode:"visible",children:b},a.mode,0,null);b.return=a;return a.child=b}function Hd(a,b,c,d){null!==d&&Ye(d);Vb(b,a.child,null,c);a=Df(b,b.pendingProps.children);a.flags|=2;b.memoizedState=null;return a}function uk(a,b,c,d,e,f,g){if(c){if(b.flags&256)return b.flags&=-257,d=vf(Error(m(422))),Hd(a,b,g,d);if(null!==b.memoizedState)return b.child=a.child,b.flags|=128,null;f=d.fallback;e=b.mode;d=Gd({mode:"visible",children:d.children},e,0,null);f=sb(f,e,g,null);f.flags|=2;d.return=
+b;f.return=b;d.sibling=f;b.child=d;0!==(b.mode&1)&&Vb(b,a.child,null,g);b.child.memoizedState=Bf(g);b.memoizedState=Cf;return f}if(0===(b.mode&1))return Hd(a,b,g,null);if("$!"===e.data){d=e.nextSibling&&e.nextSibling.dataset;if(d)var h=d.dgst;d=h;f=Error(m(419));d=vf(f,d,void 0);return Hd(a,b,g,d)}h=0!==(g&a.childLanes);if(ha||h){d=O;if(null!==d){switch(g&-g){case 4:e=2;break;case 16:e=8;break;case 64:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:case 67108864:e=
+32;break;case 536870912:e=268435456;break;default:e=0}e=0!==(e&(d.suspendedLanes|g))?0:e;0!==e&&e!==f.retryLane&&(f.retryLane=e,Oa(a,e),xa(d,a,e,-1))}Ef();d=vf(Error(m(421)));return Hd(a,b,g,d)}if("$?"===e.data)return b.flags|=128,b.child=a.child,b=vk.bind(null,a),e._reactRetry=b,null;a=f.treeContext;fa=Ka(e.nextSibling);la=b;D=!0;wa=null;null!==a&&(na[oa++]=Ma,na[oa++]=Na,na[oa++]=rb,Ma=a.id,Na=a.overflow,rb=b);b=Df(b,d.children);b.flags|=4096;return b}function vi(a,b,c){a.lanes|=b;var d=a.alternate;
+null!==d&&(d.lanes|=b);df(a.return,b,c)}function Ff(a,b,c,d,e){var f=a.memoizedState;null===f?a.memoizedState={isBackwards:b,rendering:null,renderingStartTime:0,last:d,tail:c,tailMode:e}:(f.isBackwards=b,f.rendering=null,f.renderingStartTime=0,f.last=d,f.tail=c,f.tailMode=e)}function wi(a,b,c){var d=b.pendingProps,e=d.revealOrder,f=d.tail;aa(a,b,d.children,c);d=F.current;if(0!==(d&2))d=d&1|2,b.flags|=128;else{if(null!==a&&0!==(a.flags&128))a:for(a=b.child;null!==a;){if(13===a.tag)null!==a.memoizedState&&
+vi(a,c,b);else if(19===a.tag)vi(a,c,b);else if(null!==a.child){a.child.return=a;a=a.child;continue}if(a===b)break a;for(;null===a.sibling;){if(null===a.return||a.return===b)break a;a=a.return}a.sibling.return=a.return;a=a.sibling}d&=1}y(F,d);if(0===(b.mode&1))b.memoizedState=null;else switch(e){case "forwards":c=b.child;for(e=null;null!==c;)a=c.alternate,null!==a&&null===xd(a)&&(e=c),c=c.sibling;c=e;null===c?(e=b.child,b.child=null):(e=c.sibling,c.sibling=null);Ff(b,!1,e,c,f);break;case "backwards":c=
+null;e=b.child;for(b.child=null;null!==e;){a=e.alternate;if(null!==a&&null===xd(a)){b.child=e;break}a=e.sibling;e.sibling=c;c=e;e=a}Ff(b,!0,c,null,f);break;case "together":Ff(b,!1,null,null,void 0);break;default:b.memoizedState=null}return b.child}function Fd(a,b){0===(b.mode&1)&&null!==a&&(a.alternate=null,b.alternate=null,b.flags|=2)}function Qa(a,b,c){null!==a&&(b.dependencies=a.dependencies);ra|=b.lanes;if(0===(c&b.childLanes))return null;if(null!==a&&b.child!==a.child)throw Error(m(153));if(null!==
+b.child){a=b.child;c=eb(a,a.pendingProps);b.child=c;for(c.return=b;null!==a.sibling;)a=a.sibling,c=c.sibling=eb(a,a.pendingProps),c.return=b;c.sibling=null}return b.child}function wk(a,b,c){switch(b.tag){case 3:si(b);Qb();break;case 5:Ih(b);break;case 1:ea(b.type)&&ld(b);break;case 4:gf(b,b.stateNode.containerInfo);break;case 10:var d=b.type._context,e=b.memoizedProps.value;y(ud,d._currentValue);d._currentValue=e;break;case 13:d=b.memoizedState;if(null!==d){if(null!==d.dehydrated)return y(F,F.current&
+1),b.flags|=128,null;if(0!==(c&b.child.childLanes))return ui(a,b,c);y(F,F.current&1);a=Qa(a,b,c);return null!==a?a.sibling:null}y(F,F.current&1);break;case 19:d=0!==(c&b.childLanes);if(0!==(a.flags&128)){if(d)return wi(a,b,c);b.flags|=128}e=b.memoizedState;null!==e&&(e.rendering=null,e.tail=null,e.lastEffect=null);y(F,F.current);if(d)break;else return null;case 22:case 23:return b.lanes=0,pi(a,b,c)}return Qa(a,b,c)}function Dc(a,b){if(!D)switch(a.tailMode){case "hidden":b=a.tail;for(var c=null;null!==
+b;)null!==b.alternate&&(c=b),b=b.sibling;null===c?a.tail=null:c.sibling=null;break;case "collapsed":c=a.tail;for(var d=null;null!==c;)null!==c.alternate&&(d=c),c=c.sibling;null===d?b||null===a.tail?a.tail=null:a.tail.sibling=null:d.sibling=null}}function W(a){var b=null!==a.alternate&&a.alternate.child===a.child,c=0,d=0;if(b)for(var e=a.child;null!==e;)c|=e.lanes|e.childLanes,d|=e.subtreeFlags&14680064,d|=e.flags&14680064,e.return=a,e=e.sibling;else for(e=a.child;null!==e;)c|=e.lanes|e.childLanes,
+d|=e.subtreeFlags,d|=e.flags,e.return=a,e=e.sibling;a.subtreeFlags|=d;a.childLanes=c;return b}function xk(a,b,c){var d=b.pendingProps;Ve(b);switch(b.tag){case 2:case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return W(b),null;case 1:return ea(b.type)&&(v(S),v(J)),W(b),null;case 3:d=b.stateNode;Tb();v(S);v(J);jf();d.pendingContext&&(d.context=d.pendingContext,d.pendingContext=null);if(null===a||null===a.child)pd(b)?b.flags|=4:null===a||a.memoizedState.isDehydrated&&0===(b.flags&
+256)||(b.flags|=1024,null!==wa&&(Gf(wa),wa=null));xi(a,b);W(b);return null;case 5:hf(b);var e=ub(xc.current);c=b.type;if(null!==a&&null!=b.stateNode)yk(a,b,c,d,e),a.ref!==b.ref&&(b.flags|=512,b.flags|=2097152);else{if(!d){if(null===b.stateNode)throw Error(m(166));W(b);return null}a=ub(Ea.current);if(pd(b)){d=b.stateNode;c=b.type;var f=b.memoizedProps;d[Da]=b;d[uc]=f;a=0!==(b.mode&1);switch(c){case "dialog":B("cancel",d);B("close",d);break;case "iframe":case "object":case "embed":B("load",d);break;
+case "video":case "audio":for(e=0;e<Ec.length;e++)B(Ec[e],d);break;case "source":B("error",d);break;case "img":case "image":case "link":B("error",d);B("load",d);break;case "details":B("toggle",d);break;case "input":kg(d,f);B("invalid",d);break;case "select":d._wrapperState={wasMultiple:!!f.multiple};B("invalid",d);break;case "textarea":ng(d,f),B("invalid",d)}pe(c,f);e=null;for(var g in f)if(f.hasOwnProperty(g)){var h=f[g];"children"===g?"string"===typeof h?d.textContent!==h&&(!0!==f.suppressHydrationWarning&&
+jd(d.textContent,h,a),e=["children",h]):"number"===typeof h&&d.textContent!==""+h&&(!0!==f.suppressHydrationWarning&&jd(d.textContent,h,a),e=["children",""+h]):$b.hasOwnProperty(g)&&null!=h&&"onScroll"===g&&B("scroll",d)}switch(c){case "input":Pc(d);mg(d,f,!0);break;case "textarea":Pc(d);pg(d);break;case "select":case "option":break;default:"function"===typeof f.onClick&&(d.onclick=kd)}d=e;b.updateQueue=d;null!==d&&(b.flags|=4)}else{g=9===e.nodeType?e:e.ownerDocument;"http://www.w3.org/1999/xhtml"===
+a&&(a=qg(c));"http://www.w3.org/1999/xhtml"===a?"script"===c?(a=g.createElement("div"),a.innerHTML="<script>\x3c/script>",a=a.removeChild(a.firstChild)):"string"===typeof d.is?a=g.createElement(c,{is:d.is}):(a=g.createElement(c),"select"===c&&(g=a,d.multiple?g.multiple=!0:d.size&&(g.size=d.size))):a=g.createElementNS(a,c);a[Da]=b;a[uc]=d;zk(a,b,!1,!1);b.stateNode=a;a:{g=qe(c,d);switch(c){case "dialog":B("cancel",a);B("close",a);e=d;break;case "iframe":case "object":case "embed":B("load",a);e=d;break;
+case "video":case "audio":for(e=0;e<Ec.length;e++)B(Ec[e],a);e=d;break;case "source":B("error",a);e=d;break;case "img":case "image":case "link":B("error",a);B("load",a);e=d;break;case "details":B("toggle",a);e=d;break;case "input":kg(a,d);e=ke(a,d);B("invalid",a);break;case "option":e=d;break;case "select":a._wrapperState={wasMultiple:!!d.multiple};e=E({},d,{value:void 0});B("invalid",a);break;case "textarea":ng(a,d);e=ne(a,d);B("invalid",a);break;default:e=d}pe(c,e);h=e;for(f in h)if(h.hasOwnProperty(f)){var k=
+h[f];"style"===f?sg(a,k):"dangerouslySetInnerHTML"===f?(k=k?k.__html:void 0,null!=k&&yi(a,k)):"children"===f?"string"===typeof k?("textarea"!==c||""!==k)&&Fc(a,k):"number"===typeof k&&Fc(a,""+k):"suppressContentEditableWarning"!==f&&"suppressHydrationWarning"!==f&&"autoFocus"!==f&&($b.hasOwnProperty(f)?null!=k&&"onScroll"===f&&B("scroll",a):null!=k&&$d(a,f,k,g))}switch(c){case "input":Pc(a);mg(a,d,!1);break;case "textarea":Pc(a);pg(a);break;case "option":null!=d.value&&a.setAttribute("value",""+Ua(d.value));
+break;case "select":a.multiple=!!d.multiple;f=d.value;null!=f?Db(a,!!d.multiple,f,!1):null!=d.defaultValue&&Db(a,!!d.multiple,d.defaultValue,!0);break;default:"function"===typeof e.onClick&&(a.onclick=kd)}switch(c){case "button":case "input":case "select":case "textarea":d=!!d.autoFocus;break a;case "img":d=!0;break a;default:d=!1}}d&&(b.flags|=4)}null!==b.ref&&(b.flags|=512,b.flags|=2097152)}W(b);return null;case 6:if(a&&null!=b.stateNode)Ak(a,b,a.memoizedProps,d);else{if("string"!==typeof d&&null===
+b.stateNode)throw Error(m(166));c=ub(xc.current);ub(Ea.current);if(pd(b)){d=b.stateNode;c=b.memoizedProps;d[Da]=b;if(f=d.nodeValue!==c)if(a=la,null!==a)switch(a.tag){case 3:jd(d.nodeValue,c,0!==(a.mode&1));break;case 5:!0!==a.memoizedProps.suppressHydrationWarning&&jd(d.nodeValue,c,0!==(a.mode&1))}f&&(b.flags|=4)}else d=(9===c.nodeType?c:c.ownerDocument).createTextNode(d),d[Da]=b,b.stateNode=d}W(b);return null;case 13:v(F);d=b.memoizedState;if(null===a||null!==a.memoizedState&&null!==a.memoizedState.dehydrated){if(D&&
+null!==fa&&0!==(b.mode&1)&&0===(b.flags&128)){for(f=fa;f;)f=Ka(f.nextSibling);Qb();b.flags|=98560;f=!1}else if(f=pd(b),null!==d&&null!==d.dehydrated){if(null===a){if(!f)throw Error(m(318));f=b.memoizedState;f=null!==f?f.dehydrated:null;if(!f)throw Error(m(317));f[Da]=b}else Qb(),0===(b.flags&128)&&(b.memoizedState=null),b.flags|=4;W(b);f=!1}else null!==wa&&(Gf(wa),wa=null),f=!0;if(!f)return b.flags&65536?b:null}if(0!==(b.flags&128))return b.lanes=c,b;d=null!==d;d!==(null!==a&&null!==a.memoizedState)&&
+d&&(b.child.flags|=8192,0!==(b.mode&1)&&(null===a||0!==(F.current&1)?0===L&&(L=3):Ef()));null!==b.updateQueue&&(b.flags|=4);W(b);return null;case 4:return Tb(),xi(a,b),null===a&&sc(b.stateNode.containerInfo),W(b),null;case 10:return cf(b.type._context),W(b),null;case 17:return ea(b.type)&&(v(S),v(J)),W(b),null;case 19:v(F);f=b.memoizedState;if(null===f)return W(b),null;d=0!==(b.flags&128);g=f.rendering;if(null===g)if(d)Dc(f,!1);else{if(0!==L||null!==a&&0!==(a.flags&128))for(a=b.child;null!==a;){g=
+xd(a);if(null!==g){b.flags|=128;Dc(f,!1);d=g.updateQueue;null!==d&&(b.updateQueue=d,b.flags|=4);b.subtreeFlags=0;d=c;for(c=b.child;null!==c;)f=c,a=d,f.flags&=14680066,g=f.alternate,null===g?(f.childLanes=0,f.lanes=a,f.child=null,f.subtreeFlags=0,f.memoizedProps=null,f.memoizedState=null,f.updateQueue=null,f.dependencies=null,f.stateNode=null):(f.childLanes=g.childLanes,f.lanes=g.lanes,f.child=g.child,f.subtreeFlags=0,f.deletions=null,f.memoizedProps=g.memoizedProps,f.memoizedState=g.memoizedState,
+f.updateQueue=g.updateQueue,f.type=g.type,a=g.dependencies,f.dependencies=null===a?null:{lanes:a.lanes,firstContext:a.firstContext}),c=c.sibling;y(F,F.current&1|2);return b.child}a=a.sibling}null!==f.tail&&P()>Hf&&(b.flags|=128,d=!0,Dc(f,!1),b.lanes=4194304)}else{if(!d)if(a=xd(g),null!==a){if(b.flags|=128,d=!0,c=a.updateQueue,null!==c&&(b.updateQueue=c,b.flags|=4),Dc(f,!0),null===f.tail&&"hidden"===f.tailMode&&!g.alternate&&!D)return W(b),null}else 2*P()-f.renderingStartTime>Hf&&1073741824!==c&&(b.flags|=
+128,d=!0,Dc(f,!1),b.lanes=4194304);f.isBackwards?(g.sibling=b.child,b.child=g):(c=f.last,null!==c?c.sibling=g:b.child=g,f.last=g)}if(null!==f.tail)return b=f.tail,f.rendering=b,f.tail=b.sibling,f.renderingStartTime=P(),b.sibling=null,c=F.current,y(F,d?c&1|2:c&1),b;W(b);return null;case 22:case 23:return ba=Ga.current,v(Ga),d=null!==b.memoizedState,null!==a&&null!==a.memoizedState!==d&&(b.flags|=8192),d&&0!==(b.mode&1)?0!==(ba&1073741824)&&(W(b),b.subtreeFlags&6&&(b.flags|=8192)):W(b),null;case 24:return null;
+case 25:return null}throw Error(m(156,b.tag));}function Bk(a,b,c){Ve(b);switch(b.tag){case 1:return ea(b.type)&&(v(S),v(J)),a=b.flags,a&65536?(b.flags=a&-65537|128,b):null;case 3:return Tb(),v(S),v(J),jf(),a=b.flags,0!==(a&65536)&&0===(a&128)?(b.flags=a&-65537|128,b):null;case 5:return hf(b),null;case 13:v(F);a=b.memoizedState;if(null!==a&&null!==a.dehydrated){if(null===b.alternate)throw Error(m(340));Qb()}a=b.flags;return a&65536?(b.flags=a&-65537|128,b):null;case 19:return v(F),null;case 4:return Tb(),
+null;case 10:return cf(b.type._context),null;case 22:case 23:return ba=Ga.current,v(Ga),null;case 24:return null;default:return null}}function Wb(a,b){var c=a.ref;if(null!==c)if("function"===typeof c)try{c(null)}catch(d){G(a,b,d)}else c.current=null}function If(a,b,c){try{c()}catch(d){G(a,b,d)}}function Ck(a,b){Jf=Zc;a=ch();if(Ie(a)){if("selectionStart"in a)var c={start:a.selectionStart,end:a.selectionEnd};else a:{c=(c=a.ownerDocument)&&c.defaultView||window;var d=c.getSelection&&c.getSelection();
+if(d&&0!==d.rangeCount){c=d.anchorNode;var e=d.anchorOffset,f=d.focusNode;d=d.focusOffset;try{c.nodeType,f.nodeType}catch(M){c=null;break a}var g=0,h=-1,k=-1,n=0,q=0,u=a,r=null;b:for(;;){for(var p;;){u!==c||0!==e&&3!==u.nodeType||(h=g+e);u!==f||0!==d&&3!==u.nodeType||(k=g+d);3===u.nodeType&&(g+=u.nodeValue.length);if(null===(p=u.firstChild))break;r=u;u=p}for(;;){if(u===a)break b;r===c&&++n===e&&(h=g);r===f&&++q===d&&(k=g);if(null!==(p=u.nextSibling))break;u=r;r=u.parentNode}u=p}c=-1===h||-1===k?null:
+{start:h,end:k}}else c=null}c=c||{start:0,end:0}}else c=null;Kf={focusedElem:a,selectionRange:c};Zc=!1;for(l=b;null!==l;)if(b=l,a=b.child,0!==(b.subtreeFlags&1028)&&null!==a)a.return=b,l=a;else for(;null!==l;){b=l;try{var x=b.alternate;if(0!==(b.flags&1024))switch(b.tag){case 0:case 11:case 15:break;case 1:if(null!==x){var v=x.memoizedProps,z=x.memoizedState,w=b.stateNode,A=w.getSnapshotBeforeUpdate(b.elementType===b.type?v:ya(b.type,v),z);w.__reactInternalSnapshotBeforeUpdate=A}break;case 3:var t=
+b.stateNode.containerInfo;1===t.nodeType?t.textContent="":9===t.nodeType&&t.documentElement&&t.removeChild(t.documentElement);break;case 5:case 6:case 4:case 17:break;default:throw Error(m(163));}}catch(M){G(b,b.return,M)}a=b.sibling;if(null!==a){a.return=b.return;l=a;break}l=b.return}x=zi;zi=!1;return x}function Gc(a,b,c){var d=b.updateQueue;d=null!==d?d.lastEffect:null;if(null!==d){var e=d=d.next;do{if((e.tag&a)===a){var f=e.destroy;e.destroy=void 0;void 0!==f&&If(b,c,f)}e=e.next}while(e!==d)}}
+function Id(a,b){b=b.updateQueue;b=null!==b?b.lastEffect:null;if(null!==b){var c=b=b.next;do{if((c.tag&a)===a){var d=c.create;c.destroy=d()}c=c.next}while(c!==b)}}function Lf(a){var b=a.ref;if(null!==b){var c=a.stateNode;switch(a.tag){case 5:a=c;break;default:a=c}"function"===typeof b?b(a):b.current=a}}function Ai(a){var b=a.alternate;null!==b&&(a.alternate=null,Ai(b));a.child=null;a.deletions=null;a.sibling=null;5===a.tag&&(b=a.stateNode,null!==b&&(delete b[Da],delete b[uc],delete b[Me],delete b[Dk],
+delete b[Ek]));a.stateNode=null;a.return=null;a.dependencies=null;a.memoizedProps=null;a.memoizedState=null;a.pendingProps=null;a.stateNode=null;a.updateQueue=null}function Bi(a){return 5===a.tag||3===a.tag||4===a.tag}function Ci(a){a:for(;;){for(;null===a.sibling;){if(null===a.return||Bi(a.return))return null;a=a.return}a.sibling.return=a.return;for(a=a.sibling;5!==a.tag&&6!==a.tag&&18!==a.tag;){if(a.flags&2)continue a;if(null===a.child||4===a.tag)continue a;else a.child.return=a,a=a.child}if(!(a.flags&
+2))return a.stateNode}}function Mf(a,b,c){var d=a.tag;if(5===d||6===d)a=a.stateNode,b?8===c.nodeType?c.parentNode.insertBefore(a,b):c.insertBefore(a,b):(8===c.nodeType?(b=c.parentNode,b.insertBefore(a,c)):(b=c,b.appendChild(a)),c=c._reactRootContainer,null!==c&&void 0!==c||null!==b.onclick||(b.onclick=kd));else if(4!==d&&(a=a.child,null!==a))for(Mf(a,b,c),a=a.sibling;null!==a;)Mf(a,b,c),a=a.sibling}function Nf(a,b,c){var d=a.tag;if(5===d||6===d)a=a.stateNode,b?c.insertBefore(a,b):c.appendChild(a);
+else if(4!==d&&(a=a.child,null!==a))for(Nf(a,b,c),a=a.sibling;null!==a;)Nf(a,b,c),a=a.sibling}function jb(a,b,c){for(c=c.child;null!==c;)Di(a,b,c),c=c.sibling}function Di(a,b,c){if(Ca&&"function"===typeof Ca.onCommitFiberUnmount)try{Ca.onCommitFiberUnmount(Uc,c)}catch(h){}switch(c.tag){case 5:X||Wb(c,b);case 6:var d=T,e=za;T=null;jb(a,b,c);T=d;za=e;null!==T&&(za?(a=T,c=c.stateNode,8===a.nodeType?a.parentNode.removeChild(c):a.removeChild(c)):T.removeChild(c.stateNode));break;case 18:null!==T&&(za?
+(a=T,c=c.stateNode,8===a.nodeType?Re(a.parentNode,c):1===a.nodeType&&Re(a,c),nc(a)):Re(T,c.stateNode));break;case 4:d=T;e=za;T=c.stateNode.containerInfo;za=!0;jb(a,b,c);T=d;za=e;break;case 0:case 11:case 14:case 15:if(!X&&(d=c.updateQueue,null!==d&&(d=d.lastEffect,null!==d))){e=d=d.next;do{var f=e,g=f.destroy;f=f.tag;void 0!==g&&(0!==(f&2)?If(c,b,g):0!==(f&4)&&If(c,b,g));e=e.next}while(e!==d)}jb(a,b,c);break;case 1:if(!X&&(Wb(c,b),d=c.stateNode,"function"===typeof d.componentWillUnmount))try{d.props=
+c.memoizedProps,d.state=c.memoizedState,d.componentWillUnmount()}catch(h){G(c,b,h)}jb(a,b,c);break;case 21:jb(a,b,c);break;case 22:c.mode&1?(X=(d=X)||null!==c.memoizedState,jb(a,b,c),X=d):jb(a,b,c);break;default:jb(a,b,c)}}function Ei(a){var b=a.updateQueue;if(null!==b){a.updateQueue=null;var c=a.stateNode;null===c&&(c=a.stateNode=new Fk);b.forEach(function(b){var d=Gk.bind(null,a,b);c.has(b)||(c.add(b),b.then(d,d))})}}function Aa(a,b,c){c=b.deletions;if(null!==c)for(var d=0;d<c.length;d++){var e=
+c[d];try{var f=a,g=b,h=g;a:for(;null!==h;){switch(h.tag){case 5:T=h.stateNode;za=!1;break a;case 3:T=h.stateNode.containerInfo;za=!0;break a;case 4:T=h.stateNode.containerInfo;za=!0;break a}h=h.return}if(null===T)throw Error(m(160));Di(f,g,e);T=null;za=!1;var k=e.alternate;null!==k&&(k.return=null);e.return=null}catch(n){G(e,b,n)}}if(b.subtreeFlags&12854)for(b=b.child;null!==b;)Fi(b,a),b=b.sibling}function Fi(a,b,c){var d=a.alternate;c=a.flags;switch(a.tag){case 0:case 11:case 14:case 15:Aa(b,a);
+Ha(a);if(c&4){try{Gc(3,a,a.return),Id(3,a)}catch(I){G(a,a.return,I)}try{Gc(5,a,a.return)}catch(I){G(a,a.return,I)}}break;case 1:Aa(b,a);Ha(a);c&512&&null!==d&&Wb(d,d.return);break;case 5:Aa(b,a);Ha(a);c&512&&null!==d&&Wb(d,d.return);if(a.flags&32){var e=a.stateNode;try{Fc(e,"")}catch(I){G(a,a.return,I)}}if(c&4&&(e=a.stateNode,null!=e)){var f=a.memoizedProps,g=null!==d?d.memoizedProps:f,h=a.type,k=a.updateQueue;a.updateQueue=null;if(null!==k)try{"input"===h&&"radio"===f.type&&null!=f.name&&lg(e,f);
+qe(h,g);var n=qe(h,f);for(g=0;g<k.length;g+=2){var q=k[g],u=k[g+1];"style"===q?sg(e,u):"dangerouslySetInnerHTML"===q?yi(e,u):"children"===q?Fc(e,u):$d(e,q,u,n)}switch(h){case "input":le(e,f);break;case "textarea":og(e,f);break;case "select":var r=e._wrapperState.wasMultiple;e._wrapperState.wasMultiple=!!f.multiple;var p=f.value;null!=p?Db(e,!!f.multiple,p,!1):r!==!!f.multiple&&(null!=f.defaultValue?Db(e,!!f.multiple,f.defaultValue,!0):Db(e,!!f.multiple,f.multiple?[]:"",!1))}e[uc]=f}catch(I){G(a,a.return,
+I)}}break;case 6:Aa(b,a);Ha(a);if(c&4){if(null===a.stateNode)throw Error(m(162));e=a.stateNode;f=a.memoizedProps;try{e.nodeValue=f}catch(I){G(a,a.return,I)}}break;case 3:Aa(b,a);Ha(a);if(c&4&&null!==d&&d.memoizedState.isDehydrated)try{nc(b.containerInfo)}catch(I){G(a,a.return,I)}break;case 4:Aa(b,a);Ha(a);break;case 13:Aa(b,a);Ha(a);e=a.child;e.flags&8192&&(f=null!==e.memoizedState,e.stateNode.isHidden=f,!f||null!==e.alternate&&null!==e.alternate.memoizedState||(Of=P()));c&4&&Ei(a);break;case 22:q=
+null!==d&&null!==d.memoizedState;a.mode&1?(X=(n=X)||q,Aa(b,a),X=n):Aa(b,a);Ha(a);if(c&8192){n=null!==a.memoizedState;if((a.stateNode.isHidden=n)&&!q&&0!==(a.mode&1))for(l=a,q=a.child;null!==q;){for(u=l=q;null!==l;){r=l;p=r.child;switch(r.tag){case 0:case 11:case 14:case 15:Gc(4,r,r.return);break;case 1:Wb(r,r.return);var x=r.stateNode;if("function"===typeof x.componentWillUnmount){c=r;b=r.return;try{d=c,x.props=d.memoizedProps,x.state=d.memoizedState,x.componentWillUnmount()}catch(I){G(c,b,I)}}break;
+case 5:Wb(r,r.return);break;case 22:if(null!==r.memoizedState){Gi(u);continue}}null!==p?(p.return=r,l=p):Gi(u)}q=q.sibling}a:for(q=null,u=a;;){if(5===u.tag){if(null===q){q=u;try{e=u.stateNode,n?(f=e.style,"function"===typeof f.setProperty?f.setProperty("display","none","important"):f.display="none"):(h=u.stateNode,k=u.memoizedProps.style,g=void 0!==k&&null!==k&&k.hasOwnProperty("display")?k.display:null,h.style.display=rg("display",g))}catch(I){G(a,a.return,I)}}}else if(6===u.tag){if(null===q)try{u.stateNode.nodeValue=
+n?"":u.memoizedProps}catch(I){G(a,a.return,I)}}else if((22!==u.tag&&23!==u.tag||null===u.memoizedState||u===a)&&null!==u.child){u.child.return=u;u=u.child;continue}if(u===a)break a;for(;null===u.sibling;){if(null===u.return||u.return===a)break a;q===u&&(q=null);u=u.return}q===u&&(q=null);u.sibling.return=u.return;u=u.sibling}}break;case 19:Aa(b,a);Ha(a);c&4&&Ei(a);break;case 21:break;default:Aa(b,a),Ha(a)}}function Ha(a){var b=a.flags;if(b&2){try{a:{for(var c=a.return;null!==c;){if(Bi(c)){var d=c;
+break a}c=c.return}throw Error(m(160));}switch(d.tag){case 5:var e=d.stateNode;d.flags&32&&(Fc(e,""),d.flags&=-33);var f=Ci(a);Nf(a,f,e);break;case 3:case 4:var g=d.stateNode.containerInfo,h=Ci(a);Mf(a,h,g);break;default:throw Error(m(161));}}catch(k){G(a,a.return,k)}a.flags&=-3}b&4096&&(a.flags&=-4097)}function Hk(a,b,c){l=a;Hi(a,b,c)}function Hi(a,b,c){for(var d=0!==(a.mode&1);null!==l;){var e=l,f=e.child;if(22===e.tag&&d){var g=null!==e.memoizedState||Jd;if(!g){var h=e.alternate,k=null!==h&&null!==
+h.memoizedState||X;h=Jd;var n=X;Jd=g;if((X=k)&&!n)for(l=e;null!==l;)g=l,k=g.child,22===g.tag&&null!==g.memoizedState?Ii(e):null!==k?(k.return=g,l=k):Ii(e);for(;null!==f;)l=f,Hi(f,b,c),f=f.sibling;l=e;Jd=h;X=n}Ji(a,b,c)}else 0!==(e.subtreeFlags&8772)&&null!==f?(f.return=e,l=f):Ji(a,b,c)}}function Ji(a,b,c){for(;null!==l;){b=l;if(0!==(b.flags&8772)){c=b.alternate;try{if(0!==(b.flags&8772))switch(b.tag){case 0:case 11:case 15:X||Id(5,b);break;case 1:var d=b.stateNode;if(b.flags&4&&!X)if(null===c)d.componentDidMount();
+else{var e=b.elementType===b.type?c.memoizedProps:ya(b.type,c.memoizedProps);d.componentDidUpdate(e,c.memoizedState,d.__reactInternalSnapshotBeforeUpdate)}var f=b.updateQueue;null!==f&&Hh(b,f,d);break;case 3:var g=b.updateQueue;if(null!==g){c=null;if(null!==b.child)switch(b.child.tag){case 5:c=b.child.stateNode;break;case 1:c=b.child.stateNode}Hh(b,g,c)}break;case 5:var h=b.stateNode;if(null===c&&b.flags&4){c=h;var k=b.memoizedProps;switch(b.type){case "button":case "input":case "select":case "textarea":k.autoFocus&&
+c.focus();break;case "img":k.src&&(c.src=k.src)}}break;case 6:break;case 4:break;case 12:break;case 13:if(null===b.memoizedState){var n=b.alternate;if(null!==n){var q=n.memoizedState;if(null!==q){var p=q.dehydrated;null!==p&&nc(p)}}}break;case 19:case 17:case 21:case 22:case 23:case 25:break;default:throw Error(m(163));}X||b.flags&512&&Lf(b)}catch(r){G(b,b.return,r)}}if(b===a){l=null;break}c=b.sibling;if(null!==c){c.return=b.return;l=c;break}l=b.return}}function Gi(a){for(;null!==l;){var b=l;if(b===
+a){l=null;break}var c=b.sibling;if(null!==c){c.return=b.return;l=c;break}l=b.return}}function Ii(a){for(;null!==l;){var b=l;try{switch(b.tag){case 0:case 11:case 15:var c=b.return;try{Id(4,b)}catch(k){G(b,c,k)}break;case 1:var d=b.stateNode;if("function"===typeof d.componentDidMount){var e=b.return;try{d.componentDidMount()}catch(k){G(b,e,k)}}var f=b.return;try{Lf(b)}catch(k){G(b,f,k)}break;case 5:var g=b.return;try{Lf(b)}catch(k){G(b,g,k)}}}catch(k){G(b,b.return,k)}if(b===a){l=null;break}var h=b.sibling;
+if(null!==h){h.return=b.return;l=h;break}l=b.return}}function Hc(){Hf=P()+500}function Z(){return 0!==(p&6)?P():-1!==Kd?Kd:Kd=P()}function hb(a){if(0===(a.mode&1))return 1;if(0!==(p&2)&&0!==U)return U&-U;if(null!==Ik.transition)return 0===Ld&&(Ld=Dg()),Ld;a=z;if(0!==a)return a;a=window.event;a=void 0===a?16:Lg(a.type);return a}function xa(a,b,c,d){if(50<Ic)throw Ic=0,Pf=null,Error(m(185));ic(a,c,d);if(0===(p&2)||a!==O)a===O&&(0===(p&2)&&(Md|=c),4===L&&kb(a,U)),ia(a,d),1===c&&0===p&&0===(b.mode&1)&&
+(Hc(),md&&db())}function ia(a,b){var c=a.callbackNode;tj(a,b);var d=Vc(a,a===O?U:0);if(0===d)null!==c&&Ki(c),a.callbackNode=null,a.callbackPriority=0;else if(b=d&-d,a.callbackPriority!==b){null!=c&&Ki(c);if(1===b)0===a.tag?jk(Li.bind(null,a)):wh(Li.bind(null,a)),Jk(function(){0===(p&6)&&db()}),c=null;else{switch(Eg(d)){case 1:c=De;break;case 4:c=Mg;break;case 16:c=ad;break;case 536870912:c=Ng;break;default:c=ad}c=Mi(c,Ni.bind(null,a))}a.callbackPriority=b;a.callbackNode=c}}function Ni(a,b){Kd=-1;
+Ld=0;if(0!==(p&6))throw Error(m(327));var c=a.callbackNode;if(Xb()&&a.callbackNode!==c)return null;var d=Vc(a,a===O?U:0);if(0===d)return null;if(0!==(d&30)||0!==(d&a.expiredLanes)||b)b=Nd(a,d);else{b=d;var e=p;p|=2;var f=Oi();if(O!==a||U!==b)Ra=null,Hc(),wb(a,b);do try{Kk();break}catch(h){Pi(a,h)}while(1);af();Od.current=f;p=e;null!==H?b=0:(O=null,U=0,b=L)}if(0!==b){2===b&&(e=ve(a),0!==e&&(d=e,b=Qf(a,e)));if(1===b)throw c=Jc,wb(a,0),kb(a,d),ia(a,P()),c;if(6===b)kb(a,d);else{e=a.current.alternate;
+if(0===(d&30)&&!Lk(e)&&(b=Nd(a,d),2===b&&(f=ve(a),0!==f&&(d=f,b=Qf(a,f))),1===b))throw c=Jc,wb(a,0),kb(a,d),ia(a,P()),c;a.finishedWork=e;a.finishedLanes=d;switch(b){case 0:case 1:throw Error(m(345));case 2:xb(a,ja,Ra);break;case 3:kb(a,d);if((d&130023424)===d&&(b=Of+500-P(),10<b)){if(0!==Vc(a,0))break;e=a.suspendedLanes;if((e&d)!==d){Z();a.pingedLanes|=a.suspendedLanes&e;break}a.timeoutHandle=Rf(xb.bind(null,a,ja,Ra),b);break}xb(a,ja,Ra);break;case 4:kb(a,d);if((d&4194240)===d)break;b=a.eventTimes;
+for(e=-1;0<d;){var g=31-ta(d);f=1<<g;g=b[g];g>e&&(e=g);d&=~f}d=e;d=P()-d;d=(120>d?120:480>d?480:1080>d?1080:1920>d?1920:3E3>d?3E3:4320>d?4320:1960*Mk(d/1960))-d;if(10<d){a.timeoutHandle=Rf(xb.bind(null,a,ja,Ra),d);break}xb(a,ja,Ra);break;case 5:xb(a,ja,Ra);break;default:throw Error(m(329));}}}ia(a,P());return a.callbackNode===c?Ni.bind(null,a):null}function Qf(a,b){var c=Kc;a.current.memoizedState.isDehydrated&&(wb(a,b).flags|=256);a=Nd(a,b);2!==a&&(b=ja,ja=c,null!==b&&Gf(b));return a}function Gf(a){null===
+ja?ja=a:ja.push.apply(ja,a)}function Lk(a){for(var b=a;;){if(b.flags&16384){var c=b.updateQueue;if(null!==c&&(c=c.stores,null!==c))for(var d=0;d<c.length;d++){var e=c[d],f=e.getSnapshot;e=e.value;try{if(!ua(f(),e))return!1}catch(g){return!1}}}c=b.child;if(b.subtreeFlags&16384&&null!==c)c.return=b,b=c;else{if(b===a)break;for(;null===b.sibling;){if(null===b.return||b.return===a)return!0;b=b.return}b.sibling.return=b.return;b=b.sibling}}return!0}function kb(a,b){b&=~Sf;b&=~Md;a.suspendedLanes|=b;a.pingedLanes&=
+~b;for(a=a.expirationTimes;0<b;){var c=31-ta(b),d=1<<c;a[c]=-1;b&=~d}}function Li(a){if(0!==(p&6))throw Error(m(327));Xb();var b=Vc(a,0);if(0===(b&1))return ia(a,P()),null;var c=Nd(a,b);if(0!==a.tag&&2===c){var d=ve(a);0!==d&&(b=d,c=Qf(a,d))}if(1===c)throw c=Jc,wb(a,0),kb(a,b),ia(a,P()),c;if(6===c)throw Error(m(345));a.finishedWork=a.current.alternate;a.finishedLanes=b;xb(a,ja,Ra);ia(a,P());return null}function Tf(a,b){var c=p;p|=1;try{return a(b)}finally{p=c,0===p&&(Hc(),md&&db())}}function yb(a){null!==
+lb&&0===lb.tag&&0===(p&6)&&Xb();var b=p;p|=1;var c=ca.transition,d=z;try{if(ca.transition=null,z=1,a)return a()}finally{z=d,ca.transition=c,p=b,0===(p&6)&&db()}}function wb(a,b){a.finishedWork=null;a.finishedLanes=0;var c=a.timeoutHandle;-1!==c&&(a.timeoutHandle=-1,Nk(c));if(null!==H)for(c=H.return;null!==c;){var d=c;Ve(d);switch(d.tag){case 1:d=d.type.childContextTypes;null!==d&&void 0!==d&&(v(S),v(J));break;case 3:Tb();v(S);v(J);jf();break;case 5:hf(d);break;case 4:Tb();break;case 13:v(F);break;
+case 19:v(F);break;case 10:cf(d.type._context);break;case 22:case 23:ba=Ga.current,v(Ga)}c=c.return}O=a;H=a=eb(a.current,null);U=ba=b;L=0;Jc=null;Sf=Md=ra=0;ja=Kc=null;if(null!==tb){for(b=0;b<tb.length;b++)if(c=tb[b],d=c.interleaved,null!==d){c.interleaved=null;var e=d.next,f=c.pending;if(null!==f){var g=f.next;f.next=e;d.next=g}c.pending=d}tb=null}return a}function Pi(a,b){do{var c=H;try{af();yd.current=zd;if(Ad){for(var d=C.memoizedState;null!==d;){var e=d.queue;null!==e&&(e.pending=null);d=d.next}Ad=
+!1}vb=0;N=K=C=null;zc=!1;Ac=0;Uf.current=null;if(null===c||null===c.return){L=1;Jc=b;H=null;break}a:{var f=a,g=c.return,h=c,k=b;b=U;h.flags|=32768;if(null!==k&&"object"===typeof k&&"function"===typeof k.then){var n=k,l=h,p=l.tag;if(0===(l.mode&1)&&(0===p||11===p||15===p)){var r=l.alternate;r?(l.updateQueue=r.updateQueue,l.memoizedState=r.memoizedState,l.lanes=r.lanes):(l.updateQueue=null,l.memoizedState=null)}var v=ji(g);if(null!==v){v.flags&=-257;ki(v,g,h,f,b);v.mode&1&&ii(f,n,b);b=v;k=n;var x=b.updateQueue;
+if(null===x){var z=new Set;z.add(k);b.updateQueue=z}else x.add(k);break a}else{if(0===(b&1)){ii(f,n,b);Ef();break a}k=Error(m(426))}}else if(D&&h.mode&1){var y=ji(g);if(null!==y){0===(y.flags&65536)&&(y.flags|=256);ki(y,g,h,f,b);Ye(Ub(k,h));break a}}f=k=Ub(k,h);4!==L&&(L=2);null===Kc?Kc=[f]:Kc.push(f);f=g;do{switch(f.tag){case 3:f.flags|=65536;b&=-b;f.lanes|=b;var w=gi(f,k,b);Gh(f,w);break a;case 1:h=k;var A=f.type,t=f.stateNode;if(0===(f.flags&128)&&("function"===typeof A.getDerivedStateFromError||
+null!==t&&"function"===typeof t.componentDidCatch&&(null===ib||!ib.has(t)))){f.flags|=65536;b&=-b;f.lanes|=b;var B=hi(f,h,b);Gh(f,B);break a}}f=f.return}while(null!==f)}Qi(c)}catch(ma){b=ma;H===c&&null!==c&&(H=c=c.return);continue}break}while(1)}function Oi(){var a=Od.current;Od.current=zd;return null===a?zd:a}function Ef(){if(0===L||3===L||2===L)L=4;null===O||0===(ra&268435455)&&0===(Md&268435455)||kb(O,U)}function Nd(a,b){var c=p;p|=2;var d=Oi();if(O!==a||U!==b)Ra=null,wb(a,b);do try{Ok();break}catch(e){Pi(a,
+e)}while(1);af();p=c;Od.current=d;if(null!==H)throw Error(m(261));O=null;U=0;return L}function Ok(){for(;null!==H;)Ri(H)}function Kk(){for(;null!==H&&!Pk();)Ri(H)}function Ri(a){var b=Qk(a.alternate,a,ba);a.memoizedProps=a.pendingProps;null===b?Qi(a):H=b;Uf.current=null}function Qi(a){var b=a;do{var c=b.alternate;a=b.return;if(0===(b.flags&32768)){if(c=xk(c,b,ba),null!==c){H=c;return}}else{c=Bk(c,b);if(null!==c){c.flags&=32767;H=c;return}if(null!==a)a.flags|=32768,a.subtreeFlags=0,a.deletions=null;
+else{L=6;H=null;return}}b=b.sibling;if(null!==b){H=b;return}H=b=a}while(null!==b);0===L&&(L=5)}function xb(a,b,c){var d=z,e=ca.transition;try{ca.transition=null,z=1,Rk(a,b,c,d)}finally{ca.transition=e,z=d}return null}function Rk(a,b,c,d){do Xb();while(null!==lb);if(0!==(p&6))throw Error(m(327));c=a.finishedWork;var e=a.finishedLanes;if(null===c)return null;a.finishedWork=null;a.finishedLanes=0;if(c===a.current)throw Error(m(177));a.callbackNode=null;a.callbackPriority=0;var f=c.lanes|c.childLanes;
+uj(a,f);a===O&&(H=O=null,U=0);0===(c.subtreeFlags&2064)&&0===(c.flags&2064)||Pd||(Pd=!0,Mi(ad,function(){Xb();return null}));f=0!==(c.flags&15990);if(0!==(c.subtreeFlags&15990)||f){f=ca.transition;ca.transition=null;var g=z;z=1;var h=p;p|=4;Uf.current=null;Ck(a,c);Fi(c,a);Tj(Kf);Zc=!!Jf;Kf=Jf=null;a.current=c;Hk(c,a,e);Sk();p=h;z=g;ca.transition=f}else a.current=c;Pd&&(Pd=!1,lb=a,Qd=e);f=a.pendingLanes;0===f&&(ib=null);oj(c.stateNode,d);ia(a,P());if(null!==b)for(d=a.onRecoverableError,c=0;c<b.length;c++)e=
+b[c],d(e.value,{componentStack:e.stack,digest:e.digest});if(Ed)throw Ed=!1,a=xf,xf=null,a;0!==(Qd&1)&&0!==a.tag&&Xb();f=a.pendingLanes;0!==(f&1)?a===Pf?Ic++:(Ic=0,Pf=a):Ic=0;db();return null}function Xb(){if(null!==lb){var a=Eg(Qd),b=ca.transition,c=z;try{ca.transition=null;z=16>a?16:a;if(null===lb)var d=!1;else{a=lb;lb=null;Qd=0;if(0!==(p&6))throw Error(m(331));var e=p;p|=4;for(l=a.current;null!==l;){var f=l,g=f.child;if(0!==(l.flags&16)){var h=f.deletions;if(null!==h){for(var k=0;k<h.length;k++){var n=
+h[k];for(l=n;null!==l;){var q=l;switch(q.tag){case 0:case 11:case 15:Gc(8,q,f)}var u=q.child;if(null!==u)u.return=q,l=u;else for(;null!==l;){q=l;var r=q.sibling,v=q.return;Ai(q);if(q===n){l=null;break}if(null!==r){r.return=v;l=r;break}l=v}}}var x=f.alternate;if(null!==x){var y=x.child;if(null!==y){x.child=null;do{var C=y.sibling;y.sibling=null;y=C}while(null!==y)}}l=f}}if(0!==(f.subtreeFlags&2064)&&null!==g)g.return=f,l=g;else b:for(;null!==l;){f=l;if(0!==(f.flags&2048))switch(f.tag){case 0:case 11:case 15:Gc(9,
+f,f.return)}var w=f.sibling;if(null!==w){w.return=f.return;l=w;break b}l=f.return}}var A=a.current;for(l=A;null!==l;){g=l;var t=g.child;if(0!==(g.subtreeFlags&2064)&&null!==t)t.return=g,l=t;else b:for(g=A;null!==l;){h=l;if(0!==(h.flags&2048))try{switch(h.tag){case 0:case 11:case 15:Id(9,h)}}catch(ma){G(h,h.return,ma)}if(h===g){l=null;break b}var B=h.sibling;if(null!==B){B.return=h.return;l=B;break b}l=h.return}}p=e;db();if(Ca&&"function"===typeof Ca.onPostCommitFiberRoot)try{Ca.onPostCommitFiberRoot(Uc,
+a)}catch(ma){}d=!0}return d}finally{z=c,ca.transition=b}}return!1}function Si(a,b,c){b=Ub(c,b);b=gi(a,b,1);a=fb(a,b,1);b=Z();null!==a&&(ic(a,1,b),ia(a,b))}function G(a,b,c){if(3===a.tag)Si(a,a,c);else for(;null!==b;){if(3===b.tag){Si(b,a,c);break}else if(1===b.tag){var d=b.stateNode;if("function"===typeof b.type.getDerivedStateFromError||"function"===typeof d.componentDidCatch&&(null===ib||!ib.has(d))){a=Ub(c,a);a=hi(b,a,1);b=fb(b,a,1);a=Z();null!==b&&(ic(b,1,a),ia(b,a));break}}b=b.return}}function sk(a,
+b,c){var d=a.pingCache;null!==d&&d.delete(b);b=Z();a.pingedLanes|=a.suspendedLanes&c;O===a&&(U&c)===c&&(4===L||3===L&&(U&130023424)===U&&500>P()-Of?wb(a,0):Sf|=c);ia(a,b)}function Ti(a,b){0===b&&(0===(a.mode&1)?b=1:(b=Rd,Rd<<=1,0===(Rd&130023424)&&(Rd=4194304)));var c=Z();a=Oa(a,b);null!==a&&(ic(a,b,c),ia(a,c))}function vk(a){var b=a.memoizedState,c=0;null!==b&&(c=b.retryLane);Ti(a,c)}function Gk(a,b){var c=0;switch(a.tag){case 13:var d=a.stateNode;var e=a.memoizedState;null!==e&&(c=e.retryLane);
+break;case 19:d=a.stateNode;break;default:throw Error(m(314));}null!==d&&d.delete(b);Ti(a,c)}function Mi(a,b){return xh(a,b)}function Tk(a,b,c,d){this.tag=a;this.key=c;this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null;this.index=0;this.ref=null;this.pendingProps=b;this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null;this.mode=d;this.subtreeFlags=this.flags=0;this.deletions=null;this.childLanes=this.lanes=0;this.alternate=null}function yf(a){a=
+a.prototype;return!(!a||!a.isReactComponent)}function Uk(a){if("function"===typeof a)return yf(a)?1:0;if(void 0!==a&&null!==a){a=a.$$typeof;if(a===ie)return 11;if(a===je)return 14}return 2}function eb(a,b){var c=a.alternate;null===c?(c=pa(a.tag,b,a.key,a.mode),c.elementType=a.elementType,c.type=a.type,c.stateNode=a.stateNode,c.alternate=a,a.alternate=c):(c.pendingProps=b,c.type=a.type,c.flags=0,c.subtreeFlags=0,c.deletions=null);c.flags=a.flags&14680064;c.childLanes=a.childLanes;c.lanes=a.lanes;c.child=
+a.child;c.memoizedProps=a.memoizedProps;c.memoizedState=a.memoizedState;c.updateQueue=a.updateQueue;b=a.dependencies;c.dependencies=null===b?null:{lanes:b.lanes,firstContext:b.firstContext};c.sibling=a.sibling;c.index=a.index;c.ref=a.ref;return c}function rd(a,b,c,d,e,f){var g=2;d=a;if("function"===typeof a)yf(a)&&(g=1);else if("string"===typeof a)g=5;else a:switch(a){case Bb:return sb(c.children,e,f,b);case fe:g=8;e|=8;break;case ee:return a=pa(12,c,b,e|2),a.elementType=ee,a.lanes=f,a;case ge:return a=
+pa(13,c,b,e),a.elementType=ge,a.lanes=f,a;case he:return a=pa(19,c,b,e),a.elementType=he,a.lanes=f,a;case Ui:return Gd(c,e,f,b);default:if("object"===typeof a&&null!==a)switch(a.$$typeof){case hg:g=10;break a;case gg:g=9;break a;case ie:g=11;break a;case je:g=14;break a;case Ta:g=16;d=null;break a}throw Error(m(130,null==a?a:typeof a,""));}b=pa(g,c,b,e);b.elementType=a;b.type=d;b.lanes=f;return b}function sb(a,b,c,d){a=pa(7,a,d,b);a.lanes=c;return a}function Gd(a,b,c,d){a=pa(22,a,d,b);a.elementType=
+Ui;a.lanes=c;a.stateNode={isHidden:!1};return a}function Ze(a,b,c){a=pa(6,a,null,b);a.lanes=c;return a}function $e(a,b,c){b=pa(4,null!==a.children?a.children:[],a.key,b);b.lanes=c;b.stateNode={containerInfo:a.containerInfo,pendingChildren:null,implementation:a.implementation};return b}function Vk(a,b,c,d,e){this.tag=b;this.containerInfo=a;this.finishedWork=this.pingCache=this.current=this.pendingChildren=null;this.timeoutHandle=-1;this.callbackNode=this.pendingContext=this.context=null;this.callbackPriority=
+0;this.eventTimes=we(0);this.expirationTimes=we(-1);this.entangledLanes=this.finishedLanes=this.mutableReadLanes=this.expiredLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0;this.entanglements=we(0);this.identifierPrefix=d;this.onRecoverableError=e;this.mutableSourceEagerHydrationData=null}function Vf(a,b,c,d,e,f,g,h,k,l){a=new Vk(a,b,c,h,k);1===b?(b=1,!0===f&&(b|=8)):b=0;f=pa(3,null,null,b);a.current=f;f.stateNode=a;f.memoizedState={element:d,isDehydrated:c,cache:null,transitions:null,
+pendingSuspenseBoundaries:null};ff(f);return a}function Wk(a,b,c){var d=3<arguments.length&&void 0!==arguments[3]?arguments[3]:null;return{$$typeof:Cb,key:null==d?null:""+d,children:a,containerInfo:b,implementation:c}}function Vi(a){if(!a)return cb;a=a._reactInternals;a:{if(nb(a)!==a||1!==a.tag)throw Error(m(170));var b=a;do{switch(b.tag){case 3:b=b.stateNode.context;break a;case 1:if(ea(b.type)){b=b.stateNode.__reactInternalMemoizedMergedChildContext;break a}}b=b.return}while(null!==b);throw Error(m(171));
+}if(1===a.tag){var c=a.type;if(ea(c))return uh(a,c,b)}return b}function Wi(a,b,c,d,e,f,g,h,k,l){a=Vf(c,d,!0,a,e,f,g,h,k);a.context=Vi(null);c=a.current;d=Z();e=hb(c);f=Pa(d,e);f.callback=void 0!==b&&null!==b?b:null;fb(c,f,e);a.current.lanes=e;ic(a,e,d);ia(a,d);return a}function Sd(a,b,c,d){var e=b.current,f=Z(),g=hb(e);c=Vi(c);null===b.context?b.context=c:b.pendingContext=c;b=Pa(f,g);b.payload={element:a};d=void 0===d?null:d;null!==d&&(b.callback=d);a=fb(e,b,g);null!==a&&(xa(a,e,g,f),vd(a,e,g));return g}
+function Td(a){a=a.current;if(!a.child)return null;switch(a.child.tag){case 5:return a.child.stateNode;default:return a.child.stateNode}}function Xi(a,b){a=a.memoizedState;if(null!==a&&null!==a.dehydrated){var c=a.retryLane;a.retryLane=0!==c&&c<b?c:b}}function Wf(a,b){Xi(a,b);(a=a.alternate)&&Xi(a,b)}function Xk(a){a=Bg(a);return null===a?null:a.stateNode}function Yk(a){return null}function Xf(a){this._internalRoot=a}function Ud(a){this._internalRoot=a}function Yf(a){return!(!a||1!==a.nodeType&&9!==
+a.nodeType&&11!==a.nodeType)}function Vd(a){return!(!a||1!==a.nodeType&&9!==a.nodeType&&11!==a.nodeType&&(8!==a.nodeType||" react-mount-point-unstable "!==a.nodeValue))}function Yi(){}function Zk(a,b,c,d,e){if(e){if("function"===typeof d){var f=d;d=function(){var a=Td(g);f.call(a)}}var g=Wi(b,d,a,0,null,!1,!1,"",Yi);a._reactRootContainer=g;a[Ja]=g.current;sc(8===a.nodeType?a.parentNode:a);yb();return g}for(;e=a.lastChild;)a.removeChild(e);if("function"===typeof d){var h=d;d=function(){var a=Td(k);
+h.call(a)}}var k=Vf(a,0,!1,null,null,!1,!1,"",Yi);a._reactRootContainer=k;a[Ja]=k.current;sc(8===a.nodeType?a.parentNode:a);yb(function(){Sd(b,k,c,d)});return k}function Wd(a,b,c,d,e){var f=c._reactRootContainer;if(f){var g=f;if("function"===typeof e){var h=e;e=function(){var a=Td(g);h.call(a)}}Sd(b,g,a,e)}else g=Zk(c,b,a,e,d);return Td(g)}var cg=new Set,$b={},Ia=!("undefined"===typeof window||"undefined"===typeof window.document||"undefined"===typeof window.document.createElement),Zd=Object.prototype.hasOwnProperty,
+cj=/^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/,eg={},dg={},R={};"children dangerouslySetInnerHTML defaultValue defaultChecked innerHTML suppressContentEditableWarning suppressHydrationWarning style".split(" ").forEach(function(a){R[a]=
+new Y(a,0,!1,a,null,!1,!1)});[["acceptCharset","accept-charset"],["className","class"],["htmlFor","for"],["httpEquiv","http-equiv"]].forEach(function(a){var b=a[0];R[b]=new Y(b,1,!1,a[1],null,!1,!1)});["contentEditable","draggable","spellCheck","value"].forEach(function(a){R[a]=new Y(a,2,!1,a.toLowerCase(),null,!1,!1)});["autoReverse","externalResourcesRequired","focusable","preserveAlpha"].forEach(function(a){R[a]=new Y(a,2,!1,a,null,!1,!1)});"allowFullScreen async autoFocus autoPlay controls default defer disabled disablePictureInPicture disableRemotePlayback formNoValidate hidden loop noModule noValidate open playsInline readOnly required reversed scoped seamless itemScope".split(" ").forEach(function(a){R[a]=
+new Y(a,3,!1,a.toLowerCase(),null,!1,!1)});["checked","multiple","muted","selected"].forEach(function(a){R[a]=new Y(a,3,!0,a,null,!1,!1)});["capture","download"].forEach(function(a){R[a]=new Y(a,4,!1,a,null,!1,!1)});["cols","rows","size","span"].forEach(function(a){R[a]=new Y(a,6,!1,a,null,!1,!1)});["rowSpan","start"].forEach(function(a){R[a]=new Y(a,5,!1,a.toLowerCase(),null,!1,!1)});var Zf=/[\-:]([a-z])/g,$f=function(a){return a[1].toUpperCase()};"accent-height alignment-baseline arabic-form baseline-shift cap-height clip-path clip-rule color-interpolation color-interpolation-filters color-profile color-rendering dominant-baseline enable-background fill-opacity fill-rule flood-color flood-opacity font-family font-size font-size-adjust font-stretch font-style font-variant font-weight glyph-name glyph-orientation-horizontal glyph-orientation-vertical horiz-adv-x horiz-origin-x image-rendering letter-spacing lighting-color marker-end marker-mid marker-start overline-position overline-thickness paint-order panose-1 pointer-events rendering-intent shape-rendering stop-color stop-opacity strikethrough-position strikethrough-thickness stroke-dasharray stroke-dashoffset stroke-linecap stroke-linejoin stroke-miterlimit stroke-opacity stroke-width text-anchor text-decoration text-rendering underline-position underline-thickness unicode-bidi unicode-range units-per-em v-alphabetic v-hanging v-ideographic v-mathematical vector-effect vert-adv-y vert-origin-x vert-origin-y word-spacing writing-mode xmlns:xlink x-height".split(" ").forEach(function(a){var b=
+a.replace(Zf,$f);R[b]=new Y(b,1,!1,a,null,!1,!1)});"xlink:actuate xlink:arcrole xlink:role xlink:show xlink:title xlink:type".split(" ").forEach(function(a){var b=a.replace(Zf,$f);R[b]=new Y(b,1,!1,a,"http://www.w3.org/1999/xlink",!1,!1)});["xml:base","xml:lang","xml:space"].forEach(function(a){var b=a.replace(Zf,$f);R[b]=new Y(b,1,!1,a,"http://www.w3.org/XML/1998/namespace",!1,!1)});["tabIndex","crossOrigin"].forEach(function(a){R[a]=new Y(a,1,!1,a.toLowerCase(),null,!1,!1)});R.xlinkHref=new Y("xlinkHref",
+1,!1,"xlink:href","http://www.w3.org/1999/xlink",!0,!1);["src","href","action","formAction"].forEach(function(a){R[a]=new Y(a,1,!1,a.toLowerCase(),null,!0,!0)});var Sa=zb.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,sd=Symbol.for("react.element"),Cb=Symbol.for("react.portal"),Bb=Symbol.for("react.fragment"),fe=Symbol.for("react.strict_mode"),ee=Symbol.for("react.profiler"),hg=Symbol.for("react.provider"),gg=Symbol.for("react.context"),ie=Symbol.for("react.forward_ref"),ge=Symbol.for("react.suspense"),
+he=Symbol.for("react.suspense_list"),je=Symbol.for("react.memo"),Ta=Symbol.for("react.lazy");Symbol.for("react.scope");Symbol.for("react.debug_trace_mode");var Ui=Symbol.for("react.offscreen");Symbol.for("react.legacy_hidden");Symbol.for("react.cache");Symbol.for("react.tracing_marker");var fg=Symbol.iterator,E=Object.assign,ae,ce=!1,cc=Array.isArray,Xd,yi=function(a){return"undefined"!==typeof MSApp&&MSApp.execUnsafeLocalFunction?function(b,c,d,e){MSApp.execUnsafeLocalFunction(function(){return a(b,
+c,d,e)})}:a}(function(a,b){if("http://www.w3.org/2000/svg"!==a.namespaceURI||"innerHTML"in a)a.innerHTML=b;else{Xd=Xd||document.createElement("div");Xd.innerHTML="<svg>"+b.valueOf().toString()+"</svg>";for(b=Xd.firstChild;a.firstChild;)a.removeChild(a.firstChild);for(;b.firstChild;)a.appendChild(b.firstChild)}}),Fc=function(a,b){if(b){var c=a.firstChild;if(c&&c===a.lastChild&&3===c.nodeType){c.nodeValue=b;return}}a.textContent=b},dc={animationIterationCount:!0,aspectRatio:!0,borderImageOutset:!0,
+borderImageSlice:!0,borderImageWidth:!0,boxFlex:!0,boxFlexGroup:!0,boxOrdinalGroup:!0,columnCount:!0,columns:!0,flex:!0,flexGrow:!0,flexPositive:!0,flexShrink:!0,flexNegative:!0,flexOrder:!0,gridArea:!0,gridRow:!0,gridRowEnd:!0,gridRowSpan:!0,gridRowStart:!0,gridColumn:!0,gridColumnEnd:!0,gridColumnSpan:!0,gridColumnStart:!0,fontWeight:!0,lineClamp:!0,lineHeight:!0,opacity:!0,order:!0,orphans:!0,tabSize:!0,widows:!0,zIndex:!0,zoom:!0,fillOpacity:!0,floodOpacity:!0,stopOpacity:!0,strokeDasharray:!0,
+strokeDashoffset:!0,strokeMiterlimit:!0,strokeOpacity:!0,strokeWidth:!0},$k=["Webkit","ms","Moz","O"];Object.keys(dc).forEach(function(a){$k.forEach(function(b){b=b+a.charAt(0).toUpperCase()+a.substring(1);dc[b]=dc[a]})});var ij=E({menuitem:!0},{area:!0,base:!0,br:!0,col:!0,embed:!0,hr:!0,img:!0,input:!0,keygen:!0,link:!0,meta:!0,param:!0,source:!0,track:!0,wbr:!0}),ze=null,se=null,Eb=null,Fb=null,xg=function(a,b){return a(b)},yg=function(){},te=!1,Oe=!1;if(Ia)try{var Lc={};Object.defineProperty(Lc,
+"passive",{get:function(){Oe=!0}});window.addEventListener("test",Lc,Lc);window.removeEventListener("test",Lc,Lc)}catch(a){Oe=!1}var kj=function(a,b,c,d,e,f,g,h,k){var l=Array.prototype.slice.call(arguments,3);try{b.apply(c,l)}catch(q){this.onError(q)}},gc=!1,Sc=null,Tc=!1,ue=null,lj={onError:function(a){gc=!0;Sc=a}},Ba=zb.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Scheduler,Jg=Ba.unstable_scheduleCallback,Kg=Ba.unstable_NormalPriority,xh=Jg,Ki=Ba.unstable_cancelCallback,Pk=Ba.unstable_shouldYield,
+Sk=Ba.unstable_requestPaint,P=Ba.unstable_now,Dj=Ba.unstable_getCurrentPriorityLevel,De=Ba.unstable_ImmediatePriority,Mg=Ba.unstable_UserBlockingPriority,ad=Kg,Ej=Ba.unstable_LowPriority,Ng=Ba.unstable_IdlePriority,Uc=null,Ca=null,ta=Math.clz32?Math.clz32:pj,qj=Math.log,rj=Math.LN2,Wc=64,Rd=4194304,z=0,Ae=!1,Yc=[],Va=null,Wa=null,Xa=null,jc=new Map,kc=new Map,Ya=[],Bj="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset submit".split(" "),
+Gb=Sa.ReactCurrentBatchConfig,Zc=!0,$c=null,Za=null,Ee=null,bd=null,Yb={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(a){return a.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},He=ka(Yb),Mc=E({},Yb,{view:0,detail:0}),ak=ka(Mc),ag,bg,Nc,Yd=E({},Mc,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:Fe,button:0,buttons:0,relatedTarget:function(a){return void 0===a.relatedTarget?a.fromElement===a.srcElement?a.toElement:a.fromElement:
+a.relatedTarget},movementX:function(a){if("movementX"in a)return a.movementX;a!==Nc&&(Nc&&"mousemove"===a.type?(ag=a.screenX-Nc.screenX,bg=a.screenY-Nc.screenY):bg=ag=0,Nc=a);return ag},movementY:function(a){return"movementY"in a?a.movementY:bg}}),ih=ka(Yd),al=E({},Yd,{dataTransfer:0}),Wj=ka(al),bl=E({},Mc,{relatedTarget:0}),Pe=ka(bl),cl=E({},Yb,{animationName:0,elapsedTime:0,pseudoElement:0}),Yj=ka(cl),dl=E({},Yb,{clipboardData:function(a){return"clipboardData"in a?a.clipboardData:window.clipboardData}}),
+ck=ka(dl),el=E({},Yb,{data:0}),qh=ka(el),fk=qh,fl={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},gl={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",
+112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},Gj={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"},hl=E({},Mc,{key:function(a){if(a.key){var b=fl[a.key]||a.key;if("Unidentified"!==b)return b}return"keypress"===a.type?(a=cd(a),13===a?"Enter":String.fromCharCode(a)):"keydown"===a.type||"keyup"===a.type?gl[a.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,
+metaKey:0,repeat:0,locale:0,getModifierState:Fe,charCode:function(a){return"keypress"===a.type?cd(a):0},keyCode:function(a){return"keydown"===a.type||"keyup"===a.type?a.keyCode:0},which:function(a){return"keypress"===a.type?cd(a):"keydown"===a.type||"keyup"===a.type?a.keyCode:0}}),Vj=ka(hl),il=E({},Yd,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),nh=ka(il),jl=E({},Mc,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,
+ctrlKey:0,shiftKey:0,getModifierState:Fe}),Xj=ka(jl),kl=E({},Yb,{propertyName:0,elapsedTime:0,pseudoElement:0}),Zj=ka(kl),ll=E({},Yd,{deltaX:function(a){return"deltaX"in a?a.deltaX:"wheelDeltaX"in a?-a.wheelDeltaX:0},deltaY:function(a){return"deltaY"in a?a.deltaY:"wheelDeltaY"in a?-a.wheelDeltaY:"wheelDelta"in a?-a.wheelDelta:0},deltaZ:0,deltaMode:0}),bk=ka(ll),Hj=[9,13,27,32],Ge=Ia&&"CompositionEvent"in window,Oc=null;Ia&&"documentMode"in document&&(Oc=document.documentMode);var ek=Ia&&"TextEvent"in
+window&&!Oc,Ug=Ia&&(!Ge||Oc&&8<Oc&&11>=Oc),Tg=String.fromCharCode(32),Sg=!1,Hb=!1,Kj={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0},oc=null,pc=null,ph=!1;Ia&&(ph=Lj("input")&&(!document.documentMode||9<document.documentMode));var ua="function"===typeof Object.is?Object.is:Sj,dk=Ia&&"documentMode"in document&&11>=document.documentMode,Jb=null,Ke=null,rc=null,Je=!1,Kb={animationend:gd("Animation","AnimationEnd"),
+animationiteration:gd("Animation","AnimationIteration"),animationstart:gd("Animation","AnimationStart"),transitionend:gd("Transition","TransitionEnd")},Le={},eh={};Ia&&(eh=document.createElement("div").style,"AnimationEvent"in window||(delete Kb.animationend.animation,delete Kb.animationiteration.animation,delete Kb.animationstart.animation),"TransitionEvent"in window||delete Kb.transitionend.transition);var jh=hd("animationend"),kh=hd("animationiteration"),lh=hd("animationstart"),mh=hd("transitionend"),
+fh=new Map,Zi="abort auxClick cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");
+(function(){for(var a=0;a<Zi.length;a++){var b=Zi[a],c=b.toLowerCase();b=b[0].toUpperCase()+b.slice(1);$a(c,"on"+b)}$a(jh,"onAnimationEnd");$a(kh,"onAnimationIteration");$a(lh,"onAnimationStart");$a("dblclick","onDoubleClick");$a("focusin","onFocus");$a("focusout","onBlur");$a(mh,"onTransitionEnd")})();Ab("onMouseEnter",["mouseout","mouseover"]);Ab("onMouseLeave",["mouseout","mouseover"]);Ab("onPointerEnter",["pointerout","pointerover"]);Ab("onPointerLeave",["pointerout","pointerover"]);mb("onChange",
+"change click focusin focusout input keydown keyup selectionchange".split(" "));mb("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));mb("onBeforeInput",["compositionend","keypress","textInput","paste"]);mb("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));mb("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));mb("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));
+var Ec="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),Uj=new Set("cancel close invalid load scroll toggle".split(" ").concat(Ec)),id="_reactListening"+Math.random().toString(36).slice(2),gk=/\r\n?/g,hk=/\u0000|\uFFFD/g,Jf=null,Kf=null,Rf="function"===typeof setTimeout?setTimeout:void 0,Nk="function"===typeof clearTimeout?
+clearTimeout:void 0,$i="function"===typeof Promise?Promise:void 0,Jk="function"===typeof queueMicrotask?queueMicrotask:"undefined"!==typeof $i?function(a){return $i.resolve(null).then(a).catch(ik)}:Rf,Zb=Math.random().toString(36).slice(2),Da="__reactFiber$"+Zb,uc="__reactProps$"+Zb,Ja="__reactContainer$"+Zb,Me="__reactEvents$"+Zb,Dk="__reactListeners$"+Zb,Ek="__reactHandles$"+Zb,Se=[],Mb=-1,cb={},J=bb(cb),S=bb(!1),pb=cb,La=null,md=!1,Te=!1,Ob=[],Pb=0,od=null,nd=0,na=[],oa=0,rb=null,Ma=1,Na="",la=
+null,fa=null,D=!1,wa=null,Ik=Sa.ReactCurrentBatchConfig,Vb=Dh(!0),li=Dh(!1),ud=bb(null),td=null,Rb=null,bf=null,tb=null,kk=Oa,gb=!1,wc={},Ea=bb(wc),yc=bb(wc),xc=bb(wc),F=bb(0),kf=[],yd=Sa.ReactCurrentDispatcher,sf=Sa.ReactCurrentBatchConfig,vb=0,C=null,K=null,N=null,Ad=!1,zc=!1,Ac=0,ml=0,zd={readContext:qa,useCallback:V,useContext:V,useEffect:V,useImperativeHandle:V,useInsertionEffect:V,useLayoutEffect:V,useMemo:V,useReducer:V,useRef:V,useState:V,useDebugValue:V,useDeferredValue:V,useTransition:V,
+useMutableSource:V,useSyncExternalStore:V,useId:V,unstable_isNewReconciler:!1},lk={readContext:qa,useCallback:function(a,b){Fa().memoizedState=[a,void 0===b?null:b];return a},useContext:qa,useEffect:Sh,useImperativeHandle:function(a,b,c){c=null!==c&&void 0!==c?c.concat([a]):null;return Bd(4194308,4,Vh.bind(null,b,a),c)},useLayoutEffect:function(a,b){return Bd(4194308,4,a,b)},useInsertionEffect:function(a,b){return Bd(4,2,a,b)},useMemo:function(a,b){var c=Fa();b=void 0===b?null:b;a=a();c.memoizedState=
+[a,b];return a},useReducer:function(a,b,c){var d=Fa();b=void 0!==c?c(b):b;d.memoizedState=d.baseState=b;a={pending:null,interleaved:null,lanes:0,dispatch:null,lastRenderedReducer:a,lastRenderedState:b};d.queue=a;a=a.dispatch=qk.bind(null,C,a);return[d.memoizedState,a]},useRef:function(a){var b=Fa();a={current:a};return b.memoizedState=a},useState:Qh,useDebugValue:rf,useDeferredValue:function(a){return Fa().memoizedState=a},useTransition:function(){var a=Qh(!1),b=a[0];a=pk.bind(null,a[1]);Fa().memoizedState=
+a;return[b,a]},useMutableSource:function(a,b,c){},useSyncExternalStore:function(a,b,c){var d=C,e=Fa();if(D){if(void 0===c)throw Error(m(407));c=c()}else{c=b();if(null===O)throw Error(m(349));0!==(vb&30)||Nh(d,b,c)}e.memoizedState=c;var f={value:c,getSnapshot:b};e.queue=f;Sh(Lh.bind(null,d,f,a),[a]);d.flags|=2048;Cc(9,Mh.bind(null,d,f,c,b),void 0,null);return c},useId:function(){var a=Fa(),b=O.identifierPrefix;if(D){var c=Na;var d=Ma;c=(d&~(1<<32-ta(d)-1)).toString(32)+c;b=":"+b+"R"+c;c=Ac++;0<c&&
+(b+="H"+c.toString(32));b+=":"}else c=ml++,b=":"+b+"r"+c.toString(32)+":";return a.memoizedState=b},unstable_isNewReconciler:!1},mk={readContext:qa,useCallback:Xh,useContext:qa,useEffect:qf,useImperativeHandle:Wh,useInsertionEffect:Th,useLayoutEffect:Uh,useMemo:Yh,useReducer:of,useRef:Rh,useState:function(a){return of(Bc)},useDebugValue:rf,useDeferredValue:function(a){var b=sa();return Zh(b,K.memoizedState,a)},useTransition:function(){var a=of(Bc)[0],b=sa().memoizedState;return[a,b]},useMutableSource:Jh,
+useSyncExternalStore:Kh,useId:$h,unstable_isNewReconciler:!1},nk={readContext:qa,useCallback:Xh,useContext:qa,useEffect:qf,useImperativeHandle:Wh,useInsertionEffect:Th,useLayoutEffect:Uh,useMemo:Yh,useReducer:pf,useRef:Rh,useState:function(a){return pf(Bc)},useDebugValue:rf,useDeferredValue:function(a){var b=sa();return null===K?b.memoizedState=a:Zh(b,K.memoizedState,a)},useTransition:function(){var a=pf(Bc)[0],b=sa().memoizedState;return[a,b]},useMutableSource:Jh,useSyncExternalStore:Kh,useId:$h,
+unstable_isNewReconciler:!1},Dd={isMounted:function(a){return(a=a._reactInternals)?nb(a)===a:!1},enqueueSetState:function(a,b,c){a=a._reactInternals;var d=Z(),e=hb(a),f=Pa(d,e);f.payload=b;void 0!==c&&null!==c&&(f.callback=c);b=fb(a,f,e);null!==b&&(xa(b,a,e,d),vd(b,a,e))},enqueueReplaceState:function(a,b,c){a=a._reactInternals;var d=Z(),e=hb(a),f=Pa(d,e);f.tag=1;f.payload=b;void 0!==c&&null!==c&&(f.callback=c);b=fb(a,f,e);null!==b&&(xa(b,a,e,d),vd(b,a,e))},enqueueForceUpdate:function(a,b){a=a._reactInternals;
+var c=Z(),d=hb(a),e=Pa(c,d);e.tag=2;void 0!==b&&null!==b&&(e.callback=b);b=fb(a,e,d);null!==b&&(xa(b,a,d,c),vd(b,a,d))}},rk="function"===typeof WeakMap?WeakMap:Map,tk=Sa.ReactCurrentOwner,ha=!1,Cf={dehydrated:null,treeContext:null,retryLane:0};var zk=function(a,b,c,d){for(c=b.child;null!==c;){if(5===c.tag||6===c.tag)a.appendChild(c.stateNode);else if(4!==c.tag&&null!==c.child){c.child.return=c;c=c.child;continue}if(c===b)break;for(;null===c.sibling;){if(null===c.return||c.return===b)return;c=c.return}c.sibling.return=
+c.return;c=c.sibling}};var xi=function(a,b){};var yk=function(a,b,c,d,e){var f=a.memoizedProps;if(f!==d){a=b.stateNode;ub(Ea.current);e=null;switch(c){case "input":f=ke(a,f);d=ke(a,d);e=[];break;case "select":f=E({},f,{value:void 0});d=E({},d,{value:void 0});e=[];break;case "textarea":f=ne(a,f);d=ne(a,d);e=[];break;default:"function"!==typeof f.onClick&&"function"===typeof d.onClick&&(a.onclick=kd)}pe(c,d);var g;c=null;for(l in f)if(!d.hasOwnProperty(l)&&f.hasOwnProperty(l)&&null!=f[l])if("style"===
+l){var h=f[l];for(g in h)h.hasOwnProperty(g)&&(c||(c={}),c[g]="")}else"dangerouslySetInnerHTML"!==l&&"children"!==l&&"suppressContentEditableWarning"!==l&&"suppressHydrationWarning"!==l&&"autoFocus"!==l&&($b.hasOwnProperty(l)?e||(e=[]):(e=e||[]).push(l,null));for(l in d){var k=d[l];h=null!=f?f[l]:void 0;if(d.hasOwnProperty(l)&&k!==h&&(null!=k||null!=h))if("style"===l)if(h){for(g in h)!h.hasOwnProperty(g)||k&&k.hasOwnProperty(g)||(c||(c={}),c[g]="");for(g in k)k.hasOwnProperty(g)&&h[g]!==k[g]&&(c||
+(c={}),c[g]=k[g])}else c||(e||(e=[]),e.push(l,c)),c=k;else"dangerouslySetInnerHTML"===l?(k=k?k.__html:void 0,h=h?h.__html:void 0,null!=k&&h!==k&&(e=e||[]).push(l,k)):"children"===l?"string"!==typeof k&&"number"!==typeof k||(e=e||[]).push(l,""+k):"suppressContentEditableWarning"!==l&&"suppressHydrationWarning"!==l&&($b.hasOwnProperty(l)?(null!=k&&"onScroll"===l&&B("scroll",a),e||h===k||(e=[])):(e=e||[]).push(l,k))}c&&(e=e||[]).push("style",c);var l=e;if(b.updateQueue=l)b.flags|=4}};var Ak=function(a,
+b,c,d){c!==d&&(b.flags|=4)};var Jd=!1,X=!1,Fk="function"===typeof WeakSet?WeakSet:Set,l=null,zi=!1,T=null,za=!1,Mk=Math.ceil,Od=Sa.ReactCurrentDispatcher,Uf=Sa.ReactCurrentOwner,ca=Sa.ReactCurrentBatchConfig,p=0,O=null,H=null,U=0,ba=0,Ga=bb(0),L=0,Jc=null,ra=0,Md=0,Sf=0,Kc=null,ja=null,Of=0,Hf=Infinity,Ra=null,Ed=!1,xf=null,ib=null,Pd=!1,lb=null,Qd=0,Ic=0,Pf=null,Kd=-1,Ld=0;var Qk=function(a,b,c){if(null!==a)if(a.memoizedProps!==b.pendingProps||S.current)ha=!0;else{if(0===(a.lanes&c)&&0===(b.flags&
+128))return ha=!1,wk(a,b,c);ha=0!==(a.flags&131072)?!0:!1}else ha=!1,D&&0!==(b.flags&1048576)&&yh(b,nd,b.index);b.lanes=0;switch(b.tag){case 2:var d=b.type;Fd(a,b);a=b.pendingProps;var e=Nb(b,J.current);Sb(b,c);e=mf(null,b,d,a,e,c);var f=nf();b.flags|=1;"object"===typeof e&&null!==e&&"function"===typeof e.render&&void 0===e.$$typeof?(b.tag=1,b.memoizedState=null,b.updateQueue=null,ea(d)?(f=!0,ld(b)):f=!1,b.memoizedState=null!==e.state&&void 0!==e.state?e.state:null,ff(b),e.updater=Dd,b.stateNode=
+e,e._reactInternals=b,uf(b,d,a,c),b=Af(null,b,d,!0,f,c)):(b.tag=0,D&&f&&Ue(b),aa(null,b,e,c),b=b.child);return b;case 16:d=b.elementType;a:{Fd(a,b);a=b.pendingProps;e=d._init;d=e(d._payload);b.type=d;e=b.tag=Uk(d);a=ya(d,a);switch(e){case 0:b=zf(null,b,d,a,c);break a;case 1:b=ri(null,b,d,a,c);break a;case 11:b=mi(null,b,d,a,c);break a;case 14:b=ni(null,b,d,ya(d.type,a),c);break a}throw Error(m(306,d,""));}return b;case 0:return d=b.type,e=b.pendingProps,e=b.elementType===d?e:ya(d,e),zf(a,b,d,e,c);
+case 1:return d=b.type,e=b.pendingProps,e=b.elementType===d?e:ya(d,e),ri(a,b,d,e,c);case 3:a:{si(b);if(null===a)throw Error(m(387));d=b.pendingProps;f=b.memoizedState;e=f.element;Fh(a,b);wd(b,d,null,c);var g=b.memoizedState;d=g.element;if(f.isDehydrated)if(f={element:d,isDehydrated:!1,cache:g.cache,pendingSuspenseBoundaries:g.pendingSuspenseBoundaries,transitions:g.transitions},b.updateQueue.baseState=f,b.memoizedState=f,b.flags&256){e=Ub(Error(m(423)),b);b=ti(a,b,d,c,e);break a}else if(d!==e){e=
+Ub(Error(m(424)),b);b=ti(a,b,d,c,e);break a}else for(fa=Ka(b.stateNode.containerInfo.firstChild),la=b,D=!0,wa=null,c=li(b,null,d,c),b.child=c;c;)c.flags=c.flags&-3|4096,c=c.sibling;else{Qb();if(d===e){b=Qa(a,b,c);break a}aa(a,b,d,c)}b=b.child}return b;case 5:return Ih(b),null===a&&Xe(b),d=b.type,e=b.pendingProps,f=null!==a?a.memoizedProps:null,g=e.children,Qe(d,e)?g=null:null!==f&&Qe(d,f)&&(b.flags|=32),qi(a,b),aa(a,b,g,c),b.child;case 6:return null===a&&Xe(b),null;case 13:return ui(a,b,c);case 4:return gf(b,
+b.stateNode.containerInfo),d=b.pendingProps,null===a?b.child=Vb(b,null,d,c):aa(a,b,d,c),b.child;case 11:return d=b.type,e=b.pendingProps,e=b.elementType===d?e:ya(d,e),mi(a,b,d,e,c);case 7:return aa(a,b,b.pendingProps,c),b.child;case 8:return aa(a,b,b.pendingProps.children,c),b.child;case 12:return aa(a,b,b.pendingProps.children,c),b.child;case 10:a:{d=b.type._context;e=b.pendingProps;f=b.memoizedProps;g=e.value;y(ud,d._currentValue);d._currentValue=g;if(null!==f)if(ua(f.value,g)){if(f.children===
+e.children&&!S.current){b=Qa(a,b,c);break a}}else for(f=b.child,null!==f&&(f.return=b);null!==f;){var h=f.dependencies;if(null!==h){g=f.child;for(var k=h.firstContext;null!==k;){if(k.context===d){if(1===f.tag){k=Pa(-1,c&-c);k.tag=2;var l=f.updateQueue;if(null!==l){l=l.shared;var p=l.pending;null===p?k.next=k:(k.next=p.next,p.next=k);l.pending=k}}f.lanes|=c;k=f.alternate;null!==k&&(k.lanes|=c);df(f.return,c,b);h.lanes|=c;break}k=k.next}}else if(10===f.tag)g=f.type===b.type?null:f.child;else if(18===
+f.tag){g=f.return;if(null===g)throw Error(m(341));g.lanes|=c;h=g.alternate;null!==h&&(h.lanes|=c);df(g,c,b);g=f.sibling}else g=f.child;if(null!==g)g.return=f;else for(g=f;null!==g;){if(g===b){g=null;break}f=g.sibling;if(null!==f){f.return=g.return;g=f;break}g=g.return}f=g}aa(a,b,e.children,c);b=b.child}return b;case 9:return e=b.type,d=b.pendingProps.children,Sb(b,c),e=qa(e),d=d(e),b.flags|=1,aa(a,b,d,c),b.child;case 14:return d=b.type,e=ya(d,b.pendingProps),e=ya(d.type,e),ni(a,b,d,e,c);case 15:return oi(a,
+b,b.type,b.pendingProps,c);case 17:return d=b.type,e=b.pendingProps,e=b.elementType===d?e:ya(d,e),Fd(a,b),b.tag=1,ea(d)?(a=!0,ld(b)):a=!1,Sb(b,c),ei(b,d,e),uf(b,d,e,c),Af(null,b,d,!0,a,c);case 19:return wi(a,b,c);case 22:return pi(a,b,c)}throw Error(m(156,b.tag));};var pa=function(a,b,c,d){return new Tk(a,b,c,d)},aj="function"===typeof reportError?reportError:function(a){console.error(a)};Ud.prototype.render=Xf.prototype.render=function(a){var b=this._internalRoot;if(null===b)throw Error(m(409));
+Sd(a,b,null,null)};Ud.prototype.unmount=Xf.prototype.unmount=function(){var a=this._internalRoot;if(null!==a){this._internalRoot=null;var b=a.containerInfo;yb(function(){Sd(null,a,null,null)});b[Ja]=null}};Ud.prototype.unstable_scheduleHydration=function(a){if(a){var b=nl();a={blockedOn:null,target:a,priority:b};for(var c=0;c<Ya.length&&0!==b&&b<Ya[c].priority;c++);Ya.splice(c,0,a);0===c&&Hg(a)}};var Cj=function(a){switch(a.tag){case 3:var b=a.stateNode;if(b.current.memoizedState.isDehydrated){var c=
+hc(b.pendingLanes);0!==c&&(xe(b,c|1),ia(b,P()),0===(p&6)&&(Hc(),db()))}break;case 13:yb(function(){var b=Oa(a,1);if(null!==b){var c=Z();xa(b,a,1,c)}}),Wf(a,1)}};var Gg=function(a){if(13===a.tag){var b=Oa(a,134217728);if(null!==b){var c=Z();xa(b,a,134217728,c)}Wf(a,134217728)}};var xj=function(a){if(13===a.tag){var b=hb(a),c=Oa(a,b);if(null!==c){var d=Z();xa(c,a,b,d)}Wf(a,b)}};var nl=function(){return z};var wj=function(a,b){var c=z;try{return z=a,b()}finally{z=c}};se=function(a,b,c){switch(b){case "input":le(a,
+c);b=c.name;if("radio"===c.type&&null!=b){for(c=a;c.parentNode;)c=c.parentNode;c=c.querySelectorAll("input[name="+JSON.stringify(""+b)+'][type="radio"]');for(b=0;b<c.length;b++){var d=c[b];if(d!==a&&d.form===a.form){var e=Rc(d);if(!e)throw Error(m(90));jg(d);le(d,e)}}}break;case "textarea":og(a,c);break;case "select":b=c.value,null!=b&&Db(a,!!c.multiple,b,!1)}};(function(a,b,c){xg=a;yg=c})(Tf,function(a,b,c,d,e){var f=z,g=ca.transition;try{return ca.transition=null,z=1,a(b,c,d,e)}finally{z=f,ca.transition=
+g,0===p&&Hc()}},yb);var ol={usingClientEntryPoint:!1,Events:[ec,Ib,Rc,ug,vg,Tf]};(function(a){a={bundleType:a.bundleType,version:a.version,rendererPackageName:a.rendererPackageName,rendererConfig:a.rendererConfig,overrideHookState:null,overrideHookStateDeletePath:null,overrideHookStateRenamePath:null,overrideProps:null,overridePropsDeletePath:null,overridePropsRenamePath:null,setErrorHandler:null,setSuspenseHandler:null,scheduleUpdate:null,currentDispatcherRef:Sa.ReactCurrentDispatcher,findHostInstanceByFiber:Xk,
+findFiberByHostInstance:a.findFiberByHostInstance||Yk,findHostInstancesForRefresh:null,scheduleRefresh:null,scheduleRoot:null,setRefreshHandler:null,getCurrentFiber:null,reconcilerVersion:"18.3.1"};if("undefined"===typeof __REACT_DEVTOOLS_GLOBAL_HOOK__)a=!1;else{var b=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(b.isDisabled||!b.supportsFiber)a=!0;else{try{Uc=b.inject(a),Ca=b}catch(c){}a=b.checkDCE?!0:!1}}return a})({findFiberByHostInstance:ob,bundleType:0,version:"18.3.1-next-f1338f8080-20240426",
+rendererPackageName:"react-dom"});Q.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED=ol;Q.createPortal=function(a,b){var c=2<arguments.length&&void 0!==arguments[2]?arguments[2]:null;if(!Yf(b))throw Error(m(200));return Wk(a,b,null,c)};Q.createRoot=function(a,b){if(!Yf(a))throw Error(m(299));var c=!1,d="",e=aj;null!==b&&void 0!==b&&(!0===b.unstable_strictMode&&(c=!0),void 0!==b.identifierPrefix&&(d=b.identifierPrefix),void 0!==b.onRecoverableError&&(e=b.onRecoverableError));b=Vf(a,1,!1,null,null,
+c,!1,d,e);a[Ja]=b.current;sc(8===a.nodeType?a.parentNode:a);return new Xf(b)};Q.findDOMNode=function(a){if(null==a)return null;if(1===a.nodeType)return a;var b=a._reactInternals;if(void 0===b){if("function"===typeof a.render)throw Error(m(188));a=Object.keys(a).join(",");throw Error(m(268,a));}a=Bg(b);a=null===a?null:a.stateNode;return a};Q.flushSync=function(a){return yb(a)};Q.hydrate=function(a,b,c){if(!Vd(b))throw Error(m(200));return Wd(null,a,b,!0,c)};Q.hydrateRoot=function(a,b,c){if(!Yf(a))throw Error(m(405));
+var d=null!=c&&c.hydratedSources||null,e=!1,f="",g=aj;null!==c&&void 0!==c&&(!0===c.unstable_strictMode&&(e=!0),void 0!==c.identifierPrefix&&(f=c.identifierPrefix),void 0!==c.onRecoverableError&&(g=c.onRecoverableError));b=Wi(b,null,a,1,null!=c?c:null,e,!1,f,g);a[Ja]=b.current;sc(a);if(d)for(a=0;a<d.length;a++)c=d[a],e=c._getVersion,e=e(c._source),null==b.mutableSourceEagerHydrationData?b.mutableSourceEagerHydrationData=[c,e]:b.mutableSourceEagerHydrationData.push(c,e);return new Ud(b)};Q.render=
+function(a,b,c){if(!Vd(b))throw Error(m(200));return Wd(null,a,b,!1,c)};Q.unmountComponentAtNode=function(a){if(!Vd(a))throw Error(m(40));return a._reactRootContainer?(yb(function(){Wd(null,null,a,!1,function(){a._reactRootContainer=null;a[Ja]=null})}),!0):!1};Q.unstable_batchedUpdates=Tf;Q.unstable_renderSubtreeIntoContainer=function(a,b,c,d){if(!Vd(c))throw Error(m(200));if(null==a||void 0===a._reactInternals)throw Error(m(38));return Wd(a,b,c,!1,d)};Q.version="18.3.1-next-f1338f8080-20240426"});
+})();
+</script>
+
+<!-- authoring-contract globals (mirrors How It Works.dc.html helmet) + inlined ghost art -->
+<script>
+  window.OM_SCENES = "[{\"name\":\"Arrive\",\"dur\":2.6},{\"name\":\"Meet\",\"dur\":2.8},{\"name\":\"Match\",\"dur\":2.8}]";
+  window.OM_PLAYBACK = "{\"mode\":\"loop\"}";
+  window.TWEAK_DEFAULTS = {"motionEditor":true,"showCaptions":true};
+  window.GHOSTS = {"ghosts/nervous.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg5IDc1IDMxOCAzMjUiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGMEVDRjUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjExLDE3OSkiPgogICAgICAgIDxwYXRoIGQ9Ik0wIDAgQzYuMTQ5MDQwODMgMy4xMzI1MzAyMyA5Ljc4MTI4OTg4IDcuNTI0MDIxMzEgMTIgMTQgQzEyLjk2NTE4MTUgMjEuNDA3MjA2ODQgMTEuOTQzNDQyMzQgMjcuNjM2NzE4MDQgOCAzNCBDNS4wNTQxNjAwNyAzNy41NTAxMTQ3OSAyLjUzOTEwODAzIDM5Ljk0NDM5MzQ4IC0yIDQxIEMtNy45ODAzNzIwOSA0MSAtMTAuOTk5OTg0MzIgMzkuNzkwOTg3NjkgLTE1LjQ1NzAzMTI1IDM1Ljg2MzI4MTI1IEMtMjAuNDQ2NDYzMzMgMjkuODM4MDY4MzMgLTIwLjUyMTEwNTY0IDI0LjE3ODIzOTYxIC0yMC4zNDM3NSAxNi42NDA2MjUgQy0xOS43MzY5OTI1OSAxMC4yMTQ1MTI0NiAtMTcuNzQ1MTY3NDMgNi4xNTI2MTc3IC0xMi44MTI1IDIgQy04LjY4NDg5NTIxIC0wLjYxMjk2ODcgLTQuNzQ3MzIxOTEgLTAuOTM1NjAzNTkgMCAwWiIgZmlsbD0iIzI3MTgzZiI+CiAgICAgICAgPC9wYXRoPgogICAgICAgIDxsaW5lIHgxPSItMTgiIHkxPSItNiIgeDI9IjgiIHkyPSItMTIiIHN0cm9rZT0iIzI3MTgzZiIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiPgogICAgICAgIDwvbGluZT4KICAgICAgPC9nPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyNzQuOTM3NSwxNzkuNjgzNTkzNzUpIj4KICAgICAgICA8cGF0aCBkPSJNMCAwIEM1LjI5MTg2ODg5IDIuNzQ4NTc4NDYgOC4xNjk0NDAyOCA2LjYzNzIyNzA5IDEwLjA2MjUgMTIuMzE2NDA2MjUgQzEwLjY3OTQ4ODAxIDIwLjI3NjU2MzA3IDExLjE0MjAyNzIyIDI3Ljc2NTI0MDMxIDYuMDYyNSAzNC4zMTY0MDYyNSBDMi4xOTE3ODE2MyAzOC41NDcxOTE0NCAtMS4wNzMxODE4NiA0MC4yMDEzMjk0OCAtNi42OTkyMTg3NSA0MC41MDM5MDYyNSBDLTEwLjUzMDAwNDY4IDQwLjE4MzAwMjcyIC0xMy4xMTk1MDk3MyAzOC45MTAwNzg4OCAtMTUuOTM3NSAzNi4zMTY0MDYyNSBDLTIxLjU4MzY1MjEzIDI5LjAzMTk5MjM2IC0yMi43NzExODc2MyAyMi40NDA2NTQxOSAtMjEuOTM3NSAxMy4zMTY0MDYyNSBDLTIwLjMwNzgwNjE3IDcuODk1OTAyODYgLTE3LjI1NDY5NjU1IDMuOTY5NDE4NzIgLTEyLjkzNzUgMC4zMTY0MDYyNSBDLTguNTg0OTk0OTMgLTEuMTM0NDI4NzcgLTQuMzU2MzYyNDUgLTEuNTM3MDIzMDQgMCAwWiIgZmlsbD0iIzI3MTgzZiI+CiAgICAgICAgPC9wYXRoPgogICAgICAgIDxsaW5lIHgxPSItOCIgeTE9Ii0xMiIgeDI9IjEyIiB5Mj0iLTYiIHN0cm9rZT0iIzI3MTgzZiIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiPgogICAgICAgIDwvbGluZT4KICAgICAgPC9nPgogICAgICA8cGF0aCBkPSJNMjI0LDI1MiBMMjMyLDI0OCBMMjQwLDI1NCBMMjQ4LDI0NyBMMjU2LDI1MyBMMjY0LDI0OSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjcxODNmIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+CiAgICAgIDwvcGF0aD4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTcwLDE1MCkiPgogICAgICAgIDxwYXRoIGQ9Ik0wLDAgUTIsLTQgMCwtOCBRLTIsLTQgMCwwWiIgZmlsbD0iIzg3Q0VFQiIgb3BhY2l0eT0iMC43Ij4KICAgICAgICA8L3BhdGg+CiAgICAgIDwvZz4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzMwLDE2MCkiPgogICAgICAgIDxwYXRoIGQ9Ik0wLDAgUTIsLTMgMCwtNiBRLTIsLTMgMCwwWiIgZmlsbD0iIzg3Q0VFQiIgb3BhY2l0eT0iMC42Ij4KICAgICAgICA8L3BhdGg+CiAgICAgIDwvZz4KICAgICAgPGNpcmNsZSBjeD0iMTU1IiBjeT0iMjAwIiByPSIyIiBmaWxsPSIjRkZENzAwIj4KICAgICAgPC9jaXJjbGU+CiAgICAgIDxjaXJjbGUgY3g9IjM0NSIgY3k9IjE4MCIgcj0iMS41IiBmaWxsPSIjQzA4NEZDIj4KICAgICAgPC9jaXJjbGU+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4=","ghosts/party.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg5IDc1IDMxOCAzMjUiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGRkY1RkEiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjQwLDEwOCkiPgogICAgICAgIDxwb2x5Z29uIHBvaW50cz0iMCwtMzAgLTE4LDEwIDE4LDEwIiBmaWxsPSIjN0MzQUVEIj48L3BvbHlnb24+CiAgICAgICAgPGxpbmUgeDE9Ii02IiB5MT0iLTE2IiB4Mj0iLTE0IiB5Mj0iNiIgc3Ryb2tlPSIjRkY1Q0E5IiBzdHJva2Utd2lkdGg9IjIuNSIgb3BhY2l0eT0iMC43Ij48L2xpbmU+CiAgICAgICAgPGxpbmUgeDE9IjYiIHkxPSItMTYiIHgyPSIxNCIgeTI9IjYiIHN0cm9rZT0iI0ZGRDcwMCIgc3Ryb2tlLXdpZHRoPSIyLjUiIG9wYWNpdHk9IjAuNyI+PC9saW5lPgogICAgICAgIDxjaXJjbGUgY3g9IjAiIGN5PSItMzIiIHI9IjUiIGZpbGw9IiNGRjVDQTkiPgogICAgICAgIDwvY2lyY2xlPgogICAgICAgIDxlbGxpcHNlIGN4PSIwIiBjeT0iMTAiIHJ4PSIyMCIgcnk9IjQiIGZpbGw9IiM3QzNBRUQiPjwvZWxsaXBzZT4KICAgICAgPC9nPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyMDMsMTgwKSI+CiAgICAgICAgPGNpcmNsZSBjeD0iMCIgY3k9IjE0IiByPSIxMiIgZmlsbD0iIzI3MTgzZiI+PC9jaXJjbGU+CiAgICAgICAgPGNpcmNsZSBjeD0iNCIgY3k9IjEwIiByPSI0IiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjg1Ij48L2NpcmNsZT4KICAgICAgICA8Y2lyY2xlIGN4PSItMiIgY3k9IjE2IiByPSIyIiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjQiPjwvY2lyY2xlPgogICAgICA8L2c+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI3MiwxODApIj4KICAgICAgICA8Y2lyY2xlIGN4PSIwIiBjeT0iMTQiIHI9IjExLjUiIGZpbGw9IiMyNzE4M2YiPjwvY2lyY2xlPgogICAgICAgIDxjaXJjbGUgY3g9IjQiIGN5PSIxMCIgcj0iNCIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC44NSI+PC9jaXJjbGU+CiAgICAgICAgPGNpcmNsZSBjeD0iLTIiIGN5PSIxNiIgcj0iMiIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC40Ij48L2NpcmNsZT4KICAgICAgPC9nPgogICAgICA8ZWxsaXBzZSBjeD0iMTgzIiBjeT0iMjIwIiByeD0iMTQiIHJ5PSI4IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjUiPgogICAgICA8L2VsbGlwc2U+CiAgICAgIDxlbGxpcHNlIGN4PSIzMDIiIGN5PSIyMjAiIHJ4PSIxNCIgcnk9IjgiIGZpbGw9IiNGRjhFQzYiIG9wYWNpdHk9IjAuNSI+CiAgICAgIDwvZWxsaXBzZT4KICAgICAgPHBhdGggZD0iTTIxOCwyNDIgUTI0NCwyNzAgMjcwLDI0MiIgZmlsbD0iIzI3MTgzZiIgc3Ryb2tlPSIjMjcxODNmIiBzdHJva2Utd2lkdGg9IjEiPgogICAgICA8L3BhdGg+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMzMCwzMTApIj4KICAgICAgICA8cGF0aCBkPSJNLTgsLTE4IEwtNSwwIEw1LDAgTDgsLTE4WiIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjQzA4NEZDIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjwvcGF0aD4KICAgICAgICA8cGF0aCBkPSJNLTYuNSwtMTIgTC01LDAgTDUsMCBMNi41LC0xMloiIGZpbGw9IiNGRjVDQTkiIG9wYWNpdHk9IjAuNSI+PC9wYXRoPgogICAgICAgIDxsaW5lIHgxPSIwIiB5MT0iMCIgeDI9IjAiIHkyPSI4IiBzdHJva2U9IiNDMDg0RkMiIHN0cm9rZS13aWR0aD0iMiI+PC9saW5lPgogICAgICAgIDxsaW5lIHgxPSItNiIgeTE9IjgiIHgyPSI2IiB5Mj0iOCIgc3Ryb2tlPSIjQzA4NEZDIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+PC9saW5lPgogICAgICAgIDxjaXJjbGUgY3g9Ii0yIiBjeT0iLTgiIHI9IjEuNSIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC41Ij4KICAgICAgICA8L2NpcmNsZT4KICAgICAgICA8Y2lyY2xlIGN4PSIyIiBjeT0iLTUiIHI9IjEiIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuNCI+CiAgICAgICAgPC9jaXJjbGU+CiAgICAgIDwvZz4KICAgICAgPHJlY3QgeD0iMTU1IiB5PSIxMDAiIHdpZHRoPSI0IiBoZWlnaHQ9IjQiIHJ4PSIxIiBmaWxsPSIjRkZENzAwIiBvcGFjaXR5PSIwIj4KICAgICAgPC9yZWN0PgogICAgICA8cmVjdCB4PSIzNDAiIHk9IjkwIiB3aWR0aD0iMy41IiBoZWlnaHQ9IjUiIHJ4PSIxIiBmaWxsPSIjRkY1Q0E5IiBvcGFjaXR5PSIwIj4KICAgICAgPC9yZWN0PgogICAgICA8cmVjdCB4PSIyMDAiIHk9Ijg1IiB3aWR0aD0iMyIgaGVpZ2h0PSI2IiByeD0iMSIgZmlsbD0iI0MwODRGQyIgb3BhY2l0eT0iMCI+CiAgICAgIDwvcmVjdD4KICAgICAgPHJlY3QgeD0iMjkwIiB5PSI4MCIgd2lkdGg9IjQiIGhlaWdodD0iMyIgcng9IjEiIGZpbGw9IiNGRkQ3MDAiIG9wYWNpdHk9IjAiPgogICAgICA8L3JlY3Q+CiAgICAgIDxyZWN0IHg9IjI0NSIgeT0iNzgiIHdpZHRoPSIzIiBoZWlnaHQ9IjQiIHJ4PSIxIiBmaWxsPSIjRkY1Q0E5IiBvcGFjaXR5PSIwIj4KICAgICAgPC9yZWN0PgogICAgICA8cGF0aCBkPSJNMCwtNSBMMS41LC0xLjUgTDUsMCBMMS41LDEuNSBMMCw1IEwtMS41LDEuNSBMLTUsMCBMLTEuNSwtMS41WiIgZmlsbD0iI0ZGRDcwMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYwLDE1NSkiPgogICAgICA8L3BhdGg+CiAgICAgIDxwYXRoIGQ9Ik0wLC0zIEwwLjksLTAuOSBMMywwIEwwLjksMC45IEwwLDMgTC0wLjksMC45IEwtMywwIEwtMC45LC0wLjlaIiBmaWxsPSIjRkY1Q0E5IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxNDAsMTc1KSI+CiAgICAgIDwvcGF0aD4KICAgIDwvZz4KICA8L2c+Cjwvc3ZnPg==","ghosts/laughing.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg5IDc1IDMxOCAzMjUiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGRkY1RkEiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPHBhdGggZD0iTTE5MCwxOTIgUTIwMCwyMDAgMjEwLDE5MiIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjcxODNmIiBzdHJva2Utd2lkdGg9IjQiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+PC9wYXRoPgogICAgICA8cGF0aCBkPSJNMjY1LDE5MiBRMjc1LDIwMCAyODUsMTkyIiBmaWxsPSJub25lIiBzdHJva2U9IiMyNzE4M2YiIHN0cm9rZS13aWR0aD0iNCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj48L3BhdGg+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE3OCwxOTIpIj4KICAgICAgICA8cGF0aCBkPSJNMCwwIFExLjUsLTMgMCwtNSBRLTEuNSwtMyAwLDBaIiBmaWxsPSIjODdDRUVCIiBvcGFjaXR5PSIwLjYiPgogICAgICAgIDwvcGF0aD4KICAgICAgPC9nPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyOTgsMTkyKSI+CiAgICAgICAgPHBhdGggZD0iTTAsMCBRMS41LC0zIDAsLTUgUS0xLjUsLTMgMCwwWiIgZmlsbD0iIzg3Q0VFQiIgb3BhY2l0eT0iMC42Ij4KICAgICAgICA8L3BhdGg+CiAgICAgIDwvZz4KICAgICAgPGVsbGlwc2UgY3g9IjE4MiIgY3k9IjIxNSIgcng9IjE1IiByeT0iOCIgZmlsbD0iI0ZGOEVDNiIgb3BhY2l0eT0iMC41NSI+CiAgICAgIDwvZWxsaXBzZT4KICAgICAgPGVsbGlwc2UgY3g9IjMwMiIgY3k9IjIxNSIgcng9IjE1IiByeT0iOCIgZmlsbD0iI0ZGOEVDNiIgb3BhY2l0eT0iMC41NSI+CiAgICAgIDwvZWxsaXBzZT4KICAgICAgPHBhdGggZD0iTTIxNSwyNDAgUTI0NCwyODAgMjczLDI0MCIgZmlsbD0iIzI3MTgzZiIgc3Ryb2tlPSIjMjcxODNmIiBzdHJva2Utd2lkdGg9IjEiPgogICAgICA8L3BhdGg+CiAgICAgIDxnPgogICAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE2NSwxMzApIj4KICAgICAgICAgIDxsaW5lIHgxPSIwIiB5MT0iMCIgeDI9IjAiIHkyPSIxMCIgc3Ryb2tlPSIjRkY1Q0E5IiBzdHJva2Utd2lkdGg9IjIuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj48L2xpbmU+CiAgICAgICAgICA8Y2lyY2xlIGN4PSIwIiBjeT0iMTQiIHI9IjEuNSIgZmlsbD0iI0ZGNUNBOSI+PC9jaXJjbGU+CiAgICAgICAgPC9nPgogICAgICA8L2c+CiAgICAgIDxnPgogICAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDM0MCwxMjUpIj4KICAgICAgICAgIDxsaW5lIHgxPSIwIiB5MT0iMCIgeDI9IjAiIHkyPSIxMCIgc3Ryb2tlPSIjQzA4NEZDIiBzdHJva2Utd2lkdGg9IjIuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj48L2xpbmU+CiAgICAgICAgICA8Y2lyY2xlIGN4PSIwIiBjeT0iMTQiIHI9IjEuNSIgZmlsbD0iI0MwODRGQyI+PC9jaXJjbGU+CiAgICAgICAgPC9nPgogICAgICA8L2c+CiAgICAgIDxnPgogICAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI1MCwxMTUpIj4KICAgICAgICAgIDxsaW5lIHgxPSIwIiB5MT0iMCIgeDI9IjAiIHkyPSI4IiBzdHJva2U9IiNGRkQ3MDAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj48L2xpbmU+CiAgICAgICAgICA8Y2lyY2xlIGN4PSIwIiBjeT0iMTEiIHI9IjEuMiIgZmlsbD0iI0ZGRDcwMCI+PC9jaXJjbGU+CiAgICAgICAgPC9nPgogICAgICA8L2c+CiAgICAgIDxwYXRoIGQ9Ik0wLC01IEwxLjUsLTEuNSBMNSwwIEwxLjUsMS41IEwwLDUgTC0xLjUsMS41IEwtNSwwIEwtMS41LC0xLjVaIiBmaWxsPSIjRkZENzAwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNTUsMTUwKSI+CiAgICAgIDwvcGF0aD4KICAgICAgPHBhdGggZD0iTTAsLTQgTDEuMiwtMS4yIEw0LDAgTDEuMiwxLjIgTDAsNCBMLTEuMiwxLjIgTC00LDAgTC0xLjIsLTEuMloiIGZpbGw9IiNGRjVDQTkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE0NSwxNjUpIj4KICAgICAgPC9wYXRoPgogICAgPC9nPgogIDwvZz4KPC9zdmc+","ghosts/chatting.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjMwIDUwIDUyMCAzODAiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTUwLCAwKSBzY2FsZSgwLjg1KSI+CiAgICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGRkY1RkEiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgICAgPC9wYXRoPgogICAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDIwNywxODApIj4KICAgICAgICAgIDxjaXJjbGUgY3g9IjAiIGN5PSIxNCIgcj0iMTAiIGZpbGw9IiMyNzE4M2YiPjwvY2lyY2xlPgogICAgICAgICAgPGNpcmNsZSBjeD0iMyIgY3k9IjExIiByPSIzIiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjgiPjwvY2lyY2xlPgogICAgICAgICAgPGNpcmNsZSBjeD0iLTIiIGN5PSIxNiIgcj0iMS41IiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjQiPjwvY2lyY2xlPgogICAgICAgIDwvZz4KICAgICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyNzAsMTgwKSI+CiAgICAgICAgICA8Y2lyY2xlIGN4PSIwIiBjeT0iMTQiIHI9IjkuNSIgZmlsbD0iIzI3MTgzZiI+PC9jaXJjbGU+CiAgICAgICAgICA8Y2lyY2xlIGN4PSIzIiBjeT0iMTEiIHI9IjMiIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuOCI+PC9jaXJjbGU+CiAgICAgICAgICA8Y2lyY2xlIGN4PSItMiIgY3k9IjE2IiByPSIxLjUiIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuNCI+PC9jaXJjbGU+CiAgICAgICAgPC9nPgogICAgICAgIDxlbGxpcHNlIGN4PSIxODgiIGN5PSIyMTUiIHJ4PSIxMiIgcnk9IjYiIGZpbGw9IiNGRjhFQzYiIG9wYWNpdHk9IjAuNDUiPgogICAgICAgIDwvZWxsaXBzZT4KICAgICAgICA8ZWxsaXBzZSBjeD0iMjk1IiBjeT0iMjE1IiByeD0iMTIiIHJ5PSI2IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjQ1Ij4KICAgICAgICA8L2VsbGlwc2U+CiAgICAgICAgPHBhdGggZD0iTTIyMiwyMzUgUTI0MywyNTYgMjY0LDIzNSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjcxODNmIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICA8L2c+CiAgICA8Zz4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoNjMwLCAwKSBzY2FsZSgtMC44NSwgMC44NSkiPgogICAgICAgIDxwYXRoIGQ9Ik0wIDAgQzIwLjEwMjU2NjkxIDE2LjI2MDI0ODAzIDM0Ljg3ODE5NDI4IDM3LjU3OTQ3ODk2IDM4LjE4NzUgNjMuNzY5NTMxMjUgQzM4LjQ2MDc0MjQ5IDY4LjEyMDA2NDAxIDM4LjU5ODc5NTU0IDcyLjQ1NTEwMjcyIDM4LjY4NzUgNzYuODEyNSBDMzkuNDkzOTc2MTkgMTA4LjczMTE1MTkxIDQyLjE5OTkyMTgxIDEzOS4wNjQzMDU1NiA2Ni4zMzU5Mzc1IDE2Mi43MzQzNzUgQzcwLjAwNTk1MjEzIDE2NS45Nzc2NDM3NSA3My45NTk0ODkwNSAxNjguODA3MDMxMSA3Ny45NTMxMjUgMTcxLjYzNjcxODc1IEM4Mi45OTE3MjE4IDE3NS42NDYwMDIyMSA4NS4zNjAyNzI4OSAxNzkuMjk2MjU5ODUgODYuNDg4MjgxMjUgMTg1LjU0Njg3NSBDODYuODczMzkyMDEgMTg5LjkyNjU2NjA0IDg1Ljk1MTIxMjA4IDE5My4wNjczNzM4IDgzLjM3NSAxOTYuNjI1IEM3Ny45MDk0MzcyNSAyMDIuNzIxMjA0NjEgNzAuODg5MjA3OTEgMjA1LjI5OTI5NzUgNjMuMzM1OTM3NSAyMDguMDE5NTMxMjUgQzUwLjg1Mzk4MzQzIDIxMi41Mzg4NTk0NSA0NS45ODkyMTc5NSAyMTguMzIwOTAwMDEgMzkuMDE5NTMxMjUgMjI5LjI1MzkwNjI1IEMzMy43MDg1OTU5NSAyMzcuNDY4NzE2OTIgMjcuNDkzMTY2OTUgMjQyLjk1MDE3NzUgMTcuNzUgMjQ1LjI1IEMxMC4zODgzNDggMjQ2LjM4ODc1NTU0IDMuMzQ5Mjc3NzIgMjQ1LjE3MzA1NTcgLTMuODc1IDI0My42ODc1IEMtMTAuMTI5NTk0NzMgMjQyLjUzOTc4NjMyIC0xNS45NTgxMzE1MiAyNDEuODc4MTQ3NTEgLTIxLjY1NjI1IDI0NS4xNjQwNjI1IEMtMjUuNTQ1MjM2ODggMjQ4LjA4MDgwMjY2IC0yOC45Mjc5MjUyNyAyNTEuMzk2NzgwOTEgLTMyLjMxMjUgMjU0Ljg3NSBDLTQwLjY2MTIwNTgyIDI2My40MDUxOTk0MiAtNTAuNDMzMTA1OTUgMjY4Ljk1NTk5NzI4IC02Mi41IDI2OS4yNSBDLTczLjc2NTMwNzIxIDI2OC44NzI4Njc2OSAtODIuNzk0Njc4MzkgMjYyLjkxMzc5MTE4IC05MC41MDM5MDYyNSAyNTQuOTM3NSBDLTkyLjc1MDk5MDA4IDI1Mi4yOTcyOTc4MyAtOTQuNzMwMTY4NjIgMjQ5LjUwNDkwNTgzIC05Ni43NSAyNDYuNjg3NSBDLTEwMS4zMjMyMDIxMyAyNDAuNDk0Mjk5MTUgLTEwNS41Njg3ODIzNCAyMzYuMjYzNzM2ODkgLTExMy4zMTI1IDIzNC44NzUgQy0xMTYuNzkzNzExMTYgMjM0LjYxODYzMTc0IC0xMTkuNjk1ODkwMzkgMjM1LjM2NDEzMzc2IC0xMjMuMDU0Njg3NSAyMzYuMzEyNSBDLTEzMC45MzEwMTAxNiAyMzguMDU2NzM3NTQgLTEzOC4xMjAxNDM4MiAyMzcuNDM0OTA1NDYgLTE0NS4xMzY3MTg3NSAyMzMuNDA2MjUgQy0xNTEuNzUzMDcyODUgMjI4LjU1OTgwMDMyIC0xNTQuODIxODE3MTMgMjIxLjExOTQ3NDg2IC0xNTguMjEwOTM3NSAyMTMuODYzMjgxMjUgQy0xNjMuNjMyOTAzOTkgMjA1Ljk5MjM1OTYzIC0xNzIuOTg1NjA3NjIgMjA0LjA2NDUzNTkzIC0xODEuNzEwOTM3NSAyMDEuNDk2MDkzNzUgQy0xODguNTIyMDM3IDE5OS4zNzk5Mjg0NCAtMTkzLjA2MDM5MzM1IDE5Ny4xMTU1ODk3NSAtMTk3LjE4NzUgMTkxLjA2MjUgQy0xOTkuMDM4NTUzMjMgMTg1LjcxNTAxMjg4IC0xOTkuMDcyODU1MTIgMTgxLjA0ODgzODU5IC0xOTcuMjUgMTc1LjY4NzUgQy0xOTMuMzI0MzgxMDUgMTY5Ljg2MjM4ODAxIC0xODguNzg4ODczMzcgMTY1Ljk4MjA1ODkyIC0xODIuODEyNSAxNjIuMzEyNSBDLTE2OS41MDMyMjA4OSAxNTQuMDY5MDk5MyAtMTYyLjY4MTU4NzgxIDE0MS4yMzk1MDkzMyAtMTU3LjMxMjUgMTI2LjgxMjUgQy0xNTYuOTU0MTQwNjMgMTI1Ljk2MzAwNzgxIC0xNTYuNTk1NzgxMjUgMTI1LjExMzUxNTYyIC0xNTYuMjI2NTYyNSAxMjQuMjM4MjgxMjUgQy0xNTAuOTIxMTQ1MTkgMTEwLjU3NTgzNDQzIC0xNTAuNTIzMTM3NjQgOTQuOTM4NzgyMTIgLTE0OS42NTA2MzQ3NyA4MC40NTcyNzUzOSBDLTE0Ny45NTY1NjM2OCA1Mi45Nzc2MTgzNyAtMTQwLjAwMjA5MTM2IDI3LjI0Nzc4NDA0IC0xMTkuNTI3MzQzNzUgNy43NDYwOTM3NSBDLTg2LjY2NTM1NjExIC0yMC45NDI5NDMwOCAtMzYuMTg3NTMxIC0yNS44Njg2MTYxMiAwIDBaIiBmaWxsPSIjRkVFOEYwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyOTMuMzEyNSwxMjYuMTg3NSkiPgogICAgICAgIDwvcGF0aD4KICAgICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyMDcsMTgwKSI+CiAgICAgICAgICA8Y2lyY2xlIGN4PSIwIiBjeT0iMTQiIHI9IjEwIiBmaWxsPSIjMjcxODNmIj48L2NpcmNsZT4KICAgICAgICAgIDxjaXJjbGUgY3g9IjMiIGN5PSIxMSIgcj0iMyIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC44Ij48L2NpcmNsZT4KICAgICAgICAgIDxjaXJjbGUgY3g9Ii0yIiBjeT0iMTYiIHI9IjEuNSIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC40Ij48L2NpcmNsZT4KICAgICAgICA8L2c+CiAgICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjcwLDE4MCkiPgogICAgICAgICAgPGNpcmNsZSBjeD0iMCIgY3k9IjE0IiByPSI5LjUiIGZpbGw9IiMyNzE4M2YiPjwvY2lyY2xlPgogICAgICAgICAgPGNpcmNsZSBjeD0iMyIgY3k9IjExIiByPSIzIiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjgiPjwvY2lyY2xlPgogICAgICAgICAgPGNpcmNsZSBjeD0iLTIiIGN5PSIxNiIgcj0iMS41IiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjQiPjwvY2lyY2xlPgogICAgICAgIDwvZz4KICAgICAgICA8ZWxsaXBzZSBjeD0iMTg4IiBjeT0iMjE1IiByeD0iMTIiIHJ5PSI2IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjQ1Ij4KICAgICAgICA8L2VsbGlwc2U+CiAgICAgICAgPGVsbGlwc2UgY3g9IjI5NSIgY3k9IjIxNSIgcng9IjEyIiByeT0iNiIgZmlsbD0iI0ZGOEVDNiIgb3BhY2l0eT0iMC40NSI+CiAgICAgICAgPC9lbGxpcHNlPgogICAgICAgIDxwYXRoIGQ9Ik0yMjIsMjM1IFEyNDMsMjU2IDI2NCwyMzUiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzI3MTgzZiIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiPgogICAgICAgIDwvcGF0aD4KICAgICAgPC9nPgogICAgPC9nPgogICAgPGc+CiAgICAgIDxyZWN0IHg9IjI0OCIgeT0iMTYwIiB3aWR0aD0iNDIiIGhlaWdodD0iMzAiIHJ4PSIxMCIgcnk9IjEwIiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjkiIHN0cm9rZT0iI0MwODRGQyIgc3Ryb2tlLXdpZHRoPSIxLjUiPjwvcmVjdD4KICAgICAgPHBvbHlnb24gcG9pbnRzPSIyNTIsMTg1IDI0MiwxOTUgMjU4LDE5MCIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC45IiBzdHJva2U9IiNDMDg0RkMiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWpvaW49InJvdW5kIj48L3BvbHlnb24+CiAgICAgIDxyZWN0IHg9IjI1MiIgeT0iMTgyIiB3aWR0aD0iOCIgaGVpZ2h0PSI4IiBmaWxsPSIjRkZGRkZGIj48L3JlY3Q+CiAgICAgIDxwYXRoIGQ9Ik0wLDIgQzAsMC44IC0xLDAgLTIuMiwwIEMtMy40LDAgLTQuNCwwLjggLTQuNCwyIEMtNC40LDQgMCw2LjUgMCw2LjUgQzAsNi41IDQuNCw0IDQuNCwyIEM0LjQsMC44IDMuNCwwIDIuMiwwIEMxLDAgMCwwLjggMCwyWiIgZmlsbD0iI0ZGNUNBOSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjY5LDE3MikiPgogICAgICA8L3BhdGg+CiAgICA8L2c+CiAgICA8Zz4KICAgICAgPHJlY3QgeD0iMjkwIiB5PSIyMDAiIHdpZHRoPSI0MiIgaGVpZ2h0PSIyOCIgcng9IjEwIiByeT0iMTAiIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuOSIgc3Ryb2tlPSIjRkY1Q0E5IiBzdHJva2Utd2lkdGg9IjEuNSI+PC9yZWN0PgogICAgICA8cG9seWdvbiBwb2ludHM9IjMyOCwyMjMgMzM4LDIzMyAzMjIsMjI4IiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjkiIHN0cm9rZT0iI0ZGNUNBOSIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjwvcG9seWdvbj4KICAgICAgPHJlY3QgeD0iMzIyIiB5PSIyMjAiIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIGZpbGw9IiNGRkZGRkYiPjwvcmVjdD4KICAgICAgPGNpcmNsZSBjeD0iMzAzIiBjeT0iMjE0IiByPSIyLjUiIGZpbGw9IiNDMDg0RkMiPgogICAgICA8L2NpcmNsZT4KICAgICAgPGNpcmNsZSBjeD0iMzExIiBjeT0iMjE0IiByPSIyLjUiIGZpbGw9IiNDMDg0RkMiPgogICAgICA8L2NpcmNsZT4KICAgICAgPGNpcmNsZSBjeD0iMzE5IiBjeT0iMjE0IiByPSIyLjUiIGZpbGw9IiNDMDg0RkMiPgogICAgICA8L2NpcmNsZT4KICAgIDwvZz4KICAgIDxnPgogICAgICA8cGF0aCBkPSJNMCwzIEMwLDEuMyAtMS4zLDAgLTMsMCBDLTQuNywwIC02LDEuMyAtNiwzIEMtNiw2IDAsOSAwLDkgQzAsOSA2LDYgNiwzIEM2LDEuMyA0LjcsMCAzLDAgQzEuMywwIDAsMS4zIDAsM1oiIGZpbGw9IiNGRjVDQTkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5MCwxNDApIj48L3BhdGg+CiAgICA8L2c+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAsMiBDMCwwLjggLTEsMCAtMiwwIEMtMywwIC00LDAuOCAtNCwyIEMtNCw0IDAsNiAwLDYgQzAsNiA0LDQgNCwyIEM0LDAuOCAzLDAgMiwwIEMxLDAgMCwwLjggMCwyWiIgZmlsbD0iI0MwODRGQyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjcwLDE1MCkiPjwvcGF0aD4KICAgIDwvZz4KICAgIDxnPgogICAgICA8cGF0aCBkPSJNMCwxLjUgQzAsMC42IC0wLjYsMCAtMS41LDAgQy0yLjQsMCAtMywwLjYgLTMsMS41IEMtMywzIDAsNC41IDAsNC41IEMwLDQuNSAzLDMgMywxLjUgQzMsMC42IDIuNCwwIDEuNSwwIEMwLjYsMCAwLDAuNiAwLDEuNVoiIGZpbGw9IiNGRkQ3MDAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMxMCwxNDUpIj48L3BhdGg+CiAgICA8L2c+CiAgICA8cGF0aCBkPSJNMCwtNSBMMS41LC0xLjUgTDUsMCBMMS41LDEuNSBMMCw1IEwtMS41LDEuNSBMLTUsMCBMLTEuNSwtMS41WiIgZmlsbD0iI0ZGRDcwMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTIwLDEwMCkiPgogICAgPC9wYXRoPgogICAgPHBhdGggZD0iTTAsLTQgTDEuMiwtMS4yIEw0LDAgTDEuMiwxLjIgTDAsNCBMLTEuMiwxLjIgTC00LDAgTC0xLjIsLTEuMloiIGZpbGw9IiNDMDg0RkMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDQ2MCwxMTApIj4KICAgIDwvcGF0aD4KICAgIDxwYXRoIGQ9Ik0wLC0zIEwwLjksLTAuOSBMMywwIEwwLjksMC45IEwwLDMgTC0wLjksMC45IEwtMywwIEwtMC45LC0wLjlaIiBmaWxsPSIjRkY1Q0E5IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyOTAsNTUpIj4KICAgIDwvcGF0aD4KICA8L2c+Cjwvc3ZnPg==","ghosts/blushing.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg5IDc1IDMxOCAzMjUiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGRkYwRjUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPHBhdGggZD0iTTE5MywxOTUgUTIwMywxODMgMjEzLDE5NSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMjcxODNmIiBzdHJva2Utd2lkdGg9IjMuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj48L3BhdGg+CiAgICAgIDxwYXRoIGQ9Ik0yNjMsMTk1IFEyNzMsMTgzIDI4MywxOTUiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzI3MTgzZiIgc3Ryb2tlLXdpZHRoPSIzLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCI+PC9wYXRoPgogICAgICA8ZWxsaXBzZSBjeD0iMTgwIiBjeT0iMjE1IiByeD0iMTgiIHJ5PSIxMCIgZmlsbD0iI0ZGOEVDNiIgb3BhY2l0eT0iMC42Ij4KICAgICAgPC9lbGxpcHNlPgogICAgICA8ZWxsaXBzZSBjeD0iMzA1IiBjeT0iMjE1IiByeD0iMTgiIHJ5PSIxMCIgZmlsbD0iI0ZGOEVDNiIgb3BhY2l0eT0iMC42Ij4KICAgICAgPC9lbGxpcHNlPgogICAgICA8cGF0aCBkPSJNMjE4LDIzOCBRMjQzLDI2NSAyNjgsMjM4IiBmaWxsPSJub25lIiBzdHJva2U9IiMyNzE4M2YiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj4KICAgICAgPC9wYXRoPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzMTUsMjg1KSI+CiAgICAgICAgPHJlY3QgeD0iLTE0IiB5PSItMjIiIHdpZHRoPSIyOCIgaGVpZ2h0PSI0NCIgcng9IjQiIHJ5PSI0IiBmaWxsPSIjMjcxODNmIiBvcGFjaXR5PSIwLjg1Ij48L3JlY3Q+CiAgICAgICAgPHJlY3QgeD0iLTExIiB5PSItMTgiIHdpZHRoPSIyMiIgaGVpZ2h0PSIzNiIgcng9IjIiIHJ5PSIyIiBmaWxsPSIjNEEzNTY2Ij48L3JlY3Q+CiAgICAgICAgPHBhdGggZD0iTTAsMi41IEMwLDEgLTEuNSwwIC0zLDAgQy00LjUsMCAtNiwxIC02LDIuNSBDLTYsNSAwLDggMCw4IEMwLDggNiw1IDYsMi41IEM2LDEgNC41LDAgMywwIEMxLjUsMCAwLDEgMCwyLjVaIiBmaWxsPSIjRkY1Q0E5IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLC0yKSI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxnPgogICAgICAgIDxwYXRoIGQ9Ik0wLDIgQzAsMC44IC0wLjgsMCAtMiwwIEMtMy4yLDAgLTQsMC44IC00LDIgQy00LDQgMCw2IDAsNiBDMCw2IDQsNCA0LDIgQzQsMC44IDMuMiwwIDIsMCBDMC44LDAgMCwwLjggMCwyWiIgZmlsbD0iI0ZGNUNBOSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzIwLDI2MCkiPjwvcGF0aD4KICAgICAgPC9nPgogICAgICA8Zz4KICAgICAgICA8cGF0aCBkPSJNMCwxLjUgQzAsMC42IC0wLjYsMCAtMS41LDAgQy0yLjQsMCAtMywwLjYgLTMsMS41IEMtMywzIDAsNC41IDAsNC41IEMwLDQuNSAzLDMgMywxLjUgQzMsMC42IDIuNCwwIDEuNSwwIEMwLjYsMCAwLDAuNiAwLDEuNVoiIGZpbGw9IiNDMDg0RkMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMzMCwyNTUpIj48L3BhdGg+CiAgICAgIDwvZz4KICAgICAgPGc+CiAgICAgICAgPHBhdGggZD0iTTAsMSBDMCwwLjQgLTAuNSwwIC0xLDAgQy0xLjUsMCAtMiwwLjQgLTIsMSBDLTIsMiAwLDMgMCwzIEMwLDMgMiwyIDIsMSBDMiwwLjQgMS41LDAgMSwwIEMwLjUsMCAwLDAuNCAwLDFaIiBmaWxsPSIjRkZENzAwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzMjUsMjY1KSI+PC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxwYXRoIGQ9Ik0wLC01IEwxLjUsLTEuNSBMNSwwIEwxLjUsMS41IEwwLDUgTC0xLjUsMS41IEwtNSwwIEwtMS41LC0xLjVaIiBmaWxsPSIjRkZENzAwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNTAsMTQwKSI+CiAgICAgIDwvcGF0aD4KICAgICAgPHBhdGggZD0iTTAsLTQgTDEuMiwtMS4yIEw0LDAgTDEuMiwxLjIgTDAsNCBMLTEuMiwxLjIgTC00LDAgTC0xLjIsLTEuMloiIGZpbGw9IiNGRjVDQTkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE1MCwxNTUpIj4KICAgICAgPC9wYXRoPgogICAgICA8cGF0aCBkPSJNMCwtMyBMMC45LC0wLjkgTDMsMCBMMC45LDAuOSBMMCwzIEwtMC45LDAuOSBMLTMsMCBMLTAuOSwtMC45WiIgZmlsbD0iI0MwODRGQyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTYwLDEyMCkiPgogICAgICA8L3BhdGg+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4=","ghosts/discover.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg5IDc1IDMxOCAzMjUiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGRkY1RjgiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjA1LDE4MCkiPgogICAgICAgIDxjaXJjbGUgY3g9IjAiIGN5PSIxNCIgcj0iMTEiIGZpbGw9IiMyNzE4M2YiPjwvY2lyY2xlPgogICAgICAgIDxjaXJjbGUgY3g9IjQiIGN5PSIxMSIgcj0iMy41IiBmaWxsPSIjRkZGRkZGIiBvcGFjaXR5PSIwLjg1Ij48L2NpcmNsZT4KICAgICAgICA8Y2lyY2xlIGN4PSItMSIgY3k9IjE3IiByPSIxLjUiIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuNCI+PC9jaXJjbGU+CiAgICAgIDwvZz4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjcyLDE4MCkiPgogICAgICAgIDxjaXJjbGUgY3g9IjAiIGN5PSIxNCIgcj0iMTAuNSIgZmlsbD0iIzI3MTgzZiI+PC9jaXJjbGU+CiAgICAgICAgPGNpcmNsZSBjeD0iNCIgY3k9IjExIiByPSIzLjUiIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuODUiPjwvY2lyY2xlPgogICAgICAgIDxjaXJjbGUgY3g9Ii0xIiBjeT0iMTciIHI9IjEuNSIgZmlsbD0iI0ZGRkZGRiIgb3BhY2l0eT0iMC40Ij48L2NpcmNsZT4KICAgICAgPC9nPgogICAgICA8ZWxsaXBzZSBjeD0iMTg1IiBjeT0iMjE4IiByeD0iMTMiIHJ5PSI3IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjQ1Ij4KICAgICAgPC9lbGxpcHNlPgogICAgICA8ZWxsaXBzZSBjeD0iMzAwIiBjeT0iMjE4IiByeD0iMTMiIHJ5PSI3IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjQ1Ij4KICAgICAgPC9lbGxpcHNlPgogICAgICA8cGF0aCBkPSJNMjI0LDI0MiBRMjQ0LDI1OCAyNjQsMjQyIiBmaWxsPSJub25lIiBzdHJva2U9IiMyNzE4M2YiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIj4KICAgICAgPC9wYXRoPgogICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzMzAsMjgwKSI+CiAgICAgICAgPHJlY3QgeD0iNCIgeT0iLTMyIiB3aWR0aD0iMjgiIGhlaWdodD0iMzgiIHJ4PSI0IiByeT0iNCIgZmlsbD0iIzI3MTgzZiIgb3BhY2l0eT0iMC40Ij48L3JlY3Q+CiAgICAgICAgPHJlY3QgeD0iLTIiIHk9Ii0zNiIgd2lkdGg9IjI4IiBoZWlnaHQ9IjM4IiByeD0iNCIgcnk9IjQiIGZpbGw9IiMyNzE4M2YiIG9wYWNpdHk9IjAuNzUiPjwvcmVjdD4KICAgICAgICA8cmVjdCB4PSIxIiB5PSItMzMiIHdpZHRoPSIyMiIgaGVpZ2h0PSIzMiIgcng9IjIiIHJ5PSIyIiBmaWxsPSIjNEEzNTY2Ij48L3JlY3Q+CiAgICAgICAgPGVsbGlwc2UgY3g9IjEyIiBjeT0iLTIyIiByeD0iNiIgcnk9IjciIGZpbGw9IiNGRkYwRjUiIG9wYWNpdHk9IjAuNiI+PC9lbGxpcHNlPgogICAgICAgIDxlbGxpcHNlIGN4PSIxMiIgY3k9Ii0xMyIgcng9IjQuNSIgcnk9IjMiIGZpbGw9IiNGRkYwRjUiIG9wYWNpdHk9IjAuNCI+PC9lbGxpcHNlPgogICAgICAgIDxsaW5lIHgxPSI0IiB5MT0iLTYiIHgyPSIyMCIgeTI9Ii02IiBzdHJva2U9IiNDMDg0RkMiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIG9wYWNpdHk9IjAuNSI+PC9saW5lPgogICAgICAgIDxsaW5lIHgxPSI2IiB5MT0iLTIiIHgyPSIxOCIgeTI9Ii0yIiBzdHJva2U9IiNDMDg0RkMiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIG9wYWNpdHk9IjAuMyI+PC9saW5lPgogICAgICA8L2c+CiAgICAgIDxnPgogICAgICAgIDxwYXRoIGQ9Ik0wLDIuNSBDMCwxIC0xLDAgLTIuNSwwIEMtNCwwIC01LDEgLTUsMi41IEMtNSw1IDAsNy41IDAsNy41IEMwLDcuNSA1LDUgNSwyLjUgQzUsMSA0LDAgMi41LDAgQzEsMCAwLDEgMCwyLjVaIiBmaWxsPSIjRkY1Q0E5IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNDUsMjQwKSI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxwYXRoIGQ9Ik0wLC01IEwxLjUsLTEuNSBMNSwwIEwxLjUsMS41IEwwLDUgTC0xLjUsMS41IEwtNSwwIEwtMS41LC0xLjVaIiBmaWxsPSIjRkZENzAwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNTUsMTQ1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPHBhdGggZD0iTTAsLTQgTDEuMiwtMS4yIEw0LDAgTDEuMiwxLjIgTDAsNCBMLTEuMiwxLjIgTC00LDAgTC0xLjIsLTEuMloiIGZpbGw9IiNDMDg0RkMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE0OCwxNTUpIj4KICAgICAgPC9wYXRoPgogICAgICA8cGF0aCBkPSJNMCwtMyBMMC45LC0wLjkgTDMsMCBMMC45LDAuOSBMMCwzIEwtMC45LDAuOSBMLTMsMCBMLTAuOSwtMC45WiIgZmlsbD0iI0ZGNUNBOSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzY1LDI3MCkiPgogICAgICA8L3BhdGg+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4=","ghosts/inlove.svg":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ijg5IDc1IDMxOCAzMjUiIGNsYXNzPSJ3LTcgaC03IiBhcmlhLWhpZGRlbj0idHJ1ZSI+CiAgPGc+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTAgMCBDMjAuMTAyNTY2OTEgMTYuMjYwMjQ4MDMgMzQuODc4MTk0MjggMzcuNTc5NDc4OTYgMzguMTg3NSA2My43Njk1MzEyNSBDMzguNDYwNzQyNDkgNjguMTIwMDY0MDEgMzguNTk4Nzk1NTQgNzIuNDU1MTAyNzIgMzguNjg3NSA3Ni44MTI1IEMzOS40OTM5NzYxOSAxMDguNzMxMTUxOTEgNDIuMTk5OTIxODEgMTM5LjA2NDMwNTU2IDY2LjMzNTkzNzUgMTYyLjczNDM3NSBDNzAuMDA1OTUyMTMgMTY1Ljk3NzY0Mzc1IDczLjk1OTQ4OTA1IDE2OC44MDcwMzExIDc3Ljk1MzEyNSAxNzEuNjM2NzE4NzUgQzgyLjk5MTcyMTggMTc1LjY0NjAwMjIxIDg1LjM2MDI3Mjg5IDE3OS4yOTYyNTk4NSA4Ni40ODgyODEyNSAxODUuNTQ2ODc1IEM4Ni44NzMzOTIwMSAxODkuOTI2NTY2MDQgODUuOTUxMjEyMDggMTkzLjA2NzM3MzggODMuMzc1IDE5Ni42MjUgQzc3LjkwOTQzNzI1IDIwMi43MjEyMDQ2MSA3MC44ODkyMDc5MSAyMDUuMjk5Mjk3NSA2My4zMzU5Mzc1IDIwOC4wMTk1MzEyNSBDNTAuODUzOTgzNDMgMjEyLjUzODg1OTQ1IDQ1Ljk4OTIxNzk1IDIxOC4zMjA5MDAwMSAzOS4wMTk1MzEyNSAyMjkuMjUzOTA2MjUgQzMzLjcwODU5NTk1IDIzNy40Njg3MTY5MiAyNy40OTMxNjY5NSAyNDIuOTUwMTc3NSAxNy43NSAyNDUuMjUgQzEwLjM4ODM0OCAyNDYuMzg4NzU1NTQgMy4zNDkyNzc3MiAyNDUuMTczMDU1NyAtMy44NzUgMjQzLjY4NzUgQy0xMC4xMjk1OTQ3MyAyNDIuNTM5Nzg2MzIgLTE1Ljk1ODEzMTUyIDI0MS44NzgxNDc1MSAtMjEuNjU2MjUgMjQ1LjE2NDA2MjUgQy0yNS41NDUyMzY4OCAyNDguMDgwODAyNjYgLTI4LjkyNzkyNTI3IDI1MS4zOTY3ODA5MSAtMzIuMzEyNSAyNTQuODc1IEMtNDAuNjYxMjA1ODIgMjYzLjQwNTE5OTQyIC01MC40MzMxMDU5NSAyNjguOTU1OTk3MjggLTYyLjUgMjY5LjI1IEMtNzMuNzY1MzA3MjEgMjY4Ljg3Mjg2NzY5IC04Mi43OTQ2NzgzOSAyNjIuOTEzNzkxMTggLTkwLjUwMzkwNjI1IDI1NC45Mzc1IEMtOTIuNzUwOTkwMDggMjUyLjI5NzI5NzgzIC05NC43MzAxNjg2MiAyNDkuNTA0OTA1ODMgLTk2Ljc1IDI0Ni42ODc1IEMtMTAxLjMyMzIwMjEzIDI0MC40OTQyOTkxNSAtMTA1LjU2ODc4MjM0IDIzNi4yNjM3MzY4OSAtMTEzLjMxMjUgMjM0Ljg3NSBDLTExNi43OTM3MTExNiAyMzQuNjE4NjMxNzQgLTExOS42OTU4OTAzOSAyMzUuMzY0MTMzNzYgLTEyMy4wNTQ2ODc1IDIzNi4zMTI1IEMtMTMwLjkzMTAxMDE2IDIzOC4wNTY3Mzc1NCAtMTM4LjEyMDE0MzgyIDIzNy40MzQ5MDU0NiAtMTQ1LjEzNjcxODc1IDIzMy40MDYyNSBDLTE1MS43NTMwNzI4NSAyMjguNTU5ODAwMzIgLTE1NC44MjE4MTcxMyAyMjEuMTE5NDc0ODYgLTE1OC4yMTA5Mzc1IDIxMy44NjMyODEyNSBDLTE2My42MzI5MDM5OSAyMDUuOTkyMzU5NjMgLTE3Mi45ODU2MDc2MiAyMDQuMDY0NTM1OTMgLTE4MS43MTA5Mzc1IDIwMS40OTYwOTM3NSBDLTE4OC41MjIwMzcgMTk5LjM3OTkyODQ0IC0xOTMuMDYwMzkzMzUgMTk3LjExNTU4OTc1IC0xOTcuMTg3NSAxOTEuMDYyNSBDLTE5OS4wMzg1NTMyMyAxODUuNzE1MDEyODggLTE5OS4wNzI4NTUxMiAxODEuMDQ4ODM4NTkgLTE5Ny4yNSAxNzUuNjg3NSBDLTE5My4zMjQzODEwNSAxNjkuODYyMzg4MDEgLTE4OC43ODg4NzMzNyAxNjUuOTgyMDU4OTIgLTE4Mi44MTI1IDE2Mi4zMTI1IEMtMTY5LjUwMzIyMDg5IDE1NC4wNjkwOTkzIC0xNjIuNjgxNTg3ODEgMTQxLjIzOTUwOTMzIC0xNTcuMzEyNSAxMjYuODEyNSBDLTE1Ni45NTQxNDA2MyAxMjUuOTYzMDA3ODEgLTE1Ni41OTU3ODEyNSAxMjUuMTEzNTE1NjIgLTE1Ni4yMjY1NjI1IDEyNC4yMzgyODEyNSBDLTE1MC45MjExNDUxOSAxMTAuNTc1ODM0NDMgLTE1MC41MjMxMzc2NCA5NC45Mzg3ODIxMiAtMTQ5LjY1MDYzNDc3IDgwLjQ1NzI3NTM5IEMtMTQ3Ljk1NjU2MzY4IDUyLjk3NzYxODM3IC0xNDAuMDAyMDkxMzYgMjcuMjQ3Nzg0MDQgLTExOS41MjczNDM3NSA3Ljc0NjA5Mzc1IEMtODYuNjY1MzU2MTEgLTIwLjk0Mjk0MzA4IC0zNi4xODc1MzEgLTI1Ljg2ODYxNjEyIDAgMFoiIGZpbGw9IiNGRkYwRjUiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI5My4zMTI1LDEyNi4xODc1KSI+CiAgICAgIDwvcGF0aD4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTk4LDE4MikiPgogICAgICAgIDxwYXRoIGQ9Ik0wLDUgQzAsMiAtMiwwIC01LDAgQy04LDAgLTEwLDIgLTEwLDUgQy0xMCwxMCAwLDE2IDAsMTYgQzAsMTYgMTAsMTAgMTAsNSBDMTAsMiA4LDAgNSwwIEMyLDAgMCwyIDAsNVoiIGZpbGw9IiNGRjVDQTkiIHRyYW5zZm9ybT0ic2NhbGUoMS4zKSI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI2OSwxODIpIj4KICAgICAgICA8cGF0aCBkPSJNMCw1IEMwLDIgLTIsMCAtNSwwIEMtOCwwIC0xMCwyIC0xMCw1IEMtMTAsMTAgMCwxNiAwLDE2IEMwLDE2IDEwLDEwIDEwLDUgQzEwLDIgOCwwIDUsMCBDMiwwIDAsMiAwLDVaIiBmaWxsPSIjRkY1Q0E5IiB0cmFuc2Zvcm09InNjYWxlKDEuMykiPgogICAgICAgIDwvcGF0aD4KICAgICAgPC9nPgogICAgICA8ZWxsaXBzZSBjeD0iMTgwIiBjeT0iMjIyIiByeD0iMTYiIHJ5PSI5IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjQ1Ij4KICAgICAgPC9lbGxpcHNlPgogICAgICA8ZWxsaXBzZSBjeD0iMzA2IiBjeT0iMjIyIiByeD0iMTYiIHJ5PSI5IiBmaWxsPSIjRkY4RUM2IiBvcGFjaXR5PSIwLjQ1Ij4KICAgICAgPC9lbGxpcHNlPgogICAgICA8cGF0aCBkPSJNMjIwLDI0NCBRMjQ0LDI3MiAyNjgsMjQ0IiBmaWxsPSIjMjcxODNmIiBzdHJva2U9IiMyNzE4M2YiIHN0cm9rZS13aWR0aD0iMSI+CiAgICAgIDwvcGF0aD4KICAgICAgPGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjIwLDEwMCkiPgogICAgICAgIDxwYXRoIGQ9Ik0wLDMgQzAsMS4zIC0xLjMsMCAtMywwIEMtNC43LDAgLTYsMS4zIC02LDMgQy02LDYgMCw5IDAsOSBDMCw5IDYsNiA2LDMgQzYsMS4zIDQuNywwIDMsMCBDMS4zLDAgMCwxLjMgMCwzWiIgZmlsbD0iI0ZGNUNBOSI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI3MCwxMTApIj4KICAgICAgICA8cGF0aCBkPSJNMCwyLjUgQzAsMSAtMSwwIC0yLjUsMCBDLTQsMCAtNSwxIC01LDIuNSBDLTUsNSAwLDcuNSAwLDcuNSBDMCw3LjUgNSw1IDUsMi41IEM1LDEgNCwwIDIuNSwwIEMxLDAgMCwxIDAsMi41WiIgZmlsbD0iI0MwODRGQyI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDI0NSw5NSkiPgogICAgICAgIDxwYXRoIGQ9Ik0wLDIgQzAsMC44IC0wLjgsMCAtMiwwIEMtMy4yLDAgLTQsMC44IC00LDIgQy00LDQgMCw2IDAsNiBDMCw2IDQsNCA0LDIgQzQsMC44IDMuMiwwIDIsMCBDMC44LDAgMCwwLjggMCwyWiIgZmlsbD0iI0ZGRDcwMCI+CiAgICAgICAgPC9wYXRoPgogICAgICA8L2c+CiAgICAgIDxwYXRoIGQ9Ik0wLC01IEwxLjUsLTEuNSBMNSwwIEwxLjUsMS41IEwwLDUgTC0xLjUsMS41IEwtNSwwIEwtMS41LC0xLjVaIiBmaWxsPSIjRkZENzAwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgzNTAsMTQwKSI+CiAgICAgIDwvcGF0aD4KICAgICAgPHBhdGggZD0iTTAsLTQgTDEuMiwtMS4yIEw0LDAgTDEuMiwxLjIgTDAsNCBMLTEuMiwxLjIgTC00LDAgTC0xLjIsLTEuMloiIGZpbGw9IiNGRjVDQTkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE0NSwxNTUpIj4KICAgICAgPC9wYXRoPgogICAgICA8cGF0aCBkPSJNMCwtMyBMMC45LC0wLjkgTDMsMCBMMC45LDAuOSBMMCwzIEwtMC45LDAuOSBMLTMsMCBMLTAuOSwtMC45WiIgZmlsbD0iI0MwODRGQyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYwLDI2MCkiPgogICAgICA8L3BhdGg+CiAgICA8L2c+CiAgPC9nPgo8L3N2Zz4="};
+</script>
+
+<!-- animation engine (Claude Design "omelette" animations-v2), pre-compiled -->
+<script>function _extends() { return _extends = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends.apply(null, arguments); }
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+// Copied omelette starter. Re-running copy_starter_component with this kind overwrites this file with the latest version (page content is unaffected).
+
+/* BEGIN USAGE */
+// animations-v2.jsx — timeline animation engine with scene sequencing.
+// Exports (on window): Stage, Sprite, TextSprite, ImageSprite, RectSprite,
+//   VideoSprite, PlaybackBar, Easing, interpolate, animate, clamp,
+//   useTime, useTimeline, useSprite, SceneStage, useScene.
+//
+// ALWAYS structure the piece as a scene sequence — even a single-scene
+// piece is a one-entry list. Do NOT also load animations.jsx: v2 contains
+// the whole engine (same globals; loading both means last-wins).
+//   <x-import component-from-global-scope="MyPiece"
+//             from="./animations-v2.jsx ./my-piece.jsx"></x-import>
+//
+// THE AUTHORING CONTRACT — this is what makes the host timeline's
+// trim/reorder gestures write back into YOUR file, so follow it
+// exactly:
+//   1. Declare the scene list as a JSON string literal in a plain inline
+//      <script> of the main document (NOT type="text/babel", NOT a sibling
+//      .jsx — only vanilla inline scripts are addressable for write-back):
+//        <script>window.OM_SCENES = '[{"name":"Opening","dur":3},{"name":"Peak","dur":4.5}]';<\/script>
+//   2. Pass the string through untouched: <SceneStage scenes={window.OM_SCENES} ...>
+//   3. Map scene names to components via the children object.
+//   IMPORTANT — the exportable-video contract: SceneStage/Stage OWNS it
+//   (the data-om-exportable-video-with-duration-secs attribute, the
+//   data-om-seek-to-time-frame listener, the svg/foreignObject wrapper,
+//   and font inlining). NEVER put the exportable attribute on any other
+//   element — wrapping the stage in a second "exportable root" makes the
+//   host timeline and the video exporter bind to the wrong element, and
+//   playback control / export silently break.
+//   4. ALSO declare the playback setting the same way — this is what makes
+//      the host timeline's Repeat control write back into your file:
+//        <script>window.OM_PLAYBACK = '{"mode":"loop"}';<\/script>
+//      and pass it through untouched: <SceneStage playback={window.OM_PLAYBACK} ...>
+//      Values: '{"mode":"loop"}' (play forever, the default) or
+//      '{"mode":"times","count":N}' (play N times, then hold the last
+//      frame). Omitting it keeps loop behavior but leaves the host
+//      control read-only for this document.
+//
+//   IMPORTANT — the exportable-video contract: SceneStage/Stage OWNS it
+//   (the data-om-exportable-video-with-duration-secs attribute, the
+//   data-om-seek-to-time-frame listener, the svg/foreignObject wrapper,
+//   and font inlining). NEVER put the exportable attribute on any other
+//   element — wrapping the stage in a second "exportable root" makes the
+//   host timeline and the video exporter bind to the wrong element, and
+//   playback control / export silently break.
+//
+//   <SceneStage width={1280} height={720} scenes={window.OM_SCENES}
+//               bg="#0b0b0e">
+//     {{ 'Opening': Opening, 'Peak': Peak }}
+//   </SceneStage>
+//
+// SceneStage({width, height, scenes, bg, autoplay=true, loop=true,
+//   transition='cut', children}) — wraps Stage. Scenes play in authored order; total
+// duration is the sum of durs, kept in sync with the exportable attr
+// automatically. The host timeline shows the scenes as blocks: dragging
+// an edge retimes one scene, dragging a block's body reorders — and every
+// edit lands in the JSON literal in source, then the composition reflows
+// live (no reload) via the data-om-timeline-scenes-update event. (The
+// time ruler above the blocks is a seek surface — click or drag scrubs;
+// it never edits timing.)
+//
+// TIMING IS USER-EDITABLE (time-stretch): when the user changes a scene's
+// length, the engine remaps your scene clock so the SAME choreography
+// plays faster or slower — never cut off. That only works for motion
+// driven by the scene clock, so inside a scene component ALWAYS animate
+// from useScene()'s {localTime, progress} (never your own clock, never
+// useTime directly).
+//
+// The same rule is what makes video export exact AND fast: the exporter
+// seeks each frame with a synchronous commit and may serialize the stage
+// the moment the seek event returns — anything painted from useEffect or
+// your own requestAnimationFrame lags that commit and exports stale.
+// Render everything visible from the scene clock's values and this is
+// automatic. (Nested <VideoSprite> videos are handled by the exporter.)
+//
+// TRANSITIONS: scene boundaries are hard cuts by default
+// (transition="cut") — exactly one scene is mounted at any time. Scene
+// layers are keyed by scene index, so inactive scenes are fully unmounted
+// (they do zero per-frame work) and a scene never leaks component state
+// into a neighbor, even when two adjacent scenes use the same component.
+//   transition="overlap" is opt-in and for OPAQUE scenes only: during
+// playback the outgoing scene stays mounted beneath the incoming one for
+// ~2 frames, frozen at the frame it had just rendered, so the moments
+// where the incoming scene hasn't painted real content yet (an <img>
+// still decoding, a <video> before its first frame) show the outgoing
+// scene rather than a flash of stage background. It cannot fix content
+// that paints WRONG — a video whose first frame paints black paints
+// black over the underlay too. Only use it
+// when every scene paints the full frame — a scene on a transparent stage
+// background will show the previous scene through it (ghosting); keep
+// "cut" for those. Paused seeks and video-export frame seeks
+// (data-om-seek-to-time-frame) never overlap — a seeked frame always
+// renders exactly one scene's state. Playback driven by the EDITOR's
+// play bar counts as playback too: the host marks its play-loop seeks
+// (detail.playing === true on the same seek event) and the engine reads
+// the marked stream as continuous playback, so overlap may engage —
+// including across the loop seam, matching self-driven playback — while
+// unmarked seeks (scrubs, steps, export frames) keep the
+// exactly-one-scene rule. A tick-sized forward step or drag
+// WHILE PLAYING reads as playback and may briefly overlap (bounded, ~2
+// frames). The loop wrap (last scene back to the first, when loop is on —
+// the default) is a boundary like any other and overlaps too, so the
+// frame-match contract below applies across the loop seam as well.
+//
+// THE FRAME-MATCH CONTRACT (this is what makes boundaries seamless, in
+// BOTH modes): a scene's entry/exit effects must be 0 at progress 0 and
+// at progress 1 — its first and last rendered frames are the settled
+// composition, with entrances and exits choreographed strictly inside
+// (0, 1). No entry-only squash/rotation/opacity: a scene whose frame at
+// progress 0 is mid-squash, rotated, or transparent pops at every cut and
+// ghosts under overlap.
+//
+// The provided sprites bake in entry/exit fades (entryDur/exitDur), so a
+// sprite that spans a scene edge violates the contract by construction:
+// set entryDur={0} on sprites alive at the scene's first frame and
+// exitDur={0} on sprites alive at its last, or inset the sprite's span so
+// its fades complete inside the scene. The flip side: a scene that exits
+// to fully transparent shows NOTHING at its last frame, so "overlap"
+// would hold an empty underlay — following the contract is what makes
+// overlap worth turning on.
+//
+// Scene entries are independent component instances, even when two names
+// map to the same component — state never carries across a boundary. For
+// one continuous component spanning a retimable stretch (a <video> that
+// must keep playing through), use a single scene entry with extra fields
+// driving its phases, not two entries of the same component.
+//
+// Each scene entry may carry extra fields ({"name":"Peak","dur":4,
+// "text":"ACME"}) — the active scene component receives the whole entry as
+// `scene` plus {localTime, progress, dur, index, count}, and can call
+// useScene() anywhere below. Scenes own their entrances/exits — ramp any
+// effect up only AFTER progress 0 and settle it back to 0 BEFORE progress
+// 1, per THE FRAME-MATCH CONTRACT above. The optional "nat" field is the engine's
+// time-stretch anchor — the host timeline manages it; don't set it by
+// hand.
+/* END USAGE */
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Easing functions (hand-rolled, Popmotion-style) ─────────────────────────
+// All easings take t ∈ [0,1] and return eased t ∈ [0,1] (may overshoot for back/elastic).
+const Easing = {
+  linear: t => t,
+  // Quad
+  easeInQuad: t => t * t,
+  easeOutQuad: t => t * (2 - t),
+  easeInOutQuad: t => t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t,
+  // Cubic
+  easeInCubic: t => t * t * t,
+  easeOutCubic: t => --t * t * t + 1,
+  easeInOutCubic: t => t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1,
+  // Quart
+  easeInQuart: t => t * t * t * t,
+  easeOutQuart: t => 1 - --t * t * t * t,
+  easeInOutQuart: t => t < 0.5 ? 8 * t * t * t * t : 1 - 8 * --t * t * t * t,
+  // Expo
+  easeInExpo: t => t === 0 ? 0 : Math.pow(2, 10 * (t - 1)),
+  easeOutExpo: t => t === 1 ? 1 : 1 - Math.pow(2, -10 * t),
+  easeInOutExpo: t => {
+    if (t === 0) return 0;
+    if (t === 1) return 1;
+    if (t < 0.5) return 0.5 * Math.pow(2, 20 * t - 10);
+    return 1 - 0.5 * Math.pow(2, -20 * t + 10);
+  },
+  // Sine
+  easeInSine: t => 1 - Math.cos(t * Math.PI / 2),
+  easeOutSine: t => Math.sin(t * Math.PI / 2),
+  easeInOutSine: t => -(Math.cos(Math.PI * t) - 1) / 2,
+  // Back (overshoot)
+  easeOutBack: t => {
+    const c1 = 1.70158,
+      c3 = c1 + 1;
+    return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+  },
+  easeInBack: t => {
+    const c1 = 1.70158,
+      c3 = c1 + 1;
+    return c3 * t * t * t - c1 * t * t;
+  },
+  easeInOutBack: t => {
+    const c1 = 1.70158,
+      c2 = c1 * 1.525;
+    return t < 0.5 ? Math.pow(2 * t, 2) * ((c2 + 1) * 2 * t - c2) / 2 : (Math.pow(2 * t - 2, 2) * ((c2 + 1) * (t * 2 - 2) + c2) + 2) / 2;
+  },
+  // Elastic
+  easeOutElastic: t => {
+    const c4 = 2 * Math.PI / 3;
+    if (t === 0) return 0;
+    if (t === 1) return 1;
+    return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+  }
+};
+
+// ── Core interpolation helpers ──────────────────────────────────────────────
+
+// Clamp a value to [min, max]
+const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+// interpolate([0, 0.5, 1], [0, 100, 50], ease?) -> fn(t)
+// Popmotion-style: linearly maps t across input keyframes to output values,
+// with optional easing per segment (single fn or array of fns).
+function interpolate(input, output, ease = Easing.linear) {
+  return t => {
+    if (t <= input[0]) return output[0];
+    if (t >= input[input.length - 1]) return output[output.length - 1];
+    for (let i = 0; i < input.length - 1; i++) {
+      if (t >= input[i] && t <= input[i + 1]) {
+        const span = input[i + 1] - input[i];
+        const local = span === 0 ? 0 : (t - input[i]) / span;
+        const easeFn = Array.isArray(ease) ? ease[i] || Easing.linear : ease;
+        const eased = easeFn(local);
+        return output[i] + (output[i + 1] - output[i]) * eased;
+      }
+    }
+    return output[output.length - 1];
+  };
+}
+
+// animate({from, to, start, end, ease})(t) — simpler single-segment tween.
+// Returns `from` before `start`, `to` after `end`.
+function animate({
+  from = 0,
+  to = 1,
+  start = 0,
+  end = 1,
+  ease = Easing.easeInOutCubic
+}) {
+  return t => {
+    if (t <= start) return from;
+    if (t >= end) return to;
+    const local = (t - start) / (end - start);
+    return from + (to - from) * ease(local);
+  };
+}
+
+// ── Timeline context ────────────────────────────────────────────────────────
+
+const TimelineContext = React.createContext({
+  time: 0,
+  duration: 10,
+  playing: false
+});
+const useTime = () => React.useContext(TimelineContext).time;
+const useTimeline = () => React.useContext(TimelineContext);
+
+// ── Sprite ──────────────────────────────────────────────────────────────────
+// Renders children only when the playhead is inside [start, end]. Provides
+// a sub-context with `localTime` (seconds since start) and `progress` (0..1).
+//
+//   <Sprite start={2} end={5}>
+//     {({ localTime, progress }) => <Thing x={progress * 100} />}
+//   </Sprite>
+//
+// Or as a plain wrapper — children can call useSprite() themselves.
+
+const SpriteContext = React.createContext({
+  localTime: 0,
+  progress: 0,
+  duration: 0
+});
+const useSprite = () => React.useContext(SpriteContext);
+function Sprite({
+  start = 0,
+  end = Infinity,
+  children,
+  keepMounted = false
+}) {
+  const {
+    time
+  } = useTimeline();
+  const visible = time >= start && time <= end;
+  if (!visible && !keepMounted) return null;
+  const duration = end - start;
+  const localTime = Math.max(0, time - start);
+  const progress = duration > 0 && isFinite(duration) ? clamp(localTime / duration, 0, 1) : 0;
+  const value = {
+    localTime,
+    progress,
+    duration,
+    visible
+  };
+  return /*#__PURE__*/React.createElement(SpriteContext.Provider, {
+    value: value
+  }, typeof children === 'function' ? children(value) : children);
+}
+
+// ── Sample sprite components ────────────────────────────────────────────────
+
+// TextSprite: fades/slides text in on entry, holds, then fades out on exit.
+// Props: text, x, y, size, color, font, entryDur, exitDur, align
+function TextSprite({
+  text,
+  x = 0,
+  y = 0,
+  size = 48,
+  color = '#111',
+  font = 'Inter, system-ui, sans-serif',
+  weight = 600,
+  entryDur = 0.45,
+  exitDur = 0.35,
+  entryEase = Easing.easeOutBack,
+  exitEase = Easing.easeInCubic,
+  align = 'left',
+  letterSpacing = '-0.01em'
+}) {
+  const {
+    localTime,
+    duration
+  } = useSprite();
+  const exitStart = Math.max(0, duration - exitDur);
+  let opacity = 1;
+  let ty = 0;
+  if (localTime < entryDur) {
+    const t = entryEase(clamp(localTime / entryDur, 0, 1));
+    opacity = t;
+    ty = (1 - t) * 16;
+  } else if (localTime > exitStart) {
+    const t = exitEase(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    ty = -t * 8;
+  }
+  const translateX = align === 'center' ? '-50%' : align === 'right' ? '-100%' : '0';
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: x,
+      top: y,
+      transform: `translate(${translateX}, ${ty}px)`,
+      opacity,
+      fontFamily: font,
+      fontSize: size,
+      fontWeight: weight,
+      color,
+      letterSpacing,
+      whiteSpace: 'pre',
+      lineHeight: 1.1,
+      willChange: 'transform, opacity'
+    }
+  }, text);
+}
+
+// ImageSprite: scales + fades in; optional Ken Burns drift during hold.
+function ImageSprite({
+  src,
+  x = 0,
+  y = 0,
+  width = 400,
+  height = 300,
+  entryDur = 0.6,
+  exitDur = 0.4,
+  kenBurns = false,
+  kenBurnsScale = 1.08,
+  radius = 12,
+  fit = 'cover',
+  placeholder = null // {label: string} for striped placeholder
+}) {
+  const {
+    localTime,
+    duration
+  } = useSprite();
+  const exitStart = Math.max(0, duration - exitDur);
+  let opacity = 1;
+  let scale = 1;
+  if (localTime < entryDur) {
+    const t = Easing.easeOutCubic(clamp(localTime / entryDur, 0, 1));
+    opacity = t;
+    scale = 0.96 + 0.04 * t;
+  } else if (localTime > exitStart) {
+    const t = Easing.easeInCubic(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    scale = (kenBurns ? kenBurnsScale : 1) + 0.02 * t;
+  } else if (kenBurns) {
+    const holdSpan = exitStart - entryDur;
+    const holdT = holdSpan > 0 ? (localTime - entryDur) / holdSpan : 0;
+    scale = 1 + (kenBurnsScale - 1) * holdT;
+  }
+  const content = placeholder ? /*#__PURE__*/React.createElement("div", {
+    style: {
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'repeating-linear-gradient(135deg, #e9e6df 0 10px, #dcd8cf 10px 20px)',
+      color: '#6b6458',
+      fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+      fontSize: 13,
+      letterSpacing: '0.04em',
+      textTransform: 'uppercase'
+    }
+  }, placeholder.label || 'image') : /*#__PURE__*/React.createElement("img", {
+    src: src,
+    alt: "",
+    style: {
+      width: '100%',
+      height: '100%',
+      objectFit: fit,
+      display: 'block'
+    }
+  });
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: x,
+      top: y,
+      width,
+      height,
+      opacity,
+      transform: `scale(${scale})`,
+      transformOrigin: 'center',
+      borderRadius: radius,
+      overflow: 'hidden',
+      willChange: 'transform, opacity'
+    }
+  }, content);
+}
+
+// RectSprite: simple rectangle that animates position/size/color via props.
+// Useful demo primitive — takes a `render` fn for per-frame customization.
+function RectSprite({
+  x = 0,
+  y = 0,
+  width = 100,
+  height = 100,
+  color = '#111',
+  radius = 8,
+  entryDur = 0.4,
+  exitDur = 0.3,
+  render // optional: (ctx) => style overrides
+}) {
+  const spriteCtx = useSprite();
+  const {
+    localTime,
+    duration
+  } = spriteCtx;
+  const exitStart = Math.max(0, duration - exitDur);
+  let opacity = 1;
+  let scale = 1;
+  if (localTime < entryDur) {
+    const t = Easing.easeOutBack(clamp(localTime / entryDur, 0, 1));
+    opacity = clamp(localTime / entryDur, 0, 1);
+    scale = 0.4 + 0.6 * t;
+  } else if (localTime > exitStart) {
+    const t = Easing.easeInQuad(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    scale = 1 - 0.15 * t;
+  }
+  const overrides = render ? render(spriteCtx) : {};
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: x,
+      top: y,
+      width,
+      height,
+      background: color,
+      borderRadius: radius,
+      opacity,
+      transform: `scale(${scale})`,
+      transformOrigin: 'center',
+      willChange: 'transform, opacity',
+      ...overrides
+    }
+  });
+}
+
+// ── Font inlining ───────────────────────────────────────────────────────────
+// Copy every @font-face rule from the page into a <style> inside the svg's
+// foreignObject, with font URLs rewritten to data: URLs. Makes the svg
+// self-describing so serializing it alone (video export fast path) still
+// renders with the right fonts. Sets data-om-fonts-inlined on the svg when
+// done so the exporter can wait for it.
+
+function useInlineFontsInto(svgRef) {
+  React.useEffect(() => {
+    const svg = svgRef.current;
+    const host = svg && svg.querySelector('foreignObject > div');
+    if (!svg || !host) return;
+    let cancelled = false;
+    (async () => {
+      const rules = [];
+      for (const ss of document.styleSheets) {
+        let cssRules;
+        try {
+          cssRules = ss.cssRules;
+        } catch {
+          // Cross-origin sheet without crossorigin attr (e.g. the standard
+          // fonts.googleapis.com <link>) — fetch the CSS text directly and
+          // regex-extract the @font-face blocks.
+          if (ss.href) {
+            try {
+              const txt = await fetch(ss.href).then(r => {
+                if (!r.ok) throw 0;
+                return r.text();
+              });
+              for (const ff of txt.match(/@font-face\s*{[^}]*}/g) || []) rules.push({
+                css: ff,
+                base: ss.href
+              });
+            } catch {}
+          }
+          continue;
+        }
+        if (!cssRules) continue;
+        for (const r of cssRules) {
+          if (r.type === CSSRule.FONT_FACE_RULE) {
+            rules.push({
+              css: r.cssText,
+              base: ss.href || location.href
+            });
+          }
+        }
+      }
+      const toDataURL = url => fetch(url).then(r => {
+        if (!r.ok) throw 0;
+        return r.blob();
+      }).then(b => new Promise(res => {
+        const fr = new FileReader();
+        fr.onload = () => res(fr.result);
+        fr.onerror = () => res(url);
+        fr.readAsDataURL(b);
+      })).catch(() => url);
+      const parts = await Promise.all(rules.map(async ({
+        css,
+        base
+      }) => {
+        const re = /url\((['"]?)([^'")]+)\1\)/g;
+        let out = css,
+          m;
+        while (m = re.exec(css)) {
+          const u = m[2];
+          if (u.startsWith('data:')) continue;
+          let abs;
+          try {
+            abs = new URL(u, base).href;
+          } catch {
+            continue;
+          }
+          out = out.split(m[0]).join(`url("${await toDataURL(abs)}")`);
+        }
+        return out;
+      }));
+      if (cancelled || !parts.length) {
+        svg.setAttribute('data-om-fonts-inlined', 'true');
+        return;
+      }
+      const style = document.createElement('style');
+      style.textContent = parts.join('\n');
+      host.insertBefore(style, host.firstChild);
+      svg.setAttribute('data-om-fonts-inlined', 'true');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+}
+function Stage({
+  width = 1280,
+  height = 720,
+  duration = 10,
+  background = '#f6f4ef',
+  fps = 60,
+  loop = true,
+  autoplay = true,
+  // Parsed playback object ({mode:'loop'} | {mode:'times',count:N}) or
+  // null. When present it overrides the legacy loop prop — SceneStage
+  // passes the validated value from the OM_PLAYBACK authoring contract.
+  playback = null,
+  persistKey = 'animstage',
+  children
+}) {
+  // Props arrive as strings when Stage is mounted via <x-import> (DC
+  // projects) — coerce so style={{width}} gets a number React can px-ify.
+  width = +width || 1280;
+  height = +height || 720;
+  duration = +duration || 10;
+  fps = +fps || 60;
+  if (typeof loop === 'string') loop = loop !== 'false';
+  if (typeof autoplay === 'string') autoplay = autoplay !== 'false';
+  const playTimes = playback && playback.mode === 'times' ? playback.count : null;
+  const loopEff = playback ? playback.mode === 'loop' : loop;
+  const [time, setTime] = React.useState(() => {
+    try {
+      const v = parseFloat(localStorage.getItem(persistKey + ':t') || '0');
+      return isFinite(v) ? clamp(v, 0, duration) : 0;
+    } catch {
+      return 0;
+    }
+  });
+  const [playing, setPlaying] = React.useState(autoplay);
+  // The external-playback latch: true while the HOST play bar is driving
+  // time forward as genuine continuous playback (its play-loop seeks
+  // carry detail.playing === true). The engine's own clock stays paused
+  // the whole time — exactly one clock ever drives — so this is a
+  // separate bit, not a second meaning for `playing`. Set and cleared
+  // in the seek handler below; decays via SS_EXT_PLAY_MS when the
+  // marked stream stops without a parting unmarked seek.
+  const [extPlay, setExtPlay] = React.useState(false);
+  const extPlayTimerRef = React.useRef(null);
+  const [hoverTime, setHoverTime] = React.useState(null);
+  const [scale, setScale] = React.useState(1);
+  const stageRef = React.useRef(null);
+  const canvasRef = React.useRef(null);
+  const rafRef = React.useRef(null);
+  const lastTsRef = React.useRef(null);
+
+  // Persist playhead
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(persistKey + ':t', String(time));
+    } catch {}
+  }, [time, persistKey]);
+
+  // Auto-scale to fit viewport
+  React.useEffect(() => {
+    if (!stageRef.current) return;
+    const el = stageRef.current;
+    const measure = () => {
+      const barH = 44; // playback bar height
+      const s = Math.min(el.clientWidth / width, (el.clientHeight - barH) / height);
+      setScale(Math.max(0.05, s));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [width, height]);
+
+  // Passes completed since playback last started. Lives in a ref so the
+  // per-frame wrap can count without re-running this effect; reset on
+  // every (re)start so a fresh play (or a host restart) gets the full
+  // run count again.
+  const passesRef = React.useRef(0);
+
+  // Animation loop
+  React.useEffect(() => {
+    if (!playing) {
+      lastTsRef.current = null;
+      return;
+    }
+    passesRef.current = 0;
+    const step = ts => {
+      if (lastTsRef.current == null) lastTsRef.current = ts;
+      const dt = (ts - lastTsRef.current) / 1000;
+      lastTsRef.current = ts;
+      setTime(t => {
+        let next = t + dt;
+        if (next >= duration) {
+          if (playTimes !== null) {
+            // Play N times then hold the last frame — the partial pass a
+            // mid-timeline start produces counts as a pass, so the piece
+            // never runs longer than N full durations.
+            passesRef.current += 1;
+            if (passesRef.current >= playTimes) {
+              next = duration;
+              setPlaying(false);
+            } else {
+              next = next % duration;
+            }
+          } else if (loopEff) {
+            next = next % duration;
+          } else {
+            next = duration;
+            setPlaying(false);
+          }
+        }
+        return next;
+      });
+      rafRef.current = requestAnimationFrame(step);
+    };
+    rafRef.current = requestAnimationFrame(step);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      lastTsRef.current = null;
+    };
+  }, [playing, duration, loopEff, playTimes]);
+
+  // Keyboard: space = play/pause, ← → = seek
+  React.useEffect(() => {
+    const onKey = e => {
+      if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA')) return;
+      if (e.code === 'Space') {
+        e.preventDefault();
+        setPlaying(p => !p);
+      } else if (e.code === 'ArrowLeft') {
+        setTime(t => clamp(t - (e.shiftKey ? 1 : 0.1), 0, duration));
+      } else if (e.code === 'ArrowRight') {
+        setTime(t => clamp(t + (e.shiftKey ? 1 : 0.1), 0, duration));
+      } else if (e.key === '0' || e.code === 'Home') {
+        setTime(0);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [duration]);
+
+  // Video-export protocol + the editor's play bar: hosts dispatch this
+  // event per frame; pause + sync the playhead so the frame shows exactly
+  // that timestamp. The host play bar marks its play-loop seeks with
+  // detail.playing === true — the mark latches extPlay (playback is
+  // playback even when a host clock drives it), while ANY unmarked seek
+  // (scrub, step, export frame, the transport's pause park) clears the
+  // latch in the same commit it retimes, so a seeked frame still renders
+  // exactly one scene's state. The engine's own clock pauses either way.
+  React.useEffect(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+    // Sync-seek capability: a dispatcher that marks its seek with
+    // detail.sync === true gets the commit applied via ReactDOM.flushSync,
+    // so the stage DOM reflects the seeked frame the moment dispatchEvent
+    // returns. The video exporter keys off the data-om-sync-seek
+    // advertisement to drop its two-display-refresh settle (that wait only
+    // exists to let React's async commit land — serialization needs the
+    // committed DOM, not the paint). Feature-detected: a runtime without
+    // ReactDOM.flushSync never advertises and every seek takes the async
+    // path. Unmarked seeks (scrubs, the host play bar) stay async — a
+    // forced sync render per pointermove would tax the editor for no one.
+    const canSyncSeek = typeof ReactDOM !== 'undefined' && typeof ReactDOM.flushSync === 'function';
+    const onSeek = e => {
+      const apply = () => {
+        setPlaying(false);
+        const hostPlay = !!(e.detail && e.detail.playing === true);
+        if (extPlayTimerRef.current) {
+          clearTimeout(extPlayTimerRef.current);
+          extPlayTimerRef.current = null;
+        }
+        if (hostPlay) {
+          // Watchdog: the latch is only as alive as its seek stream. If the
+          // host stops without a parting seek (tab jank, bar unmount), the
+          // latch decays on its own — and the expiry setState is itself the
+          // render that lets SceneSwitch drop an open window, so expiry can
+          // never strand a frozen two-layer frame.
+          extPlayTimerRef.current = setTimeout(() => {
+            extPlayTimerRef.current = null;
+            setExtPlay(false);
+          }, SS_EXT_PLAY_MS);
+        }
+        setExtPlay(hostPlay);
+        setTime(clamp(e.detail.time, 0, duration));
+      };
+      // flushSync is safe here: a native DOM listener runs outside React's
+      // lifecycle, and the exporter's dispatchEvent is synchronous, so the
+      // commit lands in the same JS task — the engine's own rAF loop can
+      // never interleave between seek and serialize.
+      if (canSyncSeek && e.detail && e.detail.sync === true) {
+        ReactDOM.flushSync(apply);
+      } else {
+        apply();
+      }
+    };
+    el.addEventListener('data-om-seek-to-time-frame', onSeek);
+    if (canSyncSeek) el.setAttribute('data-om-sync-seek', 'true');
+    return () => {
+      el.removeEventListener('data-om-seek-to-time-frame', onSeek);
+      el.removeAttribute('data-om-sync-seek');
+      if (extPlayTimerRef.current) {
+        clearTimeout(extPlayTimerRef.current);
+        extPlayTimerRef.current = null;
+      }
+      // Drop the latch too: this cleanup runs on every duration change
+      // (an agent edit can retime mid-host-play, no gesture involved) and
+      // the new effect instance arms no watchdog — clearing only the
+      // timer could strand extPlay true forever if the marked stream died
+      // in the gap. Fail toward cut: the next marked seek re-latches.
+      setExtPlay(false);
+    };
+  }, [duration]);
+
+  // Inline @font-face rules into the svg's foreignObject so the svg is
+  // self-describing — serializing it alone (for video export) then renders
+  // with the right fonts. Sets data-om-fonts-inlined once done.
+  useInlineFontsInto(canvasRef);
+  const displayTime = hoverTime != null ? hoverTime : time;
+  const ctxValue = React.useMemo(
+  // extPlaying is ADDITIVE: "time is advancing under an external
+  // driver's continuous playback". `playing` keeps meaning the
+  // engine's OWN clock — the hidden PlaybackBar glyph (and through it
+  // the host's clock-reporter/adoption channel) reads that — and
+  // SceneSwitch is the one consumer that widens to either.
+  () => ({
+    time: displayTime,
+    duration,
+    playing,
+    extPlaying: extPlay,
+    setTime,
+    setPlaying
+  }), [displayTime, duration, playing, extPlay]);
+  return (
+    /*#__PURE__*/
+    // data-om-starter: inert presence marker — Claude Design's starter-usage
+    // probe reads it; it renders nothing. Keep it on this root element.
+    React.createElement("div", {
+      ref: stageRef,
+      "data-om-starter": "animations-v2",
+      style: {
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        background: '#0a0a0a',
+        fontFamily: 'Inter, system-ui, sans-serif'
+      }
+    }, /*#__PURE__*/React.createElement("div", {
+      style: {
+        flex: 1,
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+        minHeight: 0
+      }
+    }, /*#__PURE__*/React.createElement("svg", {
+      ref: canvasRef,
+      width: width,
+      height: height,
+      "data-om-exportable-video-with-duration-secs": duration,
+      style: {
+        transform: `scale(${scale})`,
+        transformOrigin: 'center',
+        flexShrink: 0,
+        boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+        display: 'block'
+      }
+    }, /*#__PURE__*/React.createElement("foreignObject", {
+      x: "0",
+      y: "0",
+      width: "100%",
+      height: "100%"
+    }, /*#__PURE__*/React.createElement("div", {
+      xmlns: "http://www.w3.org/1999/xhtml",
+      style: {
+        width,
+        height,
+        background,
+        position: 'relative',
+        overflow: 'hidden'
+      }
+    }, /*#__PURE__*/React.createElement(TimelineContext.Provider, {
+      value: ctxValue
+    }, children))))), /*#__PURE__*/React.createElement(PlaybackBar, {
+      time: displayTime,
+      actualTime: time,
+      duration: duration,
+      playing: playing,
+      onPlayPause: () => setPlaying(p => !p),
+      onReset: () => {
+        setTime(0);
+      },
+      onSeek: t => setTime(t),
+      onHover: t => setHoverTime(t)
+    }))
+  );
+}
+
+// ── Playback bar ────────────────────────────────────────────────────────────
+// Play/pause, return-to-begin, scrub track, time display.
+// Uses fixed-width time fields so layout doesn't thrash.
+
+function PlaybackBar({
+  time,
+  duration,
+  playing,
+  onPlayPause,
+  onReset,
+  onSeek,
+  onHover
+}) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  const timeFromEvent = React.useCallback(e => {
+    const rect = trackRef.current.getBoundingClientRect();
+    const x = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    return x * duration;
+  }, [duration]);
+  const onTrackMove = e => {
+    if (!trackRef.current) return;
+    const t = timeFromEvent(e);
+    if (dragging) {
+      onSeek(t);
+    } else {
+      onHover(t);
+    }
+  };
+  const onTrackLeave = () => {
+    if (!dragging) onHover(null);
+  };
+  const onTrackDown = e => {
+    setDragging(true);
+    const t = timeFromEvent(e);
+    onSeek(t);
+    onHover(null);
+  };
+  React.useEffect(() => {
+    if (!dragging) return;
+    const onUp = () => setDragging(false);
+    const onMove = e => {
+      if (!trackRef.current) return;
+      const t = timeFromEvent(e);
+      onSeek(t);
+    };
+    window.addEventListener('mouseup', onUp);
+    window.addEventListener('mousemove', onMove);
+    return () => {
+      window.removeEventListener('mouseup', onUp);
+      window.removeEventListener('mousemove', onMove);
+    };
+  }, [dragging, timeFromEvent, onSeek]);
+  const pct = duration > 0 ? time / duration * 100 : 0;
+  const fmt = t => {
+    const total = Math.max(0, t);
+    const m = Math.floor(total / 60);
+    const s = Math.floor(total % 60);
+    const cs = Math.floor(total * 100 % 100);
+    return `${String(m).padStart(1, '0')}:${String(s).padStart(2, '0')}.${String(cs).padStart(2, '0')}`;
+  };
+  const mono = 'JetBrains Mono, ui-monospace, SFMono-Regular, monospace';
+  return /*#__PURE__*/React.createElement("div", {
+    "data-omelette-chrome": true,
+    style: {
+      // Slimmed to visually match the host editor bar's basic row (the
+      // single-scrubber look): transport first, tighter metrics, quieter
+      // chrome. Shown only outside the app — the host bar suppresses this
+      // whenever it is present.
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      padding: '6px 12px',
+      background: 'rgba(20,20,20,0.92)',
+      borderTop: '1px solid rgba(255,255,255,0.08)',
+      width: '100%',
+      maxWidth: 680,
+      alignSelf: 'center',
+      borderRadius: 6,
+      color: '#f6f4ef',
+      fontFamily: 'Inter, system-ui, sans-serif',
+      userSelect: 'none',
+      flexShrink: 0
+    }
+  }, /*#__PURE__*/React.createElement(IconButton, {
+    onClick: onPlayPause,
+    title: "Play/pause (space)"
+  }, playing ? /*#__PURE__*/React.createElement("svg", {
+    width: "14",
+    height: "14",
+    viewBox: "0 0 14 14",
+    fill: "none"
+  }, /*#__PURE__*/React.createElement("rect", {
+    x: "3",
+    y: "2",
+    width: "3",
+    height: "10",
+    fill: "currentColor"
+  }), /*#__PURE__*/React.createElement("rect", {
+    x: "8",
+    y: "2",
+    width: "3",
+    height: "10",
+    fill: "currentColor"
+  })) : /*#__PURE__*/React.createElement("svg", {
+    width: "14",
+    height: "14",
+    viewBox: "0 0 14 14",
+    fill: "none"
+  }, /*#__PURE__*/React.createElement("path", {
+    d: "M3 2l9 5-9 5V2z",
+    fill: "currentColor"
+  }))), /*#__PURE__*/React.createElement(IconButton, {
+    onClick: onReset,
+    title: "Return to start (0)"
+  }, /*#__PURE__*/React.createElement("svg", {
+    width: "14",
+    height: "14",
+    viewBox: "0 0 14 14",
+    fill: "none"
+  }, /*#__PURE__*/React.createElement("path", {
+    d: "M3 2v10M12 2L5 7l7 5V2z",
+    stroke: "currentColor",
+    strokeWidth: "1.5",
+    strokeLinejoin: "round",
+    strokeLinecap: "round"
+  }))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontFamily: mono,
+      fontSize: 12,
+      fontVariantNumeric: 'tabular-nums',
+      width: 64,
+      textAlign: 'right',
+      color: '#f6f4ef'
+    }
+  }, fmt(time)), /*#__PURE__*/React.createElement("div", {
+    ref: trackRef,
+    onMouseMove: onTrackMove,
+    onMouseLeave: onTrackLeave,
+    onMouseDown: onTrackDown,
+    style: {
+      flex: 1,
+      height: 22,
+      position: 'relative',
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      height: 4,
+      background: 'rgba(255,255,255,0.12)',
+      borderRadius: 2
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: 0,
+      width: `${pct}%`,
+      height: 4,
+      background: 'oklch(72% 0.12 250)',
+      borderRadius: 2
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: `${pct}%`,
+      top: '50%',
+      width: 12,
+      height: 12,
+      marginLeft: -6,
+      marginTop: -6,
+      background: '#fff',
+      borderRadius: 6,
+      boxShadow: '0 2px 4px rgba(0,0,0,0.4)'
+    }
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontFamily: mono,
+      fontSize: 12,
+      fontVariantNumeric: 'tabular-nums',
+      width: 64,
+      textAlign: 'left',
+      color: 'rgba(246,244,239,0.55)'
+    }
+  }, fmt(duration)), typeof VideoEncoder !== 'undefined' && /*#__PURE__*/React.createElement(IconButton, {
+    title: "Export video",
+    onClick: () => window.parent.postMessage({
+      type: 'omelette:request-video-export'
+    }, '*')
+  }, /*#__PURE__*/React.createElement("svg", {
+    width: "14",
+    height: "14",
+    viewBox: "0 0 14 14",
+    fill: "none"
+  }, /*#__PURE__*/React.createElement("path", {
+    d: "M7 2v7m0 0L4 6m3 3l3-3M2 12h10",
+    stroke: "currentColor",
+    strokeWidth: "1.5",
+    strokeLinecap: "round",
+    strokeLinejoin: "round"
+  }))));
+}
+function IconButton({
+  children,
+  onClick,
+  title
+}) {
+  const [hover, setHover] = React.useState(false);
+  return /*#__PURE__*/React.createElement("button", {
+    onClick: onClick,
+    title: title,
+    onMouseEnter: () => setHover(true),
+    onMouseLeave: () => setHover(false),
+    style: {
+      width: 24,
+      height: 24,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: hover ? 'rgba(255,255,255,0.12)' : 'rgba(255,255,255,0.04)',
+      border: '1px solid rgba(255,255,255,0.1)',
+      borderRadius: 5,
+      color: '#f6f4ef',
+      cursor: 'pointer',
+      padding: 0,
+      transition: 'background 120ms'
+    }
+  }, children);
+}
+
+// ── VideoSprite ─────────────────────────────────────────────────────────────
+// Renders a <video> that loops within [start,end] of its source at `speed`,
+// kept in sync with the Stage's playhead. Carries the
+// data-om-exportable-video-play-* attrs so video export can mix its audio.
+//
+//   <VideoSprite src="clip.mp4" start={2} end={5} speed={1}
+//     style={{ width: 640, height: 360 }} />
+
+function VideoSprite({
+  src,
+  start = 0,
+  end,
+  speed = 1,
+  style,
+  ...rest
+}) {
+  start = +start || 0;
+  speed = +speed || 1;
+  if (end != null) end = +end || undefined;
+  const t = useTime();
+  const ref = React.useRef(null);
+  const span = Math.max(0.001, (end ?? start + 1) - start);
+  React.useEffect(() => {
+    const v = ref.current;
+    if (!v || v.readyState < 1) return;
+    const target = start + t * speed % span;
+    if (Math.abs(v.currentTime - target) > 0.05) v.currentTime = target;
+  }, [t, start, span, speed]);
+  return /*#__PURE__*/React.createElement("video", _extends({
+    ref: ref,
+    src: src,
+    muted: true,
+    playsInline: true,
+    preload: "auto",
+    "data-om-exportable-video-play-start": start,
+    "data-om-exportable-video-play-end": end ?? start + span,
+    "data-om-exportable-video-play-speed": speed,
+    style: {
+      display: 'block',
+      objectFit: 'cover',
+      ...style
+    }
+  }, rest));
+}
+Object.assign(window, {
+  Easing,
+  interpolate,
+  animate,
+  clamp,
+  TimelineContext,
+  useTime,
+  useTimeline,
+  Sprite,
+  SpriteContext,
+  useSprite,
+  TextSprite,
+  ImageSprite,
+  RectSprite,
+  VideoSprite,
+  Stage,
+  PlaybackBar
+});
+
+// ── Scene sequencing ─────────────────────────────────────────────────────
+// Guest-side validation of a scene list (the engine's own inputs: the
+// authored prop, and host-dispatched updates). Mirrors the host parser's
+// shape rules and constants — keep in sync with parseTimelineScenes in
+// apps/web/src/shared/timeline.ts (16KB raw cap, 50 entries, dur finite in
+// (0, 300]); returns null on any violation.
+function ssParse(raw) {
+  if (typeof raw !== 'string' || !raw || raw.length > 16 * 1024) return null;
+  var parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 50) return null;
+  for (var i = 0; i < parsed.length; i++) {
+    var s = parsed[i];
+    if (typeof s !== 'object' || s === null) return null;
+    if (typeof s.name !== 'string' || typeof s.dur !== 'number') return null;
+    if (!isFinite(s.dur) || s.dur <= 0 || s.dur > 300) return null;
+  }
+  return parsed;
+}
+
+// Guest-side validation of the playback value — mirrors the host parser
+// (shared/timeline.ts parseTimelinePlayback): {"mode":"loop"} or
+// {"mode":"times","count":1..99}, strict all-or-nothing, null otherwise.
+// Callers treat null as the loop default.
+function ppParse(raw) {
+  if (typeof raw !== 'string' || !raw || raw.length > 256) return null;
+  var parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+  var keys = Object.keys(parsed);
+  if (parsed.mode === 'loop') return keys.length === 1 ? {
+    mode: 'loop'
+  } : null;
+  if (parsed.mode === 'times') {
+    if (keys.length !== 2) return null;
+    var c = parsed.count;
+    if (typeof c !== 'number' || c !== Math.floor(c) || c < 1 || c > 99) return null;
+    return {
+      mode: 'times',
+      count: c
+    };
+  }
+  return null;
+}
+
+// Stamps the playback attribute VERBATIM from the authored raw string (the
+// host's write-back anchors on that exact value) and listens for the
+// host's post-write update event. Same shape as SceneSync; only rendered
+// when the document authors a playback literal — an absent contract means
+// the attribute stays absent and the document plays its default.
+function PlaybackSync(props) {
+  var ref = React.useRef(null);
+  var raw = props.raw;
+  var onUpdate = props.onUpdate;
+  React.useEffect(function () {
+    var el = ref.current;
+    if (!el) return;
+    var root = el.closest('[data-om-exportable-video-with-duration-secs]');
+    if (!root) return;
+    root.setAttribute('data-om-timeline-playback', raw);
+    var onEvent = function (e) {
+      var next = e && e.detail;
+      if (ppParse(next)) onUpdate(next);
+    };
+    root.addEventListener('data-om-timeline-playback-update', onEvent);
+    return function () {
+      root.removeEventListener('data-om-timeline-playback-update', onEvent);
+      root.removeAttribute('data-om-timeline-playback');
+    };
+  }, [raw, onUpdate]);
+  return /*#__PURE__*/React.createElement("div", {
+    ref: ref,
+    style: {
+      display: 'none'
+    }
+  });
+}
+var SceneContext = React.createContext(null);
+function useScene() {
+  return React.useContext(SceneContext);
+}
+
+// Renders inside the Stage (so it can reach the exportable root via
+// closest()): stamps the scenes attribute VERBATIM from the current raw
+// string — the host's write-back anchors on that exact value — and listens
+// for the host's post-write update event.
+function SceneSync(props) {
+  var ref = React.useRef(null);
+  var raw = props.raw;
+  var onUpdate = props.onUpdate;
+  React.useEffect(function () {
+    var el = ref.current;
+    if (!el) return;
+    var root = el.closest('[data-om-exportable-video-with-duration-secs]');
+    if (!root) return;
+    root.setAttribute('data-om-timeline-scenes', raw);
+    var onEvent = function (e) {
+      var next = e && e.detail;
+      // Ignore anything that doesn't validate — a bad update must not tear
+      // down a working composition.
+      if (ssParse(next)) onUpdate(next);
+    };
+    root.addEventListener('data-om-timeline-scenes-update', onEvent);
+    return function () {
+      root.removeEventListener('data-om-timeline-scenes-update', onEvent);
+      root.removeAttribute('data-om-timeline-scenes');
+    };
+  }, [raw, onUpdate]);
+  return /*#__PURE__*/React.createElement("div", {
+    ref: ref,
+    style: {
+      display: 'none'
+    }
+  });
+}
+
+// ── Scene transitions ────────────────────────────────────────────────────
+// A boundary tick only counts as "natural playback" when the playhead
+// advanced by at most this many seconds. The guard keeps scrubs and long
+// jumps (which move time arbitrarily) from reading as playback, and it is
+// deliberately loose: half a second admits playback down to 2fps, because
+// a false negative silently disables overlap on exactly the heavy scenes
+// it serves, while a false positive (a slow forward drag while playing)
+// costs two cosmetic frames.
+var SS_MAX_TICK = 0.5;
+// How many engine ticks the outgoing scene stays mounted under
+// transition="overlap": the boundary commit plus one more frame.
+var SS_OVERLAP_TICKS = 2;
+// Wall-clock ceiling on a window, backstopping the tick budget: ticks are
+// only spent by renders, and a pinned clock (the PlaybackBar's hover
+// preview holds displayTime still even while playing) stops producing
+// them — without this ceiling, both layers could persist for as long as
+// the mouse rests on the scrub track. 500ms keeps the tick budget intact
+// for playback down to ~4fps; the nudge effect in SceneSwitch guarantees
+// a render arrives to enforce it even when the clock is pinned.
+var SS_OVERLAP_MAX_MS = 500;
+// How long a marked (detail.playing === true) host seek keeps the
+// external-playback latch alive with no successor. The host play bar's
+// seek pump is one-in-flight/latest-wins, so its inter-seek gap is tens
+// of milliseconds in the worst case — 400ms is far above that, and it
+// sits below SS_OVERLAP_MAX_MS so a stream that dies mid-window decays
+// the latch (and with it the window) no later than the window's own
+// wall-clock ceiling would have closed it.
+var SS_EXT_PLAY_MS = 400;
+
+// True only for a boundary crossed by what reads as natural forward
+// playback: the engine advancing one tick from scene i into scene i+1, or
+// wrapping last→first under loop. Export seeks can never pass — the
+// export protocol pauses before it retimes, and arming requires playing —
+// and neither can paused scrubs or arrow-steps, host trim/reorder events
+// (dt === 0), or long jumps. A forward drag or arrow-step WHILE PLAYING
+// that lands just past a boundary does pass — it is indistinguishable
+// from a playback tick by design — and costs a bounded, cosmetic
+// two-frame window.
+function ssNaturalAdvance(last, idx, t, count, total, playing, loopOn) {
+  if (!playing || count < 2) return false;
+  if (idx === last.idx + 1) {
+    var dt = t - last.t;
+    return dt > 0 && dt <= SS_MAX_TICK;
+  }
+  if (last.idx === count - 1 && idx === 0 && loopOn && t > 0) {
+    // Without loop the engine never wraps (it clamps and pauses at the
+    // end), so a wrap-shaped pair can only be a user gesture — a cut. And
+    // the transport's reset gestures (return-to-start, Home, '0') land on
+    // exactly t = 0 without pausing, while a genuine modulo wrap is almost
+    // surely fractional — t > 0 rejects resets, and the cheap failure mode
+    // is one skipped cosmetic overlap at the seam.
+    var dtWrap = t + total - last.t;
+    // Two layered defenses against a fake wrap after a mid-play trim
+    // shrinks the total. When the wrap happens on the rAF loop's dt=0
+    // re-priming tick (the engine path), t is exactly last.t % total, so
+    // dtWrap is exactly 0 in IEEE arithmetic and the > 0 test rejects it.
+    // When the clock is PINNED instead (the PlaybackBar hover preview sets
+    // the displayed time directly, no re-priming tick), dtWrap can land
+    // positive while t sits deep inside scene 0 — the t <= one-tick guard
+    // is what rejects that path.
+    return dtWrap > 0 && dtWrap <= SS_MAX_TICK && t <= SS_MAX_TICK;
+  }
+  return false;
+}
+
+// A scene's inner tree: the scene component under its two context
+// providers. The nested TimelineContext.Provider exists in EVERY layer,
+// not just frozen ones, for two reasons. Context propagation bypasses
+// React's identical-element bailout, so a frozen layer needs a provider
+// whose value has stopped changing — without one, Sprite/VideoSprite
+// inside the frozen scene would keep reading the live clock through the
+// outer provider, see time run past their spans, and blank out (or
+// re-seek a video) mid-overlap. And the tree at a layer's keyed position
+// must never change shape between roles: a current→previous type change
+// would remount the subtree, the very thing the scene key exists to
+// prevent. For the current layer the provider re-provides the live value
+// unchanged, which is invisible to consumers.
+function ssSceneInner(scenes, idx, wallTime, total, map, timelineValue) {
+  var scene = scenes[idx];
+  // TIME-STRETCH: when the entry carries "nat" (its natural/authored
+  // duration — the host timeline stamps it on the first trim), the user's
+  // dur edits retime the choreography rather than cutting it: localTime
+  // runs 0..nat over dur wall-seconds, so compressing a scene plays the
+  // SAME motion faster and stretching slows it. progress is unchanged
+  // either way (localTime/nat === wallTime/dur). No nat → factor 1.
+  var nat = typeof scene.nat === 'number' && isFinite(scene.nat) && scene.nat > 0 ? scene.nat : scene.dur;
+  var stretch = scene.dur > 0 ? nat / scene.dur : 1;
+  var localTime = wallTime * stretch;
+  var ctx = {
+    scene: scene,
+    localTime: localTime,
+    progress: nat > 0 ? localTime / nat : 0,
+    dur: nat,
+    index: idx,
+    count: scenes.length,
+    total: total
+  };
+  // Own-property lookup: a scene named "constructor" or "toString" must hit
+  // the unmapped-scene diagnostic, not a prototype-chain member.
+  var Comp = Object.prototype.hasOwnProperty.call(map, scene.name) ? map[scene.name] : null;
+  return /*#__PURE__*/React.createElement(TimelineContext.Provider, {
+    value: timelineValue
+  }, /*#__PURE__*/React.createElement(SceneContext.Provider, {
+    value: ctx
+  }, Comp ? /*#__PURE__*/React.createElement(Comp, ctx) :
+  /*#__PURE__*/
+  // An unmapped name renders a quiet diagnostic instead of a dead
+  // frame — the mismatch is an authoring bug worth seeing.
+  React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: 'rgba(255,255,255,0.25)',
+      font: '500 18px Inter, system-ui, sans-serif'
+    }
+  }, "unmapped scene: ", scene.name)));
+}
+
+// One scene layer: the positioned wrapper that gives a scene its stable
+// keyed identity (the scene's index in the authored list) and its role
+// styling. The SAME entry keeps its DOM when its role changes (current →
+// previous under "overlap" — no unmount/remount, so CSS transitions and
+// <video>/<canvas> state survive), while DIFFERENT entries never share
+// DOM, even when two adjacent scenes map to the same component type.
+// zIndex is set only while an overlap window is active (frozen beneath,
+// current above); outside a window the wrapper adds no stacking context.
+function ssSceneLayer(idx, z, frozen, inner) {
+  return /*#__PURE__*/React.createElement("div", {
+    key: idx,
+    "data-om-scene-layer": idx,
+    style: {
+      position: 'absolute',
+      inset: 0,
+      zIndex: z,
+      pointerEvents: frozen ? 'none' : undefined
+    }
+  }, inner);
+}
+
+// The active-scene selector. Lives INSIDE Stage so useTime sees the
+// timeline context. Renders the current scene's layer — plus, under
+// transition="overlap" and only across a naturally-played boundary, the
+// outgoing scene's layer beneath it for SS_OVERLAP_TICKS engine ticks.
+// The outgoing scene is frozen EXACTLY as last rendered: its stored inner
+// element is reused by reference, so the underlay is the frame that was
+// just on screen (no synthesized end state), React bails out of the
+// identical element (the inactive scene does zero per-frame work), and
+// its clock — both contexts — stays pinned at the pre-boundary values.
+// The scene's own internal state updates still render: the clock is
+// frozen, the subtree isn't dead.
+function SceneSwitch(props) {
+  var scenes = props.scenes;
+  var map = props.map || {};
+  var overlapMode = props.transition === 'overlap';
+  var timeline = useTimeline();
+  var t = timeline.time;
+  // Playback is playback whichever clock drives it: the engine's own rAF
+  // loop (timeline.playing) or the host play bar's marked seek stream
+  // (timeline.extPlaying). Nothing that must stay a cut sets either bit —
+  // scrubs, steps, and export frames arrive without the playing mark (an
+  // export seek may carry detail.sync, which changes WHEN the commit
+  // happens, not what it commits), and clear extPlaying in the same
+  // commit they retime — so the window invariant's "a paused render is a
+  // SEEK frame" reading is unchanged.
+  var playing = timeline.playing || timeline.extPlaying === true;
+  var starts = [0];
+  for (var i = 0; i < scenes.length; i++) starts.push(starts[i] + scenes[i].dur);
+  var total = starts[starts.length - 1];
+  // The playhead's scene; the t === total edge (export's last frame, a
+  // scrub parked at the end) belongs to the last scene, not to nothing.
+  var idx = scenes.length - 1;
+  for (var j = 0; j < scenes.length; j++) {
+    if (t < starts[j + 1]) {
+      idx = j;
+      break;
+    }
+  }
+  var wallTime = Math.min(Math.max(t - starts[idx], 0), scenes[idx].dur);
+  var inner = ssSceneInner(scenes, idx, wallTime, total, map, timeline);
+
+  // Overlap bookkeeping. It lives in refs and mutates during render, which
+  // is safe here because the mutating branches are gated on (t, idx)
+  // differing from the previous render's values — a double-invoked render
+  // re-runs them as a no-op. (A discarded concurrent render could advance
+  // the refs for a frame that never commits; this engine drives time with
+  // urgent setState from rAF, so renders aren't interleaved — and the
+  // worst case is an overlap window skipped or cut short, never a wrong
+  // seeked frame.)
+  var lastRef = React.useRef(null); // {idx, t, inner} as of the previous render
+  var overlayRef = React.useRef(null); // the active window; invariant below
+
+  // THE OVERLAP WINDOW INVARIANT. A window may exist only while ALL hold:
+  //   1. the transition mode is 'overlap';
+  //   2. this render is playing — a paused render is a SEEK frame (the
+  //      export protocol pauses in the same commit as it retimes), and a
+  //      seeked frame must show exactly one scene's state;
+  //   3. the current scene is still the one the window opened into
+  //      (idx === toIdx);
+  //   4. the scenes array is the same object the window opened under (a
+  //      host trim/reorder mid-window invalidates the frozen layer);
+  //   5. fewer than SS_OVERLAP_TICKS distinct engine ticks have rendered
+  //      since the boundary.
+  // The clause below drops the window the moment ANY of these fails, and
+  // dropping is terminal: a new window takes a new natural boundary.
+  if (overlapMode && lastRef.current) {
+    var last = lastRef.current;
+    if (last.idx !== idx) {
+      // Boundary crossed since the previous render: open a window only for
+      // a natural advance, freezing the outgoing scene's last-rendered
+      // tree. Anything else (seek, jump, edit) is a cut and clears any
+      // window already open.
+      overlayRef.current = ssNaturalAdvance(last, idx, t, scenes.length, total, playing, props.loop === true) ? {
+        fromIdx: last.idx,
+        toIdx: idx,
+        scenes: scenes,
+        ticks: 0,
+        bornAt: Date.now(),
+        inner: last.inner
+      } : null;
+    } else if (overlayRef.current && last.t !== t) {
+      overlayRef.current.ticks += 1;
+    }
+  }
+  var ov = overlayRef.current;
+  if (ov && (!overlapMode || !playing || idx !== ov.toIdx || scenes !== ov.scenes || ov.ticks >= SS_OVERLAP_TICKS || Date.now() - ov.bornAt > SS_OVERLAP_MAX_MS)) {
+    overlayRef.current = ov = null;
+  }
+  lastRef.current = {
+    idx: idx,
+    t: t,
+    inner: inner
+  };
+
+  // The nudge: while a window exists, guarantee a future render so the
+  // checks above get a chance to run even if the clock pins (see
+  // SS_OVERLAP_MAX_MS). On the normal path the window dies of its tick
+  // budget first and the armed timeout is cleaned up without firing.
+  var nudgeState = React.useState(0);
+  var setNudge = nudgeState[1];
+  React.useEffect(function () {
+    if (!overlayRef.current) return undefined;
+    var id = setTimeout(function () {
+      setNudge(function (n) {
+        return n + 1;
+      });
+    }, SS_OVERLAP_MAX_MS + 17);
+    return function () {
+      clearTimeout(id);
+    };
+  });
+  if (!ov) return [ssSceneLayer(idx, undefined, false, inner)];
+  return [ssSceneLayer(ov.fromIdx, 0, true, ov.inner), ssSceneLayer(idx, 1, false, inner)];
+}
+function SceneStage(props) {
+  var width = +props.width || 1280;
+  var height = +props.height || 720;
+  var bg = props.bg || '#0b0b0e';
+  var autoplay = props.autoplay == null ? true : String(props.autoplay) !== 'false';
+  var loop = props.loop == null ? true : String(props.loop) !== 'false';
+  // Anything other than the exact string 'overlap' means the default 'cut'
+  // — a typo must degrade to today's behavior, never to a new one.
+  var transition = props.transition === 'overlap' ? 'overlap' : 'cut';
+  // The raw string is state: a host write (trim/reorder) arrives as the
+  // scenes-update event and re-renders the whole composition from the new
+  // value — durations, order, AND the Stage duration — without a reload.
+  var state = React.useState(props.scenes);
+  var raw = state[0];
+  var setRaw = state[1];
+  var scenes = React.useMemo(function () {
+    return ssParse(raw);
+  }, [raw]);
+  // Playback raw string is state for the same reason the scenes raw is:
+  // a host write arrives as the update event and re-renders the engine
+  // with the new mode, no reload. Invalid or absent degrades to the
+  // legacy loop prop.
+  var pstate = React.useState(props.playback);
+  var praw = pstate[0];
+  var setPraw = pstate[1];
+  var pb = React.useMemo(function () {
+    return ppParse(praw);
+  }, [praw]);
+  if (!scenes) {
+    return /*#__PURE__*/React.createElement("div", {
+      style: {
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#0b0b0e',
+        color: '#c96442',
+        font: '500 16px Inter, system-ui, sans-serif',
+        textAlign: 'center'
+      }
+    }, "animations-v2: the scenes prop isn't a valid JSON scene list", /*#__PURE__*/React.createElement("br", null), "(expected '[", '{', "\"name\":\"\u2026\",\"dur\":N", '}', ", \u2026]')");
+  }
+  var total = 0;
+  for (var i = 0; i < scenes.length; i++) total += scenes[i].dur;
+  total = Math.round(total * 1000) / 1000;
+  // The loop-seam behavior (SceneSwitch's wrap overlap) follows the
+  // EFFECTIVE mode: a run-N composition doesn't wrap on its final pass,
+  // but its intermediate wraps cross the seam like any loop.
+  var loopEff = pb ? pb.mode !== 'times' || pb.count > 1 : loop;
+  var inner = /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(SceneSync, {
+    raw: raw,
+    onUpdate: setRaw
+  }), typeof praw === 'string' && praw !== '' && /*#__PURE__*/React.createElement(PlaybackSync, {
+    raw: praw,
+    onUpdate: setPraw
+  }), /*#__PURE__*/React.createElement(SceneSwitch, {
+    scenes: scenes,
+    map: props.children,
+    transition: transition,
+    loop: loopEff
+  }));
+  return /*#__PURE__*/React.createElement(Stage, {
+    width: width,
+    height: height,
+    duration: total,
+    background: bg,
+    autoplay: autoplay,
+    loop: loop,
+    playback: pb
+  }, inner);
+}
+Object.assign(window, {
+  SceneStage,
+  useScene
+});</script>
+
+<!-- tweaks panel (hidden unless a host activates edit mode), pre-compiled -->
+<script>// tweaks-panel.jsx — compact, behavior-faithful subset of the Claude Design
+// "omelette" Tweaks shell. Exports (to window): useTweaks, TweaksPanel,
+// TweakSection, TweakToggle — exactly the controls the How It Works piece
+// wires. The panel is hidden until a host posts __activate_edit_mode, so
+// standalone (no host frame) it renders nothing — the animation shows clean.
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    background:rgba(250,249,247,.82);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys) when one is present; standalone it just updates state.
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null ? keyOrEdits : {
+      [keyOrEdits]: val
+    };
+    setValues(prev => ({
+      ...prev,
+      ...edits
+    }));
+    try {
+      window.parent.postMessage({
+        type: '__edit_mode_set_keys',
+        edits
+      }, '*');
+    } catch (e) {}
+    window.dispatchEvent(new CustomEvent('tweakchange', {
+      detail: edits
+    }));
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell, hidden until a host activates edit mode. Announces
+// availability so a host toolbar can toggle it.
+function TweaksPanel({
+  title = 'Tweaks',
+  children
+}) {
+  const [open, setOpen] = React.useState(false);
+  React.useEffect(() => {
+    const onMsg = e => {
+      const t = e && e.data && e.data.type;
+      if (t === '__activate_edit_mode') setOpen(true);else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    try {
+      window.parent.postMessage({
+        type: '__edit_mode_available'
+      }, '*');
+    } catch (e) {}
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+  React.useEffect(() => {
+    document.documentElement.setAttribute('data-om-starter', 'tweaks-panel');
+    return () => document.documentElement.removeAttribute('data-om-starter');
+  }, []);
+  const dismiss = () => {
+    setOpen(false);
+    try {
+      window.parent.postMessage({
+        type: '__edit_mode_dismissed'
+      }, '*');
+    } catch (e) {}
+  };
+  if (!open) return null;
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("style", null, __TWEAKS_STYLE), /*#__PURE__*/React.createElement("div", {
+    className: "twk-panel",
+    "data-omelette-chrome": ""
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "twk-hd"
+  }, /*#__PURE__*/React.createElement("b", null, title), /*#__PURE__*/React.createElement("button", {
+    className: "twk-x",
+    "aria-label": "Close tweaks",
+    onClick: dismiss
+  }, "\u2715")), /*#__PURE__*/React.createElement("div", {
+    className: "twk-body"
+  }, children)));
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+function TweakSection({
+  label,
+  children
+}) {
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
+    className: "twk-sect"
+  }, label), children);
+}
+function TweakToggle({
+  label,
+  value,
+  onChange
+}) {
+  return /*#__PURE__*/React.createElement("div", {
+    className: "twk-row twk-row-h"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "twk-lbl"
+  }, /*#__PURE__*/React.createElement("span", null, label)), /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    className: "twk-toggle",
+    "data-on": value ? '1' : '0',
+    role: "switch",
+    "aria-checked": !!value,
+    onClick: () => onChange(!value)
+  }, /*#__PURE__*/React.createElement("i", null)));
+}
+Object.assign(window, {
+  useTweaks,
+  TweaksPanel,
+  TweakSection,
+  TweakToggle
+});</script>
+
+<!-- the How It Works piece, pre-compiled -->
+<script>// how-it-works.jsx — Crush.lu "How It Works" cinematic ghost-story loop.
+// 9:16, transparent outside a rounded story-stage panel, seamless loop.
+//
+// Three dissolving vignettes tell the FREE event flow:
+//   1. Come to a real event & check in
+//   2. Meet people live at the event
+//   3. Match, then stay in touch
+// A constant evening panel (identical every scene) keeps cuts + the loop seam
+// clean; each act's foreground blooms in, holds under a slow camera push, and
+// dissolves back to the empty panel before its edge.
+
+const CP = {
+  purple: '#9b59b6',
+  purpleDark: '#8e44ad',
+  purpleLight: '#af7ac5',
+  pink: '#ff6b9d',
+  pinkLight: '#ff8fb3',
+  pinkDark: '#d94d7b',
+  indigo: '#280d49',
+  dark: '#2c3e50',
+  gray: '#6c757d',
+  grayLt: '#9aa4b0',
+  light: '#f8f9fa',
+  white: '#F0ECF5',
+  card: '#ffffff',
+  warm: '#ffd39b',
+  grad: 'linear-gradient(135deg,#9b59b6,#ff6b9d)'
+};
+const SANS = 'Inter, system-ui, sans-serif';
+const DISPLAY = 'Fraunces, Georgia, serif';
+
+// panel-local coordinate box
+const PW = 1016,
+  PH = 1856,
+  CX = 508;
+const HowOptsContext = React.createContext({
+  showCaptions: true
+});
+const env = p => Math.sin(clamp(p, 0, 1) * Math.PI);
+const smooth = p => Easing.easeInOutCubic(clamp(p, 0, 1));
+// flat-topped envelope: 0 at both edges, 1 across the middle
+const flatEnv = (p, e = 0.15) => Easing.easeInOutSine(clamp(Math.min(p / e, (1 - p) / e), 0, 1));
+function Ghost({
+  src,
+  size,
+  blur = 0,
+  style
+}) {
+  // Resolve packaged ghost paths (e.g. "ghosts/nervous.svg") to inlined data
+  // URIs when this file is bundled into a single self-contained page; falls
+  // back to the relative path when the sibling asset is served alongside.
+  const resolved = typeof window !== 'undefined' && window.GHOSTS && window.GHOSTS[src] || src;
+  return /*#__PURE__*/React.createElement("img", {
+    src: resolved,
+    alt: "",
+    style: {
+      width: size,
+      height: size,
+      objectFit: 'contain',
+      filter: blur ? `blur(${blur}px)` : 'none',
+      ...style
+    }
+  });
+}
+function Sparkle({
+  x,
+  y,
+  s = 1,
+  color = CP.pink,
+  op = 1
+}) {
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: x,
+      top: y,
+      transform: `translate(-50%,-50%) scale(${s})`,
+      opacity: op
+    }
+  }, /*#__PURE__*/React.createElement("svg", {
+    width: "40",
+    height: "40",
+    viewBox: "0 0 24 24",
+    fill: color
+  }, /*#__PURE__*/React.createElement("path", {
+    d: "M12 0l2.2 7.2L22 9.4l-6 5 2 7.6-6-4.6-6 4.6 2-7.6-6-5 7.8-2.2z"
+  })));
+}
+function Heart({
+  x,
+  y,
+  size = 90,
+  fill = CP.pink,
+  stroke = '#fff',
+  sw = 1.5,
+  op = 1,
+  scale = 1
+}) {
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: x,
+      top: y,
+      transform: `translate(-50%,-50%) scale(${scale})`,
+      opacity: op,
+      filter: 'drop-shadow(0 8px 20px rgba(255,107,157,0.55))'
+    }
+  }, /*#__PURE__*/React.createElement("svg", {
+    width: size,
+    height: size,
+    viewBox: "0 0 24 24",
+    fill: fill,
+    stroke: stroke,
+    strokeWidth: sw,
+    strokeLinejoin: "round"
+  }, /*#__PURE__*/React.createElement("path", {
+    d: "M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 0 0-7.8 7.8l1 1L12 21l7.8-7.6 1-1a5.5 5.5 0 0 0 0-7.8z"
+  })));
+}
+
+// ── Constant story-stage panel (identical every scene) ───────────────────
+function StoryStage({
+  children
+}) {
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      fontFamily: SANS
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: 32,
+      top: 32,
+      right: 32,
+      bottom: 32,
+      borderRadius: 56,
+      overflow: 'hidden',
+      background: 'linear-gradient(165deg,#1a1a2e 0%,#2a1a48 46%,#0f3460 100%)',
+      boxShadow: '0 30px 80px rgba(20,10,40,0.5)'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      top: -220,
+      left: '50%',
+      width: 900,
+      height: 900,
+      transform: 'translateX(-50%)',
+      borderRadius: '50%',
+      background: 'radial-gradient(circle, rgba(155,89,182,0.4), rgba(26,26,46,0) 66%)'
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      bottom: -260,
+      left: '50%',
+      width: 820,
+      height: 820,
+      transform: 'translateX(-50%)',
+      borderRadius: '50%',
+      background: 'radial-gradient(circle, rgba(255,107,157,0.26), rgba(26,26,46,0) 66%)'
+    }
+  }), children));
+}
+function Camera({
+  cam,
+  fg,
+  children
+}) {
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      transform: cam,
+      transformOrigin: '50% 45%',
+      opacity: fg
+    }
+  }, children);
+}
+function Caption({
+  progress,
+  text
+}) {
+  const opts = React.useContext(HowOptsContext);
+  if (!opts.showCaptions) return null;
+  const o = flatEnv(progress, 0.18);
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      bottom: 96,
+      left: 0,
+      right: 0,
+      display: 'flex',
+      justifyContent: 'center',
+      opacity: o
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      padding: '20px 44px',
+      borderRadius: 999,
+      background: 'rgba(255,255,255,0.1)',
+      border: '1px solid rgba(255,255,255,0.16)',
+      backdropFilter: 'blur(10px)',
+      color: '#fff',
+      fontSize: 40,
+      fontWeight: 600,
+      letterSpacing: '-0.01em'
+    }
+  }, text));
+}
+function ActDots({
+  index,
+  progress
+}) {
+  const hi = flatEnv(progress, 0.18);
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      bottom: 56,
+      left: 0,
+      right: 0,
+      display: 'flex',
+      justifyContent: 'center',
+      gap: 14
+    }
+  }, [0, 1, 2].map(i => {
+    const on = i === index;
+    return /*#__PURE__*/React.createElement("div", {
+      key: i,
+      style: {
+        width: 14 + (on ? 22 * hi : 0),
+        height: 14,
+        borderRadius: 999,
+        background: on ? `rgba(255,107,157,${0.5 + 0.5 * hi})` : 'rgba(255,255,255,0.28)',
+        transition: 'none'
+      }
+    });
+  }));
+}
+
+// ── Act 1 — Come to a real event & check in ──────────────────────────────
+function ArriveAct(props) {
+  const {
+    progress,
+    localTime
+  } = props;
+  const fg = flatEnv(progress, 0.15);
+  const cam = `scale(${1 + 0.1 * smooth(progress)}) translateY(${-10 * smooth(progress)}px)`;
+  const gy = interpolate([0.12, 0.62], [1360, 1010], Easing.easeOutCubic)(progress);
+  const gfloat = Math.sin(localTime * 2) * 8;
+  const scanSweep = clamp((progress - 0.45) / 0.28, 0, 1);
+  const checked = clamp((progress - 0.72) / 0.16, 0, 1);
+  return /*#__PURE__*/React.createElement(StoryStage, null, /*#__PURE__*/React.createElement(Camera, {
+    cam: cam,
+    fg: fg
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: CX,
+      top: 300,
+      transform: 'translate(-50%,-50%)',
+      padding: '20px 48px',
+      borderRadius: 26,
+      background: CP.grad,
+      color: '#fff',
+      fontFamily: DISPLAY,
+      fontSize: 52,
+      fontWeight: 600,
+      letterSpacing: '0.01em',
+      boxShadow: '0 0 60px rgba(255,107,157,0.5)'
+    }
+  }, "Crush Night"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: CX,
+      top: 640,
+      transform: 'translate(-50%,-50%)',
+      width: 360,
+      height: 460,
+      borderRadius: '180px 180px 24px 24px',
+      background: 'linear-gradient(180deg, rgba(255,211,155,0.95), rgba(255,140,120,0.7))',
+      boxShadow: '0 0 90px rgba(255,190,120,0.6)'
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: CX,
+      top: 660,
+      transform: 'translate(-50%,-50%)',
+      width: 250,
+      height: 380,
+      borderRadius: '140px 140px 12px 12px',
+      background: 'linear-gradient(180deg,#3a1a5c,#1a1a2e)',
+      opacity: 0.85
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: CX,
+      top: gy + gfloat,
+      transform: 'translate(-50%,-50%)'
+    }
+  }, /*#__PURE__*/React.createElement(Ghost, {
+    src: "ghosts/nervous.svg",
+    size: 330
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: CX + 150,
+      top: gy - 40,
+      transform: 'translate(-50%,-50%)',
+      width: 150,
+      height: 190,
+      borderRadius: 22,
+      background: '#fff',
+      overflow: 'hidden',
+      boxShadow: '0 12px 30px rgba(0,0,0,0.35)',
+      opacity: clamp((progress - 0.3) / 0.15, 0, 1) * (1 - checked)
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 16,
+      borderRadius: 10,
+      background: 'repeating-linear-gradient(90deg,#280d49 0 8px,#fff 8px 16px)',
+      opacity: 0.85
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: `${scanSweep * 100}%`,
+      height: 6,
+      background: CP.pink,
+      boxShadow: '0 0 16px #ff6b9d'
+    }
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: CX + 150,
+      top: gy - 40,
+      transform: `translate(-50%,-50%) scale(${Easing.easeOutBack(checked)})`,
+      width: 150,
+      height: 150,
+      borderRadius: '50%',
+      background: '#3fca6b',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      opacity: checked,
+      boxShadow: '0 10px 30px rgba(63,202,107,0.5)'
+    }
+  }, /*#__PURE__*/React.createElement("svg", {
+    width: "80",
+    height: "80",
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "#fff",
+    strokeWidth: "3.4",
+    strokeLinecap: "round",
+    strokeLinejoin: "round"
+  }, /*#__PURE__*/React.createElement("path", {
+    d: "M5 13l4 4L19 7"
+  })))), /*#__PURE__*/React.createElement(Caption, {
+    progress: progress,
+    text: "Come to a real event"
+  }), /*#__PURE__*/React.createElement(ActDots, {
+    index: 0,
+    progress: progress
+  }));
+}
+
+// ── Act 2 — Meet people, live ─────────────────────────────────────────────
+function MeetAct(props) {
+  const {
+    progress,
+    localTime
+  } = props;
+  const fg = flatEnv(progress, 0.15);
+  const pan = interpolate([0, 0.5, 1], [30, -30, 0])(progress);
+  const cam = `scale(1.06) translateX(${pan}px)`;
+  const mingle = [{
+    x: 210,
+    y: 560,
+    src: 'ghosts/party.svg',
+    s: 190
+  }, {
+    x: 830,
+    y: 620,
+    src: 'ghosts/laughing.svg',
+    s: 200
+  }, {
+    x: 300,
+    y: 1120,
+    src: 'ghosts/chatting.svg',
+    s: 210
+  }];
+  const spark = clamp((progress - 0.4) / 0.4, 0, 1);
+  const otherY = 780 + Math.sin(localTime * 1.8) * 10;
+  const youY = 1230 + Math.sin(localTime * 1.8 + 1) * 10;
+  return /*#__PURE__*/React.createElement(StoryStage, null, /*#__PURE__*/React.createElement(Camera, {
+    cam: cam,
+    fg: fg
+  }, Array.from({
+    length: 9
+  }).map((_, i) => {
+    const x = 120 + i * 96;
+    const y = 150 + Math.sin(i * 0.7) * 30;
+    return /*#__PURE__*/React.createElement("div", {
+      key: i,
+      style: {
+        position: 'absolute',
+        left: x,
+        top: y,
+        width: 22,
+        height: 22,
+        borderRadius: '50%',
+        background: CP.warm,
+        boxShadow: `0 0 22px ${CP.warm}`,
+        opacity: 0.6 + 0.4 * Math.sin(localTime * 3 + i)
+      }
+    });
+  }), mingle.map((m, i) => /*#__PURE__*/React.createElement("div", {
+    key: i,
+    style: {
+      position: 'absolute',
+      left: m.x,
+      top: m.y,
+      transform: 'translate(-50%,-50%)',
+      opacity: 0.55
+    }
+  }, /*#__PURE__*/React.createElement(Ghost, {
+    src: m.src,
+    size: m.s,
+    blur: 5
+  }))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: 700,
+      top: otherY,
+      transform: 'translate(-50%,-50%)'
+    }
+  }, /*#__PURE__*/React.createElement(Ghost, {
+    src: "ghosts/blushing.svg",
+    size: 280
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: 420,
+      top: youY,
+      transform: 'translate(-50%,-50%)'
+    }
+  }, /*#__PURE__*/React.createElement(Ghost, {
+    src: "ghosts/discover.svg",
+    size: 300
+  })), /*#__PURE__*/React.createElement("svg", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      width: PW,
+      height: PH,
+      pointerEvents: 'none',
+      opacity: spark
+    }
+  }, /*#__PURE__*/React.createElement("line", {
+    x1: "470",
+    y1: youY - 60,
+    x2: "660",
+    y2: otherY + 40,
+    stroke: CP.pink,
+    strokeWidth: "4",
+    strokeDasharray: "3 16",
+    strokeLinecap: "round",
+    opacity: "0.7"
+  })), /*#__PURE__*/React.createElement(Heart, {
+    x: 585,
+    y: (youY + otherY) / 2 - 20,
+    size: 70,
+    op: spark,
+    scale: 0.6 + 0.5 * Easing.easeOutBack(spark)
+  })), /*#__PURE__*/React.createElement(Caption, {
+    progress: progress,
+    text: "Meet people \u2014 live"
+  }), /*#__PURE__*/React.createElement(ActDots, {
+    index: 1,
+    progress: progress
+  }));
+}
+
+// ── Act 3 — Match, then stay in touch ─────────────────────────────────────
+function MatchAct(props) {
+  const {
+    progress,
+    localTime
+  } = props;
+  const fg = flatEnv(progress, 0.15);
+  const cam = `scale(${1.04 + 0.06 * smooth(progress)})`;
+  const come = smooth(clamp(progress / 0.4, 0, 1)); // ghosts drift together
+  const burst = clamp((progress - 0.32) / 0.4, 0, 1);
+  const chat = clamp((progress - 0.55) / 0.35, 0, 1);
+  const leftX = 300 + 108 * come;
+  const rightX = 716 - 112 * come;
+  const gy = 1080 + Math.sin(localTime * 1.6) * 8;
+  const bubbles = [{
+    x: 300,
+    y: 640,
+    w: 200,
+    delay: 0
+  }, {
+    x: 730,
+    y: 560,
+    w: 170,
+    delay: 0.12
+  }];
+  return /*#__PURE__*/React.createElement(StoryStage, null, /*#__PURE__*/React.createElement(Camera, {
+    cam: cam,
+    fg: fg
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: rightX,
+      top: gy - 12,
+      transform: 'translate(-50%,-50%) rotate(6deg) scaleX(-1)'
+    }
+  }, /*#__PURE__*/React.createElement(Ghost, {
+    src: "ghosts/inlove.svg",
+    size: 266
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: leftX,
+      top: gy,
+      transform: 'translate(-50%,-50%) rotate(-6deg)'
+    }
+  }, /*#__PURE__*/React.createElement(Ghost, {
+    src: "ghosts/inlove.svg",
+    size: 266
+  })), /*#__PURE__*/React.createElement(Heart, {
+    x: CX,
+    y: 800,
+    size: 160,
+    op: burst,
+    scale: 0.4 + 1.0 * Easing.easeOutBack(burst)
+  }), Array.from({
+    length: 7
+  }).map((_, i) => {
+    const ang = i / 7 * Math.PI * 2;
+    const r = 60 + burst * 190;
+    return /*#__PURE__*/React.createElement(Sparkle, {
+      key: i,
+      x: CX + Math.cos(ang) * r,
+      y: 800 + Math.sin(ang) * r,
+      s: (1 - burst) * 1.1,
+      color: i % 2 ? CP.purple : CP.pink,
+      op: (1 - burst) * burst * 4
+    });
+  }), bubbles.map((b, i) => {
+    const c = clamp((chat - b.delay) / 0.4, 0, 1);
+    return /*#__PURE__*/React.createElement("div", {
+      key: i,
+      style: {
+        position: 'absolute',
+        left: b.x,
+        top: b.y,
+        transform: `translate(-50%,-50%) scale(${Easing.easeOutBack(c)})`,
+        width: b.w,
+        height: 84,
+        borderRadius: '26px 26px 26px 8px',
+        background: '#fff',
+        opacity: c,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 12,
+        boxShadow: '0 10px 26px rgba(0,0,0,0.3)'
+      }
+    }, [0, 1, 2].map(d => /*#__PURE__*/React.createElement("span", {
+      key: d,
+      style: {
+        width: 18,
+        height: 18,
+        borderRadius: '50%',
+        background: CP.purpleLight
+      }
+    })));
+  })), /*#__PURE__*/React.createElement(Caption, {
+    progress: progress,
+    text: "Match, then stay in touch"
+  }), /*#__PURE__*/React.createElement(ActDots, {
+    index: 2,
+    progress: progress
+  }));
+}
+function HowItWorksApp() {
+  const [t, setTweak] = useTweaks(window.TWEAK_DEFAULTS);
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(HowOptsContext.Provider, {
+    value: {
+      showCaptions: t.showCaptions
+    }
+  }, /*#__PURE__*/React.createElement(SceneStage, {
+    width: 1080,
+    height: 1920,
+    bg: "transparent",
+    scenes: window.OM_SCENES,
+    playback: window.OM_PLAYBACK
+  }, {
+    Arrive: ArriveAct,
+    Meet: MeetAct,
+    Match: MatchAct
+  })), /*#__PURE__*/React.createElement(TweaksPanel, null, /*#__PURE__*/React.createElement(TweakSection, {
+    label: "Playback"
+  }), /*#__PURE__*/React.createElement(TweakToggle, {
+    label: "Motion editor",
+    value: t.motionEditor,
+    onChange: v => setTweak('motionEditor', v)
+  }), /*#__PURE__*/React.createElement(TweakSection, {
+    label: "Content"
+  }), /*#__PURE__*/React.createElement(TweakToggle, {
+    label: "Captions",
+    value: t.showCaptions,
+    onChange: v => setTweak('showCaptions', v)
+  })));
+}
+Object.assign(window, {
+  HowItWorksApp
+});</script>
+
+<!-- mount -->
+<script>
+  (function () {
+    var el = document.getElementById('root');
+    if (el && window.HowItWorksApp) {
+      ReactDOM.createRoot(el).render(React.createElement(window.HowItWorksApp));
+    }
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Purpose
Adds a self-contained **"How It Works"** cinematic animation to the crush_lu static assets, implemented from the Claude Design **"Crush-Connect Live Lobby"** project (`How It Works.dc.html`).

It's a 9:16, seamlessly-looping ghost-story that explains the free event flow in three dissolving vignettes:
1. **Come to a real event** & check in
2. **Meet people — live** at the event
3. **Match, then stay in touch**

New file: `crush_lu/static/crush_lu/animations/live-lobby.html`

The design project's React components (the `animations-v2` engine, the tweaks panel, and the `how-it-works` piece) are transpiled ahead of time and bundled into a single file together with React + ReactDOM (UMD), the Crush.lu design tokens, and all ghost mascot art (inlined as data URIs). There is **no CDN, no build step, and no runtime Babel** — it renders standalone, offline. The one-line change to the design source resolves packaged ghost paths (`ghosts/*.svg`) to those inlined data URIs.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
Additive only — a single new static file; no existing code, templates, or routes are touched.

## Pull Request Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git checkout claude/funny-lovelace-xmrpju
```
* View the animation (it's fully self-contained — just open it):
```
# open directly in a browser
xdg-open crush_lu/static/crush_lu/animations/live-lobby.html   # or drag into a browser tab

# or via Django once collected/served as a static asset:
#   {% static 'crush_lu/animations/live-lobby.html' %}
```

## What to Check
Verify that the following are valid:
* The loop autoplays and cycles through all three acts (Arrive → Meet → Match) and back seamlessly (~8.2s total).
* Each act shows its foreground (marquee/doorway + check-in scan, mingling ghosts + eyes-meet spark, the matched pair + heart burst) and its caption + act-dot.
* It renders with **no network access** (React/ReactDOM and every ghost SVG are inlined). Verified in headless Chromium across all three acts.

## Other Information
* The bottom **playback bar** and the surrounding dark letterbox are the design engine's built-in preview chrome (the piece is authored as a `SceneStage`). If you'd prefer a chrome-free loop for embedding on a marketing page, that's a small follow-up — say the word and I'll strip it.
* Brand fonts (Inter / Fraunces) come from the design-system stylesheet's Google Fonts import, matching the rest of the site; they degrade gracefully to system fonts if unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG8aJu1iC18uBKEjFQmiPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG8aJu1iC18uBKEjFQmiPF)_