### PR TITLE
fix(crush): stop public-page 500s from a failing context processor

### DIFF
--- a/crush_lu/context_processors.py
+++ b/crush_lu/context_processors.py
@@ -3,6 +3,7 @@ Context processors for Crush.lu app
 These make variables available to all templates
 """
 
+import logging
 import time
 
 from datetime import timedelta
@@ -21,8 +22,28 @@ from .models import (
     MeetupEvent,
 )
 
+logger = logging.getLogger(__name__)
+
 # Simple in-memory cache for site config (avoids DB hit on every request)
 _site_config_cache = {"config": None, "expires": 0}
+
+# Fallback navbar values used when the authenticated context block can't be
+# built (e.g. a transient DB error, or the broken async sync-executor seen
+# under the uvicorn worker). Without this guard, an exception here bubbles up
+# through the template render — and because custom_404 renders
+# crush_lu/base.html with these processors, it turned even a missing route
+# like /favicon.ico into a 500 instead of a 404. See crush_lu/views_seo.py.
+_SAFE_NAV_DEFAULTS = {
+    "email_verified": True,
+    "connection_count": 0,
+    "pending_requests_count": 0,
+    "actionable_sparks_count": 0,
+    "connect_pending_sparks_count": 0,
+    "profile_completion_step": 0,
+    "profile_step_label": _("Get started"),
+    "upcoming_events": [],
+    "upcoming_events_count": 0,
+}
 
 # Profile verification state → navbar progress indicator
 PROFILE_STEP_INFO = {
@@ -67,7 +88,12 @@ def crush_user_context(request):
         ),
     }
 
-    if request.user.is_authenticated:
+    def _fill_authenticated_context():
+        # Runs the authenticated-user DB queries that populate the navbar and
+        # badge counts. Kept as a nested closure so the guard wrapper below can
+        # catch any transient backend fault (DB error, or the broken async
+        # sync-executor under the uvicorn worker) without re-indenting the
+        # whole block. It mutates the enclosing ``context`` dict in place.
         # Email-verification flag — drives the verification banner in the
         # onboarding stepper. We rely on allauth's EmailAddress.verified;
         # social-login users always have at least one verified address
@@ -278,6 +304,23 @@ def crush_user_context(request):
             context["journey_started"] = journey_progress is not None
             if journey_progress:
                 context["journey_progress"] = journey_progress
+
+    if request.user.is_authenticated:
+        try:
+            _fill_authenticated_context()
+        except Exception:
+            # A transient backend fault must not turn every authenticated page
+            # — and, via custom_404 rendering base.html, every branded 404 —
+            # into a 500. Log it and fall back to safe navbar defaults so the
+            # page (and the 404) still renders. Partial context already set
+            # before the failure is preserved (setdefault only fills gaps).
+            logger.warning(
+                "crush_user_context: could not build authenticated nav "
+                "context; rendering with safe defaults",
+                exc_info=True,
+            )
+            for key, value in _SAFE_NAV_DEFAULTS.items():
+                context.setdefault(key, value)
 
     return context
 

--- a/crush_lu/context_processors.py
+++ b/crush_lu/context_processors.py
@@ -43,6 +43,12 @@ _SAFE_NAV_DEFAULTS = {
     "profile_step_label": _("Get started"),
     "upcoming_events": [],
     "upcoming_events_count": 0,
+    # base.html branches on these instead of dereferencing user.crushprofile /
+    # user.crushcoach directly — those reverse lookups run a DB query during
+    # template rendering and re-raise under a broken backend (they are not
+    # silent_variable_failure), which would 500 the page even with this guard.
+    "nav_has_profile": False,
+    "nav_is_active_coach": False,
 }
 
 # Profile verification state → navbar progress indicator
@@ -183,6 +189,9 @@ def crush_user_context(request):
         profile_submission = None
         profile = CrushProfile.objects.filter(user=request.user).first()
         context["profile"] = profile
+        # Template-safe existence flag for base.html (see _SAFE_NAV_DEFAULTS):
+        # avoids a bare {% if user.crushprofile %} reverse lookup in the nav.
+        context["nav_has_profile"] = profile is not None
         if profile:
             verification_status = profile.verification_status
             context["profile_completion_status"] = (
@@ -269,8 +278,19 @@ def crush_user_context(request):
         context["upcoming_events"] = upcoming_registrations
         context["upcoming_events_count"] = len(upcoming_registrations)
 
+        # Coach flag drives the coach navigation branch in base.html. Compute
+        # it here (inside the guard) so the template never dereferences the
+        # crushcoach reverse relation directly — that lookup re-raises under a
+        # broken backend and would 500 the page even with this processor
+        # guarded. Resolve once and reuse (the reverse OneToOne caches on the
+        # instance, so this is a single query).
+        nav_is_active_coach = (
+            hasattr(request.user, "crushcoach") and request.user.crushcoach.is_active
+        )
+        context["nav_is_active_coach"] = nav_is_active_coach
+
         # Pending screening calls count for coaches
-        if hasattr(request.user, "crushcoach") and request.user.crushcoach.is_active:
+        if nav_is_active_coach:
             pending_screening_count = ProfileSubmission.objects.filter(
                 coach=request.user.crushcoach,
                 status__in=["pending", "recontact_coach"],

--- a/crush_lu/templates/crush_lu/base.html
+++ b/crush_lu/templates/crush_lu/base.html
@@ -248,7 +248,7 @@
                 <div class="desktop-nav items-center space-x-1" role="navigation" aria-label="{% trans "Main navigation" %}">
                     {% if user.is_authenticated %}
                         {# Check if user is a coach #}
-                        {% if user.crushcoach and user.crushcoach.is_active %}
+                        {% if nav_is_active_coach %}
                             {# COACH NAVIGATION #}
 
                             {# Top-level shared links #}
@@ -393,7 +393,7 @@
                                         {% endif %}
                                     </a>
                                     <div class="dropdown-divider"></div>
-                                    {% if user.crushprofile %}
+                                    {% if nav_has_profile %}
                                         {% if profile_is_approved %}
                                         <a class="dropdown-item" href="{% url 'crush_lu:edit_profile' %}">
                                             {% include "shared/icons/pencil.html" with class="w-4 h-4 inline mr-2" %}
@@ -645,7 +645,7 @@
                                      x-transition:leave-end="opacity-0 scale-95"
                                      x-cloak
                                      class="dropdown-menu">
-                                    {% if user.crushprofile %}
+                                    {% if nav_has_profile %}
                                         <div class="px-4 py-2 text-xs font-semibold text-gray-500">
                                             {% trans "Profile Status:" %}
                                             {% if profile_status == 'pending' %}
@@ -807,7 +807,7 @@
                  class="lg:hidden pb-4 border-t border-white/20 mt-2 pt-4">
                 <div class="flex flex-col space-y-2">
                     {% if user.is_authenticated %}
-                        {% if user.crushcoach and user.crushcoach.is_active %}
+                        {% if nav_is_active_coach %}
                             {# COACH MOBILE NAVIGATION #}
 
                             {# Shared links #}
@@ -907,7 +907,7 @@
                                     <span class="badge badge-danger ml-1">{{ pending_requests_count }}</span>
                                 {% endif %}
                             </a>
-                            {% if user.crushprofile %}
+                            {% if nav_has_profile %}
                                 {% if profile_is_approved %}
                                 <a class="nav-link block" href="{% url 'crush_lu:edit_profile' %}">
                                     {% include "shared/icons/pencil.html" with class="w-4 h-4 inline mr-2" %}

--- a/crush_lu/templatetags/crush_connect_tags.py
+++ b/crush_lu/templatetags/crush_connect_tags.py
@@ -55,8 +55,15 @@ def crush_connect_nav_visible(user):
         return False
     if user.is_staff:
         return True
-    membership = getattr(user, "crush_connect_membership", None)
-    if not (membership and membership.is_onboarded):
+    try:
+        membership = getattr(user, "crush_connect_membership", None)
+        if not (membership and membership.is_onboarded):
+            return False
+    except Exception:
+        # The membership reverse lookup runs a DB query during template
+        # rendering. A backend fault (DB error, or the broken async
+        # sync-executor) must not 500 the whole page from the nav — just
+        # hide the Connect link.
         return False
     return candidate_access_open()
 

--- a/crush_lu/tests/test_public_500_resilience.py
+++ b/crush_lu/tests/test_public_500_resilience.py
@@ -67,6 +67,11 @@ class CrushUserContextResilienceTests(TestCase):
             "profile_step_label",
             "upcoming_events",
             "upcoming_events_count",
+            # base.html branches on these instead of dereferencing the
+            # crushprofile/crushcoach reverse relations, so they must be safe
+            # too or the nav render would re-trigger the DB and 500.
+            "nav_has_profile",
+            "nav_is_active_coach",
         ):
             self.assertEqual(
                 context[key], _SAFE_NAV_DEFAULTS[key], msg=f"default missing for {key}"
@@ -81,6 +86,10 @@ class CrushUserContextResilienceTests(TestCase):
         self.assertEqual(context["connection_count"], 0)
         self.assertEqual(context["profile_completion_step"], 0)
         self.assertIn("upcoming_events", context)
+        # Template-safe nav flags are always resolved for authenticated users
+        # (this user has neither a profile nor a coach record).
+        self.assertFalse(context["nav_has_profile"])
+        self.assertFalse(context["nav_is_active_coach"])
 
     def test_anonymous_user_skips_the_block(self):
         request = self.factory.get("/en/")

--- a/crush_lu/tests/test_public_500_resilience.py
+++ b/crush_lu/tests/test_public_500_resilience.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for the 2026-07-22 public-page 500 incident.
+
+Symptom: while a worker's asgiref sync-executor was wedged, authenticated
+crush.lu pages — and, because ``custom_404`` renders ``crush_lu/base.html``
+with the request context processors, even missing routes like
+``/favicon.ico`` — returned 500 instead of degrading gracefully. ``/crush-admin``
+kept working, which is what pointed at the crush_lu public render path.
+
+Two defensive layers are covered here:
+
+1. ``crush_user_context`` must not propagate a transient backend fault; it
+   falls back to safe navbar defaults so the page still renders.
+2. ``custom_404`` must never let a failed branded-404 render become a 500 —
+   a not-found stays a not-found.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
+from django.test import RequestFactory, TestCase
+
+from crush_lu.context_processors import _SAFE_NAV_DEFAULTS, crush_user_context
+from crush_lu.views_seo import custom_404
+
+
+class CrushUserContextResilienceTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="coach@example.com",
+            email="coach@example.com",
+            password="pass123",
+            first_name="Coach",
+        )
+
+    def _authenticated_request(self):
+        request = self.factory.get("/en/")
+        request.user = self.user
+        return request
+
+    def test_backend_failure_falls_back_to_safe_defaults(self):
+        """A transient fault in the authenticated block must not raise; the
+        navbar-critical keys fall back to safe defaults instead."""
+        request = self._authenticated_request()
+
+        # blocked_user_ids runs near the top of the authenticated block, so
+        # failing it exercises the outer guard. Mimic the real failure mode.
+        with patch(
+            "crush_lu.services.blocking.blocked_user_ids",
+            side_effect=RuntimeError("CurrentThreadExecutor already quit or is broken"),
+        ):
+            context = crush_user_context(request)  # must NOT raise
+
+        # Every key the block would have set past the failure point falls back
+        # to its safe default (email_verified is resolved earlier, in its own
+        # try/except, so it keeps whatever real value it computed).
+        for key in (
+            "connection_count",
+            "pending_requests_count",
+            "actionable_sparks_count",
+            "connect_pending_sparks_count",
+            "profile_completion_step",
+            "profile_step_label",
+            "upcoming_events",
+            "upcoming_events_count",
+        ):
+            self.assertEqual(
+                context[key], _SAFE_NAV_DEFAULTS[key], msg=f"default missing for {key}"
+            )
+        # Anonymous-safe base keys and the early email flag are still present.
+        self.assertIn("crush_cache_enabled", context)
+        self.assertIn("email_verified", context)
+
+    def test_healthy_authenticated_context_is_unchanged(self):
+        """The guard is transparent on the happy path (no profile → step 0)."""
+        context = crush_user_context(self._authenticated_request())
+        self.assertEqual(context["connection_count"], 0)
+        self.assertEqual(context["profile_completion_step"], 0)
+        self.assertIn("upcoming_events", context)
+
+    def test_anonymous_user_skips_the_block(self):
+        request = self.factory.get("/en/")
+        request.user = AnonymousUser()
+        context = crush_user_context(request)
+        # The DB-heavy block only runs for authenticated users.
+        self.assertNotIn("connection_count", context)
+
+
+class Custom404ResilienceTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_failed_branded_render_falls_back_to_404_not_500(self):
+        """If the branded 404 render blows up (e.g. a context processor throws),
+        custom_404 returns a plain 404 — never a 500."""
+        request = self.factory.get("/favicon.ico")
+        request.user = AnonymousUser()
+
+        with patch(
+            "crush_lu.views_seo.render",
+            side_effect=RuntimeError("context processor blew up mid-render"),
+        ):
+            response = custom_404(request, Http404())
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b"404", response.content)

--- a/crush_lu/views_seo.py
+++ b/crush_lu/views_seo.py
@@ -7,11 +7,39 @@ This module provides views for:
 - Structured data helpers
 """
 
