### PR TITLE
Redesign crush-admin panel: tiered nav + command-center hub

### DIFF
--- a/core/templates/admin/base_site.html
+++ b/core/templates/admin/base_site.html
@@ -29,6 +29,8 @@
 
 {% block extrahead %}
 {{ block.super }}
+{# Tiered coach-panel sidebar behaviour; no-op on admin sites without tiers. #}
+<script defer src="{% static 'crush_lu/js/crush_admin_nav.js' %}"></script>
 <script defer src="{% static 'crush_lu/js/alpine-components.js' %}"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.min.js"></script>
 {% endblock %}

--- a/core/templates/admin/nav_sidebar.html
+++ b/core/templates/admin/nav_sidebar.html
@@ -1,0 +1,42 @@
+{% load i18n %}
+{% comment %}
+Shared admin sidebar override (core/templates/admin wins via TEMPLATES.DIRS).
+
+For the Crush.lu Coach Panel it groups the tiered "fake apps" produced by
+CrushLuAdminSite.get_app_list into collapsible sections so the daily workflow
+stays visible while rarely-used and dev/analytics groups fold away. Each app
+carries a `tier` key:
+  pinned    -> rendered directly (always expanded)
+  more      -> collapsed <details> "More"
+  superuser -> collapsed <details> "Developer & Analytics"
+
+Every OTHER admin site (default admin, entreprinder, power_up, …) has apps with
+no `tier`, so `regroup` yields a single empty-grouper bucket that renders
+directly through admin/app_list.html exactly like Django's stock sidebar — no
+behaviour change there. Collapsing uses native <details>/<summary> (no JS
+required, CSP-safe); crush_admin_nav.js only auto-opens the sections while the
+quick-filter has text and remembers each section's state.
+{% endcomment %}
+<button class="sticky toggle-nav-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}"></button>
+<nav class="sticky" id="nav-sidebar" aria-label="{% translate 'Sidebar' %}">
+  <input type="search" id="nav-filter"
+         placeholder="{% translate 'Start typing to filter…' %}"
+         aria-label="{% translate 'Filter navigation items' %}">
+
+  {% regroup available_apps by tier as tiered_apps %}
+  {% for tier in tiered_apps %}
+    {% if tier.grouper == 'more' or tier.grouper == 'superuser' %}
+      <details class="nav-tier" data-tier="{{ tier.grouper }}">
+        <summary class="nav-tier-summary">
+          <span class="nav-tier-label">
+            {% if tier.grouper == 'superuser' %}{% translate 'Developer & Analytics' %}{% else %}{% translate 'More' %}{% endif %}
+          </span>
+          <span class="nav-tier-count">{{ tier.list|length }}</span>
+        </summary>
+        {% include 'admin/app_list.html' with app_list=tier.list show_changelinks=False %}
+      </details>
+    {% else %}
+      {% include 'admin/app_list.html' with app_list=tier.list show_changelinks=False %}
+    {% endif %}
+  {% endfor %}
+</nav>

--- a/crush_lu/admin/site.py
+++ b/crush_lu/admin/site.py
@@ -178,27 +178,40 @@ class CrushLuAdminSite(admin.AdminSite):
             'crushconnectwaitlist': {'order': 5, 'icon': '📋', 'group': 'Crush Connect'},
             'connectinterest': {'order': 6, 'icon': '🏷️', 'group': 'Crush Connect'},
             'sparkprompt': {'order': 7, 'icon': '💬', 'group': 'Crush Connect'},
+            'connectquestionweek': {'order': 8, 'icon': '📆', 'group': 'Crush Connect'},  # weekly Q&A rotation
+            'connectquestion': {'order': 9, 'icon': '❓', 'group': 'Crush Connect'},
+            'connectquestionanswer': {'order': 10, 'icon': '💭', 'group': 'Crush Connect'},
+            'confirmedencounter': {'order': 11, 'icon': '🤝', 'group': 'Crush Connect'},
+            'confirmedencounterremovalrequest': {'order': 12, 'icon': '🚫', 'group': 'Crush Connect'},
 
             # ═══════════════════════════════════════════════════════════════════
             # GROUP 1: Users & Profiles (Core user management)
             # ═══════════════════════════════════════════════════════════════════
             'user': {'order': 0, 'icon': '🔑', 'group': 'Users & Profiles'},  # Django User accounts
             'crushprofile': {'order': 1, 'icon': '👤', 'group': 'Users & Profiles'},
-            'approvedprofile': {'order': 2, 'icon': '✅', 'group': 'Users & Profiles'},
-            'pendingreviewprofile': {'order': 3, 'icon': '⏳', 'group': 'Users & Profiles'},
-            'revisionneededprofile': {'order': 4, 'icon': '✏️', 'group': 'Users & Profiles'},
-            'recontactcoachprofile': {'order': 5, 'icon': '📞', 'group': 'Users & Profiles'},
-            'rejectedprofile': {'order': 6, 'icon': '❌', 'group': 'Users & Profiles'},
-            'incompleteprofile': {'order': 7, 'icon': '📝', 'group': 'Users & Profiles'},
-            'awaitingreviewprofile': {'order': 8, 'icon': '📋', 'group': 'Users & Profiles'},
-            'profilesubmission': {'order': 9, 'icon': '📄', 'group': 'Users & Profiles'},
-            'completedsubmission': {'order': 10, 'icon': '✔️', 'group': 'Users & Profiles'},
-            'inprocesssubmission': {'order': 11, 'icon': '🔄', 'group': 'Users & Profiles'},
-            'crushcoach': {'order': 12, 'icon': '🎓', 'group': 'Users & Profiles'},
-            'coachsession': {'order': 13, 'icon': '💬', 'group': 'Users & Profiles'},
-            'screeningslot': {'order': 14, 'icon': '📅', 'group': 'Users & Profiles'},
-            'premiummembership': {'order': 15, 'icon': '💎', 'group': 'Users & Profiles'},
-            'callattempt': {'order': 16, 'icon': '☎️', 'group': 'Users & Profiles'},
+            'profilesubmission': {'order': 2, 'icon': '📄', 'group': 'Users & Profiles'},
+            'crushcoach': {'order': 3, 'icon': '🎓', 'group': 'Users & Profiles'},
+            'coachsession': {'order': 4, 'icon': '💬', 'group': 'Users & Profiles'},
+            'screeningslot': {'order': 5, 'icon': '📅', 'group': 'Users & Profiles'},
+            'premiummembership': {'order': 6, 'icon': '💎', 'group': 'Users & Profiles'},
+            'callattempt': {'order': 7, 'icon': '☎️', 'group': 'Users & Profiles'},
+
+            # ═══════════════════════════════════════════════════════════════════
+            # GROUP: Profile Segments (saved-filter proxy views of profiles)
+            # These proxy admins stay registered (index Action Center deep-links
+            # target them); they just live in their own collapsed "More"-tier
+            # group instead of padding Users & Profiles with 9 extra rows.
+            # See docs/crush-admin-redesign.md.
+            # ═══════════════════════════════════════════════════════════════════
+            'approvedprofile': {'order': 1, 'icon': '✅', 'group': 'Profile Segments'},
+            'awaitingreviewprofile': {'order': 2, 'icon': '📋', 'group': 'Profile Segments'},
+            'pendingreviewprofile': {'order': 3, 'icon': '⏳', 'group': 'Profile Segments'},
+            'revisionneededprofile': {'order': 4, 'icon': '✏️', 'group': 'Profile Segments'},
+            'recontactcoachprofile': {'order': 5, 'icon': '📞', 'group': 'Profile Segments'},
+            'rejectedprofile': {'order': 6, 'icon': '❌', 'group': 'Profile Segments'},
+            'incompleteprofile': {'order': 7, 'icon': '📝', 'group': 'Profile Segments'},
+            'inprocesssubmission': {'order': 8, 'icon': '🔄', 'group': 'Profile Segments'},
+            'completedsubmission': {'order': 9, 'icon': '✔️', 'group': 'Profile Segments'},
 
             # ═══════════════════════════════════════════════════════════════════
             # GROUP 2: Events & Meetups (Event management)
@@ -211,6 +224,9 @@ class CrushLuAdminSite(admin.AdminSite):
             'eventpoll': {'order': 7, 'icon': '🗳️', 'group': 'Events & Meetups'},
             'eventpollvote': {'order': 8, 'icon': '📊', 'group': 'Events & Meetups'},
             'eventfeedback': {'order': 9, 'icon': '📝', 'group': 'Events & Meetups'},
+            'eventlobbyparticipation': {'order': 10, 'icon': '🚪', 'group': 'Events & Meetups'},  # live event lobby
+            'eventmeetsignal': {'order': 11, 'icon': '👋', 'group': 'Events & Meetups'},
+            'eventmeetingconfirmation': {'order': 12, 'icon': '✅', 'group': 'Events & Meetups'},
 
             # ═══════════════════════════════════════════════════════════════════
             # GROUP: Quiz Night (Live quiz event management)
@@ -267,6 +283,7 @@ class CrushLuAdminSite(admin.AdminSite):
             'pushsubscription': {'order': 1, 'icon': '🔔', 'group': 'Notifications'},
             'coachpushsubscription': {'order': 2, 'icon': '📣', 'group': 'Notifications'},
             'iosappdevice': {'order': 3, 'icon': '📱', 'group': 'Notifications'},
+            'androidappdevice': {'order': 3, 'icon': '🤖', 'group': 'Notifications'},
             'iosnativeauthcode': {'order': 4, 'icon': '🔐', 'group': 'Notifications'},
             'newsletter': {'order': 5, 'icon': '📰', 'group': 'Notifications'},
             'newsletterrecipient': {'order': 6, 'icon': '📨', 'group': 'Notifications'},
@@ -287,6 +304,23 @@ class CrushLuAdminSite(admin.AdminSite):
             # ═══════════════════════════════════════════════════════════════════
             'referralcode': {'order': 1, 'icon': '🎟️', 'group': 'Growth & Referrals'},
             'referralattribution': {'order': 2, 'icon': '🔗', 'group': 'Growth & Referrals'},
+
+            # ═══════════════════════════════════════════════════════════════════
+            # GROUP: Crush Cache (location-based scavenger hunt feature)
+            # ═══════════════════════════════════════════════════════════════════
+            'cachehunt': {'order': 1, 'icon': '🧭', 'group': 'Crush Cache'},
+            'cachestation': {'order': 2, 'icon': '📍', 'group': 'Crush Cache'},
+            'cachechallenge': {'order': 3, 'icon': '🎯', 'group': 'Crush Cache'},
+            'cacheteam': {'order': 4, 'icon': '👥', 'group': 'Crush Cache'},
+            'cacheteamprogress': {'order': 5, 'icon': '📈', 'group': 'Crush Cache'},
+            'cachestationattempt': {'order': 6, 'icon': '🗒️', 'group': 'Crush Cache'},
+            'cachechallengeattempt': {'order': 7, 'icon': '📝', 'group': 'Crush Cache'},
+
+            # ═══════════════════════════════════════════════════════════════════
+            # GROUP: Trust & Safety (moderation — reports & blocks)
+            # ═══════════════════════════════════════════════════════════════════
+            'userreport': {'order': 1, 'icon': '🚩', 'group': 'Trust & Safety'},
+            'userblock': {'order': 2, 'icon': '🛑', 'group': 'Trust & Safety'},
 
             # ═══════════════════════════════════════════════════════════════════
             # GROUP 11: Site Settings (Global configuration)
@@ -320,6 +354,24 @@ class CrushLuAdminSite(admin.AdminSite):
             'Matching', 'Analytics', 'Changelog', 'Technical & Debug', 'Other',
         }
         is_superuser = request.user.is_superuser
