### PR TITLE
feat(crush): attending the event verifies the profile

### DIFF
--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2102,18 +2102,31 @@ def _execute_luxid_direct_verify(user, profile, submission, request):
     """
     now = timezone.now()
     with transaction.atomic():
+        # Conditional claim, matching the coach/check-in verification paths
+        # (`views_checkin._apply_verification`). An unconditional save here
+        # would let a LuxID callback that read `pending` overwrite a method a
+        # door scan had already committed — and both would then emit the
+        # approval notification and referral work. Whoever claims the
+        # transition owns it; the loser leaves the record alone.
+        claimed = CrushProfile.objects.filter(
+            pk=profile.pk, verification_status__in=("incomplete", "pending")
+        ).update(
+            is_approved=True,
+            approved_at=now,
+            verification_status="verified",
+            verification_method="luxid",
+        )
+        if not claimed:
+            logger.info(
+                "[LUXID-VERIFY] Profile pk=%s was already verified by another "
+                "path; leaving it untouched",
+                profile.pk,
+            )
+            return False
         profile.is_approved = True
         profile.approved_at = now
         profile.verification_status = "verified"
         profile.verification_method = "luxid"
-        profile.save(
-            update_fields=[
-                "is_approved",
-                "approved_at",
-                "verification_status",
-                "verification_method",
-            ]
-        )
 
         if submission and submission.status == "pending":
             submission.status = "approved"
@@ -2229,10 +2242,7 @@ def auto_approve_profile_on_luxid_connect(sender, request, sociallogin, **kwargs
         if request is not None:
             messages.success(
                 request,
-                _(
-                    "Your LuxID is now connected — you can join "
-                    "Crush Connect."
-                ),
+                _("Your LuxID is now connected — you can join " "Crush Connect."),
             )
         return
 

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -712,6 +712,15 @@ document.addEventListener("alpine:init", function () {
             // --- Shared UI update logic ---
             _updateCheckinUI: function (data) {
                 var regId = data.registration_id;
+                // Attending now verifies the profile, so the row must stop
+                // showing the amber "Unverified" pill and its Verify button —
+                // otherwise the toast and the DB say verified while the list
+                // still invites a redundant (and now pointless) verification.
+                // Before the already_checked_in early return: a re-scan is
+                // exactly when a previously self-scanned attendee gets verified.
+                if (data.auto_verified) {
+                    this._markRowVerified(regId);
+                }
                 if (data.already_checked_in) return;
 
                 // Add to recent checkins list

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -658,6 +658,16 @@ document.addEventListener("alpine:init", function () {
 
             handleRemoteCheckin: function (data) {
                 var regId = data.registration_id;
+                // A verification is a genuinely new event about an ID this page
+                // has already seen: the attendee's first (unverified) scan
+                // marked the ID processed, so a later rescan that verifies them
+                // would be suppressed here and this page would keep showing the
+                // amber pill and Verify button until reload. Apply it before
+                // the duplicate check, which exists to stop repeat *check-in*
+                // toasts, not state changes.
+                if (data.auto_verified) {
+                    this._markRowVerified(regId);
+                }
                 if (this.processedIds[regId]) return;
                 this.processedIds[regId] = true;
 

--- a/crush_lu/tests/test_coach_mark_verified.py
+++ b/crush_lu/tests/test_coach_mark_verified.py
@@ -91,6 +91,19 @@ class CoachMarkVerifiedTests(SiteTestMixin, TestCase):
             is_published=True,
         )
 
+    def _grant_premium(self, user):
+        """An ACTIVE PremiumMembership — the real entitlement.
+
+        `assigned_coach` is not it: a coach is granted free on first attendance,
+        so the two must be set independently in tests or the premium rule looks
+        like it fires for ordinary attendees.
+        """
+        from crush_lu.models import PremiumMembership
+
+        return PremiumMembership.objects.create(
+            user=user, coach=self.other_coach, status="active"
+        )
+
     def _make_attendee(self, username, assigned_coach=None, status="confirmed"):
         user = User.objects.create_user(
             username=username, email=username, password="pass12345", first_name="Al"
@@ -169,10 +182,30 @@ class CoachMarkVerifiedTests(SiteTestMixin, TestCase):
         self.assertIsNone(older_pending.reviewed_at)
         self.assertEqual(expired.status, "expired")
 
+    def test_assigned_coach_alone_does_not_make_a_member_premium(self):
+        """Any coach may verify a walk-in who merely has a coach.
+
+        This is the door case that used to break: check-in assigns
+        `event.coaches.first()` to every unverified attendee, so keying the
+        premium rule off that FK meant every OTHER coach got a 403 when they
+        tried to verify someone who had just been scanned.
+        """
+        profile, reg = self._make_attendee(
+            "coached@example.com", assigned_coach=self.other_coach
+        )
+        # No PremiumMembership -> not premium, whatever the FK says.
+        self.client.force_login(self.coach_user)
+        resp = self.client.post(self._url(reg))
+        self.assertEqual(resp.status_code, 200)
+        profile.refresh_from_db()
+        self.assertEqual(profile.verification_status, "verified")
+        self.assertEqual(profile.verification_method, "coach_event")
+
     def test_premium_member_requires_assigned_coach(self):
         profile, reg = self._make_attendee(
             "premium@example.com", assigned_coach=self.other_coach
         )
+        self._grant_premium(profile.user)
 
         # The event-running coach is NOT the assigned coach -> 403.
         self.client.force_login(self.coach_user)

--- a/crush_lu/tests/test_verify_on_checkin.py
+++ b/crush_lu/tests/test_verify_on_checkin.py
@@ -281,3 +281,38 @@ def test_rescan_of_an_already_verified_attendee_reports_no_new_verification(
     again = _scan(reg, event, as_coach=coach).json()
     assert again["already_checked_in"] is True
     assert again["auto_verified"] is False
+
+
+def test_repeated_rescans_fire_the_side_effects_only_once(
+    event, coach, monkeypatch, django_capture_on_commit_callbacks
+):
+    """The welcome email has no double-send guard of its own.
+
+    `check_and_apply_profile_approved_reward` self-guards, but
+    `notify_profile_approved` does not — so the verification must happen exactly
+    once. The `select_for_update` on the re-scan path is what serialises genuine
+    concurrent scans; this pins the observable outcome.
+    """
+    calls = {"notify": 0}
+    import crush_lu.notification_service as notifications
+
+    monkeypatch.setattr(
+        notifications,
+        "notify_profile_approved",
+        lambda **kw: calls.__setitem__("notify", calls["notify"] + 1),
+    )
+
+    profile, reg = _attendee(event, "doublescan")
+    # First scan has no coach session, so it only checks in.
+    _scan(reg, event, as_coach=None)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        first = _scan(reg, event, as_coach=coach).json()
+    with django_capture_on_commit_callbacks(execute=True):
+        second = _scan(reg, event, as_coach=coach).json()
+
+    assert first["auto_verified"] is True
+    assert second["auto_verified"] is False
+    assert calls["notify"] == 1
+    profile.refresh_from_db()
+    assert profile.verification_status == "verified"

--- a/crush_lu/tests/test_verify_on_checkin.py
+++ b/crush_lu/tests/test_verify_on_checkin.py
@@ -316,3 +316,40 @@ def test_repeated_rescans_fire_the_side_effects_only_once(
     assert calls["notify"] == 1
     profile.refresh_from_db()
     assert profile.verification_status == "verified"
+
+
+def test_rescan_outside_the_checkin_window_does_not_verify(event, coach):
+    """Tickets do not expire — a months-old QR must not grant verification."""
+    profile, reg = _attendee(event, "oldticket")
+    reg.status = "attended"
+    reg.save(update_fields=["status"])
+    # Move the event far outside the +/-12h window.
+    MeetupEvent.objects.filter(pk=event.pk).update(
+        date_time=timezone.now() - timedelta(days=60)
+    )
+
+    payload = _scan(reg, event, as_coach=coach).json()
+
+    assert payload["already_checked_in"] is True
+    assert payload["auto_verified"] is False
+    profile.refresh_from_db()
+    assert profile.verification_status == "pending"
+
+
+def test_a_concurrent_verification_wins_only_once(event, coach):
+    """The pending -> verified claim is conditional, so one path wins.
+
+    Simulates the LuxID callback landing first: the row is already `verified`
+    when the scan's claim UPDATE runs, so it matches nothing and the scan must
+    not overwrite the method or re-run the side effects.
+    """
+    profile, reg = _attendee(event, "concurrent")
+    CrushProfile.objects.filter(pk=profile.pk).update(
+        verification_status="verified", is_approved=True, verification_method="luxid"
+    )
+
+    payload = _scan(reg, event, as_coach=coach).json()
+
+    assert payload["auto_verified"] is False
+    profile.refresh_from_db()
+    assert profile.verification_method == "luxid"

--- a/crush_lu/tests/test_verify_on_checkin.py
+++ b/crush_lu/tests/test_verify_on_checkin.py
@@ -1,0 +1,208 @@
+"""Attending the event verifies the profile — with two deliberate exceptions.
+
+Scanning an attendee in at the door now sets `verified` / `coach_event` for the
+ordinary walk-in, so a coach does not tap a second button. Held back for:
+
+* **premium members** — "only their own coach verifies" is intentional there;
+* **profiles with no photo** — since the fast-track change a member can complete
+  their profile without one, so a scan cannot confirm an identity against
+  anything.
+
+And the auto-verify only fires for a request carrying an **active coach's
+session**: `event_checkin_api` authenticates on the signed token alone, and the
+attendee holds their own QR, so without that check a member could POST their own
+check-in URL and self-verify.
+
+Run with: pytest crush_lu/tests/test_verify_on_checkin.py -v
+"""
+
+from datetime import date, timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.signing import Signer
+from django.test import Client
+from django.utils import timezone
+
+from crush_lu.models import (
+    CrushCoach,
+    CrushProfile,
+    EventRegistration,
+    MeetupEvent,
+    PremiumMembership,
+    UserDataConsent,
+)
+
+User = get_user_model()
+
+pytestmark = [pytest.mark.django_db, pytest.mark.urls("azureproject.urls_crush")]
+
+# A 1x1 GIF — enough for `photo_1` to be truthy.
+_GIF = (
+    b"GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!"
+    b"\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+)
+
+
+@pytest.fixture
+def event():
+    ev = MeetupEvent.objects.create(
+        title="Door event",
+        description="x",
+        event_type="mixer",
+        # Inside the +/-12h check-in window.
+        date_time=timezone.now() + timedelta(hours=1),
+        location="Luxembourg",
+        address="1 Test Street",
+        max_participants=30,
+        registration_deadline=timezone.now() + timedelta(minutes=30),
+        is_published=True,
+    )
+    return ev
+
+
+@pytest.fixture
+def coach():
+    user = User.objects.create_user(
+        username="doorcoach@t.test", email="doorcoach@t.test", password="pw12345678"
+    )
+    UserDataConsent.objects.update_or_create(
+        user=user, defaults={"crushlu_consent_given": True}
+    )
+    return CrushCoach.objects.create(user=user, bio="c", is_active=True)
+
+
+def _premium_coach():
+    """PremiumMembership requires a coach FK, so give it its own."""
+    user = User.objects.create_user(
+        username="premcoach@t.test", email="premcoach@t.test", password="pw12345678"
+    )
+    return CrushCoach.objects.create(user=user, bio="p", is_active=True)
+
+
+def _attendee(event, name, with_photo=True, premium=False):
+    email = f"{name}@t.test"
+    user = User.objects.create_user(username=email, email=email, password="pw12345678")
+    UserDataConsent.objects.update_or_create(
+        user=user, defaults={"crushlu_consent_given": True}
+    )
+    profile = CrushProfile.objects.create(
+        user=user,
+        date_of_birth=date(1994, 3, 2),
+        gender="F",
+        location="Luxembourg",
+        is_active=True,
+    )
+    if with_photo:
+        profile.photo_1.save(f"{name}.gif", SimpleUploadedFile(f"{name}.gif", _GIF))
+    CrushProfile.objects.filter(pk=profile.pk).update(
+        verification_status="pending", is_approved=False, phone_verified=True
+    )
+    if premium:
+        PremiumMembership.objects.create(
+            user=user, coach=_premium_coach(), status="active"
+        )
+    reg = EventRegistration.objects.create(event=event, user=user, status="confirmed")
+    return profile, reg
+
+
+def _scan(reg, event, as_coach=None):
+    """POST the signed check-in URL, optionally with a coach's session."""
+    client = Client()
+    if as_coach is not None:
+        client.force_login(as_coach.user)
+    token = Signer().sign(f"{reg.id}:{event.id}")
+    return client.post(f"/api/events/checkin/{reg.id}/{token}/")
+
+
+def test_scan_by_a_coach_verifies_an_ordinary_attendee(event, coach):
+    profile, reg = _attendee(event, "walkin")
+    response = _scan(reg, event, as_coach=coach)
+
+    assert response.status_code == 200
+    assert response.json()["auto_verified"] is True
+    reg.refresh_from_db()
+    profile.refresh_from_db()
+    assert reg.status == "attended"
+    assert profile.verification_status == "verified"
+    assert profile.is_approved is True
+    assert profile.verification_method == "coach_event"
+
+
+def test_toast_reports_the_attendee_as_verified(event, coach):
+    """The scanner must not warn "Unverified Profile" about someone it just verified."""
+    _profile, reg = _attendee(event, "toast")
+    payload = _scan(reg, event, as_coach=coach).json()
+    assert payload["profile"]["is_approved"] is True
+
+
+def test_premium_member_is_left_to_their_own_coach(event, coach):
+    profile, reg = _attendee(event, "premium", premium=True)
+    response = _scan(reg, event, as_coach=coach)
+
+    assert response.status_code == 200
+    assert response.json()["auto_verified"] is False
+    reg.refresh_from_db()
+    profile.refresh_from_db()
+    assert reg.status == "attended"  # still checked in
+    assert profile.verification_status == "pending"  # but not verified
+
+
+def test_profile_without_a_photo_is_not_auto_verified(event, coach):
+    """Nothing on screen to compare the person against, so nobody checked."""
+    profile, reg = _attendee(event, "nophoto", with_photo=False)
+    response = _scan(reg, event, as_coach=coach)
+
+    assert response.status_code == 200
+    assert response.json()["auto_verified"] is False
+    reg.refresh_from_db()
+    profile.refresh_from_db()
+    assert reg.status == "attended"
+    assert profile.verification_status == "pending"
+
+
+def test_self_scan_without_a_coach_session_checks_in_but_does_not_verify(event):
+    """The attendee holds their own QR — it must not be a self-verify."""
+    profile, reg = _attendee(event, "selfscan")
+    response = _scan(reg, event, as_coach=None)
+
+    assert response.status_code == 200
+    assert response.json()["auto_verified"] is False
+    reg.refresh_from_db()
+    profile.refresh_from_db()
+    assert reg.status == "attended"  # unchanged behaviour
+    assert profile.verification_status == "pending"
+    assert profile.is_approved is False
+
+
+def test_inactive_coach_session_does_not_verify(event, coach):
+    profile, reg = _attendee(event, "inactive")
+    CrushCoach.objects.filter(pk=coach.pk).update(is_active=False)
+    response = _scan(reg, event, as_coach=coach)
+
+    assert response.json()["auto_verified"] is False
+    profile.refresh_from_db()
+    assert profile.verification_status == "pending"
+
+
+def test_already_verified_profile_is_untouched(event, coach):
+    profile, reg = _attendee(event, "already")
+    CrushProfile.objects.filter(pk=profile.pk).update(
+        verification_status="verified", is_approved=True, verification_method="luxid"
+    )
+    _scan(reg, event, as_coach=coach)
+
+    profile.refresh_from_db()
+    # LuxID verification must not be overwritten with coach_event.
+    assert profile.verification_method == "luxid"
+
+
+def test_rejected_profile_is_not_verified_by_attending(event, coach):
+    profile, reg = _attendee(event, "rejected")
+    CrushProfile.objects.filter(pk=profile.pk).update(verification_status="rejected")
+    response = _scan(reg, event, as_coach=coach)
+
+    assert response.json()["auto_verified"] is False
+    profile.refresh_from_db()
+    assert profile.verification_status == "rejected"

