### PR TITLE
fix(crush): address Claude bot review on PR #681

### DIFF
--- a/crush_lu/services/event_lobby.py
+++ b/crush_lu/services/event_lobby.py
@@ -277,8 +277,16 @@ def crush_flow_decision(requester, target, event, now=None) -> str:
     ``requester`` on ``target`` for ``event`` be redirected to the Event
     Lobby recap instead?
 
-    The redirect criterion is the read-time recap roster, not participation
-    row existence:
+    The pair-level check comes first and is unconditional: a counterpart
+    hidden by a pending/approved encounter removal gets NEITHER flow, no
+    matter the phase or the feature flag. Falling back to My Crush would
+    route a coach at someone who had the encounter removed, and these pairs
+    stay mutually invisible in later lobbies as well — so the pair is
+    rejected without disclosing why (block semantics). Only *phase/feature*
+    failures fall back to My Crush.
+
+    The redirect criterion is then the read-time recap roster, not
+    participation row existence:
 
     - the lobby feature flag must be on and the recap window still open
       (a pair can stay eligible after the fixed 48h recap closes while the
@@ -287,22 +295,18 @@ def crush_flow_decision(requester, target, event, now=None) -> str:
     - the requester must currently pass the viewer gate (eligibility + own
       participation), otherwise the redirect would dead-end in a locked
       lobby — My Crush applies;
-    - the target must actually be present in the requester's recap roster,
-      i.e. currently eligible and not hidden by a pending/approved encounter
-      removal. A removal pair gets NEITHER flow — falling back to My Crush
-      would route a coach at someone who had the encounter removed, so the
-      pair is rejected without disclosing why (block semantics).
+    - the target must actually be present in the requester's recap roster.
 
     Blocked pairs are rejected by the callers before this runs.
     """
+    if target.pk in hidden_encounter_user_ids(requester):
+        return CRUSH_FLOW_UNAVAILABLE
     if not lobby_feature_enabled():
         return CRUSH_FLOW_CRUSH
     if event_lobby_phase(event, now) != PHASE_RECAP:
         return CRUSH_FLOW_CRUSH
     if viewer_participation(requester, event) is None:
         return CRUSH_FLOW_CRUSH
-    if target.pk in hidden_encounter_user_ids(requester):
-        return CRUSH_FLOW_UNAVAILABLE
     if eligible_participations(event).filter(user=target).exists():
         return CRUSH_FLOW_REDIRECT
     return CRUSH_FLOW_CRUSH

--- a/crush_lu/templates/crush_lu/request_connection.html
+++ b/crush_lu/templates/crush_lu/request_connection.html
@@ -71,7 +71,7 @@
 
                     <div class="flex flex-col gap-3">
                         <button type="submit"
-                                onclick="return confirm('{% trans "Declare your crush? It stays completely private and cannot be undone. Your Crush Coach will call you within 48 hours to talk about it." %}');"
+                                onclick="return confirm('{% filter escapejs %}{% trans "Declare your crush? It stays completely private and cannot be undone. Your Crush Coach will call you within 48 hours to talk about it." %}{% endfilter %}');"
                                 class="btn-crush-primary w-full py-3 text-lg font-semibold">
                             {% include "shared/icons/heart.html" with class="w-5 h-5" %} {% trans "Declare My Crush!" %}
                         </button>

--- a/crush_lu/tests/test_crush_member_flow.py
+++ b/crush_lu/tests/test_crush_member_flow.py
@@ -499,6 +499,58 @@ class TestOnePairOneFlow:
         assert "HX-Redirect" not in response
         assert not EventConnection.objects.filter(event=event).exists()
 
+    def test_removal_pair_gets_neither_flow_when_recap_closed(self, client):
+        """The pair-level removal check is independent of the recap phase: a
+        phase failure must not fall back to My Crush for a hidden pair
+        (§9.1 — only phase/feature failures fall back)."""
+        user_a = _make_member("pf_g", gender="M")
+        user_b = _make_member("pf_h", gender="F")
+        event = _make_event()
+        _join(user_a, event)
+        _join(user_b, event)
+        _end_event(event, hours_ago=49)  # recap closed
+        event.connection_window_hours = 168  # crush window still open
+        event.save(update_fields=["connection_window_hours"])
+        low, high = ConfirmedEncounter.canonical_pair(user_a, user_b)
+        ConfirmedEncounter.objects.create(
+            user_low=low, user_high=high, status="removal_pending"
+        )
+        _login(client, user_a)
+
+        response = client.post(_declare_url(event, user_b), {"note": ""})
+        assert response.status_code == 302
+        assert response.url != _lobby_url(event)
+        assert not EventConnection.objects.filter(event=event).exists()
+
+        response = client.post(_inline_url(event, user_b), {"note": ""})
+        assert "HX-Redirect" not in response
+        assert not EventConnection.objects.filter(event=event).exists()
+
+    def test_removal_pair_gets_neither_flow_when_lobby_flag_off(
+        self, client, settings
+    ):
+        """A flag-off must not fall back to My Crush for a removal pair."""
+        settings.CRUSH_EVENT_LOBBY_ENABLED = False
+        user_a = _make_member("pf_i", gender="M")
+        user_b = _make_member("pf_j", gender="F")
+        event = _ended_event()
+        _attend(user_a, event)
+        _attend(user_b, event)
+        low, high = ConfirmedEncounter.canonical_pair(user_a, user_b)
+        ConfirmedEncounter.objects.create(
+            user_low=low, user_high=high, status="removed"
+        )
+        _login(client, user_a)
+
+        response = client.post(_declare_url(event, user_b), {"note": ""})
+        assert response.status_code == 302
+        assert response.url != _lobby_url(event)
+        assert not EventConnection.objects.filter(event=event).exists()
+
+        response = client.post(_inline_url(event, user_b), {"note": ""})
+        assert "HX-Redirect" not in response
+        assert not EventConnection.objects.filter(event=event).exists()
+
 
 class TestRecipientPrivacy:
     """§5/§13: a crush is private until the coach-facilitated introduction."""


### PR DESCRIPTION
## Purpose

Addresses both findings from the Claude bot code review on #681. Targets the Phase C branch so it merges into that PR before it lands on `main`.

* **`crush_flow_decision` let a "My Crush!" declaration through against a removal-hidden pair once the recap phase closed** (`crush_lu/services/event_lobby.py`). `hidden_encounter_user_ids(requester)` only ran *after* the `lobby_feature_enabled()`, `event_lobby_phase() == PHASE_RECAP` and `viewer_participation()` gates all passed — each of which returns `CRUSH_FLOW_CRUSH` early. So with the lobby flag off, with the 48h recap window closed while `connection_window_hours` is still open, or with a requester who isn't a lobby participant, a direct POST to `request_connection` / `request_connection_inline` could create a crush lead — and route a coach — against someone with a pending or approved encounter-removal request. Spec §9.1 makes the pair-level check independent: only *phase/feature* failures fall back to My Crush. Moved the check to the top of the function so it is unconditional.
* **Missing `escapejs` on a translated string inside `onclick="confirm(...)"`** (`crush_lu/templates/crush_lu/request_connection.html:74`). The `{% trans %}` output was embedded directly in a single-quoted JS string literal. Once Phase E adds FR/DE copy, a French elision (*c'est*, *n'est*) would close the string and silently disable the confirmation dialog. Now wrapped in `{% filter escapejs %}…{% endfilter %}`, matching `coach_spark_assign.html` and `delete_crushlu_profile_confirm.html`.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

The behavior change is a narrowing: removal-hidden pairs that previously fell through to a crush declaration outside the recap phase are now rejected, which is what §9.1 specifies. No API, model, or migration changes.

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
git checkout claude/bot-pr-review-ps6iba
pytest crush_lu/tests/test_crush_member_flow.py
```

Two new regression tests in `TestOnePairOneFlow`:

* `test_removal_pair_gets_neither_flow_when_recap_closed` — recap closed at 49h with `connection_window_hours = 168`, `removal_pending` encounter
* `test_removal_pair_gets_neither_flow_when_lobby_flag_off` — `CRUSH_EVENT_LOBBY_ENABLED = False`, `removed` encounter

Both assert no `EventConnection` row and no recap redirect from either write endpoint. Both **fail** against the pre-fix service code (a lead is created); both pass with it.

## What to Check

* `crush_flow_decision` still returns `CRUSH_FLOW_REDIRECT` / `CRUSH_FLOW_CRUSH` identically for non-removal pairs — the existing `TestOnePairOneFlow` fallback tests cover the flag-off and recap-closed paths and still pass.
* Moving the check first adds one `ConfirmedEncounter` query on the flag-off path, where the function previously short-circuited with no query. It runs per declaration attempt and per `connection_actions` render, not in a loop.
* The `escapejs` change is render-only; the English copy is unaffected.

## Other Information

Full `crush_lu` suite: ~2200 tests, 0 failures (concurrent-declaration test still skips on SQLite). `manage.py check` clean. `ruff check` on the changed Python files reports only a pre-existing `BLE001` at `event_lobby.py:1045`, untouched by this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkBFmtLsY5qsExrcceRY6K)_