+
+        # Sidebar tiers (rendered by the nav_sidebar.html override):
+        #   pinned    -> always expanded (the daily coach workflow)
+        #   more      -> collapsed under a "More" section
+        #   superuser -> collapsed under a "Developer & Analytics" section
+        # Each fake-app below gets a 'tier' key so the template can group them.
+        # See docs/crush-admin-redesign.md.
+        PINNED_GROUPS = {
+            'Crush Connect', 'Users & Profiles', 'Events & Meetups',
+            'Connections', 'Notifications',
+        }
+
+        def tier_for(group_key):
+            if group_key in SUPERUSER_ONLY_GROUPS:
+                return 'superuser'
+            if group_key in PINNED_GROUPS:
+                return 'pinned'
+            return 'more'
 
         # Create grouped app list - transform single crush_lu app into multiple sections
         new_app_list = []
@@ -401,13 +453,16 @@ class CrushLuAdminSite(admin.AdminSite):
                     ('💕 Connections', 'Connections'),                 # Post-event connections, messages
                     ('🔔 Notifications', 'Notifications'),             # Push notifications, email prefs
 
-                    # === WEEKLY USE (Features & Growth) ===
+                    # === WEEKLY / OCCASIONAL (collapsed under "More") ===
+                    ('🛡️ Trust & Safety', 'Trust & Safety'),           # Reports & blocks (moderation)
+                    ('🗂️ Profile Segments', 'Profile Segments'),       # Saved-filter proxy views of profiles
                     ('✨ Special Journey', 'Special Journey'),         # VIP journey creation & monitoring
                     ('📈 Growth & Referrals', 'Growth & Referrals'),   # Referral tracking, marketing
 
                     # === EVENT-SPECIFIC (During Events Only) ===
                     ('🧠 Quiz Night', 'Quiz Night'),                   # Live quiz management
                     ('🗳️ Activity Voting', 'Activity Voting'),         # Live event voting sessions