--- a/crush_lu/tests/test_verify_on_checkin.py
+++ b/crush_lu/tests/test_verify_on_checkin.py
@@ -353,3 +353,48 @@ def test_a_concurrent_verification_wins_only_once(event, coach):
     assert payload["auto_verified"] is False
     profile.refresh_from_db()
     assert profile.verification_method == "luxid"
+
+
+def test_manual_verify_still_works_for_an_incomplete_profile(event, coach, client):
+    """The Verify button must keep working for non-`pending` profiles.
+
+    The scanner offers it for every unapproved profile, and the endpoint has
+    always guarded only on "already verified". Narrowing the shared claim to
+    `pending` broke this and — worse — reported `already_verified`, which makes
+    the client drop the button while the row stays unapproved.
+    """
+    profile, reg = _attendee(event, "incompleteprof")
+    CrushProfile.objects.filter(pk=profile.pk).update(
+        verification_status="incomplete", is_approved=False
+    )
+
+    client.force_login(coach.user)
+    response = client.post(f"/api/events/{event.id}/verify/{reg.id}/")
+
+    assert response.status_code == 200
+    assert response.json().get("already_verified") is not True
+    profile.refresh_from_db()
+    assert profile.verification_status == "verified"
+    assert profile.is_approved is True
+
+
+def test_luxid_does_not_overwrite_a_scan_that_verified_first(event, coach):
+    """LuxID must respect the same pending -> verified claim.
+
+    Otherwise a callback that read `pending` resumes after a door scan has
+    committed and overwrites `verification_method`, and both paths emit the
+    approval notification and referral work.
+    """
+    from crush_lu.signals import _execute_luxid_direct_verify
+
+    profile, reg = _attendee(event, "luxidrace")
+    # The door scan wins first.
+    assert _scan(reg, event, as_coach=coach).json()["auto_verified"] is True
+
+    # LuxID resumes holding its stale `pending` instance.
+    stale = CrushProfile.objects.get(pk=profile.pk)
+    stale.verification_status = "pending"
+    _execute_luxid_direct_verify(stale.user, stale, None, None)
+
+    profile.refresh_from_db()
+    assert profile.verification_method == "coach_event"

