### PR TITLE
fix(crush): neutralize Interest model's verbose_name after cross-product rename

### DIFF
--- a/crush_lu/admin/site.py
+++ b/crush_lu/admin/site.py
@@ -177,7 +177,7 @@ class CrushLuAdminSite(admin.AdminSite):
             'curiosityspark': {'order': 3, 'icon': '✨', 'group': 'Crush Connect'},
             'connectcoachpick': {'order': 4, 'icon': '🎯', 'group': 'Crush Connect'},
             'crushconnectwaitlist': {'order': 5, 'icon': '📋', 'group': 'Crush Connect'},
-            'interest': {'order': 6, 'icon': '🏷️', 'group': 'Crush Connect'},
+            'interest': {'order': 6, 'icon': '🏷️', 'group': 'Crush Connect'},  # cross-product taxonomy; also used by CrushProfile.interests_new
             'sparkprompt': {'order': 7, 'icon': '💬', 'group': 'Crush Connect'},
             'connectquestionweek': {'order': 8, 'icon': '📆', 'group': 'Crush Connect'},  # weekly Q&A rotation
             'connectquestion': {'order': 9, 'icon': '❓', 'group': 'Crush Connect'},

--- a/crush_lu/migrations/0197_alter_interest_options.py
+++ b/crush_lu/migrations/0197_alter_interest_options.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Neutralize ``Interest``'s admin display name.
+
+    Left over from the ``ConnectInterest`` → ``Interest`` rename (0194): the
+    verbose names still said "Connect Interest" even though the taxonomy is
+    now cross-product (shared by ``CrushConnectMembership.interests`` and
+    ``CrushProfile.interests_new``).
+    """
+
+    dependencies = [
+        ("crush_lu", "0196_seed_interest_additions"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="interest",
+            options={
+                "ordering": ["category", "sort_order", "label"],
+                "verbose_name": "Interest",
+                "verbose_name_plural": "Interests",
+            },
+        ),
+    ]

--- a/crush_lu/models/crush_connect.py
+++ b/crush_lu/models/crush_connect.py
@@ -565,9 +565,10 @@ class SparkPrompt(models.Model):
 
 class Interest(models.Model):
     """
-    A curated interest/hobby a member can attach to their Crush Connect
-    catalogue profile (mirrors ``Trait``/``SparkPrompt``).
+    A curated interest/hobby a member can attach to their profile.
 
+    Cross-product taxonomy (mirrors ``Trait``/``SparkPrompt``): shared by
+    ``CrushConnectMembership.interests`` and ``CrushProfile.interests_new``.
     Curated rather than free-text so the shared data needs no moderation,
     can't leak identifying details, and translates cleanly. ``label`` is
     translated via modeltranslation; set ``is_active=False`` to retire an
@@ -603,8 +604,8 @@ class Interest(models.Model):
 
     class Meta:
         ordering = ["category", "sort_order", "label"]
-        verbose_name = _("Connect Interest")
-        verbose_name_plural = _("Connect Interests")
+        verbose_name = _("Interest")
+        verbose_name_plural = _("Interests")
 
     def __str__(self):
         return self.label


### PR DESCRIPTION
## Purpose
* Follow-up to #670 (`ConnectInterest` → `Interest` rename, Event Identity Phase B). The renamed model's `Meta.verbose_name`/`verbose_name_plural` still said "Connect Interest"/"Connect Interests", but the taxonomy is now cross-product — shared by `CrushConnectMembership.interests` and `CrushProfile.interests_new` — so the admin display name shouldn't be Connect-specific anymore.
* Updates the class docstring to describe the cross-product usage instead of only the Crush Connect catalogue profile.
* Annotates the admin sidebar grouping entry (`crush_lu/admin/site.py`) to note `Interest` is shared taxonomy, not Connect-exclusive (left it in the `Crush Connect` group since that's still where it's primarily curated).
* Adds migration `0197_alter_interest_options` (`AlterModelOptions`) so migration state stays in sync with the `Meta` change.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
Verbose name / docstring / comment change plus a no-op `AlterModelOptions` migration (no schema change).

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
```
git checkout claude/interest-verbose-names-tjap9m
python manage.py migrate                                   # 0197 applies cleanly
python manage.py makemigrations --check --dry-run          # no pending changes
```

## What to Check
* `Interest`'s admin display name now reads "Interest"/"Interests" instead of "Connect Interest"/"Connect Interests".
* Migration `0197_alter_interest_options` applies cleanly on top of `0196_seed_interest_additions`.
* No functional/behavioral change — display name and docs only.

## Other Information
Based on `feat/crush-event-identity-models` (#670) since that's where the `ConnectInterest` → `Interest` rename lives; targets that branch rather than `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fqv3LeH7utcidupRF4uWVc)_