+                    ('🧭 Crush Cache', 'Crush Cache'),                 # Location scavenger hunt
 
                     # === SEASONAL / OCCASIONAL ===
                     ('🎄 Advent Calendar', 'Advent Calendar'),         # December only
@@ -438,6 +493,7 @@ class CrushLuAdminSite(admin.AdminSite):
                             'app_url': '#',
                             'has_module_perms': True,
                             'models': groups[group_key],
+                            'tier': tier_for(group_key),
                         })
             elif app['app_label'] == 'auth':
                 # Skip auth app - User model is merged into Users & Profiles group

--- a/crush_lu/static/crush_lu/css/admin-custom.css
+++ b/crush_lu/static/crush_lu/css/admin-custom.css
@@ -1214,3 +1214,94 @@ a.metric-card:hover {
         font-size: 28px;
     }
 }
+
+/* ==========================================================================
+   Sidebar tiers (collapsible "More" / "Developer & Analytics" sections)
+   Rendered by templates/admin/nav_sidebar.html. Colors use Django admin theme
+   variables so they track the admin's own light/dark theme; spacing/radius use
+   the crush design tokens above.
+   ========================================================================== */
+#nav-sidebar details.nav-tier {
+    border-top: 1px solid var(--border-color, var(--card-border));
+}
+
+#nav-sidebar .nav-tier-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm) var(--spacing-md);
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--body-quiet-color, var(--text-muted));
+    transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+/* Hide the native disclosure triangle; we draw our own chevron. */
+#nav-sidebar .nav-tier-summary::-webkit-details-marker {
+    display: none;
+}
+
+#nav-sidebar .nav-tier-summary::before {
+    content: "\25B8"; /* ▸ */
+    font-size: 0.75em;
+    line-height: 1;
+    transition: transform var(--transition-fast);
+}
+
+#nav-sidebar details.nav-tier[open] > .nav-tier-summary::before {
+    transform: rotate(90deg);
+}
+
+#nav-sidebar .nav-tier-summary:hover {
+    color: var(--body-fg, var(--text-primary));
+    background: var(--darkened-bg, var(--table-header-bg));
+}
+
+#nav-sidebar .nav-tier-label {
+    flex: 1 1 auto;
+}
+
+#nav-sidebar .nav-tier-count {
+    flex: 0 0 auto;
+    min-width: 1.4em;
+    text-align: center;
+    padding: 1px var(--spacing-sm);
+    border-radius: var(--radius-pill);
+    background: var(--darkened-bg, var(--table-header-bg));
+    color: var(--body-quiet-color, var(--text-muted));
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0;
+}
+
+/* ==========================================================================
+   Index "browse in the sidebar" hint (replaces the old full model dump)
+   ========================================================================== */
+.model-browser-hint {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-md);
+    margin-top: var(--spacing-sm);
+    border: 1px dashed var(--card-border);
+    border-radius: var(--radius-md);
+    background: var(--funnel-bg);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.model-browser-hint-icon {
+    font-size: 1.2rem;
+    line-height: 1.3;
+    flex: 0 0 auto;
+}
+
+.model-browser-hint strong {
+    color: var(--text-primary);
+}

