### PR TITLE
fix(android): harden Crush.lu Android for Play Store readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,14 @@ SECRET_KEY=your-development-secret-key-change-in-production
 # FIREBASE_API_KEY=AIzaSyxxx
 # FIREBASE_AUTH_DOMAIN=project-xxx.firebaseapp.com
 
+# --- Android App Links (Play Store signing) ---
+# Drives /.well-known/assetlinks.json. Comma-separated SHA-256 fingerprints of
+# the Play app signing certificate(s). Empty (the default) serves a web-only
+# assetlinks, so Android App Links verification fails closed until this is set.
+# Get the fingerprint from Play Console > App integrity > App signing. Required
+# for https://crush.lu/... links to open in the app rather than the browser.
+# ANDROID_APP_SHA256_CERT_FINGERPRINTS=AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89
+
 # --- WhatsApp Cloud API (Meta) ---
 # Server-side only. Drives /hub/whatsapp/* and /api/webhooks/whatsapp/.
 # Get the access token from the Meta dashboard ("Generate token" on the WhatsApp

--- a/crush_lu/tests/test_android_app_readiness.py
+++ b/crush_lu/tests/test_android_app_readiness.py
@@ -105,6 +105,24 @@ def test_assetlinks_includes_android_app_when_fingerprint_configured(client, set
     assert android_target["sha256_cert_fingerprints"] == ["AA:BB:CC:DD:EE:FF"]
 
 
+def test_assetlinks_web_only_when_fingerprint_unset(client, settings):
+    # The default production state until the Play signing fingerprint is
+    # configured: assetlinks.json must serve the web target only, with no
+    # android_app entry, so verification fails closed rather than pointing
+    # Android at an unverified app target.
+    settings.ANDROID_APP_SHA256_CERT_FINGERPRINTS = []
+
+    response = client.get("/.well-known/assetlinks.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["target"]["namespace"] == "web"
+    assert all(
+        target["target"]["namespace"] != "android_app" for target in payload
+    )
+
+
 def test_android_native_request_suppresses_commerce(rf, settings):
     from crush_lu.context_processors import crush_user_context
 

--- a/mobile/android/CrushLU/README.md
+++ b/mobile/android/CrushLU/README.md
@@ -20,6 +20,38 @@ Native Android WebView shell for the Crush.lu Play Store submission.
 
 You can also run `./gradlew bundleRelease` from this directory. On Windows PowerShell, use `.\gradlew.bat bundleRelease`. The Play upload file will be created at `app/build/outputs/bundle/release/app-release.aab`.
 
+## Signing & Release CI
+
+Signed production builds are produced by the `android-release.yml` workflow
+(triggered by a `v*` tag or a manual `workflow_dispatch`). It is the only path
+that uploads to the Play Store. Do **not** commit signing secrets — they live in
+GitHub Actions secrets and are injected at run time.
+
+The workflow expects these repository secrets:
+
+| Secret | Purpose |
+|--------|---------|
+| `ANDROID_KEYSTORE_BASE64` | The Play upload keystore (`crush-lu-upload.jks`), base64-encoded. Decoded into `app/keystores/` at build time. |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password. |
+| `ANDROID_KEY_ALIAS` | Signing key alias (e.g. `crush-lu-upload`). |
+| `ANDROID_KEY_PASSWORD` | Signing key password. |
+| `ANDROID_SERVICE_ACCOUNT_JSON` | Google Play service account JSON (only required for the Play upload step). |
+
+The build is driven by gradle properties passed on the command line, never read
+from a committed `gradle.properties`:
+
+- `CRUSH_ENV` — `production` (default) or `staging`. The local-dev `local`
+  variant (`http://10.0.2.2:8000`, package `lu.crush.app.local`) is for emulator
+  use only and is never built by CI.
+- `CRUSH_VERSION_CODE` — a monotonic value computed at run time
+  (seconds since 2024-01-01) under a serialized concurrency group, so Play
+  always sees increasing codes. The literal fallback of `4` in
+  `app/build.gradle.kts` is local-only and never uploaded.
+
+Releases run one at a time (concurrency group `android-release`,
+`cancel-in-progress: false`) and upload to the `internal` track. Release notes
+ship from `distribution/whatsnew/whatsnew-en-US` — edit before each release.
+
 ## Backend Environment
 
 Set these in production before submitting:

--- a/mobile/android/CrushLU/app/build.gradle.kts
+++ b/mobile/android/CrushLU/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 val uploadStoreFile = providers.gradleProperty("CRUSH_UPLOAD_STORE_FILE")
@@ -48,9 +49,10 @@ android {
         }
         minSdk = 26
         targetSdk = 35
-        // CI passes -PCRUSH_VERSION_CODE=<git commit count> so every uploaded
-        // build gets a unique, always-increasing code with no manual bump. The
-        // literal is only a fallback for local builds (which never upload).
+        // CI (android-release.yml) passes -PCRUSH_VERSION_CODE=<seconds since
+        // 2024-01-01>, a monotonic value computed at run time under a serialized
+        // concurrency group so Play always sees increasing codes. The literal
+        // fallback is only for local builds, which never upload.
         versionCode = providers.gradleProperty("CRUSH_VERSION_CODE").map { it.toInt() }.getOrElse(4)
         versionName = "1.0.2"
         buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
@@ -90,7 +92,8 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("com.google.android.material:material:1.12.0")
 
-    // Firebase Cloud Messaging (FCM)
+    // Firebase Cloud Messaging (FCM) + Crashlytics (crash reporting)
     implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
     implementation("com.google.firebase:firebase-messaging")
+    implementation("com.google.firebase:firebase-crashlytics")
 }

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MyFirebaseMessagingService.java
@@ -30,7 +30,11 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onNewToken(@NonNull String token) {
         super.onNewToken(token);
-        Log.d(TAG, "Refreshed FCM registration token: " + token);
+        // The registration token is a credential-equivalent identifier; never
+        // leak it (or push payloads below) to logcat on release builds.
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Refreshed FCM registration token: " + token);
+        }
 
         // Store the token in SharedPreferences
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
@@ -43,20 +47,26 @@ public class MyFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
-        Log.d(TAG, "From: " + remoteMessage.getFrom());
 
-        // Check if message contains data payload
         Map<String, String> data = remoteMessage.getData();
-        if (data.size() > 0) {
-            Log.d(TAG, "Message data payload: " + data);
+
+        // Push payloads (sender, data, title/body) are private user content;
+        // only log them on debug builds.
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "From: " + remoteMessage.getFrom());
+            if (data.size() > 0) {
+                Log.d(TAG, "Message data payload: " + data);
+            }
         }
 
         // Check if message contains a notification payload
         if (remoteMessage.getNotification() != null) {
             String title = remoteMessage.getNotification().getTitle();
             String body = remoteMessage.getNotification().getBody();
-            Log.d(TAG, "Message Notification Title: " + title);
-            Log.d(TAG, "Message Notification Body: " + body);
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "Message Notification Title: " + title);
+                Log.d(TAG, "Message Notification Body: " + body);
+            }
 
             // Display a notification if the app is in the foreground
             sendNotification(title, body, data);