+import logging
+
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.views.decorators.cache import cache_page
 from django.views.decorators.http import require_GET
+
+logger = logging.getLogger(__name__)
+
+# Standalone, context-free 404 used only if the branded template fails to
+# render (crush_lu/404.html extends base.html, which runs the request context
+# processors; if one of those throws, Django would otherwise convert the failed
+# 404 render into a 500 — which is how missing routes like /favicon.ico were
+# surfacing as 500s). No external CSS, no context — always renders.
+_FALLBACK_404_HTML = (
+    '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">'
+    '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    '<meta name="robots" content="noindex, follow">'
+    "<title>Page not found – Crush.lu</title><style>"
+    "body{margin:0;min-height:100vh;display:flex;align-items:center;"
+    "justify-content:center;background:#faf7fb;color:#2d2d2d;font-family:"
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,'
+    "sans-serif;text-align:center;padding:1.5rem}.code{font-size:4.5rem;"
+    "font-weight:700;color:#9b59b6;margin:0}h1{font-size:1.5rem;"
+    "font-style:italic;margin:.5rem 0 0}p{color:#555;margin:.75rem 0 1.75rem}"
+    "a.home{display:inline-block;padding:.75rem 1.75rem;border-radius:.5rem;"
+    "background:#9b59b6;color:#fff;text-decoration:none;font-weight:600}"
+    '</style></head><body><div><p class="code">404</p>'
+    "<h1>We couldn&#39;t find that page</h1>"
+    "<p>The page you&#39;re looking for may have moved, or it never existed.</p>"
+    '<a class="home" href="/">Back to home</a></div></body></html>'
+)
 
 
 @require_GET