--- a/crush_lu/static/crush_lu/js/crush_admin_nav.js
+++ b/crush_lu/static/crush_lu/js/crush_admin_nav.js
@@ -1,0 +1,76 @@
+'use strict';
+/*
+ * Crush.lu Coach Panel sidebar behaviour.
+ *
+ * The sidebar (templates/admin/nav_sidebar.html) folds the "More" and
+ * "Developer & Analytics" tiers into native <details> sections. Two jobs here,
+ * both CSP-safe (external file, no inline handlers):
+ *   1. Remember each tier's open/closed state across page loads.
+ *   2. While Django's #nav-filter quick-search has text, force every tier open
+ *      so matches inside a collapsed section are actually visible; restore the
+ *      previous state when the search is cleared.
+ */
+(function () {
+    function ready(fn) {
+        if (document.readyState !== 'loading') {
+            fn();
+        } else {
+            document.addEventListener('DOMContentLoaded', fn);
+        }
+    }
+
+    ready(function () {
+        var nav = document.getElementById('nav-sidebar');
+        if (!nav) {
+            return;
+        }
+
+        var tiers = Array.prototype.slice.call(nav.querySelectorAll('details.nav-tier'));
+        if (!tiers.length) {
+            return;
+        }
+
+        var filtering = false;
+
+        // 1. Persist open/closed state per tier.
+        tiers.forEach(function (d) {
+            var key = 'crush.admin.navTier.' + (d.dataset.tier || 'tier');
+            if (localStorage.getItem(key) === 'open') {
+                d.open = true;
+            }
+            d.addEventListener('toggle', function () {
+                // Ignore programmatic opens driven by the filter below.
+                if (filtering) {
+                    return;
+                }
+                localStorage.setItem(key, d.open ? 'open' : 'closed');
+            });
+        });
+
+        // 2. Auto-open every tier while the quick-filter is active.
+        var filter = document.getElementById('nav-filter');
+        if (filter) {
+            var apply = function () {
+                var active = filter.value.trim().length > 0;
+                if (active === filtering) {
+                    return;
+                }
+                filtering = active;
+                tiers.forEach(function (d) {
+                    if (active) {
+                        d.dataset.prevOpen = d.open ? '1' : '0';
+                        d.open = true;
+                    } else if (d.dataset.prevOpen !== undefined) {
+                        d.open = d.dataset.prevOpen === '1';
+                        delete d.dataset.prevOpen;
+                    }
+                });
+            };
+            filter.addEventListener('input', apply);
+            filter.addEventListener('keyup', apply);
+            // Django's nav_sidebar.js restores a stored filter value on load;
+            // reflect that here so tiers open if a filter is already applied.
+            apply();
+        }
+    });
+})();

