### PR TITLE
fix(crush): address Codex round 3 and the last bot finding on #683

### DIFF
--- a/crush_lu/models/connections.py
+++ b/crush_lu/models/connections.py
@@ -489,6 +489,24 @@ class EventConnection(models.Model):
         )
 
     @property
+    def has_active_recipient_coach(self):
+        """
+        Is there a live co-coach to work the recipient half of this lead?
+
+        ``assign_recipient_coach`` leaves ``recipient_coach`` null whenever
+        both sides share a coach or the recipient has no active coach of
+        their own — by design, because the routed coach then performs both
+        halves of the outreach. A co-coach who is *later deactivated* leaves
+        the same situation behind a non-null column: ``coach_required`` bars
+        them from every coach view, so the task is theirs and unreachable.
+
+        Both cases must therefore read the same, or the recipient's answer
+        has no writer at all and ``can_share_contacts`` can never become
+        true — the lead would sit at ``coach_approved`` forever.
+        """
+        return self.recipient_coach is not None and self.recipient_coach.is_active
+
+    @property
     def call_by(self):
         """
         "Call by" deadline for a crush lead (spec §6/O8: 48h SLA).

--- a/crush_lu/services/crush_leads.py
+++ b/crush_lu/services/crush_leads.py
@@ -9,6 +9,7 @@ notification; member surfaces are Phase C.
 """
 
 import logging
+import time
 
 from django.db import transaction
 from django.utils import timezone
@@ -120,8 +121,24 @@ def _delivery_failed(result) -> bool:
 
 REMINDER_BATCH_LIMIT = 200
 
+# Wall-clock budget for one sweep. The `CrushLeadReminders` timer calls this
+# through `_call_admin_endpoint`, which gives up at 60s, and each lead can
+# make several serial Web Push calls at up to `PUSH_TIMEOUT` each — so the
+# count cap alone does not bound the run: a handful of stalled endpoints can
+# burn the caller's whole budget, and the Django request would then keep
+# going until gunicorn kills it at 120s, leaving most of the batch late with
+# nothing to show for it. Stop early instead and let the next hourly run take
+# the rest, the same way the count cap does.
+REMINDER_TIME_BUDGET = 45.0
 
-def sweep_lead_reminders(now=None, notify=None, limit=REMINDER_BATCH_LIMIT):
+
+def sweep_lead_reminders(
+    now=None,
+    notify=None,
+    limit=REMINDER_BATCH_LIMIT,
+    time_budget=REMINDER_TIME_BUDGET,
+    clock=None,
+):
     """
     Send the 24h untouched-lead reminder to each routed coach (spec §6/O8).
 
@@ -142,16 +159,20 @@ def sweep_lead_reminders(now=None, notify=None, limit=REMINDER_BATCH_LIMIT):
     endpoint block them all until the request is killed — and a rollback at
     that point would lose the stamps of reminders already delivered, so the
     next sweep would send them again. Each lead is therefore locked, sent
-    and committed on its own, and the batch is bounded by ``limit``.
+    and committed on its own, and the batch is bounded by ``limit`` *and* by
+    ``time_budget`` — see ``REMINDER_TIME_BUDGET`` for why a count alone does
+    not fit inside the caller's timeout.
 
-    ``notify`` is injectable for tests; it defaults to the coach push
-    notification helper.
+    ``notify`` and ``clock`` are injectable for tests; they default to the
+    coach push notification helper and a monotonic clock.
     """
     now = now or timezone.now()
     if notify is None:
         from crush_lu.coach_notifications import notify_coach_crush_lead_reminder
 
         notify = notify_coach_crush_lead_reminder
+    clock = clock or time.monotonic
+    started = clock()
 
     sent = 0
     failed = 0
@@ -170,7 +191,19 @@ def sweep_lead_reminders(now=None, notify=None, limit=REMINDER_BATCH_LIMIT):
             limit,
         )
 
-    for lead_id in candidate_ids:
+    for index, lead_id in enumerate(candidate_ids):
+        if clock() - started >= time_budget:
+            # Out of time, not out of work: the remaining leads keep their
+            # null `reminder_sent_at` and are picked up by the next run.
+            truncated = True
+            logger.warning(
+                "[crush_lead_reminders] time budget %.0fs exhausted after "
+                "%d of %d leads; more are due",
+                time_budget,
+                index,
+                len(candidate_ids),
+            )
+            break
         try:
             with transaction.atomic():
                 lead = (
@@ -181,8 +214,18 @@ def sweep_lead_reminders(now=None, notify=None, limit=REMINDER_BATCH_LIMIT):
                 )
                 # Locked by a concurrent sweep, or no longer eligible because
                 # the coach acted between the scan and now — either way it is
-                # not ours to send.
-                if lead is None or lead.reminder_sent_at is not None:
+                # not ours to send. Re-apply the *whole* predicate, not just
+                # the stamp: a call scheduled or completed in that window, or
+                # a decline, makes the lead ineligible too, and sending anyway
+                # would put a stale reminder naming the requester on a lock
+                # screen and consume the stamp for a lead nobody owes a call.
+                if lead is None or not reminder_due(lead, now):
+                    continue
+                # `reminder_due` covers the lead's own state; the routed
+                # coach is the other half of `reminder_candidates`, and a
+                # deactivation in the same window would leave nobody to
+                # notify.
+                if lead.assigned_coach is None or not lead.assigned_coach.is_active:
                     continue
                 lead.reminder_sent_at = now
                 lead.save(update_fields=["reminder_sent_at"])

--- a/crush_lu/templates/crush_lu/coach_connection_review.html
+++ b/crush_lu/templates/crush_lu/coach_connection_review.html
@@ -224,6 +224,20 @@
             </div>
         {% endif %}
 
