### PR TITLE
fix(deps): patch 3 Dependabot alerts in dev dependency chain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1457,9 +1457,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "overrides": {
     "hono": "^4.12.25",
-    "fast-uri": "^3.1.2",
+    "@hono/node-server": "^2.0.5",
+    "fast-uri": "^3.1.4",
     "ip-address": "^10.1.1",
     "undici": "^6.27.0",
     "qs": "^6.15.2"


### PR DESCRIPTION
## Purpose
Clears the three open Dependabot alerts on the default branch. All three are `dev` scope in the root `package-lock.json`, reached through a single chain:

```
@upstash/context7-mcp (devDependency)
  └─ @modelcontextprotocol/sdk 1.29.0
       ├─ @hono/node-server  → #50
       └─ ajv → fast-uri     → #51, #52
```

| Alert | Sev | Package | Issue | Fix |
|---|---|---|---|---|
| [#52](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/security/dependabot/52) | High (7.5) | `fast-uri` 3.1.2 | Host confusion — literal `\` not treated as an authority delimiter, so `http://evil.com\@allowed.com` parses to a different host than Node's `fetch()` | → 3.1.4 |
| [#51](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/security/dependabot/51) | High (7.5) | `fast-uri` 3.1.2 | Host confusion — failed IDN canonicalization silently leaves Unicode hosts unnormalized (`127。0。0。1` ≠ `127.0.0.1`) | → 3.1.4 |
| [#50](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/security/dependabot/50) | Medium (5.9) | `@hono/node-server` 1.19.13 | Path traversal in `serve-static` on Windows via encoded backslash (`%5C`) | → 2.0.11 |

**Real-world exposure was low.** The npm side of this repo is Tailwind CLI, prettier, and two local MCP servers — none of it ships with the Django app on Azure. Both bug classes also need a code path we don't run: the `fast-uri` issues matter only when it backs a host allowlist / SSRF filter, and the hono issue only affects `serve-static`, which the MCP SDK doesn't use. Patched rather than dismissed because the fix turned out to be two lines.

Two lines in `package.json` `overrides`, 7 lines of lockfile:
* `fast-uri` override `^3.1.2` → `^3.1.4` (patch-level, same major)
* new `@hono/node-server` override `^2.0.5` — no 1.x patch exists, so a major bump is the only route

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

`@hono/node-server` v2 crosses a major against the SDK's declared `^1.19.9`, so it was verified rather than assumed (see below). No app code, no Python, no migrations.

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform.git
cd Multi-Domain-Django-Platform
git checkout claude/github-vulnerabilities-2cb068
npm install
```

Confirm the tree resolves to patched versions:
```
npm ls fast-uri @hono/node-server
```
Expect `fast-uri@3.1.4` and `@hono/node-server@2.0.11`.

Exercise the SDK code path that actually consumes the bumped adapter (`streamableHttp.js` imports `getRequestListener`), and the build tooling:
```
npx tailwindcss -i ./tailwind-src/crush_lu/tailwind-input.css -o /tmp/out.css --minify
npx prettier --version
npx context7-mcp --help
```

## What to Check
Verify that the following are valid:
* `npm ls` reports `fast-uri@3.1.4` and `@hono/node-server@2.0.11` — **done**
* The MCP SDK still works on the v2 adapter — **done**: stood up a real `StreamableHTTPServerTransport` (which calls `getRequestListener` internally) and drove an `initialize` request through it end-to-end → HTTP 200 with a valid `serverInfo` response
* v2 still exports the only two symbols the SDK imports, `getRequestListener` and `serve` — **done**
* v2's `hono: ^4` peer is satisfied — **done**, the existing `hono` override already pins `^4.12.25`
* Build tooling unaffected — **done**: Tailwind CLI 4.3.3 builds crush_lu CSS clean (638 KB minified, written to a temp path so tracked CSS is untouched); prettier 3.9.5 and `@playwright/mcp` 0.0.78 both load; `context7-mcp` CLI reports its options
* Dependabot alerts #50/#51/#52 auto-close once this merges

## Other Information
* Alerts are tracked against the **default branch**, so they stay open until this lands on `main`.
* One thing not covered: `context7-mcp --transport http` exits before binding without `UPSTASH_REDIS_REST_URL`/`_TOKEN`. That's a pre-existing config requirement of that server, not a regression from this bump — and the `StreamableHTTPServerTransport` test above covers the same adapter code path.
* `@modelcontextprotocol/sdk` 1.29.0 is already the latest release and still declares `@hono/node-server: ^1.19.9`, so there's no upstream version to wait for. The override can be dropped once the SDK bumps its own dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