--- a/crush_lu/templates/admin/crush_lu/index.html
+++ b/crush_lu/templates/admin/crush_lu/index.html
@@ -94,23 +94,22 @@
         </a>
     </div>
 
+        {% comment %}
+           Curated launchers for the bespoke tools that are NOT reachable from
+           the model sidebar. Plain model changelists (Events, Connections,
+           Polls, …) now live in the tiered sidebar, so they were dropped here
+           to keep this a short, high-signal launcher.
+        {% endcomment %}
         <div class="quick-links-panel">
-        <h3><span>&#x1F680;</span> Quick Links</h3>
+        <h3><span>&#x1F9F0;</span> Tools &amp; Dashboards</h3>
         <div class="quick-links-grid">
             <a href="{% url 'crush_admin_dashboard' %}" class="quick-link">
                 <span class="quick-link-icon">&#x1F4CA;</span>
-                <span class="quick-link-text">Analytics Dashboard</span>
-            </a>
-            <a href="{% url 'crush_admin:crush_lu_profilesubmission_changelist' %}?status__exact=pending" class="quick-link">
-                <span class="quick-link-icon">&#x1F4DD;</span>
-                <span class="quick-link-text">Pending Reviews</span>
-                {% if pending_actions.total_pending > 0 %}
-                <span class="quick-link-badge">{{ pending_actions.total_pending }}</span>
-                {% endif %}
+                <span class="quick-link-text">Analytics</span>
             </a>
             <a href="{% url 'campaign_dashboard' %}" class="quick-link">
                 <span class="quick-link-icon">&#x1F4E2;</span>
-                <span class="quick-link-text">Campaign Dashboard</span>
+                <span class="quick-link-text">Campaigns</span>
             </a>
             <a href="{% url 'user_segments_dashboard' %}" class="quick-link">
                 <span class="quick-link-icon">&#x1F465;</span>
@@ -124,25 +123,20 @@
                 <span class="quick-link-icon">&#x1F4E7;</span>
                 <span class="quick-link-text">Email Templates</span>
             </a>
-            <a href="{% url 'crush_admin:crush_lu_meetupevent_changelist' %}" class="quick-link">
-                <span class="quick-link-icon">&#x1F389;</span>
-                <span class="quick-link-text">Manage Events</span>
-            </a>
-            <a href="{% url 'crush_admin:crush_lu_crushprofile_changelist' %}?is_approved__exact=0" class="quick-link">
-                <span class="quick-link-icon">&#x23F3;</span>
-                <span class="quick-link-text">Unapproved Profiles</span>
-            </a>
-            <a href="{% url 'crush_admin:crush_lu_eventconnection_changelist' %}" class="quick-link">
-                <span class="quick-link-icon">&#x1F495;</span>
-                <span class="quick-link-text">Connections</span>
-            </a>
-            <a href="{% url 'crush_admin:crush_lu_eventpoll_changelist' %}" class="quick-link">
-                <span class="quick-link-icon">&#x1F4CA;</span>
-                <span class="quick-link-text">Event Polls</span>
-            </a>
             <a href="{% url 'poll_analytics_dashboard' %}" class="quick-link">
                 <span class="quick-link-icon">&#x1F5F3;</span>
                 <span class="quick-link-text">Poll Analytics</span>
+            </a>
+            <a href="{% url 'merge_accounts_confirm' %}" class="quick-link">
+                <span class="quick-link-icon">&#x1F500;</span>
+                <span class="quick-link-text">Merge Accounts</span>
+            </a>
+            <a href="{% url 'crush_admin:crush_lu_profilesubmission_changelist' %}?status__exact=pending" class="quick-link">
+                <span class="quick-link-icon">&#x1F4DD;</span>
+                <span class="quick-link-text">Pending Reviews</span>
+                {% if pending_actions.total_pending > 0 %}
+                <span class="quick-link-badge">{{ pending_actions.total_pending }}</span>
+                {% endif %}
             </a>
         </div>
     </div>
@@ -248,49 +242,17 @@
     </div>
 
         <div id="content-main">
+        {% comment %}
+           The full model list now lives in the collapsible left sidebar (with a
+           type-to-filter search), so it is no longer duplicated here — this page
+           is the command center. The hint keeps model browsing discoverable even
+           if the sidebar is toggled shut.
+        {% endcomment %}
         {% if app_list %}
