### PR TITLE
ci: restore Claude auto code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,37 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+# A new push to the PR cancels the still-running review of the previous push
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,12 @@ concurrency:
 
 jobs:
   claude-review:
-    if: ${{ !github.event.pull_request.draft }}
+    # Skip drafts, forked PRs, and Dependabot PRs — the latter two don't get
+    # Actions secrets on pull_request, so the OAuth token would be empty
+    if: >-
+      ${{ !github.event.pull_request.draft &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Restores the automatic Claude code review on pull requests. The workflow file was removed in 2baee938 (Feb 2026) while the `CLAUDE_CODE_OAUTH_TOKEN` secret stayed in place, so re-adding the file is all that's needed.

- Re-adds `.github/workflows/claude-code-review.yml` in the current `claude-code-action@v1` + `code-review` plugin format (same as the official `/install-github-app` template)
- New vs. the old file: a per-PR concurrency group cancels the in-flight review when a new push supersedes it, and draft PRs are skipped until marked ready

## Test plan

- [ ] This PR itself should receive a Claude review (a `pull_request` workflow added in a PR runs on that PR) — its appearance is the end-to-end proof
- [ ] If the run fails on GitHub token exchange, the Claude GitHub App was uninstalled since January; re-run `/install-github-app` from the Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)