--- a/crush_lu/tests/test_verify_on_checkin.py
+++ b/crush_lu/tests/test_verify_on_checkin.py
@@ -206,3 +206,78 @@ def test_rejected_profile_is_not_verified_by_attending(event, coach):
     assert response.json()["auto_verified"] is False
     profile.refresh_from_db()
     assert profile.verification_status == "rejected"
+
+
+def test_referral_reward_and_welcome_email_fire(
+    event, coach, monkeypatch, django_capture_on_commit_callbacks
+):
+    """The auto-verify must run the same side effects as the Verify button.
+
+    Event verification is the primary path for new members, so skipping these
+    silently stops paying referrers and stops welcoming people.
+
+    The side effects are deferred with `transaction.on_commit` so an email is
+    never sent for a rolled-back check-in — which also means the test must
+    capture and run those callbacks, since pytest rolls its transaction back.
+    """
+    calls = {"reward": 0, "notify": 0}
+    import crush_lu.referrals as referrals
+    import crush_lu.notification_service as notifications
+
+    monkeypatch.setattr(
+        referrals,
+        "check_and_apply_profile_approved_reward",
+        lambda profile: calls.__setitem__("reward", calls["reward"] + 1),
+    )
+    monkeypatch.setattr(
+        notifications,
+        "notify_profile_approved",
+        lambda **kw: calls.__setitem__("notify", calls["notify"] + 1),
+    )
+
+    _profile, reg = _attendee(event, "sideeffects")
+    with django_capture_on_commit_callbacks(execute=True):
+        assert _scan(reg, event, as_coach=coach).json()["auto_verified"] is True
+    assert calls == {"reward": 1, "notify": 1}
+
+
+def test_pending_submission_is_approved_by_the_auto_verify(event, coach):
+    """Not just the profile fields — the submission must close too."""
+    from crush_lu.models import ProfileSubmission
+
+    profile, reg = _attendee(event, "submission")
+    sub = ProfileSubmission.objects.create(profile=profile, status="pending")
+
+    assert _scan(reg, event, as_coach=coach).json()["auto_verified"] is True
+    sub.refresh_from_db()
+    assert sub.status == "approved"
+    assert sub.reviewed_at is not None
+    assert sub.coach_id == coach.id
+
+
+def test_rescan_by_a_coach_verifies_a_self_scanned_attendee(event, coach):
+    """A first scan without a coach session must not strand them unverified."""
+    profile, reg = _attendee(event, "rescan")
+
+    first = _scan(reg, event, as_coach=None).json()
+    assert first["auto_verified"] is False
+    profile.refresh_from_db()
+    assert profile.verification_status == "pending"
+
+    second = _scan(reg, event, as_coach=coach).json()
+    assert second["already_checked_in"] is True
+    assert second["auto_verified"] is True
+    profile.refresh_from_db()
+    assert profile.verification_status == "verified"
+    assert profile.verification_method == "coach_event"
+
+
+def test_rescan_of_an_already_verified_attendee_reports_no_new_verification(
+    event, coach
+):
+    profile, reg = _attendee(event, "rescan2")
+    _scan(reg, event, as_coach=coach)
+
+    again = _scan(reg, event, as_coach=coach).json()
+    assert again["already_checked_in"] is True
+    assert again["auto_verified"] is False

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -21,9 +21,76 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from .decorators import coach_required
-from .models import EventRegistration
+from .models import CrushProfile, EventRegistration
 
 logger = logging.getLogger(__name__)