-            {% for app in app_list %}
-            <div class="model-group" x-data="modelGroup" data-group-id="{{ app.app_label }}" data-default-open="true">
-                <div class="model-group-header" @click="toggle">
-                    <span class="model-group-title">
-                        {% if app.app_label == 'crush_lu' %}&#x1F495;{% elif app.app_label == 'auth' %}&#x1F512;{% else %}&#x1F4E6;{% endif %}
-                        {{ app.name }}
-                    </span>
-                    <button class="model-group-toggle" :class="toggleClass" :aria-expanded="ariaExpanded">
-                        &#x25BC;
-                    </button>
-                </div>
-                <div class="model-group-content" :class="contentClass">
-                    <table>
-                        {% for model in app.models %}
-                        <tr class="model-{{ model.object_name|lower }}">
-                            {% if model.admin_url %}
-                            <th scope="row"><a href="{{ model.admin_url }}">{{ model.name }}</a></th>
-                            {% else %}
-                            <th scope="row">{{ model.name }}</th>
-                            {% endif %}
-
-                            {% if model.add_url %}
-                            <td><a href="{{ model.add_url }}" class="addlink">{% trans 'Add' %}</a></td>
-                            {% else %}
-                            <td>&nbsp;</td>
-                            {% endif %}
-
-                            {% if model.admin_url and show_changelinks %}
-                            {% if model.view_only %}
-                            <td><a href="{{ model.admin_url }}" class="viewlink">{% trans 'View' %}</a></td>
-                            {% else %}
-                            <td><a href="{{ model.admin_url }}" class="changelink">{% trans 'Change' %}</a></td>
-                            {% endif %}
-                            {% elif show_changelinks %}
-                            <td>&nbsp;</td>
-                            {% endif %}
-                        </tr>
-                        {% endfor %}
-                    </table>
-                </div>
-            </div>
-            {% endfor %}
+        <div class="model-browser-hint">
+            <span class="model-browser-hint-icon">&#x1F9ED;</span>
+            <span>Browse every model in the <strong>left sidebar</strong> — start typing in its search box to filter across all sections. Rarely-used and developer groups are tucked under <em>More</em> and <em>Developer &amp; Analytics</em>.</span>
+        </div>
         {% else %}
             <p>{% trans 'You don\'t have permission to view or edit anything.' %}</p>
         {% endif %}

--- a/crush_lu/tests/test_admin_smoke.py
+++ b/crush_lu/tests/test_admin_smoke.py
@@ -233,6 +233,83 @@ class AdminMenuOrganizationTests(SiteTestMixin, TestCase):
                     "CrushConnectMembership"):
             self.assertIn(obj, names)
 
+    # -- Redesign: tiered sidebar (see docs/crush-admin-redesign.md) ----------
+
+    def test_no_model_falls_into_the_other_catch_all(self):
+        """Every registered model must have an explicit group.
+
+        'Other' is a runtime safety net so a newly-registered model is never
+        invisible — but it should stay *empty* in a healthy tree. If this fails,
+        add the listed model(s) to ``custom_order`` in
+        ``CrushLuAdminSite.get_app_list``.
+        """
+        app_list = self._app_list_for(self.superuser)
+        stragglers = sorted(
+            m["object_name"]
+            for app in app_list
+            if app["name"].strip().endswith("Other")
+            for m in app["models"]
+        )
+        self.assertEqual(
+            stragglers, [], f"Uncategorised models in the 'Other' group: {stragglers}"
+        )
+
+    def test_every_group_carries_a_known_tier(self):
+        """Each sidebar group is tagged with a tier the nav override understands."""
+        for app in self._app_list_for(self.superuser):
+            self.assertIn(
+                app.get("tier"),
+                {"pinned", "more", "superuser"},
+                f"{app['name']} has an unknown sidebar tier: {app.get('tier')!r}",
+            )
+
+    def test_pinned_tier_is_the_daily_workflow(self):
+        """The always-expanded tier is exactly the five daily-workflow groups."""
+        pinned = {
+            a["name"]
+            for a in self._app_list_for(self.superuser)
+            if a.get("tier") == "pinned"
+        }
+        self.assertEqual(
+            pinned,
+            {
+                "💞 Crush Connect",
+                "👥 Users & Profiles",
+                "🎉 Events & Meetups",
+                "💕 Connections",
+                "🔔 Notifications",
+            },
+        )
+
+    def test_coach_sees_no_superuser_tier_groups(self):
+        coach = User.objects.get(pk=self.coach_pk)
+        superuser_tier = [
+            a["name"]
+            for a in self._app_list_for(coach)
+            if a.get("tier") == "superuser"
+        ]
+        self.assertEqual(superuser_tier, [])
+
+    def test_index_renders_as_command_center(self):
+        """The index renders the redesigned hub + tiered sidebar end to end.
+
+        Guards both the Phase 2 body rewrite (curated Tools panel, no duplicated
+        model dump) and the Phase 1 sidebar override (collapsible tiers).
+        """
+        self.client.force_login(self.superuser)
+        resp = self.client.get(reverse(f"{crush_admin_site.name}:index"))
+        self.assertEqual(resp.status_code, 200)
+        html = resp.content.decode()
+        # Curated launcher replaced the old flat "Quick Links" list.
+        self.assertIn("Tools &amp; Dashboards", html)
+        self.assertNotIn(">Quick Links<", html)
+        # The full model dump no longer duplicates the sidebar in the body.
+        self.assertNotIn('x-data="modelGroup"', html)
+        self.assertIn("model-browser-hint", html)
+        # Tiered sidebar is present, with the collapsible superuser section.
+        self.assertIn("nav-tier", html)
+        self.assertIn("Developer &amp; Analytics", html)
+
 
 @override_settings(**CRUSH_LU_URL_SETTINGS)
 class EventRegistrationChangelistQueryTests(SiteTestMixin, TestCase):