--- a/mobile/android/CrushLU/build.gradle.kts
+++ b/mobile/android/CrushLU/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("com.android.application") version "8.7.3" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.firebase.crashlytics") version "3.0.3" apply false
 }


### PR DESCRIPTION
## What

Follow-up to the store-readiness audit of the Crush.lu Android app. The audit overstated several items — after reading the worktree, **most "blockers" were already solved** (signing secrets, monotonic `versionCode`, and the assetlinks backend were all built). The remaining real work:

| Change | Files |
|---|---|
| **Firebase Crashlytics** added (plugin `3.0.3` + `firebase-crashlytics` dep under the existing BOM) — release builds now report field crashes | `build.gradle.kts`, `app/build.gradle.kts` |
| **FCM logging gated** behind `BuildConfig.DEBUG` — no more token / push-payload leaks to logcat on release | `MyFirebaseMessagingService.java` |
| **Stale `versionCode` comment fixed** — CI injects a monotonic seconds-since-2024-01-01 value, not a git commit count | `app/build.gradle.kts` |
| **Assetlinks default-path test** — asserts the web-only state production ships until the Play signing fingerprint is configured | `test_android_app_readiness.py` |
| **Docs** — `ANDROID_APP_SHA256_CERT_FINGERPRINTS` in `.env.example`; signing-CI secrets section in Android README | `.env.example`, `README.md` |

## Why

- **Crashlytics**: the app was a WebView shell + FCM with zero crash reporting. A v1 store app needs field-crash visibility.
- **FCM logging leak**: `Log.d(TAG, "Refreshed FCM registration token: " + token)` and full notification title/body/data ran on every release build — credential-equivalent token + private user content in a globally-readable log.
- **Stale comment**: the build.gradle comment claimed CI passed `<git commit count>`; CI actually injects a timestamp (see `android-release.yml`). Misleading for the next reader.
- **Test gap**: the assetlinks view had a test for the fingerprint-configured case but not the empty default (the state production serves today) — verification behavior was untested.
- **Docs**: the App Links env var and the five signing CI secrets lived only in inline code comments / `docs/app-store/*`, invisible to anyone reading `.env.example` or the Android README.

## What was reconciled vs. the original audit (not changed — already solved)

- **Signing secrets in CI**: `.github/workflows/android-release.yml` already injects all four `CRUSH_UPLOAD_*` from GitHub Actions secrets (base64-decoded keystore). The plaintext `gradle.properties` from the audit lives only in a local working tree, is gitignored, and never ships.
- **Monotonic versionCode**: CI already computes seconds-since-epoch under a serialized concurrency group. Only the comment was wrong.
- **App Links / assetlinks**: fully built end-to-end (`crush_lu/views_pwa.py` view, `urls_crush.py` route, `settings.py` setting, test). Setting the fingerprint in production is an ops/env task, out of code scope.

## Verification

- `./gradlew :app:assembleDebug` → **BUILD SUCCESSFUL** (Crashlytics plugin + dependency resolve; logging changes compile)
- `./gradlew :app:bundleRelease` → **BUILD SUCCESSFUL**, `app-release.aab` (5.7 MB) — release path intact
- Production manifest confirms `package="lu.crush.app"`, host `crush.lu`, **no `.local` suffix**
- `pytest crush_lu/tests/test_android_app_readiness.py` → **6 passed** (includes the new default-path test)

## Out of scope (flagged in the plan, not addressed here)

- Setting `ANDROID_APP_SHA256_CERT_FINGERPRINTS` in production (runtime env var, ops task)
- iOS Crashlytics
- R8/minify + ProGuard rules (defensible to leave off for a thin WebView shell)