### PR TITLE
Stop the check-in WebSocket from hot-looping when the channel layer drops it

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -438,6 +438,7 @@ document.addEventListener("alpine:init", function () {
             ws: null,
             connected: false,
             reconnectAttempts: 0,
+            stableTimer: null,
             eventId: 0,
 
             // Toast state
@@ -647,15 +648,29 @@ document.addEventListener("alpine:init", function () {
                 this.ws = new WebSocket(url);
                 this.ws.onopen = function () {
                     self.connected = true;
-                    self.reconnectAttempts = 0;
+                    // Only count this as healthy once it has SURVIVED a while.
+                    // The channel layer can accept a socket and then drop it a
+                    // few seconds later (idle blocking-read timeout); resetting
+                    // the counter on open alone turned that into a permanent
+                    // ~6s reconnect loop that never backed off and never
+                    // reached the attempt cap — every open coach phone hammered
+                    // the server all evening.
+                    clearTimeout(self.stableTimer);
+                    self.stableTimer = setTimeout(function () {
+                        self.reconnectAttempts = 0;
+                    }, 30000);
                 };
                 this.ws.onclose = function () {
                     self.connected = false;
+                    clearTimeout(self.stableTimer);
                     if (self.reconnectAttempts >= 20) return;
-                    var delay = Math.min(
+                    // Jitter: several coaches open the wizard at once at the
+                    // door, and lockstep retries would arrive as one burst.
+                    var base = Math.min(
                         1000 * Math.pow(2, self.reconnectAttempts),
                         30000,
                     );
+                    var delay = base * (0.8 + Math.random() * 0.4);
                     self.reconnectAttempts++;
                     setTimeout(function () {
                         self.connectWebSocket();


### PR DESCRIPTION
## Purpose
* The coach check-in wizard reconnects its WebSocket **roughly every 6 seconds, forever**, whenever the channel layer can't serve it. Staging logs show the cycle precisely: connection accepted → `redis.exceptions.TimeoutError` ~5s later → immediate reconnect → repeat, indefinitely.
* **Cause:** `onopen` reset `reconnectAttempts` to 0 — but the socket genuinely *does* open before dying. So the exponential backoff was recomputed from zero every cycle (always ~1s) and the 20-attempt circuit breaker never tripped. With several coaches holding the wizard open at the door, every phone hammers the server for the whole event.
* **Fix:** the counter now resets only after a connection has **survived 30 seconds**. A socket that dies quickly escalates 1s → 2s → 4s → … → 30s and eventually stops; a genuinely healthy connection still regains its full retry budget. Added ±20% jitter so simultaneous coach devices don't retry in lockstep.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform
cd Multi-Domain-Django-Platform
git checkout fix/checkin-ws-reconnect-backoff
```

* Test the code
```
.venv/Scripts/Activate.ps1
pytest crush_lu/tests/test_verify_on_checkin.py crush_lu/tests/test_event_tickets.py crush_lu/tests/test_template_hygiene.py
```

Behaviour check (the dev server has no Redis, so `/ws/checkin/` fails immediately — a convenient reproduction): open `/coach/events/<id>/checkin/`, then in the console inspect the Alpine component. `reconnectAttempts` should climb (1, 2, 3 …) with growing gaps. Calling `ws.onopen()` must **not** reset it to 0 — it arms a stability timer instead. That reset-on-open was the bug.

## What to Check
Verify that the following are valid
* `reconnectAttempts` is only zeroed by the 30s stability timer, and that timer is cleared in `onclose` so a short-lived socket can't reset it late.
* The 20-attempt cap is now actually reachable, so a persistently broken channel layer stops retrying instead of looping forever.
* Jitter (`base * (0.8 + Math.random() * 0.4)`) keeps the cap semantics intact — worst case ~36s between the final retries.
* The `stableTimer` field is declared in component state (CSP-safe Alpine: named handlers/getters only, no inline expressions).

## Other Information
**This is a symptom fix, deliberately scoped.** The underlying cause is `channels-redis` 4.3.0's `brpop_timeout = 5` racing the client-side read timeout under `redis` 8.0.0, so an *idle* channel raises `TimeoutError` instead of returning empty — which is why the failures land at exactly 5.0s intervals. That affects **both slots equally** (verified: one shared Azure Redis, prod DB 0 / staging DB 1; the cache is healthy at peak 50/256 clients, 1–12% load), and fixing it touches the channel layer for every WebSocket feature (Quiz Night, Empire, Event Lobby, Crush Cache). Deliberately left until after the 2026-07-29 event.

Check-in never depended on the WebSocket: the scanning device updates from its own HTTP response, and only cross-device live sync is degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