+        {% if not lead_open %}
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-0">
+                {% trans "This lead is closed — no further action is possible." %}
+            </p>
+        {% elif lead_needs_claim %}
+            {% comment %}
+            Everything below writes to the lead, and the server refuses a
+            workspace write on a lead nobody owns. Rendering the controls
+            next to the claim prompt only invites a rejected POST.
+            {% endcomment %}
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-0">
+                {% trans "Claim this lead to start working it." %}
+            </p>
+        {% else %}
         {# Step 1 — take the lead #}
         {% if connection.status == 'pending' %}
             <form method="post" class="mb-4">
@@ -287,7 +301,9 @@
                     </dd>
                 </div>
                 <div class="flex justify-between gap-4">
-                    <dt class="text-gray-500 dark:text-gray-400">{% trans "Recipient (their coach)" %}</dt>
+                    <dt class="text-gray-500 dark:text-gray-400">
+                        {% if records_recipient_answer %}{% trans "Recipient (your call too)" %}{% else %}{% trans "Recipient (their coach)" %}{% endif %}
+                    </dt>
                     <dd class="font-medium {% if connection.recipient_consents_to_share %}text-green-600 dark:text-green-400{% else %}text-gray-400 dark:text-gray-500{% endif %}">
                         {% if connection.recipient_consents_to_share %}{% trans "Yes" %}{% else %}{% trans "Not recorded" %}{% endif %}
                     </dd>
@@ -301,6 +317,36 @@
                     <input type="hidden" name="consent" value="yes">
                     <button type="submit" class="btn-crush-outline btn-sm">{% trans "They consented on the call" %}</button>
                 </form>
+            {% endif %}
+
+            {% comment %}
+            No live co-coach means nobody else can ever write the recipient's
+            answer, and without it the lead can never reach `shared`.
+            {% endcomment %}
+            {% if records_recipient_answer %}
+                {% if recipient_answer %}
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mb-3">
+                        {% trans "Recipient's answer is recorded and final." %}
+                    </p>
+                {% else %}
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mb-2">
+                        {% trans "No separate coach covers the recipient, so you reach out to them and record their answer here." %}
+                    </p>
+                    <div class="flex flex-wrap gap-2 mb-3">
+                        <form method="post">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="crush_record_recipient_consent">
+                            <input type="hidden" name="consent" value="yes">
+                            <button type="submit" class="btn-crush-solid btn-sm">{% trans "They said yes" %}</button>
+                        </form>
+                        <form method="post">
+                            {% csrf_token %}
+                            <input type="hidden" name="action" value="crush_record_recipient_consent">
+                            <input type="hidden" name="consent" value="no">
+                            <button type="submit" class="btn-crush-outline btn-sm">{% trans "They said no" %}</button>
+                        </form>
+                    </div>
+                {% endif %}
             {% endif %}
 
             {% if connection.status != 'shared' %}
@@ -320,6 +366,7 @@
                 <p class="text-sm text-green-600 dark:text-green-400 mb-0">{% trans "Contacts shared — the introduction is done." %}</p>
             {% endif %}
         </div>
+        {% endif %}
     </div>
     {% endif %}
     <!-- Coach Notes & Introduction Form -->
@@ -404,6 +451,13 @@
     {% endif %}
 
     <!-- Coach Message -->
+    {% comment %}
+    A crush lead has no thread before the introduction (§7): the two members
+    have not been told about each other yet. The server refuses `send_message`
+    on a pre-`shared` crush row, so rendering the form here would only offer a
+    control that cannot work.
+    {% endcomment %}
+    {% if show_conversation %}
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5 mb-6">
         <h4 class="font-semibold dark:text-white mb-4">{% trans "Conversation" %}</h4>
 
@@ -446,6 +500,7 @@
         </form>
         {% endif %}
     </div>
+    {% endif %}
 
     <!-- Timeline -->
     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5">

--- a/crush_lu/tests/test_crush_leads_phase_d.py
+++ b/crush_lu/tests/test_crush_leads_phase_d.py
@@ -15,6 +15,7 @@ Covers (Phase D scope):
 Run with: pytest crush_lu/tests/test_crush_leads_phase_d.py -v
 """
 from datetime import date, timedelta
+from unittest import mock
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -1338,7 +1339,7 @@ class TestOutreachRaceOnAClosingLead:
     """Bot review follow-up: `record_outreach` re-fetched under the lock but
     checked status against the instance read at request entry."""
 
-    def test_outreach_is_not_stamped_onto_a_lead_closed_under_it(self):
+    def _pair(self):
         routed = _make_coach("or_routed@example.com")
         cocoach = _make_coach("or_cocoach@example.com")
         requester, req_p = _make_user("or_req@example.com", "M")
@@ -1350,20 +1351,78 @@ class TestOutreachRaceOnAClosingLead:
         lead = _lead(requester, recipient, _make_event())
         lead.assign_coach()
         lead.refresh_from_db()
+        return cocoach, lead
 
-        # Stand in for the concurrent decline: the row is closed in the DB
-        # while the co-coach's request already holds a stale open instance.
+    def _url(self, lead):
+        return reverse(
+            "crush_lu:coach_crush_outreach_task",
+            kwargs={"connection_id": lead.pk},
+        )
+
+    def test_outreach_is_not_stamped_onto_a_lead_closed_under_it(self):
+        cocoach, lead = self._pair()
+
+        # Closed before the request starts, so this is caught by the entry
+        # pre-check rather than the locked re-read — the genuine race is
+        # covered by the stale-instance test below.
         EventConnection.objects.filter(pk=lead.pk).update(status="declined")
 
         client = Client()
         _login(client, cocoach.user)
-        client.post(
-            reverse(
-                "crush_lu:coach_crush_outreach_task",
-                kwargs={"connection_id": lead.pk},
-            ),
-            {"action": "record_outreach"},
-        )
+        client.post(self._url(lead), {"action": "record_outreach"})
 
         lead.refresh_from_db()
         assert lead.recipient_outreach_at is None
+
+    def _post_with_a_stale_open_instance(self, cocoach, lead, action):
+        """Drive a POST whose request-entry read saw the lead open while the
+        row closed before the lock — the only window in which the in-lock
+        status re-check does any work the entry pre-check hasn't already."""
+        stale = EventConnection.objects.select_related(
+            "recipient", "event", "assigned_coach"
+        ).get(pk=lead.pk)
+        EventConnection.objects.filter(pk=lead.pk).update(status="declined")
+
+        client = Client()
+        _login(client, cocoach.user)
+        with mock.patch(
+            "crush_lu.views_coach.get_object_or_404", return_value=stale
+        ):
+            return client.post(self._url(lead), {"action": action}, follow=True)
+
+    def test_the_locked_recheck_catches_a_lead_that_closes_mid_request(self):
+        cocoach, lead = self._pair()
+
+        self._post_with_a_stale_open_instance(cocoach, lead, "record_outreach")
+
+        lead.refresh_from_db()
+        assert lead.recipient_outreach_at is None
+        assert lead.system_actions == []
+
+    def test_outreach_on_a_lead_closing_mid_request_does_not_claim_success(self):
+        """The write is correctly skipped, so the co-coach must not read
+        "Outreach recorded." — an SLA with no record of it would disagree."""
+        cocoach, lead = self._pair()
+
+        response = self._post_with_a_stale_open_instance(
+            cocoach, lead, "record_outreach"
+        )
+
+        notes = [str(m) for m in response.context["messages"]]
+        assert any("closed" in m for m in notes)
+        assert not any("Outreach recorded" in m for m in notes)
+
+    def test_an_answer_on_a_lead_closing_mid_request_says_it_closed(self):
+        """Not "already recorded" — no answer was recorded, by anyone."""
+        cocoach, lead = self._pair()
+
+        response = self._post_with_a_stale_open_instance(
+            cocoach, lead, "record_consent"
+        )
+
+        lead.refresh_from_db()
+        assert lead.recipient_response is None
+        notes = [str(m) for m in response.context["messages"]]
+        assert any("closed" in m for m in notes)
+        assert not any("already recorded" in m for m in notes)
+        assert not any("Consent recorded" in m for m in notes)

--- a/crush_lu/tests/test_crush_leads_phase_d_codex3.py
+++ b/crush_lu/tests/test_crush_leads_phase_d_codex3.py
@@ -1,0 +1,764 @@
+""""My Crush!" Phase D — Codex round-3 review findings.
+
+Spec: docs/superpowers/specs/2026-07-21-crush-my-crush-post-event-flow.md
+
+Nine findings on commit ``a389767``, all against the routed-coach workspace
+and the reminder sweep added earlier in the phase. The through-line is that
+Phase D shipped the *queue* and the *SLA* before the controls they key off,
+so several of these are the second half of a fix rather than a new one:
+
+- the recipient's answer had no writer when there is no live co-coach, so
+  ``can_share_contacts`` could never become true (P1, a hard deadlock);
+- a deactivated ``recipient_coach`` left the same hole behind a non-null
+  column (P1);
+- workspace writes did not require ownership, so a pool lead could be worked
+  by anyone (P1);
+- a decline was not terminal against the legacy ``approve`` handler;
+- correcting a completed call did not withdraw the completion;
+- a pre-``shared`` crush lead could still accumulate coach messages;
+- routed-coach audit appends were unlocked;
+- the sweep re-checked only the reminder stamp under the row lock;
+- the sweep's batch cap did not fit the caller's time budget.
+
+Run with: pytest crush_lu/tests/test_crush_leads_phase_d_codex3.py -v
+"""
+from datetime import date, timedelta
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from crush_lu.models import (
+    CrushCoach,
+    CrushProfile,
+    EventConnection,
+    MeetupEvent,
+    UserDataConsent,
+)
+from crush_lu.services import crush_leads
+from crush_lu.services.crush_leads import REMINDER_AFTER, sweep_lead_reminders
+
+User = get_user_model()
+
+pytestmark = [pytest.mark.django_db, pytest.mark.urls("azureproject.urls_crush")]
+
+
+def _make_user(username, gender="M"):
+    user = User.objects.create_user(
+        username=username, email=username, password="testpass123"
+    )
+    profile = CrushProfile.objects.create(
+        user=user,
+        date_of_birth=date(1995, 5, 15),
+        gender=gender,
+        location="Luxembourg",
+        is_approved=True,
+        is_active=True,
+    )
+    return user, profile
+
+
+def _make_coach(username, is_active=True):
+    user = User.objects.create_user(
+        username=username, email=username, password="coachpass123"
+    )
+    return CrushCoach.objects.create(user=user, bio="Test coach", is_active=is_active)
+
+
+def _make_event(title="Codex R3 Event"):
+    return MeetupEvent.objects.create(
+        title=title,
+        description="Event for Codex round-3 tests",
+        event_type="mixer",
+        date_time=timezone.now() - timedelta(hours=2),
+        location="Luxembourg",
+        address="1 Test Street",
+        max_participants=20,
+        registration_deadline=timezone.now() - timedelta(days=3),
+        is_published=True,
+    )
+
+
+def _lead(requester, recipient, event, coach=None, **kwargs):
+    kwargs.setdefault("flow", EventConnection.FLOW_CRUSH)
+    lead = EventConnection.objects.create(
+        requester=requester, recipient=recipient, event=event, **kwargs
+    )
+    if coach is not None:
+        lead.assigned_coach = coach
+        lead.save(update_fields=["assigned_coach"])
+    return lead
+
+
+def _login(client, user):
+    # The consent middleware turns an unconsented POST into a redirect, so a
+    # test asserting "nothing changed" would otherwise pass vacuously.
+    UserDataConsent.objects.update_or_create(
+        user=user, defaults={"crushlu_consent_given": True}
+    )
+    client.force_login(user)
+
+
+def _review_url(lead):
+    return reverse(
+        "crush_lu:coach_connection_review", kwargs={"connection_id": lead.pk}
+    )
+
+
+def _notes(response):
+    return [str(m) for m in response.context["messages"]]
+
+
+class TestRecipientAnswerHasAWriter:
+    """P1: with no live co-coach nothing could write
+    `recipient_consents_to_share`, so `can_share_contacts` stayed false and
+    the lead could never reach `shared` — a hard deadlock, not a nuisance."""
+
+    def _same_coach_lead(self, coach_active=True):
+        """Both halves on one coach: `assign_recipient_coach` returns None."""
+        coach = _make_coach("r3_solo@example.com", is_active=coach_active)
+        requester, req_p = _make_user("r3_solo_req@example.com", "M")
+        recipient, rec_p = _make_user("r3_solo_rec@example.com", "F")
+        for profile in (req_p, rec_p):
+            profile.assigned_coach = coach
+            profile.save(update_fields=["assigned_coach"])
+        lead = _lead(requester, recipient, _make_event())
+        lead.assign_coach()
+        lead.assign_recipient_coach()
+        lead.refresh_from_db()
+        return coach, lead
+
+    def test_no_cocoach_means_the_routed_coach_records_the_answer(self):
+        coach, lead = self._same_coach_lead()
+        assert lead.recipient_coach is None
+        assert lead.has_active_recipient_coach is False
+
+        client = Client()
+        _login(client, coach.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+        client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "yes"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.recipient_consents_to_share is True
+        assert lead.recipient_response == EventConnection.RECIPIENT_RESPONSE_CONSENTED
+
+    def test_the_lead_can_actually_reach_shared_without_a_cocoach(self):
+        """The deadlock itself: every step through the UI, ending at
+        `shared`. Before the fix this could not terminate at all."""
+        coach, lead = self._same_coach_lead()
+        client = Client()
+        _login(client, coach.user)
+        url = _review_url(lead)
+
+        client.post(url, {"action": "crush_start_review"})
+        client.post(url, {"action": "crush_complete_call", "call_outcome": "completed"})
+        client.post(url, {"action": "crush_record_consent", "consent": "yes"})
+        client.post(
+            url, {"action": "crush_record_recipient_consent", "consent": "yes"}
+        )
+        client.post(url, {"action": "approve"})
+        client.post(url, {"action": "crush_share"})
+
+        lead.refresh_from_db()
+        assert lead.status == "shared"
+        assert lead.shared_at is not None
+
+    def test_a_decline_recorded_this_way_still_ends_the_lead(self):
+        coach, lead = self._same_coach_lead()
+        client = Client()
+        _login(client, coach.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+
+        client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "no"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.status == "declined"
+        assert lead.recipient_consents_to_share is False
+
+    def test_the_answer_backfills_outreach_like_the_cocoach_surface_does(self):
+        coach, lead = self._same_coach_lead()
+        client = Client()
+        _login(client, coach.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+
+        client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "yes"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.recipient_outreach_at is not None
+        inferred = [
+            a for a in lead.system_actions if a["type"] == "recipient_outreach"
+        ]
+        # Audited as inferred, so the trail still distinguishes a back-fill
+        # from a coach explicitly recording that they made contact.
+        assert inferred and inferred[0]["details"].get("inferred") is True
+
+    def test_the_answer_is_final_here_too(self):
+        coach, lead = self._same_coach_lead()
+        client = Client()
+        _login(client, coach.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+        client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "yes"},
+        )
+
+        response = client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "no"},
+            follow=True,
+        )
+
+        lead.refresh_from_db()
+        assert lead.recipient_consents_to_share is True
+        assert lead.status != "declined"
+        assert any("already recorded" in m for m in _notes(response))
+
+    def test_the_routed_coach_cannot_answer_over_a_live_cocoach(self):
+        """When a co-coach exists the answer is theirs to record — this
+        control must not become a way around the recipient's own coach."""
+        routed = _make_coach("r3_routed@example.com")
+        cocoach = _make_coach("r3_cocoach@example.com")
+        requester, req_p = _make_user("r3_req@example.com", "M")
+        recipient, rec_p = _make_user("r3_rec@example.com", "F")
+        req_p.assigned_coach = routed
+        req_p.save(update_fields=["assigned_coach"])
+        rec_p.assigned_coach = cocoach
+        rec_p.save(update_fields=["assigned_coach"])
+        lead = _lead(requester, recipient, _make_event())
+        lead.assign_coach()
+        lead.refresh_from_db()
+        assert lead.recipient_coach == cocoach
+
+        client = Client()
+        _login(client, routed.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+        response = client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "yes"},
+            follow=True,
+        )
+
+        lead.refresh_from_db()
+        assert lead.recipient_consents_to_share is False
+        assert any("their answer" in m or "own coach" in m for m in _notes(response))
+
+
+class TestDeactivatedRecipientCoachDoesNotStrandTheLead:
+    """P1: `coach_required` bars a deactivated co-coach from every view while
+    the exact-owner filter hid the task from everyone else, so the recipient's
+    answer had no route at all — the same deadlock behind a non-null column."""
+
+    def _lead_with_stale_cocoach(self):
+        routed = _make_coach("r3_stale_routed@example.com")
+        cocoach = _make_coach("r3_stale_co@example.com")
+        requester, req_p = _make_user("r3_stale_req@example.com", "M")
+        recipient, rec_p = _make_user("r3_stale_rec@example.com", "F")
+        req_p.assigned_coach = routed
+        req_p.save(update_fields=["assigned_coach"])
+        rec_p.assigned_coach = cocoach
+        rec_p.save(update_fields=["assigned_coach"])
+        lead = _lead(requester, recipient, _make_event())
+        lead.assign_coach()
+        lead.refresh_from_db()
+        assert lead.recipient_coach == cocoach
+        # The co-coach leaves after routing.
+        cocoach.is_active = False
+        cocoach.save(update_fields=["is_active"])
+        lead.refresh_from_db()
+        return routed, lead
+
+    def test_a_stale_cocoach_reads_as_no_cocoach(self):
+        _, lead = self._lead_with_stale_cocoach()
+        assert lead.recipient_coach is not None
+        assert lead.has_active_recipient_coach is False
+
+    def test_the_routed_coach_picks_up_the_stranded_answer(self):
+        routed, lead = self._lead_with_stale_cocoach()
+        client = Client()
+        _login(client, routed.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+
+        client.post(
+            _review_url(lead),
+            {"action": "crush_record_recipient_consent", "consent": "yes"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.recipient_consents_to_share is True
+
+    def test_the_control_is_offered_on_the_page(self):
+        routed, lead = self._lead_with_stale_cocoach()
+        client = Client()
+        _login(client, routed.user)
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+
+        body = client.get(_review_url(lead)).content.decode()
+
+        assert "crush_record_recipient_consent" in body
+
+
+class TestWorkspaceWritesRequireOwnership:
+    """P1: the outer guard only rejects a lead routed to *someone else*, so on
+    an unrouted pool lead every workspace write was open to any active coach."""
+
+    def _pool_lead(self):
+        owner = _make_coach("r3_pool_owner@example.com")
+        stranger = _make_coach("r3_pool_stranger@example.com")
+        requester, _ = _make_user("r3_pool_req@example.com", "M")
+        recipient, _ = _make_user("r3_pool_rec@example.com", "F")
+        lead = _lead(requester, recipient, _make_event())
+        assert lead.assigned_coach is None
+        return owner, stranger, lead
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"action": "crush_complete_call", "call_outcome": "completed"},
+            {"action": "crush_record_consent", "consent": "yes"},
+            {"action": "crush_share"},
+            {"action": "crush_schedule_call", "scheduled_at": "2030-01-01T10:00"},
+        ],
+    )
+    def test_an_unclaimed_lead_refuses_every_workspace_write(self, payload):
+        _, stranger, lead = self._pool_lead()
+        client = Client()
+        _login(client, stranger.user)
+
+        response = client.post(_review_url(lead), payload, follow=True)
+
+        lead.refresh_from_db()
+        assert lead.coach_call_completed_at is None
+        assert lead.coach_call_scheduled_at is None
+        assert lead.requester_consents_to_share is False
+        assert lead.status != "shared"
+        assert lead.system_actions == []
+        assert any("Claim" in m for m in _notes(response))
+
+    def test_claiming_by_starting_review_is_still_allowed(self):
+        """The triage path stays open — that was the intentional part."""
+        _, stranger, lead = self._pool_lead()
+        client = Client()
+        _login(client, stranger.user)
+
+        client.post(_review_url(lead), {"action": "crush_start_review"})
+
+        lead.refresh_from_db()
+        assert lead.assigned_coach == stranger
+        assert lead.status == "coach_reviewing"
+
+    def test_the_page_does_not_offer_controls_it_will_refuse(self):
+        _, stranger, lead = self._pool_lead()
+        client = Client()
+        _login(client, stranger.user)
+
+        body = client.get(_review_url(lead)).content.decode()
+
+        assert "crush_complete_call" not in body
+        assert "crush_share" not in body
+
+
+class TestDeclinesAreTerminal:
+    """P2: `approve` set `coach_approved` unconditionally, so a stale page
+    could reopen a lead the co-coach had just declined."""
+
+    def _declined_lead(self):
+        routed = _make_coach("r3_term_routed@example.com")
+        requester, req_p = _make_user("r3_term_req@example.com", "M")
+        recipient, _ = _make_user("r3_term_rec@example.com", "F")
+        req_p.assigned_coach = routed
+        req_p.save(update_fields=["assigned_coach"])
+        lead = _lead(
+            requester,
+            recipient,
+            _make_event(),
+            routed,
+            status="declined",
+            recipient_response=EventConnection.RECIPIENT_RESPONSE_DECLINED,
+        )
+        return routed, lead
+
+    def test_approve_cannot_reopen_a_declined_crush_lead(self):
+        routed, lead = self._declined_lead()
+        client = Client()
+        _login(client, routed.user)
+
+        response = client.post(_review_url(lead), {"action": "approve"}, follow=True)
+
+        lead.refresh_from_db()
+        assert lead.status == "declined"
+        assert lead.coach_approved_at is None
+        assert any("closed" in m for m in _notes(response))
+
+    def test_a_legacy_declined_row_keeps_its_old_behaviour(self):
+        """The guard is crush-only — legacy rows are not in this flow and
+        were not part of the finding."""
+        routed, lead = self._declined_lead()
+        lead.flow = EventConnection.FLOW_LEGACY
+        lead.save(update_fields=["flow"])
+        client = Client()
+        _login(client, routed.user)
+
+        client.post(_review_url(lead), {"action": "approve"})
+
+        lead.refresh_from_db()
+        assert lead.status == "coach_approved"
+
+    def test_the_workspace_also_refuses_a_closed_lead(self):
+        routed, lead = self._declined_lead()
+        client = Client()
+        _login(client, routed.user)
+
+        response = client.post(
+            _review_url(lead),
+            {"action": "crush_record_consent", "consent": "yes"},
+            follow=True,
+        )
+
+        lead.refresh_from_db()
+        assert lead.requester_consents_to_share is False
+        assert any("closed" in m for m in _notes(response))
+
+
+class TestCorrectingACompletedCall:
+    """P2: re-logging a non-completed outcome re-armed the reminder but left
+    `coach_call_completed_at` set, so the lead stayed out of
+    `open_crush_leads()` and the re-armed reminder could never fire."""
+
+    def _reviewing_lead(self):
+        coach = _make_coach("r3_call_coach@example.com")
+        requester, req_p = _make_user("r3_call_req@example.com", "M")
+        recipient, _ = _make_user("r3_call_rec@example.com", "F")
+        req_p.assigned_coach = coach
+        req_p.save(update_fields=["assigned_coach"])
+        lead = _lead(
+            requester, recipient, _make_event(), coach, status="coach_reviewing"
+        )
+        return coach, lead
+
+    def test_a_non_completed_correction_withdraws_the_completion(self):
+        coach, lead = self._reviewing_lead()
+        client = Client()
+        _login(client, coach.user)
+        client.post(
+            _review_url(lead),
+            {"action": "crush_complete_call", "call_outcome": "completed"},
+        )
+        lead.refresh_from_db()
+        assert lead.coach_call_completed_at is not None
+
+        client.post(
+            _review_url(lead),
+            {"action": "crush_complete_call", "call_outcome": "no_answer"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.call_outcome == "no_answer"
+        assert lead.coach_call_completed_at is None
+
+    def test_the_corrected_lead_comes_back_onto_the_queue(self):
+        """The point of the correction: a lead logged completed by mistake
+        has to become workable again, not vanish with a re-armed reminder."""
+        coach, lead = self._reviewing_lead()
+        client = Client()
+        _login(client, coach.user)
+        client.post(
+            _review_url(lead),
+            {"action": "crush_complete_call", "call_outcome": "completed"},
+        )
+        assert not EventConnection.objects.crush_leads_for_coach(coach).exists()
+
+        client.post(
+            _review_url(lead),
+            {"action": "crush_complete_call", "call_outcome": "unreachable"},
+        )
+
+        assert EventConnection.objects.crush_leads_for_coach(coach).filter(
+            pk=lead.pk
+        ).exists()
+
+    def test_completing_still_closes_the_sla(self):
+        coach, lead = self._reviewing_lead()
+        client = Client()
+        _login(client, coach.user)
+
+        client.post(
+            _review_url(lead),
+            {"action": "crush_complete_call", "call_outcome": "completed"},
+        )
+
+        lead.refresh_from_db()
+        assert lead.coach_call_completed_at is not None
+        assert not EventConnection.objects.crush_leads_for_coach(coach).exists()
+
+
+class TestNoMessagesBeforeTheIntroduction:
+    """P2: non-`crush_` actions fell through to `send_message`, so a coach
+    could write thread rows while the pair still knew nothing of each other."""
+
+    def _lead(self, status="coach_reviewing"):
+        coach = _make_coach("r3_msg_coach@example.com")
+        requester, req_p = _make_user("r3_msg_req@example.com", "M")
+        recipient, _ = _make_user("r3_msg_rec@example.com", "F")
+        req_p.assigned_coach = coach
+        req_p.save(update_fields=["assigned_coach"])
+        return coach, _lead(
+            requester, recipient, _make_event(), coach, status=status
+        )
+
+    def test_a_pre_shared_crush_lead_refuses_a_coach_message(self):
+        coach, lead = self._lead()
+        client = Client()
+        _login(client, coach.user)
+
+        response = client.post(
+            _review_url(lead),
+            {"action": "send_message", "message": "Hello there"},
+            follow=True,
+        )
+
+        assert lead.messages.count() == 0
+        assert any("introduction" in m for m in _notes(response))
+
+    def test_the_form_is_not_rendered_before_the_introduction(self):
+        coach, lead = self._lead()
+        client = Client()
+        _login(client, coach.user)
+
+        body = client.get(_review_url(lead)).content.decode()
+
+        assert 'value="send_message"' not in body
+
+    def test_a_shared_lead_opens_the_thread(self):
+        coach, lead = self._lead(status="shared")
+        client = Client()
+        _login(client, coach.user)
+
+        client.post(
+            _review_url(lead), {"action": "send_message", "message": "Introduced!"}
+        )
+
+        assert lead.messages.count() == 1
+
+    def test_a_legacy_row_is_unaffected(self):
+        coach, lead = self._lead()
+        lead.flow = EventConnection.FLOW_LEGACY
+        lead.save(update_fields=["flow"])
+        client = Client()
+        _login(client, coach.user)
+
+        client.post(
+            _review_url(lead), {"action": "send_message", "message": "Legacy note"}
+        )
+
+        assert lead.messages.count() == 1
+
+
+class TestRoutedCoachAuditIsLocked:
+    """P2: the workspace appended to `system_actions` from the instance loaded
+    at request entry, so a concurrently committed co-coach entry was lost."""
+
+    def test_a_concurrent_cocoach_entry_survives_a_workspace_write(self):
+        routed = _make_coach("r3_audit_routed@example.com")
+        cocoach = _make_coach("r3_audit_co@example.com")
+        requester, req_p = _make_user("r3_audit_req@example.com", "M")
+        recipient, rec_p = _make_user("r3_audit_rec@example.com", "F")
+        req_p.assigned_coach = routed
+        req_p.save(update_fields=["assigned_coach"])
+        rec_p.assigned_coach = cocoach
+        rec_p.save(update_fields=["assigned_coach"])
+        lead = _lead(requester, recipient, _make_event(), status="coach_reviewing")
+        lead.assign_coach()
+        lead.refresh_from_db()
+
+        # The instance this request read at entry, *before* the co-coach's
+        # append — the only window in which the lock does any work. Mutating
+        # the row before the POST would not exercise it: the entry read would
+        # already carry the co-coach's entry.
+        stale = EventConnection.objects.select_related(
+            "requester", "recipient", "event", "assigned_coach"
+        ).get(pk=lead.pk)
+        lead.log_system_action("recipient_outreach", actor="cocoach:other")
+        lead.save(update_fields=["system_actions"])
+        assert stale.system_actions == []
+
+        client = Client()
+        _login(client, routed.user)
+        with mock.patch(
+            "crush_lu.views_coach.get_object_or_404", return_value=stale
+        ):
+            client.post(
+                _review_url(lead), {"action": "crush_record_consent", "consent": "yes"}
+            )
+
+        lead.refresh_from_db()
+        types = [a["type"] for a in lead.system_actions]
+        # Both survive: the append-only trail is the point, and the business
+        # field landing without its audit row defeats it.
+        assert "recipient_outreach" in types
+        assert "crush_requester_consent" in types
+        assert lead.requester_consents_to_share is True
+
+
+class TestSweepRechecksEligibilityUnderTheLock:
+    """P2: only `reminder_sent_at` was revalidated on the locked row, so a
+    call scheduled or completed since the scan still drew a reminder."""
+
+    def _due_lead(self, coach=None):
+        coach = coach or _make_coach("r3_sweep_coach@example.com")
+        requester, req_p = _make_user("r3_sweep_req@example.com", "M")
+        recipient, _ = _make_user("r3_sweep_rec@example.com", "F")
+        req_p.assigned_coach = coach
+        req_p.save(update_fields=["assigned_coach"])
+        lead = _lead(requester, recipient, _make_event(), coach)
+        EventConnection.objects.filter(pk=lead.pk).update(
+            requested_at=timezone.now() - REMINDER_AFTER - timedelta(hours=1)
+        )
+        lead.refresh_from_db()
+        return coach, lead
+
+    def _sweep_racing(self, mutate):
+        """Run a sweep in which ``mutate`` lands *after* the candidate scan
+        and *before* any row lock — the only window the in-lock re-check
+        covers. Mutating before the sweep would just drop the lead from
+        ``reminder_candidates()`` and prove nothing about the re-check."""
+        sent = []
+
+        def notify(coach, lead):
+            sent.append(lead.pk)
+            return {"success": 1, "failed": 0, "total": 1}
+
+        class _Scanned:
+            """Stands in for the candidate queryset, firing the concurrent
+            write at the moment the sweep finishes reading its ids."""
+
+            def __init__(self, queryset):
+                self._queryset = queryset
+
+            def values_list(self, *args, **kwargs):
+                ids = list(self._queryset.values_list(*args, **kwargs))
+                mutate()
+                return ids
+
+        real = crush_leads.reminder_candidates
+        with mock.patch.object(
+            crush_leads,
+            "reminder_candidates",
+            lambda now=None: _Scanned(real(now)),
+        ):
+            return sweep_lead_reminders(notify=notify), sent
+
+    def test_a_call_scheduled_since_the_scan_cancels_the_reminder(self):
+        _, lead = self._due_lead()
+
+        result, sent = self._sweep_racing(
+            lambda: EventConnection.objects.filter(pk=lead.pk).update(
+                coach_call_scheduled_at=timezone.now()
+            )
+        )
+
+        assert sent == []
+        assert result["sent"] == 0
+        lead.refresh_from_db()
+        # ...and the stamp is not consumed, so nothing is silently swallowed.
+        assert lead.reminder_sent_at is None
+
+    def test_a_lead_declined_since_the_scan_is_not_reminded(self):
+        _, lead = self._due_lead()
+
+        result, sent = self._sweep_racing(
+            lambda: EventConnection.objects.filter(pk=lead.pk).update(
+                status="declined"
+            )
+        )
+
+        assert sent == []
+        assert result["sent"] == 0
+
+    def test_a_still_eligible_lead_is_reminded(self):
+        """Positive control — the re-check must not swallow the normal path."""
+        _, lead = self._due_lead()
+
+        result, sent = self._sweep_racing(lambda: None)
+
+        assert sent == [lead.pk]
+        assert result["sent"] == 1
+        lead.refresh_from_db()
+        assert lead.reminder_sent_at is not None
+
+
+class TestSweepFitsTheCallersTimeBudget:
+    """P2: 200 leads x serial pushes at up to 10s each does not fit the Azure
+    Function's 60s timeout, so the count cap alone left most of a batch late."""
+
+    def _due_leads(self, count):
+        coach = _make_coach("r3_budget_coach@example.com")
+        event = _make_event()
+        leads = []
+        for i in range(count):
+            requester, req_p = _make_user(f"r3_budget_req{i}@example.com", "M")
+            recipient, _ = _make_user(f"r3_budget_rec{i}@example.com", "F")
+            req_p.assigned_coach = coach
+            req_p.save(update_fields=["assigned_coach"])
+            lead = _lead(requester, recipient, event, coach)
+            EventConnection.objects.filter(pk=lead.pk).update(
+                requested_at=timezone.now() - REMINDER_AFTER - timedelta(hours=1)
+            )
+            leads.append(lead)
+        return coach, leads
+
+    def test_the_sweep_stops_when_the_budget_is_spent(self):
+        _, leads = self._due_leads(4)
+        ticks = iter([0, 0, 10, 20, 30, 40, 50, 60, 70])
+        sent = []
+
+        def notify(coach, lead):
+            sent.append(lead.pk)
+            return {"success": 1, "failed": 0, "total": 1}
+
+        result = sweep_lead_reminders(
+            notify=notify, time_budget=25, clock=lambda: next(ticks)
+        )
+
+        assert len(sent) < len(leads)
+        assert result["truncated"] is True
+
+    def test_the_leads_it_skipped_stay_queued(self):
+        """Out of time is not out of work — the rest must remain eligible."""
+        _, leads = self._due_leads(4)
+        ticks = iter([0, 0, 10, 20, 30, 40, 50, 60, 70])
+
+        sweep_lead_reminders(
+            notify=lambda c, l: {"success": 1, "failed": 0, "total": 1},
+            time_budget=25,
+            clock=lambda: next(ticks),
+        )
+
+        unsent = [
+            lead
+            for lead in leads
+            if EventConnection.objects.get(pk=lead.pk).reminder_sent_at is None
+        ]
+        assert unsent, "the truncated remainder must stay eligible"
+
+    def test_a_sweep_inside_its_budget_is_not_truncated(self):
+        _, leads = self._due_leads(3)
+
+        result = sweep_lead_reminders(
+            notify=lambda c, l: {"success": 1, "failed": 0, "total": 1},
+            clock=lambda: 0,
+        )
+
+        assert result["sent"] == len(leads)
+        assert result["truncated"] is False

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -4868,6 +4868,7 @@ def coach_crush_outreach_task(request, connection_id):
             # instance loaded before the transaction can clobber an audit
             # entry the response branch committed in between — leaving the
             # business fields correct but the append-only trail missing a row.
+            closed_under_lock = False
             with transaction.atomic():
                 connection = (
                     EventConnection.objects.select_for_update()
@@ -4878,10 +4879,9 @@ def coach_crush_outreach_task(request, connection_id):
                 # instance read at request entry: the routed coach could have
                 # declined the lead in between, and outreach must not be
                 # timestamped onto an already-closed lead.
-                if (
-                    connection.recipient_outreach_at is None
-                    and connection.status in EventConnection.OPEN_LEAD_STATUSES
-                ):
+                if connection.status not in EventConnection.OPEN_LEAD_STATUSES:
+                    closed_under_lock = True
+                elif connection.recipient_outreach_at is None:
                     connection.recipient_outreach_at = now
                     connection.log_system_action(
                         "recipient_outreach",
@@ -4891,11 +4891,21 @@ def coach_crush_outreach_task(request, connection_id):
                     connection.save(
                         update_fields=["recipient_outreach_at", "system_actions"]
                     )
-            messages.success(request, _("Outreach recorded."))
+            if closed_under_lock:
+                # The write was skipped because the lead closed while this
+                # request waited on the row lock — reporting "recorded" would
+                # tell the co-coach an outreach the SLA has no record of did
+                # land. Re-recording an outreach on a *live* lead is still a
+                # true no-op, so that case keeps the success message: it is
+                # accurate about the resulting state.
+                messages.info(request, _("This lead is closed."))
+            else:
+                messages.success(request, _("Outreach recorded."))
 
         elif action in ("record_consent", "record_decline"):
             consented = action == "record_consent"
             recorded = False
+            closed_under_lock = False
             with transaction.atomic():
                 # Lock and re-read: two concurrent submissions could both
                 # observe recipient_response=None and both pass the guard,
@@ -4907,10 +4917,9 @@ def coach_crush_outreach_task(request, connection_id):
                     .select_related("recipient", "event", "assigned_coach")
                     .get(pk=connection.pk)
                 )
-                if (
-                    connection.recipient_response is None
-                    and connection.status in EventConnection.OPEN_LEAD_STATUSES
-                ):
+                if connection.status not in EventConnection.OPEN_LEAD_STATUSES:
+                    closed_under_lock = True
+                elif connection.recipient_response is None:
                     recorded = True
                     connection.recipient_response = (
                         EventConnection.RECIPIENT_RESPONSE_CONSENTED
@@ -4980,6 +4989,12 @@ def coach_crush_outreach_task(request, connection_id):
                     request,
                     _("Consent recorded.") if consented else _("Decline recorded."),
                 )
+            elif closed_under_lock:
+                # No answer was recorded here — the lead closed while this
+                # request waited on the row lock. Saying the answer "was
+                # already recorded" would send the co-coach looking for a
+                # decision nobody made.
+                messages.info(request, _("This lead is closed."))
             else:
                 # The answer is final by design, so a stale page, a
                 # double-click, or the losing side of a concurrent submission

--- a/crush_lu/views_coach.py
+++ b/crush_lu/views_coach.py
@@ -4019,8 +4019,40 @@ def coach_connection_review(request, connection_id):
             messages.success(request, _("Notes saved."))
 
         elif action == "approve":
+            # A declined crush lead is over: the co-coach recorded the
+            # recipient's refusal, or a member blocked the pair. This handler
+            # sets `coach_approved` unconditionally, so without the guard a
+            # routed coach holding a page from before the decline can reopen a
+            # cancelled lead and leave it contradicting itself — a `declined`
+            # recipient_response sitting on an approved row, with the
+            # introduction one consent away from happening anyway.
+            # Deliberately narrow: only `declined` is terminal here. `accepted`
+            # is not a closed state, and legacy rows keep their old behaviour.
+            if (
+                connection.flow == EventConnection.FLOW_CRUSH
+                and connection.status == "declined"
+            ):
+                messages.info(request, _("This lead is closed."))
+                return redirect(
+                    "crush_lu:coach_connection_review", connection_id=connection.id
+                )
+
             # Approve the connection - move to coach_approved
             with transaction.atomic():
+                # Re-read under the lock: the decline this guard defends
+                # against can land between the check above and the write.
+                if connection.flow == EventConnection.FLOW_CRUSH:
+                    locked = (
+                        EventConnection.objects.select_for_update()
+                        .only("id", "status")
+                        .get(pk=connection.pk)
+                    )
+                    if locked.status == "declined":
+                        messages.info(request, _("This lead is closed."))
+                        return redirect(
+                            "crush_lu:coach_connection_review",
+                            connection_id=connection.id,
+                        )
                 connection.coach_notes = request.POST.get("coach_notes", "").strip()
                 connection.coach_introduction = request.POST.get(
                     "coach_introduction", ""
@@ -4106,106 +4138,233 @@ def coach_connection_review(request, connection_id):
                     "crush_lu:coach_connection_review", connection_id=connection.id
                 )
 
+            # An unrouted pool lead passes the ownership check above, because
+            # that only rejects a row assigned to *someone else*. Opening and
+            # claiming one is deliberate (it is how a lead gets triaged), but
+            # every other write needs an owner: otherwise any active coach can
+            # mark an unowned lead's call completed — dropping it out of
+            # `open_crush_leads()` while it still belongs to nobody — or move
+            # its consent and audit state without taking responsibility for it.
+            if action != "crush_start_review" and connection.assigned_coach is None:
+                messages.error(request, _("Claim this lead before working it."))
+                return redirect(
+                    "crush_lu:coach_connection_review", connection_id=connection.id
+                )
+
             actor = f"coach:{coach.user.username}"
             now = timezone.now()
 
-            if action == "crush_start_review":
-                # `pending` is the normal starting state here — waiting for
-                # `accepted` would wait forever.
-                if connection.status == "pending":
-                    connection.status = "coach_reviewing"
-                    connection.assigned_coach = coach
-                    connection.log_system_action("crush_start_review", actor=actor)
-                    connection.save(
-                        update_fields=["status", "assigned_coach", "system_actions"]
+            # Every branch below appends to `system_actions` and saves the
+            # whole JSON field. Reading it from the instance loaded at request
+            # entry would overwrite an entry the co-coach's surface committed
+            # in between — the business fields survive, the append-only trail
+            # does not. Lock and re-read once here and dispatch inside the
+            # lock, the same way both co-coach branches do.
+            with transaction.atomic():
+                connection = (
+                    EventConnection.objects.select_for_update()
+                    .select_related(
+                        "requester", "recipient", "event", "assigned_coach",
+                        "recipient_coach",
                     )
-                    messages.success(request, _("Lead is now under your review."))
-                else:
-                    messages.info(request, _("This lead is already under review."))
+                    .get(pk=connection.pk)
+                )
 
-            elif action == "crush_schedule_call":
-                raw = request.POST.get("scheduled_at", "").strip()
-                scheduled = parse_datetime(raw) if raw else None
-                if scheduled is None:
-                    messages.error(request, _("Enter a valid date and time."))
-                else:
-                    if timezone.is_naive(scheduled):
-                        scheduled = timezone.make_aware(scheduled)
-                    connection.coach_call_scheduled_at = scheduled
-                    connection.log_system_action(
-                        "crush_call_scheduled",
-                        actor=actor,
-                        scheduled_at=scheduled.isoformat(),
+                # A lead the co-coach declined, or a member blocked, is over.
+                # Without this a stale workspace page could log a call or move
+                # the consent state of a cancelled pair.
+                if connection.status not in EventConnection.OPEN_LEAD_STATUSES:
+                    messages.info(request, _("This lead is closed."))
+                    return redirect(
+                        "crush_lu:coach_connection_review",
+                        connection_id=connection.id,
                     )
-                    connection.save(
-                        update_fields=["coach_call_scheduled_at", "system_actions"]
-                    )
-                    messages.success(request, _("Call scheduled."))
 
-            elif action == "crush_complete_call":
-                outcome = request.POST.get("call_outcome", "")
-                valid = {c[0] for c in EventConnection.CALL_OUTCOME_CHOICES}
-                if outcome not in valid:
-                    messages.error(request, _("Choose a call outcome."))
-                else:
-                    connection.call_outcome = outcome
-                    fields = ["call_outcome", "system_actions"]
-                    # Only a genuinely completed call closes the SLA. A
-                    # no-answer / unreachable lead stays open and keeps its
-                    # queue row — that is the point of tracking the outcome.
-                    if outcome == "completed":
-                        connection.coach_call_completed_at = now
-                        fields.append("coach_call_completed_at")
+                if action == "crush_start_review":
+                    # `pending` is the normal starting state here — waiting for
+                    # `accepted` would wait forever.
+                    if connection.status == "pending":
+                        connection.status = "coach_reviewing"
+                        connection.assigned_coach = coach
+                        connection.log_system_action("crush_start_review", actor=actor)
+                        connection.save(
+                            update_fields=["status", "assigned_coach", "system_actions"]
+                        )
+                        messages.success(request, _("Lead is now under your review."))
                     else:
-                        # Re-arm the reminder so an unreachable member gets
-                        # chased again rather than silently dropped.
-                        connection.reminder_sent_at = None
-                        fields.append("reminder_sent_at")
+                        messages.info(request, _("This lead is already under review."))
+
+                elif action == "crush_schedule_call":
+                    raw = request.POST.get("scheduled_at", "").strip()
+                    scheduled = parse_datetime(raw) if raw else None
+                    if scheduled is None:
+                        messages.error(request, _("Enter a valid date and time."))
+                    else:
+                        if timezone.is_naive(scheduled):
+                            scheduled = timezone.make_aware(scheduled)
+                        connection.coach_call_scheduled_at = scheduled
+                        connection.log_system_action(
+                            "crush_call_scheduled",
+                            actor=actor,
+                            scheduled_at=scheduled.isoformat(),
+                        )
+                        connection.save(
+                            update_fields=["coach_call_scheduled_at", "system_actions"]
+                        )
+                        messages.success(request, _("Call scheduled."))
+
+                elif action == "crush_complete_call":
+                    outcome = request.POST.get("call_outcome", "")
+                    valid = {c[0] for c in EventConnection.CALL_OUTCOME_CHOICES}
+                    if outcome not in valid:
+                        messages.error(request, _("Choose a call outcome."))
+                    else:
+                        connection.call_outcome = outcome
+                        fields = [
+                            "call_outcome",
+                            "coach_call_completed_at",
+                            "system_actions",
+                        ]
+                        # Only a genuinely completed call closes the SLA. A
+                        # no-answer / unreachable lead stays open and keeps its
+                        # queue row — that is the point of tracking the outcome.
+                        if outcome == "completed":
+                            connection.coach_call_completed_at = now
+                        else:
+                            # Correcting a completed call to a non-completed
+                            # outcome has to withdraw the completion too. Left
+                            # set, the lead reads as completed, stays out of
+                            # `open_crush_leads()` and off the queue — so the
+                            # re-armed reminder below would never fire either,
+                            # and the correction would quietly lose the lead.
+                            connection.coach_call_completed_at = None
+                            # Re-arm the reminder so an unreachable member gets
+                            # chased again rather than silently dropped.
+                            connection.reminder_sent_at = None
+                            fields.append("reminder_sent_at")
+                        connection.log_system_action(
+                            "crush_call_logged", actor=actor, outcome=outcome
+                        )
+                        connection.save(update_fields=fields)
+                        messages.success(request, _("Call outcome recorded."))
+
+                elif action == "crush_record_consent":
+                    # The crusher consents verbally on the call — the member-side
+                    # consent form is closed for crush leads (§7), so the routed
+                    # coach is the only one who can record it.
+                    consented = request.POST.get("consent") == "yes"
+                    connection.requester_consents_to_share = consented
                     connection.log_system_action(
-                        "crush_call_logged", actor=actor, outcome=outcome
+                        "crush_requester_consent", actor=actor, consented=consented
                     )
-                    connection.save(update_fields=fields)
-                    messages.success(request, _("Call outcome recorded."))
-
-            elif action == "crush_record_consent":
-                # The crusher consents verbally on the call — the member-side
-                # consent form is closed for crush leads (§7), so the routed
-                # coach is the only one who can record it.
-                consented = request.POST.get("consent") == "yes"
-                connection.requester_consents_to_share = consented
-                connection.log_system_action(
-                    "crush_requester_consent", actor=actor, consented=consented
-                )
-                connection.save(
-                    update_fields=["requester_consents_to_share", "system_actions"]
-                )
-                messages.success(request, _("Consent recorded."))
-
-            elif action == "crush_share":
-                if connection.can_share_contacts:
-                    connection.status = "shared"
-                    connection.shared_at = now
-                    connection.log_system_action("crush_shared", actor=actor)
                     connection.save(
-                        update_fields=["status", "shared_at", "system_actions"]
+                        update_fields=["requester_consents_to_share", "system_actions"]
                     )
-                    messages.success(
-                        request, _("Introduction made — contacts shared.")
-                    )
-                else:
-                    messages.error(
-                        request,
-                        _(
-                            "Both members must consent and the lead must be "
-                            "approved before sharing."
-                        ),
-                    )
+                    messages.success(request, _("Consent recorded."))
+
+                elif action == "crush_record_recipient_consent":
+                    # No live co-coach means no co-coach task exists, and the
+                    # recipient has no consent form of their own — so without
+                    # this nothing could ever write `recipient_consents_to_share`
+                    # and `can_share_contacts` would stay false forever, leaving
+                    # the lead stuck at `coach_approved`. The routed coach makes
+                    # both calls in that case, which is exactly what
+                    # `assign_recipient_coach` returning None already assumes.
+                    if connection.has_active_recipient_coach:
+                        messages.error(
+                            request,
+                            _("The recipient's own coach records their answer."),
+                        )
+                    elif connection.recipient_response is not None:
+                        messages.info(
+                            request,
+                            _("This answer was already recorded and cannot be changed."),
+                        )
+                    else:
+                        consented = request.POST.get("consent") == "yes"
+                        connection.recipient_response = (
+                            EventConnection.RECIPIENT_RESPONSE_CONSENTED
+                            if consented
+                            else EventConnection.RECIPIENT_RESPONSE_DECLINED
+                        )
+                        connection.recipient_response_at = now
+                        connection.recipient_consents_to_share = consented
+                        fields = [
+                            "recipient_response",
+                            "recipient_response_at",
+                            "recipient_consents_to_share",
+                            "system_actions",
+                        ]
+                        connection.log_system_action(
+                            "recipient_consent" if consented else "recipient_decline",
+                            actor=actor,
+                            by_routed_coach=True,
+                        )
+                        if connection.recipient_outreach_at is None:
+                            # Same back-fill the co-coach surface does: an
+                            # answer can only exist because someone spoke to
+                            # them, so the SLA must not read as never contacted.
+                            connection.recipient_outreach_at = now
+                            connection.log_system_action(
+                                "recipient_outreach", actor=actor, inferred=True
+                            )
+                            fields.append("recipient_outreach_at")
+                        if not consented:
+                            # A decline ends the lead, and the crusher is never
+                            # told they were refused.
+                            connection.status = "declined"
+                            fields.append("status")
+                        connection.save(update_fields=fields)
+                        messages.success(
+                            request,
+                            _("Recipient consent recorded.")
+                            if consented
+                            else _("Recipient decline recorded."),
+                        )
+
+                elif action == "crush_share":
+                    if connection.can_share_contacts:
+                        connection.status = "shared"
+                        connection.shared_at = now
+                        connection.log_system_action("crush_shared", actor=actor)
+                        connection.save(
+                            update_fields=["status", "shared_at", "system_actions"]
+                        )
+                        messages.success(
+                            request, _("Introduction made — contacts shared.")
+                        )
+                    else:
+                        messages.error(
+                            request,
+                            _(
+                                "Both members must consent and the lead must be "
+                                "approved before sharing."
+                            ),
+                        )
 
             return redirect(
                 "crush_lu:coach_connection_review", connection_id=connection.id
             )
 
         elif action == "send_message":
+            # No chat exists on a crush lead before the introduction (§7):
+            # the two members have not been told about each other yet, and
+            # `shared` is the moment that changes. Any action not starting
+            # with `crush_` falls through to here, so the invariant has to
+            # hold server-side rather than by the member surfaces declining
+            # to render a thread.
+            if (
+                connection.flow == EventConnection.FLOW_CRUSH
+                and connection.status != "shared"
+            ):
+                messages.error(
+                    request,
+                    _("Messages open once the introduction has been made."),
+                )
+                return redirect(
+                    "crush_lu:coach_connection_review", connection_id=connection.id
+                )
+
             # Coach sends a facilitation message
             message_text = request.POST.get("message", "").strip()
             if message_text and len(message_text) <= 500:
@@ -4294,6 +4453,18 @@ def coach_connection_review(request, connection_id):
         "show_facilitation": show_facilitation,
         "is_crush_lead": is_crush_lead,
         "lead_needs_claim": lead_needs_claim,
+        "lead_open": connection.status in EventConnection.OPEN_LEAD_STATUSES,
+        # With no live co-coach there is no co-coach task, and the recipient
+        # has no consent form of their own — so this coach records both
+        # answers or the lead can never reach `shared`.
+        "records_recipient_answer": (
+            is_crush_lead and not connection.has_active_recipient_coach
+        ),
+        "recipient_answer": connection.recipient_response,
+        # A crush lead has no thread until the introduction is made (§7).
+        "show_conversation": (
+            not is_crush_lead or connection.status == "shared"
+        ),
         "call_outcome_choices": EventConnection.CALL_OUTCOME_CHOICES,
         "can_share_now": connection.can_share_contacts,
         "intro_templates": intro_templates_for_picker,

--- a/docs/superpowers/specs/2026-07-25-crush-my-crush-staging-verification.md
+++ b/docs/superpowers/specs/2026-07-25-crush-my-crush-staging-verification.md
@@ -1,0 +1,109 @@
+# "My Crush!" — staging verification checklist
+
+Spec: `docs/superpowers/specs/2026-07-21-crush-my-crush-post-event-flow.md`
+
+**Status: open. Do this once Phase E lands and the whole flow is deployed to
+staging — not before.** Phases B–D each shipped one slice of the flow, so
+until Phase E there is no end-to-end path to walk.
+
+## Why this file exists
+
+Everything below is covered by unit tests, and those tests pass. They are
+still not proof. Each item here is a place where the test asserts against a
+**substitute** for the real thing — an injected notifier instead of Web Push,
+a mocked clock instead of elapsed time, a hand-mutated row instead of two
+concurrent requests. The logic is verified; the wiring is not.
+
+The three review rounds on #683 landed in exactly this gap twice: a failure
+test whose fake notifier *raised* passed while the real helper *returned* its
+errors, and a race test that closed the row before the request so it never
+reached the code it was written for. A green suite did not catch either.
+
+So: none of these are known bugs. They are the claims a test cannot make.
+
+## Infrastructure — the reminder sweep
+
+The sweep (`crush_lu/services/crush_leads.py`) is driven by the
+`CrushLeadReminders` timer on the `crush-hybrid-maintenance` Function App,
+hourly at :45, via `POST /api/admin/crush-lead-reminders/`.
+
+- [ ] **`DJANGO_CRUSH_LEAD_REMINDERS_URL` is actually set** on the Function
+      App. Unset logs an error and no-ops, so the 24h reminder would silently
+      never fire — and nothing else in the system would notice. This is the
+      single highest-value check on the page.
+- [ ] A real reminder push **arrives on a real device**, and its body does not
+      contain the `requester_note` (it is deliberately kept out of the payload
+      — push surfaces on a lock screen).
+- [ ] A coach with **two devices, one with `notify_screening_reminders` off**,
+      receives the reminder only on the opted-in device. Unit-tested against a
+      captured send list; never against real subscriptions.
+- [ ] **VAPID misconfiguration is distinguishable from opt-out.** Break the
+      VAPID keys deliberately, run the sweep, confirm `reminder_sent_at` rolls
+      back and the lead is still eligible on the next run. Both paths return a
+      zero-total result; only a flag separates them.
+- [ ] **Delivery failure rolls the stamp back** with the real push helper, not
+      an injected one. This is the exact shape that fooled the first fix.
+- [ ] **The timer's 60s budget holds** under a realistic backlog. The
+      wall-clock budget (`REMINDER_TIME_BUDGET`, 45s) is tested with a fake
+      clock; it has never met a slow endpoint. Check the Function does not
+      time out and that `truncated` shows up in logs rather than a silent
+      partial sweep.
+- [ ] **Two overlapping timer deliveries send exactly one reminder** per lead.
+      `skip_locked` is the mechanism; SQLite in tests does not exercise it, and
+      staging is Postgres.
+
+## Concurrency — verified only against simulated races
+
+Every race below is unit-tested by hand-constructing the interleaving (a
+stale instance held across a committed write, or a `.update()` between scan
+and lock). None has been observed with two real requests.
+
+- [ ] Two coaches acting on the same lead at once leave a **consistent
+      `system_actions` trail** — no entry overwritten. Appending to a JSON
+      field is a read-modify-write; the locks are correct in principle.
+- [ ] The co-coach recording an answer while the routed coach **declines**
+      resolves one way only, with a message matching what actually happened
+      ("this lead is closed", not "already recorded").
+- [ ] `record_outreach` on a lead closing underneath it neither stamps the
+      field nor reports success.
+- [ ] Postgres row locking behaves as assumed throughout — the suite runs on
+      SQLite, so `select_for_update` is effectively a no-op there.
+
+## The flow end to end (needs Phase E)
+
+- [ ] **Different coaches on each half:** declare → routed coach calls the
+      crusher → co-coach reaches the recipient → consent → introduction. The
+      privacy line holds throughout: the co-coach never sees the crusher's
+      identity or note.
+- [ ] **Same coach on both halves**, and **recipient's coach deactivated
+      mid-flow** — both now route through `crush_record_recipient_consent` on
+      the routed coach's page. This was a hard deadlock until #685; walk it
+      end to end rather than trusting the unit test.
+- [ ] A **declined** recipient ends the lead and the crusher is never told
+      they were refused — check every surface, including notifications.
+- [ ] An **unrouted pool lead** can be opened and claimed but not worked, and
+      its note stays shut until a coach owns it.
+- [ ] A **mutual crush** flags both coaches without either learning the other
+      side's note.
+
+## UI (Phase E scope, listed here so it is not lost)
+
+- [ ] Coach surfaces in **DE and FR** — all Phase D strings are wrapped but
+      the catalogues have not been extracted.
+- [ ] **Dark mode and light mode** on the outreach task and the lead
+      workspace. A white-on-white button already shipped once in this phase
+      and was only caught by review.
+- [ ] **Mobile widths** for the workspace, which is the densest coach surface
+      in the app.
+
+## Deliberately not built
+
+Recorded so a future reader does not mistake these for oversights:
+
+- **A constrained triage surface for unrouted leads.** Routing tier 4 catches
+  any active coach, so a lead is unrouted only when the platform has zero
+  active coaches. If staging ever produces an unrouted lead with active
+  coaches present, that reachability argument is wrong — reopen it.
+- **Reverting a `shared` lead via the legacy `approve` action.** The terminal
+  guard covers `declined` only. No review round raised it; noted in case
+  staging shows it matters.


### PR DESCRIPTION
Targets `feat/crush-my-crush-phase-d-coach-ui` so it lands inside #683 rather than as a separate change.

## Purpose

Two rounds of review feedback on #683 that were still open:

* **Codex round 3** (posted on `a389767`, 9 findings — 3 × P1, 6 × P2), all unresolved. I read each against the code rather than the summary; all nine are real. The through-line is that Phase D shipped the queue, the SLA and the reminder *before* the controls they key off, so several are the second half of an earlier fix rather than a new problem.
* **The last claude[bot] finding**: `record_outreach` reported `"Outreach recorded."` even when the locked status re-check correctly skipped the write.

### P1 — the recipient's answer had no writer

`assign_recipient_coach` leaves `recipient_coach` null whenever both sides share a coach or the recipient has no active coach, and only the co-coach surface could write `recipient_consents_to_share`. On those leads `can_share_contacts` could never become true and the lead sat at `coach_approved` forever. Codex was right that the tests hid it: the same-coach test only asserted no task was created, and the workflow test set the flag directly. Adds `crush_record_recipient_consent`, rendered only when there is no live co-coach, with the co-coach branch's semantics (final answer, inferred outreach back-fill, decline ends the lead).

### P1 — a deactivated `recipient_coach` left the identical hole

`coach_required` bars them from every view while the exact-owner filter hides the task from everyone else. `has_active_recipient_coach` makes "no co-coach" and "stale co-coach" read the same, so the routed coach picks it up — the recovery the routed side already got in `05d8bf4`.

### P1 — workspace writes did not require ownership

The outer guard only rejects a lead routed to *someone else*, so on an unrouted pool lead any active coach could complete the call — dropping it out of `open_crush_leads()` while it still belonged to nobody — or move its consent and audit state. Claiming via `crush_start_review` stays open (that was the intentional part); everything else needs an owner, and the template no longer renders controls the server will refuse.

### P2 findings

* **Declines are terminal.** `approve` set `coach_approved` unconditionally, so a stale page could reopen a lead the co-coach had just declined. Guarded and re-checked under the lock. Deliberately narrowed to `declined` — `accepted` is not a closed state, and blocking it regressed `test_approve_leaves_the_other_lead_untouched`.
* **Correcting a completed call** to `no_answer`/`unreachable` re-armed the reminder but left `coach_call_completed_at` set, so the lead stayed off the queue and the re-armed reminder could never fire. The correction now withdraws the completion.
* **No messages before the introduction.** Any non-`crush_` action fell through to `send_message`. Rejected server-side; the form is no longer rendered on a pre-`shared` crush lead.
* **Routed-coach audit appends** now lock and re-read, like both co-coach branches.
* **Sweep eligibility** re-checked only `reminder_sent_at` on the locked row, so a call scheduled or a decline landing since the scan still drew a lock-screen reminder naming the requester. Reapplies the full `reminder_due()` predicate plus the routed coach's active state.
* **Sweep time budget.** 200 leads × serial pushes at up to 10s each does not fit the Function's 60s timeout. Adds a wall-clock budget that stops early and reports `truncated` rather than running on to gunicorn's kill with most of the batch late.

### The bot finding

`messages.success` sat outside both the `if` and the `with transaction.atomic()`. That re-check exists for exactly one case — the routed coach declining while the request waits on the row lock — and there the co-coach was told an outreach landed that the SLA has no record of. Same bug class `8ec9b3c` fixed for the answer branch. The answer branch had the mirror image: its "already recorded" notice also covered the closed-under-lock case, where no answer was recorded by anyone.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
git checkout claude/review-claude-codex-findings-57rr53
pytest crush_lu/tests/test_crush_leads_phase_d_codex3.py
pytest crush_lu/tests/test_crush_leads_phase_d.py
```

Full suite on this branch: **2387 passed, 27 skipped** (SQLite). `ruff check . --select=E9,F63,F7,F82` clean.

## What to Check

* **The tests were verified against the bug, not just written.** 26 of the 32 new tests in `test_crush_leads_phase_d_codex3.py` fail against `a389767`; the 6 that pass are positive controls (legacy rows unaffected, claiming still allowed, a `shared` lead still opens its thread, an eligible lead still reminded).
* **Two tests were rewritten after they passed pre-fix** — worth a look, since this is the third time this trap has come up on this PR. The audit-lock and sweep-eligibility races both need the concurrent write to land *between* the entry read and the lock; mutating before the request just drops the row from the candidate scan and proves nothing. Same reason the earlier `record_outreach` race test needed repairing.
* `has_active_recipient_coach` is the single predicate behind both P1 recipient-side findings — worth confirming you agree that a deactivated co-coach should mean "the routed coach covers both halves" rather than a claim path on the recipient task. That mirrors what `assign_recipient_coach` returning `None` already assumes.
* The `approve` guard is crush-only and `declined`-only. Reverting a `shared` lead via `approve` is still possible; no finding raised it and widening the guard felt out of scope, but say the word.
* Template comments use `{% comment %}` — `test_no_multiline_template_comments` rejects multi-line `{# #}`, which caught my first pass.

## Other Information

Not addressed, deliberately, both carried over from earlier rounds and unchanged by this work:

* Translations (Codex P2) — deferred to Phase E per the spec's own delivery plan.
* The constrained triage surface for unrouted leads (Codex P2) — closed in-thread on reachability grounds. Note this round's ownership fix tightens that area anyway: an unrouted lead is now openable and claimable but not *workable*.

Unrelated to the findings: #683 still shows a merge conflict against `main` after #681 landed — 17 hunks across 4 files, of which the `connections.py` and `crush_leads.py` ones are genuine Phase C ↔ Phase D integration rather than the mechanical take-this-branch resolution the PR body predicted. Left alone; it belongs on the PR branch, not in this fix.