--- a/docs/crush-admin-redesign.md
+++ b/docs/crush-admin-redesign.md
@@ -1,0 +1,114 @@
+# Crush.lu Coach Panel (`/crush-admin/`) — Redesign Audit
+
+> Phase 0 deliverable of the coach-panel redesign. This is the review that drives
+> the Phase 1–3 implementation. Audience: **superuser** — nothing is removed from
+> reach; the goal is organisation and findability.
+
+## 1. Why
+
+`CrushLuAdminSite` (`crush_lu/admin/site.py`) registers **~103 models across 17
+sidebar groups**. All of them render **twice** — in the left `nav_sidebar` *and*
+as 17 collapsible tables in the index body — with no prioritisation, so a
+December-only Advent Calendar group carries the same visual weight as daily
+profile review. The landing page also stacks Action Center + 4 stat cards + 11
+quick-links + a 3-tab "Today's Focus" **on top of** that full model dump.
+
+## 2. Group inventory & usage tiers
+
+Tiers below become a declarative `TIER` field on the `custom_order` map in Phase 1.
+
+| Group | ~Models | Tier | Rationale |
+|---|---|---|---|
+| Users & Profiles | 17 | **PINNED** | Daily profile review / coach assignment — the core job |
+| Crush Connect | 7 | **PINNED** | The live matchmaking product (memberships, drops, sparks) |
+| Events & Meetups | 8 | **PINNED** | Event ops, registrations, invitations |
+| Connections | 3 | **PINNED** | Post-event mutual connections & messages |
+| Notifications | 12 | **PINNED** | Push, newsletters, campaigns, email prefs, reminders |
+| Special Journey | 10 | MORE | VIP journeys — created occasionally, not daily |
+| Growth & Referrals | 2 | MORE | Referral tracking — weekly glance |
+| Quiz Night | 6 | MORE | Only during live quiz events |
+| Activity Voting | 4 | MORE | Only during live events |
+| Advent Calendar | 5 | MORE | Seasonal (December only) |
+| Wallet & Passes | 2 | MORE | Apple/Google wallet — rarely touched |
+| Site Settings | 1 | MORE | Global config — set-and-forget |
+| Matching | 2 | SUPERUSER | Trait/score engine internals |
+| Analytics | 1 | SUPERUSER | Weekly KPI snapshots (internal) |
+| Changelog | 2 | SUPERUSER | Patch notes |
+| Technical & Debug | 3 | SUPERUSER | PWA installs, OAuth state, GDPR consent audit |
+| Other | 0* | SUPERUSER | Auto catch-all — must stay empty for known models |
+
+`PINNED` = expanded by default. `MORE` = collapsed by default. `SUPERUSER` =
+collapsed **and** hidden from non-superuser coaches (existing
+`SUPERUSER_ONLY_GROUPS` behaviour, preserved).
+
+\* "Other" is a safety net; Phase 1 verification asserts no known model lands there.
+
+## 3. Bespoke tool dashboards (not model admins)
+
+These are the real high-value daily destinations, currently buried among the 11
+flat quick-links. Phase 2 promotes them into a curated "Tools" grid.
+
+| Tool | URL name | View |
+|---|---|---|
+| Analytics Dashboard | `crush_admin_dashboard` | `admin_views.crush_admin_dashboard` |
+| Campaign Dashboard | `campaign_dashboard` | `admin/campaign_dashboard.py` |
+| User Segments | `user_segments_dashboard` | `admin/user_segments.py` |
+| Profile Reminders | `profile_reminders_panel` | `admin/profile_reminders.py` |
+| Email Templates | `email_template_manager` | `admin_views` |
+| Poll Analytics | `poll_analytics_dashboard` | `admin/poll_analytics.py` |
+| Account Merge | `merge_accounts_confirm` | `admin_views.merge_accounts_confirm` |
+
+## 4. Profile proxy models — decision
+
+`Users & Profiles` carries **9 proxy models** that are all just
+`CrushProfileAdmin` / `ProfileSubmissionAdmin` subclasses with a `get_queryset`
+filter + `has_add_permission = False` (`crush_lu/admin/profiles.py`):
+
+| Proxy | Filters | Equivalent changelist query |
+|---|---|---|
+| ApprovedProfile | `verification_status="verified"` | `crushprofile?verification_status__exact=verified` |
+| AwaitingReviewProfile | `verification_status="pending"` | `…=pending` |
+| IncompleteProfile | `verification_status="incomplete"` | `…=incomplete` |
+| PendingReviewProfile | `profilesubmission__status="pending"` | via submission status |
+| RevisionNeededProfile | `profilesubmission__status="revision"` | via submission status |
+| RecontactCoachProfile | `profilesubmission__status="recontact_coach"` | via submission status |
+| RejectedProfile | `profilesubmission__status="rejected"` | via submission status |
+| CompletedSubmission | `status in [approved, rejected]` | `profilesubmission?status…` |
+| InProcessSubmission | `status in [pending, revision, recontact_coach]` | `profilesubmission?status…` |
+
+**Decision: keep them registered, stop listing them as 9 flat top-level rows.**
+They provide genuinely useful curated querysets and are targeted by existing
+deep-links (index Action Center → `crush_lu_profilesubmission_changelist?...`), so
+**do not unregister** them. Instead, in Phase 1 they render as a **collapsed
+"Profile segments" sub-list** nested under the two real models (`CrushProfile`,
+`ProfileSubmission`). This removes ~9 rows from the always-visible menu while
+keeping every view one expand away. Implemented purely in `get_app_list` ordering
++ the `nav_sidebar` override — **no model/migration changes**.
+
+## 5. Index page audit
+
+Current `templates/admin/crush_lu/index.html` (330 lines) renders, top to bottom:
+Action Center → 4 stat cards → **11 quick-links** → 3-tab Today's Focus → **all 17
+model groups as tables** → Recent Actions sidebar. The bottom half duplicates the
+left nav.
+
+**Decision:** the tiered `nav_sidebar` becomes the canonical model browser; the
+index drops the 17-group dump and becomes a focused command center:
+Action Center → trimmed stats → Today's Focus → curated **Tools grid** (§3).
+
+## 6. Constraints carried into implementation
+
+- Preserve the `get_app_list` `app_label is not None` guard (keeps `app_index.html`
+  working).
+- Keep the `"Other"` catch-all and `SUPERUSER_ONLY_GROUPS` gating.
+- Reuse `admin-custom.css` `:root` tokens; brand hexes are synced across 3 files
+  (`admin-custom.css`, `tailwind-src/crush_lu/tailwind-input.css`, `base_site.html`).
+- Alpine CSP build: compose with `mixin` + `Alpine.data`, no inline arg expressions.
+- Keep the proxy admins registered; only their *placement* changes.
+
+## 7. Phase order
+
+1. **Phase 1** — declarative tiers on `custom_order`, nested profile segments,
+   `nav_sidebar.html` override (collapsible tiers + search).
+2. **Phase 2** — index hub rewrite (drop model dump, add Tools grid).
+3. **Phase 3** — visual pass on `admin-custom.css` + full verification.


