### PR TITLE
fix(ws): stop idle WebSockets dying every 5s on the Redis channel layer

### DIFF
--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -338,14 +338,37 @@ CACHES = {
 }
 
 # Channel Layers - Redis for production WebSocket support (Django Channels)
+#
+# THIS is the channel layer Azure actually runs. asgi.py/wsgi.py load this
+# module whenever WEBSITE_HOSTNAME is set, and it overrides settings.py's
+# CHANNEL_LAYERS wholesale — note it keys on AZURE_REDIS_CONNECTIONSTRING while
+# settings.py keys on REDIS_URL, which is unset here. Change both together.
+#
+# socket_timeout MUST stay above channels-redis' brpop_timeout
+# (`channels_redis/core.py`, class attribute, 5s). The layer listens with
+# `BRPOP <channel> 5`, which on an idle channel blocks for the full five
+# seconds by design — and redis-py 8.0 applies `DEFAULT_SOCKET_TIMEOUT = 5`
+# (`redis/_defaults.py`) where older releases defaulted to None. Two identical
+# five-second timers race, the client one wins, and every idle WebSocket dies
+# at exactly 5.0s with "Timeout reading from ...redis.cache.windows.net:6380".
+# Observed on production 2026-07-28 on /ws/checkin/, once per socket per 5s.
+#
+# Passing the host as a dict keeps this scoped to the channel layer:
+# `decode_hosts` forwards dict entries verbatim and `create_pool` calls
+# `from_url(address, **host)`. Putting it on the connection string instead
+# would also raise the CACHES read timeout above, slowing down how fast a
+# wedged Redis surfaces on the page-render path.
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [
-                os.environ.get(
-                    "AZURE_REDIS_CONNECTIONSTRING", "redis://localhost:6379/0"
-                )
+                {
+                    "address": os.environ.get(
+                        "AZURE_REDIS_CONNECTIONSTRING", "redis://localhost:6379/0"
+                    ),
+                    "socket_timeout": 10,
+                }
             ],
         },
     },

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -261,7 +261,28 @@ if os.environ.get("REDIS_URL"):
         "default": {
             "BACKEND": "channels_redis.core.RedisChannelLayer",
             "CONFIG": {
-                "hosts": [os.environ["REDIS_URL"]],
+                # socket_timeout MUST stay above channels-redis' brpop_timeout
+                # (`channels_redis/core.py`, class attribute, 5s). The layer
+                # listens with `BRPOP <channel> 5`, which on an idle channel
+                # blocks for the full five seconds by design — and redis-py 8.0
+                # applies `DEFAULT_SOCKET_TIMEOUT = 5` (`redis/_defaults.py`)
+                # where older releases defaulted to None. Two identical
+                # five-second timers race, the client one wins, and every idle
+                # WebSocket dies at exactly 5.0s with
+                # "Timeout reading from ...redis.cache.windows.net:6380".
+                #
+                # Passing the host as a dict keeps this scoped to the channel
+                # layer: `decode_hosts` forwards dict entries verbatim and
+                # `create_pool` calls `from_url(address, **host)`. Setting it
+                # on REDIS_URL instead would also raise the CACHES read
+                # timeout, slowing down how fast a wedged Redis surfaces on
+                # the page-render path.
+                "hosts": [
+                    {
+                        "address": os.environ["REDIS_URL"],
+                        "socket_timeout": 10,
+                    }
+                ],
             },
         },
     }


### PR DESCRIPTION
## The bug

Every WebSocket on an idle channel dies at exactly **5.0 seconds** with:

```
redis.exceptions.TimeoutError: Timeout reading from django-app-...-rediscache.redis.cache.windows.net:6380
```

Observed continuously on **production** 2026-07-28 on `/ws/checkin/12/` — the event door page, the night before the 2026-07-29 event.

## Root cause: two five-second timers race

| Source | Value |
|---|---|
| `channels_redis/core.py` (class attr) | `brpop_timeout = 5` |
| `redis/_defaults.py` | `DEFAULT_SOCKET_TIMEOUT = 5` |

The layer listens with `BRPOP <channel> 5`, which on an idle channel blocks for the full five seconds **by design**. redis-py then applies its own five-second socket read timeout and gives up at the same instant.

It's a dead heat, not a flake — which is why it fires on *every* idle socket rather than occasionally.

**Nothing in our code changed to cause this.** redis-py 8.0 introduced `DEFAULT_SOCKET_TIMEOUT`; older releases defaulted to `None`, and channels-redis has always assumed no read timeout.

## The fix

`brpop_timeout` is a class attribute, not an `__init__` kwarg, so it can't be raised through `CONFIG` without subclassing. Raising the client's read timeout is the supported side of the race — `decode_hosts` forwards dict host entries verbatim and `create_pool` calls `from_url(address, **host)`, so `socket_timeout` lands on the pool.

```python
"hosts": [{"address": ..., "socket_timeout": 10}]
```

**Scoped to the channel layer on purpose.** `CACHES` and `CHANNEL_LAYERS` share the same Redis URL. Setting `socket_timeout` on the URL/connection string would also raise the *cache* read timeout, slowing how quickly a wedged Redis surfaces on the page-render path — which is exactly the shape of the 2026-07-22 incident. The cache keeps redis-py's 5s default.

## Applied in both places, and this part matters

`production.py` **overrides `settings.py`'s `CHANNEL_LAYERS` wholesale** and keys on `AZURE_REDIS_CONNECTIONSTRING`, where `settings.py` keys on `REDIS_URL` (unset on Azure). `asgi.py`/`wsgi.py` load `production.py` whenever `WEBSITE_HOSTNAME` is set.

**Patching only `settings.py` would have been a silent no-op in production.** Both are patched, and `production.py` now carries a comment saying so.

## Verification

Loaded `azureproject.production` with Azure-shaped env and asserted the real pool config:

```
settings module -> azureproject.production
hosts          -> [{'address': 'rediss://...:6380/0', 'socket_timeout': 10}]
socket_timeout -> 10 | brpop_timeout -> 5
CACHE location -> rediss://...:6380/0        <- untouched
```

- `manage.py check` — no issues
- `ruff` / `black` — identical result to unmodified `origin/main` on both files (10 pre-existing ruff errors, 1 pre-existing black reformat; **zero introduced**)

**Still to do before this is trusted:** confirm on staging that a `/ws/checkin/` socket survives past 5s. The bug reproduces on staging identically, so it's a real test rather than a hope.

## Risk

Config-only, no migrations. Worst case a socket waits 10s instead of 5s before failing a genuinely dead connection — on a background listener, not a request path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
