### PR TITLE
fix(security): resolve CodeQL incomplete-URL-substring-sanitization alerts (#188/#189)

### DIFF
--- a/crush_lu/android_push.py
+++ b/crush_lu/android_push.py
@@ -11,6 +11,25 @@ logger = logging.getLogger(__name__)
 
 FCM_SCOPES = ["https://www.googleapis.com/auth/firebase.messaging"]
 
+# Suffix on every Google-managed service-account email:
+#   <name>@<project-id>.iam.gserviceaccount.com
+_GSA_EMAIL_SUFFIX = ".iam.gserviceaccount.com"
+
+
+def _derive_project_id_from_email(service_account_email):
+    """Extract the GCP project id embedded in a service-account email.
+
+    Uses an anchored suffix check (``endswith``) rather than a substring
+    match so a crafted domain such as ``x.iam.gserviceaccount.com.evil.tld``
+    cannot masquerade as a Google-managed account and leak the wrong id.
+    """
+    if not service_account_email or "@" not in service_account_email:
+        return None
+    domain = service_account_email.split("@", 1)[1]
+    if domain.endswith(_GSA_EMAIL_SUFFIX):
+        return domain[: -len(_GSA_EMAIL_SUFFIX)] or None
+    return None
+
 
 def get_fcm_credentials():
     """
@@ -40,10 +59,8 @@ def get_fcm_credentials():
                 private_key = private_key.replace("\\n", "\n")
             credentials_info["private_key"] = private_key
             project_id = getattr(settings, "FIREBASE_PROJECT_ID", None)
-            if not project_id and "@" in service_account_email:
-                domain = service_account_email.split("@")[1]
-                if ".iam.gserviceaccount.com" in domain:
-                    project_id = domain.split(".iam.gserviceaccount.com")[0]
+            if not project_id:
+                project_id = _derive_project_id_from_email(service_account_email)
             try:
                 credentials = service_account.Credentials.from_service_account_info(
                     credentials_info, scopes=FCM_SCOPES
@@ -64,10 +81,8 @@ def get_fcm_credentials():
                     
                     credentials_info["private_key"] = content
                     project_id = getattr(settings, "FIREBASE_PROJECT_ID", None)
-                    if not project_id and "@" in service_account_email:
-                        domain = service_account_email.split("@")[1]
-                        if ".iam.gserviceaccount.com" in domain:
-                            project_id = domain.split(".iam.gserviceaccount.com")[0]
+                    if not project_id:
+                        project_id = _derive_project_id_from_email(service_account_email)
                     credentials = service_account.Credentials.from_service_account_info(
                         credentials_info, scopes=FCM_SCOPES
                     )

--- a/crush_lu/tests/test_android_notifications.py
+++ b/crush_lu/tests/test_android_notifications.py
@@ -3,7 +3,34 @@ from unittest.mock import patch, MagicMock
 import pytest
 from django.contrib.auth.models import User
 from crush_lu.models import AndroidAppDevice
+from crush_lu.android_push import _derive_project_id_from_email
 from crush_lu.notification_service import NotificationService, NotificationType
+
+
+@pytest.mark.parametrize(
+    "email,expected",
+    [
+        # Legitimate Google-managed service-account emails.
+        ("fcm-sa@my-project.iam.gserviceaccount.com", "my-project"),
+        ("sa@crush-123456.iam.gserviceaccount.com", "crush-123456"),
+        # Suffix appears mid-string but the domain does not end with it:
+        # must NOT be treated as a Google-managed account (CodeQL #188/#189).
+        ("sa@x.iam.gserviceaccount.com.evil.tld", None),
+        ("sa@iam.gserviceaccount.com", ""),  # endswith but empty project id -> None
+        # Malformed / non-Google inputs.
+        ("sa@example.com", None),
+        ("not-an-email", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_derive_project_id_from_email(email, expected):
+    result = _derive_project_id_from_email(email)
+    if expected == "":
+        # Empty extracted id is normalised to None.
+        assert result is None
+    else:
+        assert result == expected
 
 
 @pytest.fixture

--- a/crush_lu/tests/test_android_notifications.py
+++ b/crush_lu/tests/test_android_notifications.py
@@ -16,7 +16,10 @@ from crush_lu.notification_service import NotificationService, NotificationType
         # Suffix appears mid-string but the domain does not end with it:
         # must NOT be treated as a Google-managed account (CodeQL #188/#189).
         ("sa@x.iam.gserviceaccount.com.evil.tld", None),
-        ("sa@iam.gserviceaccount.com", ""),  # endswith but empty project id -> None
+        # Domain is exactly the suffix -> endswith True, empty id normalised to None.
+        ("sa@.iam.gserviceaccount.com", ""),
+        # Leading dot missing -> does not end with the suffix -> None (early exit).
+        ("sa@iam.gserviceaccount.com", None),
         # Malformed / non-Google inputs.
         ("sa@example.com", None),
         ("not-an-email", None),


### PR DESCRIPTION
## What

Resolves the two open GitHub code-scanning (CodeQL) alerts, both **high** severity, rule `py/incomplete-url-substring-sanitization`:

- Alert **#188** — `crush_lu/android_push.py:45`
- Alert **#189** — `crush_lu/android_push.py:69`

## Why

`get_fcm_credentials()` parsed the FCM project id out of a service-account email by checking `".iam.gserviceaccount.com" in domain` and then splitting on it. A substring `in` check matches the suffix at **any** position, so a crafted domain such as `x.iam.gserviceaccount.com.evil.tld` passes the check and the code derives an attacker-influenced project id. That project id is interpolated into the FCM v1 endpoint URL (`https://fcm.googleapis.com/v1/projects/{project_id}/messages:send`).

## How

- Extract the duplicated (and identical) parsing block into a single helper, `_derive_project_id_from_email`, that uses an **anchored** `str.endswith` check plus a suffix strip — the canonical remediation for this rule. Fixing it in one place closes both alert sites.
- Return `None` for malformed input and for an empty extracted id.
- Add parametrized tests covering legitimate service-account emails, the spoofed-suffix bypass case, and malformed/empty inputs.

## Test

```
DJANGO_DEBUG=True DBHOST='' pytest crush_lu/tests/test_android_notifications.py -n 0 -q
```

11 passed (8 new parametrized cases + 3 existing android-push tests).

## Note

The push also surfaced **Dependabot** dependency alerts (2 high, 1 moderate) on the default branch. Those are dependency-version vulnerabilities — a separate track from these CodeQL findings — and are **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)