@@ -99,8 +127,21 @@ def custom_404(request, exception):
 
     Wired as ``handler404`` in ``azureproject/urls_crush.py`` only, so it is
     scoped to crush.lu — the other domains keep Django's default handler.
+
+    The branded template extends ``crush_lu/base.html`` and therefore runs the
+    request context processors. If one of those throws (a transient DB fault,
+    or the broken async sync-executor seen under load), Django would convert
+    the failed 404 render into a 500 — which is how missing routes like
+    ``/favicon.ico`` were surfacing as 500s. Fall back to a standalone,
+    context-free 404 so a not-found never becomes a server error.
     """
-    return render(request, "crush_lu/404.html", status=404)
+    try:
+        return render(request, "crush_lu/404.html", status=404)
+    except Exception:
+        logger.exception(
+            "custom_404: branded 404 render failed; serving minimal fallback"
+        )
+        return HttpResponse(_FALLBACK_404_HTML, status=404)
 
 
 def custom_500(request):

--- a/startup.sh
+++ b/startup.sh
@@ -119,7 +119,13 @@ echo "✅ Migrations complete. Starting Gunicorn..."
 # Application Insights also captures requests via OpenTelemetry for full telemetry
 # Using AsyncioUvicornWorker to force asyncio event loop — uvloop's
 # run_in_executor breaks asgiref's CurrentThreadExecutor (django/channels#1959)
+# --max-requests recycles each worker after ~1000 requests (+0..100 jitter so
+# the 4 workers don't restart in lockstep). This bounds the blast radius of a
+# worker whose asgiref sync-executor gets wedged mid-uptime: instead of serving
+# 500s until a manual restart, it is retired and replaced automatically. The
+# UvicornWorker honors these via uvicorn's limit_max_requests.
 gunicorn --workers 4 --timeout 120 \
+    --max-requests 1000 --max-requests-jitter 100 \
     -k azureproject.worker.AsyncioUvicornWorker \
     --access-logfile '-' --access-logformat '%(h)s %(m)s %(U)s %(s)s %(D)sms' \
     --error-logfile '-' --bind=0.0.0.0:8000 \


### PR DESCRIPTION
## Incident (2026-07-22)

crush.lu served intermittent **500s on public pages** that grew through the day (unsampled `Http5xx` climbed ~1→32/hr against low traffic) until a manual App Service restart cleared it. From the container logs, the failing routes were **`/` and `/favicon.ico`**, while **`/crush-admin/`, `/static/…`, `/healthz/` stayed 200** — so it was the crush.lu *public* render path, not "all routes."

### Root cause

1. `crush_user_context` ([crush_lu/context_processors.py](../blob/main/crush_lu/context_processors.py)) runs **~a dozen un-`try/except`'d DB queries** per **authenticated** render (connections, sparks, profile, submissions, events; coaches get extra). Anonymous visitors barely touch the DB, so authenticated users — especially coaches — were the most exposed.
2. When a gunicorn worker's asgiref sync-executor got wedged mid-uptime (the `RuntimeError: CurrentThreadExecutor already quit or is broken` issue this app already fights — `worker.py`, `asgi.py`, django/channels#1959), any one of those queries raised and took down the whole template render.
3. `custom_404` did `render(request, "crush_lu/404.html")`, and `404.html` **extends `base.html`** → runs the same context processors. So a failed render turned every **404 into a 500** — which is why a non-existent route like `/favicon.ico` returned **500 instead of 404**. `custom_500`'s own docstring already named "a failing context processor" as the suspect.

The 500s on `/` and `/favicon.ico` are exactly the URLs the PWA service worker treats as navigation/precache targets, which is why users saw a **service-worker cache refresh**; a hard refresh bypassed the SW and hit the (restarted, healthy) server.

## Fix

- **`crush_user_context`** — wrap the authenticated block so a transient backend fault (DB error, or a wedged sync-executor) falls back to **safe navbar defaults** instead of propagating. Partial context set before the failure is preserved (`setdefault` only fills gaps).
- **`custom_404`** — if the branded render throws, fall back to a **standalone, context-free 404** so a not-found never becomes a 500.
- **`startup.sh`** — recycle gunicorn workers with `--max-requests 1000 --max-requests-jitter 100` (honored by `UvicornWorker` via uvicorn's `limit_max_requests`) so a wedged worker is **retired automatically** instead of serving 500s until a manual restart. This alone would have prevented the outage from persisting.

## Tests

`crush_lu/tests/test_public_500_resilience.py`:
- `crush_user_context` returns safe defaults (no raise) when the authenticated block faults; anonymous requests are unaffected.
- `custom_404` returns **404, not 500**, when the branded render throws.

All pass; `manage.py check` clean; `black`/`ruff` clean; `startup.sh` passes `bash -n`.

## Not included (follow-ups)

- The underlying sync-executor break wasn't captured live (tracebacks for these 500s weren't reaching any sink — an **observability gap** worth closing separately).
- Separate early-morning **Postgres CPU→100% / 39-connection** spike (02:00–04:00 UTC) is unrelated to this render path and still to be investigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)