### PR DESCRIPTION
## Why

The Coach Panel (`/crush-admin/`) had grown to ~100 models across 17 sidebar groups, **listed twice** (left nav + a full dump on the index page), with no prioritisation — a December-only Advent Calendar sat at the same weight as daily profile review. Worse, **18 registered models from live features were silently orphaned** in a superuser-only "Other" bucket.

Optimised for the superuser who uses everything: **nothing is removed from reach** — the daily workflow is surfaced and the rest folds away.

## What changed

**Navigation** (`crush_lu/admin/site.py`, `core/templates/admin/nav_sidebar.html`, `crush_admin_nav.js`)
- Declarative sidebar **tiers**: 5 pinned groups stay expanded; the rest collapse under **More (10)** and **Developer & Analytics (4)** — native `<details>` (CSP-safe). The nav script auto-opens tiers while the quick-filter is active and remembers each section's state.
- Split the 9 profile proxy views out of Users & Profiles into a collapsed **Profile Segments** group (17 rows → 7). Proxies stay registered so Action Center deep-links keep resolving.
- **Categorised the 18 orphaned models** (Crush Cache, Connect Q&A, Confirmed Encounters, Event Lobby, Trust & Safety, Android devices). "Other" is now empty.

**Landing hub** (`crush_lu/templates/admin/crush_lu/index.html`)
- Dropped the duplicated model dump (that's the sidebar's job now).
- Replaced 11 flat quick-links with a curated **Tools & Dashboards** grid (the bespoke dashboards not reachable from the model list).
- Kept Action Center + stats + Today's Focus.

**Notes**
- Overrides live in `core/templates/admin/` — the active `TEMPLATES["DIRS"]` location in this project (not the app-level `crush_lu/templates/`, which is shadowed).
- Reuses the existing `admin-custom.css` design tokens; dark-mode aware.

## Verification
- **Full suite: 2151 passed, 27 skipped** (+5 new regression tests: tiers, empty "Other", coach gating, index render).
- Design-token linter clean; `manage.py check` clean.
- Verified live in the browser as a superuser (pinned tiers, collapsible More/Developer sections, curated Tools grid).

See `docs/crush-admin-redesign.md` for the full audit.

## Open question
The left sidebar is now the canonical model browser and the index is a pure hub. If reviewers prefer keeping model browsing on the index instead, that inversion is easy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)