### PR TITLE
Assign the scanning coach on check-in, not event.coaches.first()

### DIFF
--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2431,9 +2431,14 @@ def assign_coach_on_first_attendance(sender, instance, created, **kwargs):
     Premium gates (``coach_assigned`` events and Crush Connect) depend on
     ``CrushProfile.assigned_coach``. This is the path that earns it: when a
     registration is marked "attended" and the member has no coach yet, the
-    event's first assigned coach becomes their permanent coach. Idempotent —
-    once a coach is assigned the member keeps it, and events with no coaches
-    simply leave the member unassigned until a coached event is attended.
+    coach who scanned them in (``instance._checkin_coach``, set by
+    ``views_checkin.event_checkin_api``) becomes their permanent coach —
+    the person who actually met them at the door, not whoever happens to be
+    first in the event's coach list. Anonymous/admin attendance transitions
+    carry no scanner and fall back to the event's first assigned coach.
+    Idempotent — once a coach is assigned the member keeps it, and events
+    with no coaches simply leave the member unassigned until a coached event
+    is attended.
     """
     if instance.status != "attended":
         return
@@ -2442,7 +2447,7 @@ def assign_coach_on_first_attendance(sender, instance, created, **kwargs):
     if profile is None or profile.assigned_coach_id:
         return
 
-    coach = instance.event.coaches.first()
+    coach = getattr(instance, "_checkin_coach", None) or instance.event.coaches.first()
     if coach is None:
         return
 

--- a/crush_lu/tests/test_verify_on_checkin.py
+++ b/crush_lu/tests/test_verify_on_checkin.py
@@ -398,3 +398,63 @@ def test_luxid_does_not_overwrite_a_scan_that_verified_first(event, coach):
 
     profile.refresh_from_db()
     assert profile.verification_method == "coach_event"
+
+
+# ---------------------------------------------------------------------------
+# Coach assignment: the scanner, not the coach-list order, decides who you get
+# ---------------------------------------------------------------------------
+
+
+def _second_coach():
+    """A later-created (higher-pk) coach, so `event.coaches.first()` is NOT it."""
+    user = User.objects.create_user(
+        username="secondcoach@t.test", email="secondcoach@t.test", password="pw12345678"
+    )
+    UserDataConsent.objects.update_or_create(
+        user=user, defaults={"crushlu_consent_given": True}
+    )
+    return CrushCoach.objects.create(user=user, bio="s", is_active=True)
+
+
+def test_scanning_coach_becomes_the_assigned_coach(event, coach):
+    """The member's permanent coach is whoever actually met them at the door.
+
+    `assign_coach_on_first_attendance` used to take `event.coaches.first()`,
+    linking the member to whichever coach happened to sort first — not the one
+    who checked them in.
+    """
+    scanner = _second_coach()
+    event.coaches.add(coach, scanner)
+    profile, reg = _attendee(event, "assignscan")
+
+    response = _scan(reg, event, as_coach=scanner)
+
+    assert response.status_code == 200
+    profile.refresh_from_db()
+    assert event.coaches.first() == coach  # the scanner is NOT first in the list
+    assert profile.assigned_coach_id == scanner.id
+    assert profile.assigned_coach_at is not None
+
+
+def test_anonymous_scan_still_assigns_the_events_first_coach(event, coach):
+    """No coach session on the request -> the legacy fallback stands."""
+    scanner = _second_coach()
+    event.coaches.add(coach, scanner)
+    profile, reg = _attendee(event, "assignanon")
+
+    _scan(reg, event, as_coach=None)
+
+    profile.refresh_from_db()
+    assert profile.assigned_coach_id == coach.id
+
+
+def test_existing_coach_is_never_reassigned_by_a_scan(event, coach):
+    scanner = _second_coach()
+    event.coaches.add(coach, scanner)
+    profile, reg = _attendee(event, "assignkeep")
+    CrushProfile.objects.filter(pk=profile.pk).update(assigned_coach=coach)
+
+    _scan(reg, event, as_coach=scanner)
+
+    profile.refresh_from_db()
+    assert profile.assigned_coach_id == coach.id

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -430,6 +430,10 @@ def event_checkin_api(request, registration_id, token):
                     )
                 )
             return JsonResponse(response_data)
+        # The scanning coach becomes the member's permanent coach (when they
+        # have none): read by `assign_coach_on_first_attendance` during the
+        # save below, in preference to `event.coaches.first()`.
+        registration._checkin_coach = _scanning_coach(request)
         registration.status = "attended"
         registration.checked_in_at = now
         registration.save(update_fields=["status", "checked_in_at", "updated_at"])


### PR DESCRIPTION
## Purpose
* The coach who **scans a member in at the door becomes their permanent coach**. `assign_coach_on_first_attendance` previously took `event.coaches.first()`, linking the member to whichever coach happened to sort first in the event's coach list — not the one who actually met them.
* Complements #697 (attending verifies the profile), which landed the auto-verify half of the door rework: together, one scan by any coach now checks the member in, verifies them (photo present, non-premium), **and makes the scanner their coach**.

> Scope note: this PR was originally a full check-in rework; #697 merged an independent, more hardened implementation of the verification half first (conditional pending→verified claim vs. LuxID races, window-gated re-scans, on-commit side effects, premium gated on `has_active_premium`). This branch was rebuilt on top of it and now carries only the remaining piece: scanner-based coach assignment.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform
cd Multi-Domain-Django-Platform
git checkout fix/checkin-scanner-coach-verify
```

* Test the code
```
.venv/Scripts/Activate.ps1
pytest crush_lu/tests/test_verify_on_checkin.py crush_lu/tests/test_coach_mark_verified.py crush_lu/tests/test_event_tickets.py
```

Manual E2E (done locally on the SQLite dev server): event with two coaches; logged in as the **second** coach (not `coaches.first()`) and clicked **Check In** on an unverified, coach-less attendee with a photo. Result: registration `attended`, profile `verified` / `coach_event` (via #697's auto-verify), and `assigned_coach` = the scanning coach — with the roster pill flipping to Verified live.

## What to Check
Verify that the following are valid
* `event_checkin_api` sets `registration._checkin_coach = _scanning_coach(request)` before the save; the signal prefers it and keeps the `event.coaches.first()` fallback for anonymous/admin attendance transitions (self-scans still assign the first coach, as before).
* An already-assigned coach is never reassigned (signal early-returns on `assigned_coach_id`).
* Interplay with #697 is unchanged: auto-verify still keys on coach session + `pending` + photo + non-premium; `coach_mark_verified` premium gating (`has_active_premium`) is untouched by this PR.
* New tests at the bottom of `test_verify_on_checkin.py`: scanner beats `coaches.first()`, anonymous fallback preserved, existing coach kept.

## Other Information
Time-sensitive: the next event is Wednesday 2026-07-29 — this needs to merge and ride the pending slot swap (together with #697, already on main) to be live at the door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
