### PR TITLE
fix(crush): recover plural, Luxembourgish & regional interest surface forms

### DIFF
--- a/crush_lu/management/commands/migrate_interests_to_taxonomy.py
+++ b/crush_lu/management/commands/migrate_interests_to_taxonomy.py
@@ -87,6 +87,19 @@ _RAW_RULES = [
     (["tech", "technology", "technik", "coding", "programming", "informatique"], ["tech"]),
     (["water sports", "surfing", "kayak", "paddle", "wassersport"], ["water-sports"]),
     (["badminton", "squash", "padel", "table tennis", "ping pong", "volleyball", "basketball", "tennis"], ["ball-racket-sports"]),
+    # --- inflections & regional surface forms (from the 2026-07-23 prod
+    # dry-run's unmatched sample; each is an unambiguous FR/DE/LU rendering of
+    # a concept the taxonomy already has, never a new one) ---
+    (["sport"], ["fitness"]),
+    (["promenade", "walking", "montagne", "spazieren"], ["hiking"]),
+    (["voyager", "sightseeing"], ["city-trips"]),
+    (["katzen", "kaatzen", "hund", "hunde", "chien"], ["animals-pets"]),
+    (["gärtneren", "jardin"], ["gardening"]),
+    (["sauna"], ["spa"]),
+    (["tanze"], ["dancing"]),
+    (["koche"], ["cooking"]),
+    (["handball"], ["ball-racket-sports"]),
+    (["eishockey", "eis-hockey"], ["winter-sports"]),
     # --- verbatim create-profile wizard category labels (spec §2) ---
     (["sports & fitness", "sport & fitness"], ["fitness"]),
     (["outdoors & travel"], ["hiking", "city-trips"]),
@@ -100,9 +113,15 @@ _RAW_RULES = [
 # but leaves standalone letters like ``ß`` intact, so an ASCII class would treat
 # them as separators — "Spaß" would match the "spa" surface form and wrongly
 # pick up spa-wellness on a German profile.
+#
+# A trailing ``s?`` absorbs plurals, which members write constantly:
+# "Randonnées", "voyages", "danses" all missed their singular surface form
+# before. Measured on the 2026-07-23 production dry-run's unmatched sample, this
+# alone recovers ~19% of them. Deliberately NOT ``e?s?`` — that matches the same
+# sample but also turns "blue skies" into winter-sports.
 _RULES = [
     (
-        [re.compile(r"(?<!\w)" + re.escape(_fold(s)) + r"(?!\w)") for s in surfaces],
+        [re.compile(r"(?<!\w)" + re.escape(_fold(s)) + r"s?(?!\w)") for s in surfaces],
         slugs,
     )
     for surfaces, slugs in _RAW_RULES

--- a/crush_lu/management/commands/migrate_interests_to_taxonomy.py
+++ b/crush_lu/management/commands/migrate_interests_to_taxonomy.py
@@ -100,6 +100,22 @@ _RAW_RULES = [
     (["koche"], ["cooking"]),
     (["handball"], ["ball-racket-sports"]),
     (["eishockey", "eis-hockey"], ["winter-sports"]),
+    # Luxembourgish spellings — the national language, absent from the first
+    # pass (DE/FR/EN only). These recur across the 2026-07-23 re-run's remaining
+    # unmatched set, always as an existing concept: liesen/liersen = lesen,
+    # lafen = laufen, spazéieren = spazieren, Déieren = Tiere, bastelen = basteln.
+    (["liesen", "liersen"], ["reading"]),
+    (["lafen"], ["running"]),
+    (["spazéieren", "spazeieren"], ["hiking"]),
+    (["déieren"], ["animals-pets"]),
+    (["bastelen"], ["diy-crafts"]),
+    # FR/PT/EN renderings of existing concepts, each from the same unmatched set.
+    (["piscine", "piscina", "natation"], ["swimming"]),
+    (["caminhada"], ["hiking"]),
+    (["literature", "littérature"], ["reading"]),
+    (["cake", "gâteau", "kuchen"], ["baking"]),
+    (["photoshoot"], ["photography"]),
+    (["cardio", "hiit"], ["fitness"]),
     # --- verbatim create-profile wizard category labels (spec §2) ---
     (["sports & fitness", "sport & fitness"], ["fitness"]),
     (["outdoors & travel"], ["hiking", "city-trips"]),

--- a/crush_lu/tests/test_event_identity.py
+++ b/crush_lu/tests/test_event_identity.py
@@ -98,6 +98,48 @@ def test_standalone_non_ascii_letters_do_not_break_the_token_boundary():
 
 
 @pytest.mark.django_db
+def test_plural_surface_forms_match():
+    """Members write plurals; the singular surface form must still match.
+    Measured on the 2026-07-23 production dry-run, this recovers ~19% of the
+    profiles that matched nothing."""
+    p = _make_profile("plural@example.com", interests="Randonnées et voyages")
+    _run("--execute")
+    assert set(p.interests_new.values_list("slug", flat=True)) == {
+        "hiking",
+        "city-trips",
+    }
+
+
+@pytest.mark.django_db
+def test_plural_tolerance_does_not_swallow_unrelated_words():
+    """The suffix is ``s?`` and not ``e?s?`` on purpose: the wider form matches
+    the same profiles but also reads "blue skies" as the "ski" surface form."""
+    p = _make_profile("skies@example.com", interests="blue skies")
+    _run("--execute")
+    assert set(p.interests_new.values_list("slug", flat=True)) == set()
+
+
+@pytest.mark.django_db
+def test_regional_surface_forms_from_the_prod_corpus():
+    """Real unmatched production values, each an unambiguous FR/DE/LU rendering
+    of a concept the taxonomy already carries."""
+    cases = {
+        "Sport": {"fitness"},
+        "Meng Kaatzen": {"animals-pets"},
+        "Sauna, Gärtneren": {"spa", "gardening"},
+        "Handball": {"ball-racket-sports"},
+    }
+    profiles = {
+        text: _make_profile(f"regional{i}@example.com", interests=text)
+        for i, text in enumerate(cases)
+    }
+    _run("--execute")
+    for text, expected in cases.items():
+        got = set(profiles[text].interests_new.values_list("slug", flat=True))
+        assert got == expected, f"{text!r} → {got}"
+
+
+@pytest.mark.django_db
 def test_unmatched_profile_gets_nothing():
     p = _make_profile("nomatch@example.com", interests="oil rig engineer")
     _run("--execute")

--- a/crush_lu/tests/test_event_identity.py
+++ b/crush_lu/tests/test_event_identity.py
@@ -140,6 +140,37 @@ def test_regional_surface_forms_from_the_prod_corpus():
 
 
 @pytest.mark.django_db
+def test_luxembourgish_surface_forms():
+    """Luxembourgish spellings of existing concepts — the national language was
+    absent from the first pass. Real values from the 2026-07-23 prod re-run."""
+    cases = {
+        "Lafen, liesen, spazeieren": {"running", "reading", "hiking"},
+        "Natur, liesen, Déieren.": {"reading", "animals-pets"},
+        "Vespa fueren an drun bastelen": {"diy-crafts"},
+        "Piscine - Golf": {"swimming"},
+        "Cakes": {"baking"},
+    }
+    profiles = {
+        text: _make_profile(f"lu{i}@example.com", interests=text)
+        for i, text in enumerate(cases)
+    }
+    _run("--execute")
+    for text, expected in cases.items():
+        got = set(profiles[text].interests_new.values_list("slug", flat=True))
+        assert got == expected, f"{text!r} → {got}"
+
+
+@pytest.mark.django_db
+def test_added_surfaces_do_not_false_match_lookalikes():
+    """The new one-word surfaces must stay bounded — no substring bleed into
+    unrelated words."""
+    for text in ("cheesecake", "stranded", "cardiologist", "literate"):
+        p = _make_profile(f"lookalike-{text}@example.com", interests=text)
+        _run("--execute")
+        assert set(p.interests_new.values_list("slug", flat=True)) == set(), text
+
+
+@pytest.mark.django_db
 def test_unmatched_profile_gets_nothing():
     p = _make_profile("nomatch@example.com", interests="oil rig engineer")
     _run("--execute")


### PR DESCRIPTION
## Purpose

The [Event Identity](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/blob/main/docs/superpowers/specs/2026-07-21-crush-event-identity-redesign.md) Phase B dry-run ran against production on 2026-07-23 and **cleared the §14 gate at 88.13%** (490 of 556 profiles matched ≥1 interest, threshold 85%). This PR acts on what the *unmatched* list showed, before the first `--execute`.

### The systematic miss: plurals

Members write plurals. The token boundary rejected the trailing `s`, so `Randonnées`, `voyages` and `danses` all failed against surface forms whose singular (`randonnée`, `voyage`, `danse`) was already in the map.

A trailing `s?` recovers **5 of the 26 unmatched samples (~19%)**, roughly **+2 points corpus-wide**.

Deliberately **not** `e?s?`. Measured: it matches exactly the same samples, but also reads `blue skies` as the `ski` surface form → winter-sports. `test_plural_tolerance_does_not_swallow_unrelated_words` pins that choice.

### Surface forms the corpus asked for

Each is an unambiguous FR/DE/LU rendering of a concept the taxonomy **already carries** — no new slugs, so no migration:

| Added | → | From the unmatched list |
| --- | --- | --- |
| `sport` | fitness | "Sport", "Sport.", "Sport (même essayer…)" — several profiles say only this |
| `promenade`, `walking`, `montagne`, `spazieren` | hiking | "Promenades dans la nature", "la montagne" |
| `voyager`, `sightseeing` | city-trips | "j'aime voyager", "Sightseeing, long drive" |
| `katzen`, `kaatzen`, `hund`, `hunde`, `chien` | animals-pets | "Meng Kaatzen" |
| `gärtneren`, `jardin` | gardening | "Sauna, Gärtneren, Permakultur" |
| `sauna` | spa | same |
| `tanze` | dancing | "Ich tanze gerne" (conjugated; `tanzen` does not match `tanze`) |
| `koche` | cooking | "ich koche gerne" |
| `handball` | ball-racket-sports | "Handball, party" |
| `eishockey`, `eis-hockey` | winter-sports | "Eis-Hockey" |

Deliberately **not** added, because they collide with unrelated words: `marche` (→ `marché`, market), `chat` (FR cat / messaging), bare `foot`.

### Not fixable without a product decision

Still unmatched, and each needs a taxonomy slug that does not exist — flagging rather than guessing: **golf** (2 sightings), **combat sports** (boxe, jiujitsu — this is O3's deferred 14th "Martial arts", 2 occurrences), **journaling/writing**. The rest of the residual is genuinely unmappable: prose, names, emoji-only, non-Latin scripts.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
Keyword-map only. No migrations, no model or form changes. `--execute` has not run anywhere; `--repopulate` is additive and never removes a member's own selections, so this also applies cleanly if the map is refined again later.

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
python -m pytest crush_lu/tests/test_event_identity.py
python manage.py migrate_interests_to_taxonomy          # dry-run, no writes
```

Full `crush_lu` suite: **2083 passed, 21 skipped**. Ruff CI gate clean.

## What to Check

* Compounds stay protected by the lookbehind — `Wassersport` still resolves to `water-sports` alone, not `water-sports` + `fitness`.
* `Spaß` still matches nothing (the round-5 `ß` fix is intact under the new suffix).
* `Water sports` now also picks up `fitness` via the bare `sport` rule. Additive and harmless — the median profile matches 2 interests against a cap of 8 — but it is a deliberate accepted overlap, not an oversight.
* The >8 cap ordering test still passes unchanged, so plural tolerance did not disturb the deterministic tie-break.

## Other Information

`--execute` remains gated on the next slot swap regardless: production's database has no `Interest` table yet (0194–0198 are unapplied there). Re-running the read-only dry-run after this lands will measure the real gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — second pass (Luxembourgish)

Re-ran the prod dry-run after the plural commit: **88.13% → 93.17%** (490 → 518 of 556). The unmatched set is now 38 (< the 40-line sample cap), i.e. the report shows *all* of it, so this second commit closes the last cleanly-recoverable cluster rather than guessing.

**Luxembourgish was missing entirely** — the first pass was DE/FR/EN only, but LU is the national language and recurs: `liesen`/`liersen` (reading), `lafen` (running), `spazéieren` (walking→hiking), `Déieren` (animals), `bastelen` (DIY). Plus FR/PT/EN renderings from the same set: `piscine`/`piscina` (swimming), `caminhada` (hiking), `literature`/`littérature` (reading), `cake` (baking), `photoshoot` (photography), `cardio`/`hiit` (fitness). Every one maps to an existing slug — still no new taxonomy.

These flip **11 of the 38** remaining profiles (→ ~95%). `test_added_surfaces_do_not_false_match_lookalikes` pins the bounded-match safety: `cheesecake`, `stranded`, `cardiologist`, `literate` all match nothing.

**Genuinely needs a product decision (new slug), still deferred:** `golf` (2), combat/martial arts — `boxe` (this is O3's deferred 14th interest), `journaling`/writing. Everything else remaining is prose, names, emoji, or non-Latin script.

**Confirmed on prod:** the second re-run measured **95.14%** (529/556) — matching the local prediction exactly. Unmatched is now **27**, and all of it is genuinely unmappable (prose, emoji-only, names) except the three slug-decisions above. This is the last map pass; further gains need new taxonomy, not new surface forms.
