### PR TITLE
refactor(crush): use the canonical button variants on the door rows

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -884,8 +884,12 @@ document.addEventListener("alpine:init", function () {
                 if (!undoUrl) return null;
                 var undoBtn = document.createElement("button");
                 undoBtn.type = "button";
+                // Must stay identical to the server-rendered twin in
+                // coach_event_checkin.html — a row that came back through undo
+                // sits next to rows that never left, and a drifted class list
+                // shows up as two differently-shaped buttons in the same list.
                 undoBtn.className =
-                    "manual-undo-btn px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 underline decoration-dotted transition-colors";
+                    "manual-undo-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400";
                 undoBtn.setAttribute("data-undo-url", undoUrl);
                 undoBtn.setAttribute("data-reg-id", regId);
                 undoBtn.textContent = i18n.undoAction || "Undo";
@@ -1294,8 +1298,10 @@ document.addEventListener("alpine:init", function () {
                     );
                     var newBtn = document.createElement("button");
                     newBtn.type = "button";
+                    // Keep in sync with the server-rendered twin in
+                    // coach_event_checkin.html (see _buildUndoButton).
                     newBtn.className =
-                        "manual-checkin-btn px-3 py-1.5 text-xs font-medium bg-crush-purple text-white rounded-lg hover:bg-crush-purple/90 transition-colors";
+                        "manual-checkin-btn btn-crush-solid btn-sm text-white";
                     newBtn.setAttribute("data-checkin-url", checkinUrl || "");
                     newBtn.setAttribute("data-reg-id", id);
                     newBtn.textContent = i18n.checkIn || "Check In";

--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -295,12 +295,33 @@
                 comes first in the document — undo would otherwise rebuild the
                 Check In button inside the avatar.
             {% endcomment %}
+            {% comment %}
+                Row controls use the canonical variants from STYLE.md §2:
+                .btn-crush-solid + .btn-sm for the actions, .btn-link for the
+                quiet undo. Two overrides are deliberate and should not be
+                "cleaned up":
+
+                  - bg-*/focus:ring-* on Verify and the waitlist promote. The
+                    tones carry meaning (green = identity, amber = waitlist)
+                    and STYLE.md sanctions a tinted .btn-crush-solid for the
+                    rare non-purple solid.
+                  - text-white on all three solids. The component's own
+                    text-white resolves to brand white #f0ecf5, which drops
+                    light-mode contrast below AA on this surface (Check In
+                    4.67 -> 4.01, the tinted pair to ~2.75). Pure #fff keeps
+                    every button at or above where it was, and the door is
+                    read on a phone in a dim venue.
+
+                Note .btn-sm is INERT on .btn-crush-outline — that component is
+                unlayered, so its padding beats the layered utility. The two
+                are only combinable on .btn-crush-solid.
+            {% endcomment %}
             <div class="flex-shrink-0 flex items-center gap-2" data-row-actions>
                 {# Verify-in-person: shown for unverified attendees #}
                 {% if reg.user.crushprofile and not reg.user.crushprofile.is_approved %}
                 <button
                     type="button"
-                    class="manual-verify-btn px-3 py-1.5 text-xs font-medium bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                    class="manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white"
                     data-verify-url="/api/events/{{ event.id }}/verify/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="markVerified"
@@ -311,7 +332,7 @@
                 {% if reg.status != 'attended' %}
                 <button
                     type="button"
-                    class="manual-checkin-btn px-3 py-1.5 text-xs font-medium bg-crush-purple text-white rounded-lg hover:bg-crush-purple/90 transition-colors"
+                    class="manual-checkin-btn btn-crush-solid btn-sm text-white"
                     data-checkin-url="/api/events/checkin/{{ reg.id }}/{{ reg.checkin_token }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="manualCheckin"
@@ -336,7 +357,7 @@
                 {% if reg.checked_in_at %}
                 <button
                     type="button"
-                    class="manual-undo-btn px-2 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 underline decoration-dotted transition-colors"
+                    class="manual-undo-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400"
                     data-undo-url="/api/events/{{ event.id }}/undo-checkin/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="undoCheckin"
@@ -399,7 +420,7 @@
                 </div>
                 <button
                     type="button"
-                    class="waitlist-promote-btn flex-shrink-0 px-3 py-1.5 text-xs font-medium bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
+                    class="waitlist-promote-btn flex-shrink-0 btn-crush-solid btn-sm bg-amber-600 hover:bg-amber-700 focus:ring-amber-500 text-white"
                     data-promote-url="/api/events/{{ event.id }}/promote/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="promoteFromWaitlist"


### PR DESCRIPTION
## Purpose

Closes #711.

Three door row controls hand-rolled their styling instead of using the variants `crush_lu/STYLE.md` §2 documents, so they bypassed centralized sizing, focus rings, dark mode and any future theme change. They now use the canonical variants.

| Control | Before | After |
| --- | --- | --- |
| Check In | `px-3 py-1.5 text-xs bg-crush-purple rounded-lg …` | `btn-crush-solid btn-sm text-white` |
| Verify | `px-3 py-1.5 text-xs bg-green-600 rounded-lg …` | same + `bg-green-600 hover:bg-green-700 focus:ring-green-500` |
| Waitlist promote | `px-3 py-1.5 text-xs bg-amber-600 rounded-lg …` | same + `bg-amber-600 hover:bg-amber-700 focus:ring-amber-500` |
| Undo | `px-2 py-1.5 … underline decoration-dotted` | `btn-link` + explicit sizing (stays a quiet dotted link) |

**Scope is five call sites, not the three the issue lists.** Both JS-built buttons have server-rendered twins in the same template — a row that comes back through undo sits next to rows that never left, so the pair has to move together or the same list renders two button shapes. The adjacent `manual-verify-btn` had the identical divergence and would otherwise have been a `rounded-lg` rectangle sitting between two pills.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Two findings a reviewer should know

**1. `.btn-sm` is INERT on `.btn-crush-outline`.**

That component is unlayered raw CSS (see the existing comment about `display: inline-block` in `tailwind-src/crush_lu/tailwind-input.css`), so unlayered beats *all* layered CSS regardless of specificity, and its `padding: var(--space-3) var(--space-8)` always wins over `.btn-sm`.

The scanner control at `coach_event_checkin.html:101` that #711 cites as *"already complies"* computes `padding: 12px 32px`, not `8px 16px` — it is rendering full-size today.

This is why undo uses `.btn-link` rather than the `.btn-crush-outline` + `.btn-sm` the issue suggested: that pairing would have put a full-size pill in a dense row. The wider problem (~15 occurrences across ~10 templates, all silently full-size) is deliberately left for its own change.

**2. `.btn-crush-solid`'s `text-white` is brand `#f0ecf5`, not `#fff`.**

The component's `@apply text-white` resolves to `var(--color-white)` = `#f0ecf5`, while the `text-white` *utility* written in a class attribute yields `#fff`. Dropping the hand-rolled classes therefore *lowered* light-mode contrast on every button — Check In **4.67 → 4.01**, crossing below WCAG AA 4.5, and the tinted pair to ~2.75. An explicit `text-white` keeps all three at or above where they were.

Measured before/after by injecting both class strings into the real row container:

| | light | dark |
| --- | --- | --- |
| Check In | 4.67 → 4.67 | 4.67 → **5.87** |
| Verify | 3.22 → 3.22 | 3.22 → 3.22 |
| Promote | 3.20 → 3.20 | 3.20 → 3.20 |

Note the tinted pair was **already** ~3.2 (below AA) before this PR. Those tones carry meaning (green = identity, amber = waitlist), so changing them is a product decision, not a styling cleanup — left alone here.

## How to Test

```
git checkout claude/easiest-issue-cd336e
```

```bash
python crush_lu/scripts/lint_design_tokens.py
python -m pytest crush_lu/tests/test_checkin_door_actions.py crush_lu/tests/test_coach.py crush_lu/tests/test_coach_event_detail.py crush_lu/tests/test_coach_mark_verified.py crush_lu/tests/test_verify_on_checkin.py crush_lu/tests/test_event_identity_surfaces.py crush_lu/tests/test_event_identity_ui.py
```

Manually: open a coach check-in page for an event with a confirmed row, an unverified row, an attended row and a waitlisted row, at 375px width in both themes.

## What to Check

* Design-token linter clean — 373 files scanned. (`coach_*` templates are exempt from the deprecated-button rule, so the linter cannot catch this class of drift; it was verified by hand.)
* 120 tests pass across the coach / check-in / identity modules.
* At 375px: all four controls are 44px tall and the page does not scroll horizontally (`scrollWidth 375 == clientWidth 375`), including the crowded row where Verify and Check In appear together.
* Undo driven end-to-end in a browser: the JS-built replacement comes back **byte-identical** to the server-rendered twin — same class list and same computed padding / font-size / background / radius — and the undo button is removed.
* Undo's own computed style is unchanged from before this PR in both themes (transparent background, `6px 8px`, 12px, gray → red on hover).

## Other Information

**No Tailwind rebuild needed.** Prod serves the committed `crush_lu/static/crush_lu/css/tailwind.css`, so this was checked rather than assumed: all 215 classes the template references already exist in the committed bundle (the only two absentees are JS hook classes with no styling). This PR only reshuffles existing classes.

Verification ran against a local SQLite instance on port 8010 — port 8000 was held by an unrelated server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