+
+
+def _scanning_coach(request):
+    """The active coach whose session made this request, or ``None``.
+
+    ``event_checkin_api`` authenticates on the **signed token only** — it has no
+    ``@coach_required`` — because the QR itself is the credential. That is fine
+    for marking attendance, but the attendee holds their own QR: without this
+    check a member could POST their own check-in URL and self-verify.
+
+    The scanner page is used by a logged-in coach and posts same-origin
+    (`fetch(url, {method:"POST"})` sends cookies), so a genuine door scan always
+    carries a coach session and a self-post never does.
+    """
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return None
+    coach = getattr(user, "crushcoach", None)
+    return coach if coach is not None and coach.is_active else None
+
+
+def _auto_verify_on_attendance(request, registration, now):
+    """Verify a `pending` profile because a coach checked them in at the door.
+
+    Attending the event *is* the verification for the ordinary walk-in, so the
+    coach should not have to tap a second button. Two deliberate exceptions keep
+    their own explicit action (the Verify button stays visible for exactly
+    these):
+
+    * **Premium members** — the "only their own coach may verify" rule is
+      intentional for paying members, so it is left to that coach.
+    * **Profiles with no photo** — since the fast-track change (PR #650) a
+      member can complete their profile without one, and a scan cannot confirm
+      an identity there is nothing on screen to compare. Verification would be
+      asserting something nobody checked.
+
+    Returns True when the profile was verified here.
+    """
+    if _scanning_coach(request) is None:
+        return False
+
+    profile = CrushProfile.objects.filter(user_id=registration.user_id).first()
+    if profile is None or profile.verification_status != "pending":
+        return False
+    if profile.has_active_premium:
+        return False
+    if not profile.photo_1:
+        return False
+
+    profile.is_approved = True
+    profile.approved_at = now
+    profile.verification_status = "verified"
+    profile.verification_method = "coach_event"
+    profile.save(
+        update_fields=[
+            "is_approved",
+            "approved_at",
+            "verification_status",
+            "verification_method",
+        ]
+    )
+    logger.info(
+        "[CHECKIN-VERIFY] Verified profile pk=%s via attendance at event pk=%s",
+        profile.pk,
+        registration.event_id,
+    )
+    return True
 
 
 @csrf_exempt
@@ -168,6 +235,9 @@ def event_checkin_api(request, registration_id, token):
         registration.checked_in_at = now
         registration.save(update_fields=["status", "checked_in_at", "updated_at"])
 
+        # Attending IS the verification, for the ordinary case.
+        auto_verified = _auto_verify_on_attendance(request, registration, now)
+
         # Quiz table assignment (if this is a quiz night event)
         try:
             quiz_event = getattr(registration.event, "quiz", None)
@@ -216,7 +286,12 @@ def event_checkin_api(request, registration_id, token):
         "attendee_name": display_name,
         "checked_in_at": now.isoformat(),
         "message": f"{display_name} has been checked in!",
+        # Built AFTER the auto-verify above, so `profile.is_approved` in the
+        # toast reflects this scan rather than the pre-check-in state — the
+        # scanner must not show an "Unverified Profile" warning for someone it
+        # just verified.
         "profile": _get_profile_data(registration),
+        "auto_verified": auto_verified,
     }
     if table_assignment:
         response_data["table_number"] = table_assignment["table_number"]
@@ -280,8 +355,13 @@ def coach_mark_verified(request, event_id, registration_id):
             )
 
         # Premium members may only be verified by their own assigned coach.
