### PR TITLE
feat(crush): let coaches record the My Crush! call

### DIFF
--- a/crush_lu/templates/crush_lu/coach_connection_review.html
+++ b/crush_lu/templates/crush_lu/coach_connection_review.html
@@ -151,6 +151,68 @@
         </div>
     </div>
 
+    <!-- My Crush! call tracking — the lead's own action surface -->
+    {% if show_call_tracking %}
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5 mb-6 border border-crush-purple/30">
+        <div class="flex items-start justify-between gap-3 mb-3">
+            <div>
+                <h4 class="font-semibold dark:text-white">{% trans "My Crush! call" %}</h4>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                    {% blocktrans with name=connection.requester.first_name %}Call {{ name }} about their declaration, then record what happened.{% endblocktrans %}
+                </p>
+            </div>
+            {% if connection.call_by %}
+            <span class="shrink-0 text-xs font-medium px-2.5 py-1 rounded-full bg-crush-purple/10 text-crush-purple dark:text-crush-pink">
+                {% blocktrans with deadline=connection.call_by %}Call by {{ deadline }}{% endblocktrans %}
+            </span>
+            {% endif %}
+        </div>
+
+        {% if connection.call_outcome %}
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            {% trans "Last recorded outcome:" %} <strong>{{ connection.get_call_outcome_display }}</strong>
+            {% if connection.coach_call_scheduled_at %}
+                &middot; {% blocktrans with scheduled=connection.coach_call_scheduled_at %}next call {{ scheduled }}{% endblocktrans %}
+            {% endif %}
+        </p>
+        {% endif %}
+
+        <form method="post" class="space-y-3">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="record_call">
+            <div>
+                <label for="call_outcome" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans "Outcome" %}</label>
+                <select id="call_outcome" name="call_outcome" required
+                        class="w-full sm:w-auto px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg">
+                    <option value="">{% trans "Choose an outcome…" %}</option>
+                    {% for value, label in call_outcome_choices %}
+                        <option value="{{ value }}">{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div>
+                <label for="call_scheduled_at" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    {% trans "Next call (optional — ignored when the call is completed)" %}
+                </label>
+                <input type="datetime-local" id="call_scheduled_at" name="call_scheduled_at"
+                       class="w-full sm:w-auto px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg">
+            </div>
+            <button type="submit" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium bg-crush-purple text-white hover:bg-crush-purple/90 rounded-lg transition-colors">
+                {% trans "Record call" %}
+            </button>
+            <p class="text-xs text-gray-400 dark:text-gray-500">
+                {% trans "“Call completed” closes the 48h SLA and removes this lead from your queue. Any other outcome keeps it there." %}
+            </p>
+        </form>
+    </div>
+    {% elif connection.flow == 'crush' and connection.coach_call_completed_at %}
+    <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl p-4 mb-6">
+        <p class="text-sm text-green-800 dark:text-green-300">
+            {% blocktrans with when=connection.coach_call_completed_at outcome=connection.get_call_outcome_display %}Coach call recorded {{ when }} — {{ outcome }}.{% endblocktrans %}
+        </p>
+    </div>
+    {% endif %}
+
     <!-- Coach Action: Start Review / Claim -->
     {% if connection.status == 'accepted' and not connection.assigned_coach %}
         <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-5 mb-6">

--- a/crush_lu/tests/test_crush_member_flow.py
+++ b/crush_lu/tests/test_crush_member_flow.py
@@ -1280,3 +1280,153 @@ class TestCodexRound2:
 
         assert "HX-Redirect" in response
         assert response.status_code != 302
+
+
+class TestCoachCallRecording:
+    """The member is promised a call within 48h; the coach needs somewhere to
+    write down that it happened, or the lead accrues SLA breach forever."""
+
+    def _routed_lead(self, coach):
+        crusher = _plain("call_a", gender="M")
+        target = _plain("call_b", gender="F")
+        event = _ended_event()
+        _attend(crusher, event)
+        _attend(target, event)
+        return EventConnection.objects.create(
+            requester=crusher,
+            recipient=target,
+            event=event,
+            flow=EventConnection.FLOW_CRUSH,
+            assigned_coach=coach,
+            requester_note="Call me about this.",
+        )
+
+    def _review_url(self, lead):
+        return reverse(
+            "crush_lu:coach_connection_review",
+            kwargs={"connection_id": lead.pk},
+        )
+
+    def test_pending_lead_offers_the_call_form(self, client):
+        """The queue links here from `pending`, where none of the legacy
+        accepted/reviewing controls render."""
+        coach = _make_coach("call_coach1@example.com")
+        lead = self._routed_lead(coach)
+        assert lead.status == "pending"
+        _login(client, coach.user)
+
+        response = client.get(self._review_url(lead))
+
+        assert response.status_code == 200
+        assert response.context["show_call_tracking"] is True
+        assert b'value="record_call"' in response.content
+
+    def test_completed_call_leaves_the_queue_and_the_reminder_sweep(
+        self, client
+    ):
+        from crush_lu.services.crush_leads import reminder_due
+
+        coach = _make_coach("call_coach2@example.com")
+        lead = self._routed_lead(coach)
+        _login(client, coach.user)
+
+        response = client.post(
+            self._review_url(lead),
+            {"action": "record_call", "call_outcome": "completed"},
+        )
+
+        assert response.status_code == 302
+        lead.refresh_from_db()
+        assert lead.call_outcome == "completed"
+        assert lead.coach_call_completed_at is not None
+        assert lead not in EventConnection.objects.open_crush_leads()
+        assert reminder_due(lead) is False
+
+        queue = client.get(reverse("crush_lu:coach_action_queue"))
+        assert queue.context["counts"].get("crush_lead", 0) == 0
+
+    def test_unsuccessful_attempt_keeps_the_lead_in_the_queue(self, client):
+        """A call that didn't happen is still owed — recording "no answer"
+        must not silently close the SLA."""
+        coach = _make_coach("call_coach3@example.com")
+        lead = self._routed_lead(coach)
+        _login(client, coach.user)
+
+        client.post(
+            self._review_url(lead),
+            {"action": "record_call", "call_outcome": "no_answer"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.call_outcome == "no_answer"
+        assert lead.coach_call_completed_at is None
+        assert lead in EventConnection.objects.open_crush_leads()
+
+    def test_reschedule_records_the_next_call_time(self, client):
+        from crush_lu.services.crush_leads import reminder_due
+
+        coach = _make_coach("call_coach4@example.com")
+        lead = self._routed_lead(coach)
+        _login(client, coach.user)
+
+        client.post(
+            self._review_url(lead),
+            {
+                "action": "record_call",
+                "call_outcome": "rescheduled",
+                "call_scheduled_at": "2026-08-01T14:30",
+            },
+        )
+
+        lead.refresh_from_db()
+        assert lead.call_outcome == "rescheduled"
+        assert lead.coach_call_scheduled_at is not None
+        assert lead.coach_call_scheduled_at.date().isoformat() == "2026-08-01"
+        # A scheduled call counts as touched: no 24h nag on top of it.
+        assert reminder_due(lead) is False
+
+    def test_invalid_outcome_writes_nothing(self, client):
+        coach = _make_coach("call_coach5@example.com")
+        lead = self._routed_lead(coach)
+        _login(client, coach.user)
+
+        client.post(
+            self._review_url(lead),
+            {"action": "record_call", "call_outcome": "definitely_not_valid"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.call_outcome is None
+        assert lead.coach_call_completed_at is None
+
+    def test_other_coach_cannot_record_the_call(self, client):
+        coach = _make_coach("call_coach6@example.com")
+        other = _make_coach("call_other6@example.com")
+        lead = self._routed_lead(coach)
+        _login(client, other.user)
+
+        response = client.post(
+            self._review_url(lead),
+            {"action": "record_call", "call_outcome": "completed"},
+        )
+
+        assert response.status_code == 404
+        lead.refresh_from_db()
+        assert lead.coach_call_completed_at is None
+
+    def test_legacy_connection_has_no_call_to_record(self, client):
+        coach = _make_coach("call_coach7@example.com")
+        lead = self._routed_lead(coach)
+        lead.flow = EventConnection.FLOW_LEGACY
+        lead.save(update_fields=["flow"])
+        _login(client, coach.user)
+
+        review = client.get(self._review_url(lead))
+        client.post(
+            self._review_url(lead),
+            {"action": "record_call", "call_outcome": "completed"},
+        )
+
+        assert review.context["show_call_tracking"] is False
+        lead.refresh_from_db()
+        assert lead.coach_call_completed_at is None

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -4,6 +4,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib import messages
 from django.core.paginator import Paginator
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 from django.db import transaction
 from django.db.models import (
@@ -3922,6 +3923,57 @@ def coach_connection_review(request, connection_id):
                         )
                 messages.success(request, _("Connection is now under your review."))
 
+        elif action == "record_call":
+            # "My Crush!" coach call (spec §7). Nothing in production wrote
+            # the call fields, so a lead never left `open_crush_leads()` — it
+            # sat in the queue this PR's own inbox change put it in, accruing
+            # SLA breach forever. Crush leads only: a legacy connection has no
+            # call to record.
+            if connection.flow != EventConnection.FLOW_CRUSH:
+                messages.error(request, _("This is not a My Crush! lead."))
+                return redirect(
+                    "crush_lu:coach_connection_review", connection_id=connection_id
+                )
+
+            outcome = request.POST.get("call_outcome", "").strip()
+            valid_outcomes = {c[0] for c in EventConnection.CALL_OUTCOME_CHOICES}
+            if outcome not in valid_outcomes:
+                messages.error(request, _("Choose a call outcome."))
+                return redirect(
+                    "crush_lu:coach_connection_review", connection_id=connection_id
+                )
+
+            connection.call_outcome = outcome
+            connection.assigned_coach = coach
+            update_fields = ["call_outcome", "assigned_coach"]
+
+            if outcome == "completed":
+                # The call happened: the lead has had its coach contact, so it
+                # leaves the queue and the reminder sweep (both key off
+                # `coach_call_completed_at`).
+                connection.coach_call_completed_at = timezone.now()
+                update_fields.append("coach_call_completed_at")
+                success_message = _("Call recorded. This lead has left your queue.")
+            else:
+                # No answer / unreachable / rescheduled: the call is still
+                # owed, so the lead deliberately stays in the queue. A
+                # reschedule stamps the new time, which also counts as
+                # "touched" for the 24h reminder.
+                scheduled_for = parse_datetime(
+                    request.POST.get("call_scheduled_at", "").strip()
+                )
+                if scheduled_for is not None:
+                    if timezone.is_naive(scheduled_for):
+                        scheduled_for = timezone.make_aware(scheduled_for)
+                    connection.coach_call_scheduled_at = scheduled_for
+                    update_fields.append("coach_call_scheduled_at")
+                success_message = _(
+                    "Call attempt recorded. The lead stays in your queue."
+                )
+
+            connection.save(update_fields=update_fields)
+            messages.success(request, success_message)
+
         elif action == "save_notes":
             # Save coach notes and introduction without changing status
             connection.coach_notes = request.POST.get("coach_notes", "").strip()
@@ -4062,6 +4114,16 @@ def coach_connection_review(request, connection_id):
             connection.flow != EventConnection.FLOW_CRUSH
             or connection.assigned_coach_id == coach.id
         ),
+        # Call tracking is the crush lead's own action surface: the queue
+        # links here from `pending` onward, where none of the legacy
+        # accepted/reviewing controls render. Shown to the routed coach only,
+        # and only while the call is still owed.
+        "show_call_tracking": (
+            connection.flow == EventConnection.FLOW_CRUSH
+            and connection.assigned_coach_id == coach.id
+            and connection.coach_call_completed_at is None
+        ),
+        "call_outcome_choices": EventConnection.CALL_OUTCOME_CHOICES,
     }
     return render(request, "crush_lu/coach_connection_review.html", context)
 


### PR DESCRIPTION
## Purpose

* Closes the one Codex round-2 finding that `a57c74f` on #681 left open: *"Provide an actionable path for pending crush calls"* (P2).
* **This PR was rewritten.** It originally carried fixes for 8 findings; `a57c74f` landed on the base branch covering 9 of the 11 independently, so everything duplicated has been dropped. What remains is the single non-overlapping piece, rebased onto the new base — one commit, three files.

### Why this isn't Phase D

`a57c74f` deferred call-recording as *"#683 scope, since this PR adds no coach queue."* Two things about that:

* **This branch does add the queue.** `2102391` (the fix for Codex's *"Surface pending crush leads in the coach inbox"*) is what put crush leads into `coach_action_queue`, SLA-tracked against `call_by`. So on #681 as it stands, leads enter a queue they can never leave.
* **#683 doesn't add the writes either.** Its branch has no assignment to `coach_call_scheduled_at`, `coach_call_completed_at` or `call_outcome` — it adds the queue UI, the mutual flagging and the 24h reminder, but nothing that lets a coach mark the call done. The gap is currently unowned in code on both branches.

Happy to move this to #683 instead if you'd rather keep it with the rest of the coach workflow — it's the same three files either way.

### What it does

Nothing in production wrote the call fields; they were read-only in practice (`crush_leads.reminder_due`, `open_crush_leads`). So every declared lead accrued SLA breach forever, and the queue link opened a review page whose controls only render for `accepted`/`coach_reviewing`/`coach_approved` rows — which a freshly declared `pending` lead is not.

Adds a `record_call` action plus a call panel on the review page, shown to the routed coach from `pending` onward and only while the call is still owed:

* **Call completed** stamps `coach_call_completed_at`, which drops the lead from both `open_crush_leads()` and the reminder sweep.
* **No answer / unreachable** deliberately keep it queued — the call is still owed, and silently closing the SLA would be the wrong record to keep.
* **Rescheduled** stamps `coach_call_scheduled_at`, which `reminder_due()` already treats as touched, so a booked call doesn't also get a 24h nag.

Outcomes are validated against `CALL_OUTCOME_CHOICES`; a legacy row has no call to record and is rejected. Authorization is the existing routed-coach 404 — another coach can't reach the write.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

Purely additive. No migration — the call fields already exist from Phase B (`0198`).

## Pull Request Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform
cd Multi-Domain-Django-Platform
git checkout claude/pr-codex-findings-review-1cbmm1
pip install -r requirements.txt
```

```
pytest crush_lu/tests -m "not playwright"
python manage.py check
python manage.py makemigrations --check --dry-run
python crush_lu/scripts/lint_design_tokens.py crush_lu/templates/crush_lu/coach_connection_review.html
```

7 tests in `TestCoachCallRecording` (`crush_lu/tests/test_crush_member_flow.py`): the form renders on a `pending` lead; completing drops it from the queue and the reminder; an unsuccessful attempt keeps it; a reschedule records the next time and suppresses the reminder; an invalid outcome writes nothing; another coach gets 404; a legacy row is refused.

## What to Check

* Declare a crush, open the lead from the coach inbox at `pending` — the call panel is there where previously no control rendered.
* Record "call completed" → lead leaves the inbox and `reminder_due()` goes false. Record "no answer" → both stay.
* The panel does not appear for an unrouted pool lead (claim first), for another coach, or once the call is already completed.

## Other Information

Full `crush_lu` suite green locally on SQLite: **2219 passed, 22 skipped**. `manage.py check` clean, `makemigrations --check` reports no changes, design-token lint clean.

Note that `test-and-validate.yml` only triggers on PRs targeting `main`/`develop`, so no CI will report on this PR — it runs once the change reaches #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAcBLRi7UHBHjFUXH8WV1B