### PR TITLE
ci(crush): deploy the CSS the build job actually builds

### DIFF
--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -59,7 +59,27 @@ jobs:
         run: |
           npm ci
           npm run build:css:all
-          echo "✅ CSS build complete (collectstatic runs during Oryx build on Azure)"
+          echo "✅ CSS build complete"
+
+      # Without this the build above is decorative: the runner is discarded and
+      # the `deploy` job checks out afresh, so `collectstatic` packages the CSS
+      # that happens to be COMMITTED rather than the CSS just built. A stale
+      # tracked tailwind.css therefore shipped straight to production — it did,
+      # for several days, missing 5 utility classes added in #681.
+      - name: Upload built CSS
+        uses: actions/upload-artifact@v7
+        with:
+          name: built-css
+          # All four platform bundles from `build:css:all`. The common ancestor
+          # is the repo root, so the download restores each file in place.
+          path: |
+            crush_lu/static/crush_lu/css/tailwind.css
+            power_up/static/power_up/css/tailwind.css
+            tableau/static/tableau/css/tailwind.css
+            arborist/static/arborist/css/tailwind.css
+          # Fail loudly rather than silently deploying stale CSS again.
+          if-no-files-found: error
+          retention-days: 1
 
   # Deploy after build (tests already passed on the PR)
   deploy:
@@ -67,9 +87,29 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read    # Required to download the built-css artifact
       id-token: write  # Required for Azure OIDC authentication
     steps:
       - uses: actions/checkout@v7
+
+      # MUST come after checkout (which would otherwise overwrite these with the
+      # committed versions) and before collectstatic. This is what makes the
+      # `build` job's CSS the CSS that actually ships.
+      - name: Download built CSS
+        uses: actions/download-artifact@v7
+        with:
+          name: built-css
+
+      - name: Verify the built CSS landed
+        run: |
+          set -e
+          for f in crush_lu/static/crush_lu/css/tailwind.css \
+                   power_up/static/power_up/css/tailwind.css \
+                   tableau/static/tableau/css/tailwind.css \
+                   arborist/static/arborist/css/tailwind.css; do
+            test -s "$f" || { echo "❌ missing or empty after download: $f"; exit 1; }
+          done
+          echo "✅ All four CSS bundles present — collectstatic will package the built output"
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/deploy-azure-app-service-optimized.yml
+++ b/.github/workflows/deploy-azure-app-service-optimized.yml
@@ -95,6 +95,21 @@ jobs:
       # MUST come after checkout (which would otherwise overwrite these with the
       # committed versions) and before collectstatic. This is what makes the
       # `build` job's CSS the CSS that actually ships.
+      # Delete the tracked bundles FIRST, or the verification below is
+      # meaningless: checkout has already written a committed, non-empty
+      # tailwind.css to each of these paths, so a download that restored
+      # nothing (wrong artifact name, changed layout) would still pass an
+      # existence check — and collectstatic would package the stale committed
+      # file, which is the exact bug this job exists to prevent.
+      - name: Clear tracked CSS bundles
+        run: |
+          set -e
+          rm -f crush_lu/static/crush_lu/css/tailwind.css \
+                power_up/static/power_up/css/tailwind.css \
+                tableau/static/tableau/css/tailwind.css \
+                arborist/static/arborist/css/tailwind.css
+          echo "🧹 Tracked CSS removed — only the artifact can satisfy the check below"
+
       - name: Download built CSS
         uses: actions/download-artifact@v7
         with:
@@ -109,7 +124,7 @@ jobs:
                    arborist/static/arborist/css/tailwind.css; do
             test -s "$f" || { echo "❌ missing or empty after download: $f"; exit 1; }
           done
-          echo "✅ All four CSS bundles present — collectstatic will package the built output"
+          echo "✅ All four CSS bundles restored from the artifact"
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/docs/superpowers/specs/2026-07-27-crush-pre-event-readiness.md
+++ b/docs/superpowers/specs/2026-07-27-crush-pre-event-readiness.md
@@ -267,10 +267,16 @@ Detail and rationale in `2026-07-25-crush-my-crush-staging-verification.md`.
       - **Gitignoring the file would ship production with no CSS.** The option
         floated earlier is actively harmful and must not be taken.
 
-      The real fix is to make the pipeline authoritative: either build CSS inside
-      the `deploy` job before `collectstatic`, or upload the `build` job's output
-      as an artifact and download it in `deploy`. Only once the pipeline
-      genuinely produces the CSS does untracking it become safe.
+      **FIXED** — the `build` job now uploads all four platform bundles as a
+      `built-css` artifact and `deploy` downloads them after checkout and before
+      `collectstatic`, with `if-no-files-found: error` and an explicit
+      non-empty check so a silent regression fails the deploy instead of
+      shipping stale CSS again.
+
+      Untracking `tailwind.css` becomes *technically* safe once that lands, but
+      it is still not recommended: the file is useful for local dev without a
+      build step, and keeping it tracked means the artifact and the repo can be
+      diffed against each other. Revisit deliberately, not as a side effect.
 - [ ] **Reminder sweep for pool leads is deliberately not built** (§10.1). A
       coach who never opens their inbox learns nothing about an unclaimed lead.
       Open ops question, not an oversight.


### PR DESCRIPTION
## The bug

The `build` job runs `npm ci && npm run build:css:all` — and then **uploads
nothing**. The workflow contained no `upload-artifact`/`download-artifact`
anywhere. Its runner is discarded, and the `deploy` job takes a **fresh
`actions/checkout`** and runs `collectstatic` over the **tracked** files.

**So production has been serving whatever `tailwind.css` is committed to git.
The CSS build job is decorative.**

## This already bit production

The committed `crush_lu/static/crush_lu/css/tailwind.css` was last built
**2026-07-23** while templates changed **2026-07-24** in #681 — so five utility
classes were missing **from production CSS** for several days. The
`.btn-crush-solid` fix in #693 only reached prod because that PR happened to
rebuild and commit the artifact by hand.

It also made an obvious-looking cleanup dangerous: **gitignoring the built file**
— which was floated while triaging the drift — would have shipped production with
**no CSS at all**.

## The fix

`build` uploads all four platform bundles (`crush_lu`, `power_up`, `tableau`,
`arborist`) as a `built-css` artifact. `deploy` downloads them **after** checkout
(which would otherwise overwrite them with the committed versions) and **before**
`collectstatic`.

```
deploy steps:
  actions/checkout@v7
  Download built CSS        <-- new
  Verify the built CSS landed  <-- new
  Setup Python
  Build deployment package locally   (runs collectstatic)
  ...
```

`actions: read` added to the deploy job's permissions for the download.

## Two guards, because this failure mode is silent

The whole problem was that nothing complained — a stale artifact deploys exactly
like a fresh one. So:

- **`if-no-files-found: error`** on the upload — a renamed or moved output fails
  the build rather than quietly producing an empty artifact.
- **An explicit non-empty check** on all four paths after the download. Without
  it, a partial or failed restore would fall through to `collectstatic` and ship
  the committed files again — precisely the behaviour being fixed.

## Note on untracking

Untracking `tailwind.css` becomes *technically* safe once this lands, but I'd
still keep it tracked: it's useful for local dev without a build step, and it
lets the artifact and the repo be diffed against each other. Left as a deliberate
future decision rather than a side effect of this PR.

## Verification

YAML parses and step order confirmed programmatically (download and verify sit
between checkout and `collectstatic`). The real proof is the next deploy to
staging — the "Verify the built CSS landed" step will fail loudly if the artifact
hand-off doesn't work, rather than silently shipping stale CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