-        if profile.assigned_coach_id:
-            if profile.assigned_coach_id != coach.id:
+        # Gate on the real entitlement, not on `assigned_coach`. A coach is
+        # granted free on first attendance (`assign_coach_on_first_attendance`),
+        # so keying off the FK made an ordinary attendee "premium" the moment
+        # they were scanned — and every coach except the event's `.first()` one
+        # then got a 403 trying to verify them at the door.
+        if profile.has_active_premium:
+            if profile.assigned_coach_id and profile.assigned_coach_id != coach.id:
                 return JsonResponse(
                     {
                         "success": False,

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -58,18 +58,27 @@ def _apply_verification(profile, method, coach, now):
     DB writes only — safe to call inside a transaction. Run the side effects
     after it commits.
     """
+    # Conditional pending -> verified claim, so exactly one verification path
+    # wins. A LuxID callback can land concurrently with a coach scan: both
+    # would otherwise read `pending`, both approve, the later save would
+    # overwrite the method that actually came first, and both would send the
+    # welcome email. The UPDATE's own WHERE clause settles it without needing
+    # every caller to hold the same lock.
+    claimed = CrushProfile.objects.filter(
+        pk=profile.pk, verification_status="pending"
+    ).update(
+        is_approved=True,
+        approved_at=now,
+        verification_status="verified",
+        verification_method=method,
+    )
+    if not claimed:
+        return False
+    # Keep the in-memory instance consistent with the row we just wrote.
     profile.is_approved = True
     profile.approved_at = now
     profile.verification_status = "verified"
     profile.verification_method = method
-    profile.save(
-        update_fields=[
-            "is_approved",
-            "approved_at",
-            "verification_status",
-            "verification_method",
-        ]
-    )
 
     # Approve a pending submission opportunistically, gated on the
     # expired-latest invariant: when the newest row was closed out by the pivot
@@ -101,6 +110,7 @@ def _apply_verification(profile, method, coach, now):
                 "coach",
             ]
         )
+    return True
 
 
 def _run_post_verification_side_effects(user, profile, request, ref):
@@ -127,6 +137,31 @@ def _run_post_verification_side_effects(user, profile, request, ref):
         )
     except Exception:
         logger.warning("Failed to send approval notification for registration %s", ref)
+
+
+def _evaluate_lobby_participation(registration):
+    """Crush Connect lobby participation, after attendance is committed.
+
+    Called from the normal check-in AND after a re-scan verification: the gate
+    requires `verification_status == "verified"`, so a member verified by the
+    re-scan produced nothing on their earlier (pending) scan.
+
+    Best-effort — a lobby failure must be logged but must never fail or delay a
+    valid event check-in (spec §10.1/§19).
+    """
+    try:
+        from .services.event_lobby import handle_checkin as lobby_handle_checkin
+
+        _participation, created = lobby_handle_checkin(registration)
+        if created:
+            from .views_event_lobby import broadcast_participant_joined
+
+            broadcast_participant_joined(registration.event_id)
+    except Exception:
+        logger.exception(
+            "Event lobby participation evaluation failed for registration %s",
+            registration.id,
+        )
 
 
 def _auto_verify_on_attendance(request, registration, now):
@@ -159,7 +194,9 @@ def _auto_verify_on_attendance(request, registration, now):
     if not profile.photo_1:
         return None
 
-    _apply_verification(profile, "coach_event", coach, now)
+    if not _apply_verification(profile, "coach_event", coach, now):
+        # Another path (e.g. a concurrent LuxID callback) verified them first.
+        return None
     logger.info(
         "[CHECKIN-VERIFY] Verified profile pk=%s via attendance at event pk=%s",
         profile.pk,
@@ -230,6 +267,22 @@ def event_checkin_api(request, registration_id, token):
             status=400,
         )
 
+    # Check-in window, computed here because the already-attended branch below
+    # must respect it too: tickets do not expire, so without this a coach could
+    # scan a months-old QR and newly approve a pending profile (with referral
+    # credit and a welcome email) at a moment when an ordinary check-in would
+    # be refused outright. The rejection itself stays where it was — a re-scan
+    # outside the window still reports "already checked in" as before, it just
+    # no longer verifies.
+    checkin_window_hours = getattr(settings, "EVENT_CHECKIN_WINDOW_HOURS", 12)
+    now = timezone.now()
+    event_start = registration.event.date_time
+    from datetime import timedelta
+
+    window_start = event_start - timedelta(hours=checkin_window_hours)
+    window_end = event_start + timedelta(hours=checkin_window_hours)
+    within_checkin_window = window_start <= now <= window_end
+
     # Check if already attended
     if registration.status == "attended":
         # A re-scan must still verify. Two ways to be here with a pending
@@ -244,16 +297,17 @@ def event_checkin_api(request, registration_id, token):
         # self-guards, but `notify_profile_approved` does not — the attendee
         # would get two "you're approved" emails. Serialising here means the
         # loser re-reads `verified` and does nothing.
-        # `now` is only bound below, with the check-in window check.
-        with transaction.atomic():
-            locked_registration = (
-                EventRegistration.objects.select_for_update()
-                .select_related("event", "user")
-                .get(id=registration_id)
-            )
-            rescan_verified = _auto_verify_on_attendance(
-                request, locked_registration, timezone.now()
-            )
+        rescan_verified = None
+        if within_checkin_window:
+            with transaction.atomic():
+                locked_registration = (
+                    EventRegistration.objects.select_for_update()
+                    .select_related("event", "user")
+                    .get(id=registration_id)
+                )
+                rescan_verified = _auto_verify_on_attendance(
+                    request, locked_registration, now
+                )
         if rescan_verified is not None:
             # `registration` was loaded with `user__crushprofile` selected, so
             # its cached profile predates the write above — re-read it or the
@@ -284,6 +338,12 @@ def event_checkin_api(request, registration_id, token):
             _run_post_verification_side_effects(
                 registration.user, rescan_verified, request, registration.id
             )
+            # Re-evaluate lobby participation. `participant_gate` requires
+            # `verification_status == "verified"`, so the hook that ran on the
+            # original (pending) scan created nothing — without this the member
+            # stays off the live roster until they open the lobby themselves and
+            # trip its self-heal.
+            _evaluate_lobby_participation(registration)
             _broadcast_checkin(registration.event_id, response_data)
         return JsonResponse(response_data)
 
@@ -297,16 +357,9 @@ def event_checkin_api(request, registration_id, token):
             status=400,
         )
 
-    # Check event is within check-in window
-    checkin_window_hours = getattr(settings, "EVENT_CHECKIN_WINDOW_HOURS", 12)
-    now = timezone.now()
-    event_start = registration.event.date_time
-    from datetime import timedelta
-
-    window_start = event_start - timedelta(hours=checkin_window_hours)
-    window_end = event_start + timedelta(hours=checkin_window_hours)
-
-    if not (window_start <= now <= window_end):
+    # Check event is within check-in window (computed above, before the
+    # already-attended branch, which needs it too).
+    if not within_checkin_window:
         return JsonResponse(
             {
                 "success": False,
@@ -401,21 +454,8 @@ def event_checkin_api(request, registration_id, token):
             )
 
     # Crush Connect Event Lobby: evaluate participation only after attendance
-    # committed. Best-effort — a lobby failure must be logged but must never
-    # fail or delay a valid event check-in (spec §10.1/§19).
-    try:
-        from .services.event_lobby import handle_checkin as lobby_handle_checkin
-
-        _lobby_participation, lobby_created = lobby_handle_checkin(registration)
-        if lobby_created:
-            from .views_event_lobby import broadcast_participant_joined
-
-            broadcast_participant_joined(registration.event_id)
-    except Exception:
-        logger.exception(
-            "Event lobby participation evaluation failed for registration %s",
-            registration.id,
-        )
+    # committed.
+    _evaluate_lobby_participation(registration)
 
     display_name = _get_display_name(registration)
 
@@ -534,7 +574,21 @@ def coach_mark_verified(request, event_id, registration_id):
 
         # Same workflow the auto-verify on attendance runs, so the two paths
         # cannot drift apart.
-        _apply_verification(profile, method, coach, now)
+        if not _apply_verification(profile, method, coach, now):
+            # Lost the pending -> verified claim to a concurrent path. Report
+            # the same idempotent success as an already-verified profile
+            # rather than running the side effects a second time.
+            profile.refresh_from_db()
+            return JsonResponse(
+                {
+                    "success": True,
+                    "already_verified": True,
+                    "registration_id": registration.id,
+                    "attendee_name": _get_display_name(registration),
+                    "verification_method": profile.verification_method,
+                    "message": str(_("Already verified.")),
+                }
+            )
 
     logger.info(
         "Coach %s verified registration %s (user %s) at event %s via %s",

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -237,10 +237,22 @@ def event_checkin_api(request, registration_id, token):
         # endpoint deliberately still allows), or the row was marked attended
         # before this feature existed. Without this the coach is silently back
         # to tapping Verify.
+        # Lock the registration first, matching the main check-in path below.
+        # Without it two near-simultaneous re-scans (a double-tap, or two
+        # coaches scanning the same badge) can both read `pending`, both
+        # verify, and both schedule the side effects. The referral reward
+        # self-guards, but `notify_profile_approved` does not — the attendee
+        # would get two "you're approved" emails. Serialising here means the
+        # loser re-reads `verified` and does nothing.
         # `now` is only bound below, with the check-in window check.
         with transaction.atomic():
+            locked_registration = (
+                EventRegistration.objects.select_for_update()
+                .select_related("event", "user")
+                .get(id=registration_id)
+            )
             rescan_verified = _auto_verify_on_attendance(
-                request, registration, timezone.now()
+                request, locked_registration, timezone.now()
             )
         if rescan_verified is not None:
             # `registration` was loaded with `user__crushprofile` selected, so
@@ -339,12 +351,21 @@ def event_checkin_api(request, registration_id, token):
             if table_info:
                 response_data.update(table_info)
             if already_verified_profile is not None:
+                # This branch is the loser of the `select_for_update` race, but
+                # it still performs real writes, so it must announce them like
+                # its sibling above — otherwise other coaches watching the live
+                # list never see the row flip to verified until they reload.
+                # Deferred to commit so the broadcast cannot describe a state
+                # that gets rolled back.
                 transaction.on_commit(
-                    lambda: _run_post_verification_side_effects(
-                        registration.user,
-                        already_verified_profile,
-                        request,
-                        registration.id,
+                    lambda: (
+                        _run_post_verification_side_effects(
+                            registration.user,
+                            already_verified_profile,
+                            request,
+                            registration.id,
+                        ),
+                        _broadcast_checkin(registration.event_id, response_data),
                     )
                 )
             return JsonResponse(response_data)

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -45,7 +45,15 @@ def _scanning_coach(request):
     return coach if coach is not None and coach.is_active else None
 
 
-def _apply_verification(profile, method, coach, now):
+#: Statuses the manual Verify button may transition from. The endpoint has
+#: always guarded only on "already verified" and approved anything else, so
+#: narrowing this to `pending` would silently stop coaches verifying
+#: `incomplete` walk-ins at the door — the scanner still offers the button for
+#: every unapproved profile.
+MANUAL_VERIFY_CLAIM_FROM = ("incomplete", "pending", "rejected")
+
+
+def _apply_verification(profile, method, coach, now, claim_from=("pending",)):
     """Persist a verification — fields AND the pending submission.
 
     Shared by the manual Verify button and the auto-verify on attendance so the
@@ -65,7 +73,7 @@ def _apply_verification(profile, method, coach, now):
     # welcome email. The UPDATE's own WHERE clause settles it without needing
     # every caller to hold the same lock.
     claimed = CrushProfile.objects.filter(
-        pk=profile.pk, verification_status="pending"
+        pk=profile.pk, verification_status__in=claim_from
     ).update(
         is_approved=True,
         approved_at=now,
@@ -574,11 +582,27 @@ def coach_mark_verified(request, event_id, registration_id):
 
         # Same workflow the auto-verify on attendance runs, so the two paths
         # cannot drift apart.
-        if not _apply_verification(profile, method, coach, now):
-            # Lost the pending -> verified claim to a concurrent path. Report
-            # the same idempotent success as an already-verified profile
-            # rather than running the side effects a second time.
+        if not _apply_verification(
+            profile, method, coach, now, claim_from=MANUAL_VERIFY_CLAIM_FROM
+        ):
+            # The claim can only fail here because another path verified them
+            # first — every other status is claimable. Report the same
+            # idempotent success as an already-verified profile rather than
+            # running the side effects twice. Reporting this for a still-
+            # unapproved profile would be worse than useless: the client
+            # removes the Verify button on `already_verified`, so the row would
+            # claim verified while the database disagreed.
             profile.refresh_from_db()
+            if profile.verification_status != "verified":
+                return JsonResponse(
+                    {
+                        "success": False,
+                        "error": str(
+                            _("Could not verify this profile. Please try again.")
+                        ),
+                    },
+                    status=409,
+                )
             return JsonResponse(
                 {
                     "success": True,

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -21,7 +21,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from .decorators import coach_required
-from .models import CrushProfile, EventRegistration
+from .models import CrushProfile, EventRegistration, ProfileSubmission
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,90 @@ def _scanning_coach(request):
     return coach if coach is not None and coach.is_active else None
 
 
+def _apply_verification(profile, method, coach, now):
+    """Persist a verification — fields AND the pending submission.
+
+    Shared by the manual Verify button and the auto-verify on attendance so the
+    two cannot drift: an earlier version of the auto-verify wrote only the
+    profile fields, silently skipping the submission approval (and the referral
+    reward and welcome email in `_run_post_verification_side_effects`). Because
+    it marked the profile verified immediately, the manual path that does that
+    work would never run afterwards.
+
+    DB writes only — safe to call inside a transaction. Run the side effects
+    after it commits.
+    """
+    profile.is_approved = True
+    profile.approved_at = now
+    profile.verification_status = "verified"
+    profile.verification_method = method
+    profile.save(
+        update_fields=[
+            "is_approved",
+            "approved_at",
+            "verification_status",
+            "verification_method",
+        ]
+    )
+
+    # Approve a pending submission opportunistically, gated on the
+    # expired-latest invariant: when the newest row was closed out by the pivot
+    # cleanup (latest_for_profile returns None), the member is a self-serve
+    # case — never resurrect an older pending row.
+    submission = None
+    if ProfileSubmission.latest_for_profile(profile) is not None:
+        submission = (
+            ProfileSubmission.objects.filter(profile=profile, status="pending")
+            .order_by("-submitted_at")
+            .first()
+        )
+    if submission:
+        submission.status = "approved"
+        submission.reviewed_at = now
+        submission.review_call_completed = True
+        if not submission.coach_id:
+            submission.coach = coach
+        submission.coach_notes = (
+            (submission.coach_notes + "\n" if submission.coach_notes else "")
+            + "Verified in person at event by coach"
+        ).strip()
+        submission.save(
+            update_fields=[
+                "status",
+                "reviewed_at",
+                "coach_notes",
+                "review_call_completed",
+                "coach",
+            ]
+        )
+
+
+def _run_post_verification_side_effects(user, profile, request, ref):
+    """Referral credit + welcome email. Call AFTER the transaction commits.
+
+    Event verification is the primary path for new members, so skipping these
+    would silently stop paying referrers and stop welcoming people. Both are
+    best-effort: neither may break the door flow.
+    """
+    try:
+        from .referrals import check_and_apply_profile_approved_reward
+
+        check_and_apply_profile_approved_reward(profile)
+    except Exception:
+        logger.warning(
+            "Failed to apply profile-approved referral reward for registration %s", ref
+        )
+
+    try:
+        from .notification_service import notify_profile_approved
+
+        notify_profile_approved(
+            user=user, profile=profile, coach_notes=None, request=request
+        )
+    except Exception:
+        logger.warning("Failed to send approval notification for registration %s", ref)
+
+
 def _auto_verify_on_attendance(request, registration, now):
     """Verify a `pending` profile because a coach checked them in at the door.
 
@@ -60,37 +144,28 @@ def _auto_verify_on_attendance(request, registration, now):
       an identity there is nothing on screen to compare. Verification would be
       asserting something nobody checked.
 
-    Returns True when the profile was verified here.
+    Returns the verified profile (so the caller can run the side effects once
+    the transaction commits), or ``None``.
     """
-    if _scanning_coach(request) is None:
-        return False
+    coach = _scanning_coach(request)
+    if coach is None:
+        return None
 
     profile = CrushProfile.objects.filter(user_id=registration.user_id).first()
     if profile is None or profile.verification_status != "pending":
-        return False
+        return None
     if profile.has_active_premium:
-        return False
+        return None
     if not profile.photo_1:
-        return False
+        return None
 
-    profile.is_approved = True
-    profile.approved_at = now
-    profile.verification_status = "verified"
-    profile.verification_method = "coach_event"
-    profile.save(
-        update_fields=[
-            "is_approved",
-            "approved_at",
-            "verification_status",
-            "verification_method",
-        ]
-    )
+    _apply_verification(profile, "coach_event", coach, now)
     logger.info(
         "[CHECKIN-VERIFY] Verified profile pk=%s via attendance at event pk=%s",
         profile.pk,
         registration.event_id,
     )
-    return True
+    return profile
 
 
 @csrf_exempt
@@ -157,6 +232,24 @@ def event_checkin_api(request, registration_id, token):
 
     # Check if already attended
     if registration.status == "attended":
+        # A re-scan must still verify. Two ways to be here with a pending
+        # profile: the first scan carried no coach session (the self-scan this
+        # endpoint deliberately still allows), or the row was marked attended
+        # before this feature existed. Without this the coach is silently back
+        # to tapping Verify.
+        # `now` is only bound below, with the check-in window check.
+        with transaction.atomic():
+            rescan_verified = _auto_verify_on_attendance(
+                request, registration, timezone.now()
+            )
+        if rescan_verified is not None:
+            # `registration` was loaded with `user__crushprofile` selected, so
+            # its cached profile predates the write above — re-read it or the
+            # toast would report the attendee as still unverified.
+            registration = EventRegistration.objects.select_related(
+                "event", "user", "user__crushprofile"
+            ).get(id=registration_id)
+
         display_name = _get_display_name(registration)
         response_data = {
             "success": True,
@@ -170,10 +263,16 @@ def event_checkin_api(request, registration_id, token):
             ),
             "message": f"{display_name} was already checked in.",
             "profile": _get_profile_data(registration),
+            "auto_verified": rescan_verified is not None,
         }
         table_info = _get_existing_table_assignment(registration)
         if table_info:
             response_data.update(table_info)
+        if rescan_verified is not None:
+            _run_post_verification_side_effects(
+                registration.user, rescan_verified, request, registration.id
+            )
+            _broadcast_checkin(registration.event_id, response_data)
         return JsonResponse(response_data)
 
     # Verify status is confirmed
@@ -213,6 +312,14 @@ def event_checkin_api(request, registration_id, token):
             .get(id=registration_id)
         )
         if registration.status == "attended":
+            # A re-scan must still be able to verify. Two ways to arrive here
+            # with a pending profile: the first scan carried no coach session
+            # (the self-scan case this endpoint deliberately still allows), or
+            # the registration was marked attended before this feature existed.
+            # Without this the coach is silently back to tapping Verify.
+            already_verified_profile = _auto_verify_on_attendance(
+                request, registration, now
+            )
             display_name = _get_display_name(registration)
             response_data = {
                 "success": True,
@@ -226,17 +333,36 @@ def event_checkin_api(request, registration_id, token):
                 ),
                 "message": f"{display_name} was already checked in.",
                 "profile": _get_profile_data(registration),
+                "auto_verified": already_verified_profile is not None,
             }
             table_info = _get_existing_table_assignment(registration)
             if table_info:
                 response_data.update(table_info)
+            if already_verified_profile is not None:
+                transaction.on_commit(
+                    lambda: _run_post_verification_side_effects(
+                        registration.user,
+                        already_verified_profile,
+                        request,
+                        registration.id,
+                    )
+                )
             return JsonResponse(response_data)
         registration.status = "attended"
         registration.checked_in_at = now
         registration.save(update_fields=["status", "checked_in_at", "updated_at"])
 
-        # Attending IS the verification, for the ordinary case.
-        auto_verified = _auto_verify_on_attendance(request, registration, now)
+        # Attending IS the verification, for the ordinary case. Side effects
+        # (referral credit, welcome email) run on commit — never inside the
+        # transaction, or a rollback would leave the email already sent.
+        verified_profile = _auto_verify_on_attendance(request, registration, now)
+        auto_verified = verified_profile is not None
+        if auto_verified:
+            transaction.on_commit(
+                lambda: _run_post_verification_side_effects(
+                    registration.user, verified_profile, request, registration.id
+                )
+            )
 
         # Quiz table assignment (if this is a quiz night event)
         try:
@@ -316,8 +442,6 @@ def coach_mark_verified(request, event_id, registration_id):
     For a premium member (one with an ``assigned_coach``) only that assigned
     coach may verify them, and the method is recorded as ``premium_coach``.
     """
-    from .models import ProfileSubmission
-
     coach = request.coach
     now = timezone.now()
 
@@ -387,49 +511,9 @@ def coach_mark_verified(request, event_id, registration_id):
                 }
             )
 
-        profile.is_approved = True
-        profile.approved_at = now
-        profile.verification_status = "verified"
-        profile.verification_method = method
-        profile.save(
-            update_fields=[
-                "is_approved",
-                "approved_at",
-                "verification_status",
-                "verification_method",
-            ]
-        )
-
-        # Approve a pending submission opportunistically, gated on the
-        # expired-latest invariant: when the newest row was closed out by
-        # the pivot cleanup (latest_for_profile returns None), the member
-        # is a self-serve case — never resurrect an older pending row.
-        submission = None
-        if ProfileSubmission.latest_for_profile(profile) is not None:
-            submission = (
-                ProfileSubmission.objects.filter(profile=profile, status="pending")
-                .order_by("-submitted_at")
-                .first()
-            )
-        if submission:
-            submission.status = "approved"
-            submission.reviewed_at = now
-            submission.review_call_completed = True
-            if not submission.coach_id:
-                submission.coach = coach
-            submission.coach_notes = (
-                (submission.coach_notes + "\n" if submission.coach_notes else "")
-                + "Verified in person at event by coach"
-            ).strip()
-            submission.save(
-                update_fields=[
-                    "status",
-                    "reviewed_at",
-                    "coach_notes",
-                    "review_call_completed",
-                    "coach",
-                ]
-            )
+        # Same workflow the auto-verify on attendance runs, so the two paths
+        # cannot drift apart.
+        _apply_verification(profile, method, coach, now)
 
     logger.info(
         "Coach %s verified registration %s (user %s) at event %s via %s",
@@ -440,32 +524,12 @@ def coach_mark_verified(request, event_id, registration_id):
         method,
     )
 
-    # Credit the referrer if this attendee was referred (mirrors the LuxID and
-    # coach-review paths). Event verification is now the primary path for new
-    # users, so the profile-approved referral bonus must fire here too.
-    # Best-effort: never let the reward step break the in-person check-in flow.
-    try:
-        from .referrals import check_and_apply_profile_approved_reward
-
-        check_and_apply_profile_approved_reward(profile)
-    except Exception:
-        logger.warning(
-            "Failed to apply profile-approved referral reward for registration %s",
-            registration.id,
-        )
-
-    # Welcome the freshly-verified member (mirrors the LuxID path). Best-effort:
-    # never let an email failure break the in-person check-in flow.
-    try:
-        from .notification_service import notify_profile_approved
-
-        notify_profile_approved(
-            user=registration.user, profile=profile, coach_notes=None, request=request
-        )
-    except Exception:
-        logger.warning(
-            "Failed to send approval notification for registration %s", registration.id
-        )
+    # Referral credit + welcome email. Shared with the auto-verify on
+    # attendance: event verification is the primary path for new members, so
+    # both paths must run these or referrers silently stop being paid.
+    _run_post_verification_side_effects(
+        registration.user, profile, request, registration.id
+    )
 
     response_data = {
         "success": True,


### PR DESCRIPTION
Two taps at the door become one: scanning an attendee in now sets `verified` /
`is_approved` / method `coach_event` when their profile is `pending`. Attending
**is** the verification for an ordinary walk-in — which is what the product copy
has always promised: *"New members get verified in person at the event."*

## This removes a trap that would have hit Wednesday

Check-in assigns `event.coaches.first()` to every unverified attendee, and
`coach_mark_verified` refused any coach who wasn't that person. So the moment an
attendee was scanned, **only one coach could verify them** — the other three got:

```
403 "This premium member is verified by their own coach."
```

Event 12 has four coaches and 10 unverified attendees, all of whom would have
been assigned Tom Swayer on scan. Reproduced end to end before the fix; a second
coach now verifies successfully (`200`, `coach_event`).

The root cause is the `assigned_coach` / Premium conflation **in its third
location** — a coach is granted *free* on first attendance, so keying the premium
rule off that FK made every freshly-scanned walk-in look like a paying member.
The guard now reads `has_active_premium`, the real entitlement, exactly as
`CrushProfile.has_active_premium`'s own docstring says it should.

## Two deliberate exceptions

The Verify button stays visible for precisely these:

| case | why |
|---|---|
| **Premium members** | "only their own coach verifies" is intentional there |
| **Profiles with no photo** | #650 (shipping on this same swap) drops `photo_1` from completion, so a scan has nothing to compare the person against — auto-verifying would assert a check nobody performed |

## The auto-verify requires a coach session

`event_checkin_api` authenticates on the **signed token alone** — no
`@coach_required`, because the QR is the credential — and **the attendee holds
their own QR**. Without a guard, a member could POST their own check-in URL and
self-verify into Crush Connect, matches and profile-photo visibility.

A door scan always carries a coach session (the scanner posts same-origin, so
cookies ride along); a self-post never does. **Attendance marking itself is
unchanged**, so nothing that works today breaks — a self-post still checks in,
it just doesn't verify.

## Verified end to end, not just in tests

Two attendees seeded, one with a photo and one without, both checked in through
the real coach UI:

| attendee | photo | status | verification | Verify button after |
|---|---|---|---|---|
| door.photo | ✓ | attended | **verified** / `coach_event` | gone |
| door.nophoto | ✗ | attended | **pending** | still shown |

And the original 403: a coach who is *not* the assigned coach now verifies the
no-photo attendee successfully.

## Tests

9 new cases: happy path, both exceptions, the self-scan guard, an inactive-coach
session, a `rejected` profile, and that an existing **`luxid`** verification is
never overwritten with `coach_event`.

`test_coach_mark_verified.py` had encoded the old conflation — it gave an
attendee an `assigned_coach` with **no `PremiumMembership`** and asserted a 403.
That expectation is wrong by design now; updated to grant a real
`PremiumMembership`, plus a new case asserting an assigned coach alone does not
make someone premium.

No migration. 24 verification tests + the event/lobby/quiz/gate suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
