### PR TITLE
Fix past event list under live overlaps

### DIFF
--- a/crush_lu/tests/test_event_time_states.py
+++ b/crush_lu/tests/test_event_time_states.py
@@ -342,6 +342,26 @@ class LiveEventDiscoveryTests(TestCase):
         self.assertIn(future_event, events)
         self.assertNotIn(ended_event, events)
 
+    def test_event_list_fills_past_after_many_overlapping_live_events(self):
+        now = timezone.now()
+        for index in range(50):
+            _make_event(
+                f"Overlapping live event {index}",
+                now - timedelta(hours=25),
+                duration_minutes=26 * 60,
+            )
+        older_past = _make_event("Older past event", now - timedelta(days=8))
+
+        response = self.client.get(
+            reverse("crush_lu:event_list"), HTTP_HOST="crush.lu"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        visible_past = [
+            event for event, _attended in response.context["past_events_with_attendance"]
+        ]
+        self.assertIn(older_past, visible_past)
+
 
 class UpcomingRegistrantSegmentTests(TestCase):
     def test_excludes_recently_ended_event_and_keeps_long_live_event(self):

--- a/crush_lu/views_events.py
+++ b/crush_lu/views_events.py
@@ -167,12 +167,28 @@ def event_list(request):
     )
     upcoming_events = [e for e in upcoming_events if e.end_time >= now]
 
-    past_events = list(
+    boundary_past = [
+        event
+        for event in MeetupEvent.objects.with_registration_counts()
+        .filter(
+            is_published=True,
+            is_cancelled=False,
+            date_time__gte=generous_cutoff,
+            date_time__lt=now,
+        )
+        .order_by("-date_time")
+        if event.end_time < now
+    ]
+    older_past = list(
         MeetupEvent.objects.with_registration_counts()
-        .filter(is_published=True, is_cancelled=False, date_time__lt=now)
-        .order_by("-date_time")[:50]
+        .filter(
+            is_published=True,
+            is_cancelled=False,
+            date_time__lt=generous_cutoff,
+        )
+        .order_by("-date_time")[:10]
     )
-    past_events = [e for e in past_events if e.end_time < now][:10]
+    past_events = (boundary_past + older_past)[:10]
 
     visible_upcoming = _filter_private_events(upcoming_events, request.user)
     visible_past = _filter_private_events(past_events, request.user)


### PR DESCRIPTION
## Summary

- split recently started past candidates from events older than the maximum live-event window
- keep older completed events available when many multi-day events are still live
- add regression coverage for the overlap scenario

## Root cause

The event list selected only the 50 most recently started events before checking each event's computed `end_time`. When those candidates were still live, they were discarded after the database slice and older completed events never reached the Past section.

This follow-up carries forward the review fix that landed on the original branch seconds after PR #668 merged.

## Impact

The Past Events section remains populated with completed events even when many overlapping long-running events occupy the recent start-time window. No model, migration, or API changes are involved.

## Validation

- `pytest crush_lu/tests/test_event_time_states.py -q -n 0 --create-db` — 14 passed
- `git diff --check origin/main...HEAD` — passed
