### PR TITLE
chore: gitignore .zcode/ agent plan artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ yarn-error.log*
 /.claude/hooks/*
 !/.claude/hooks/session-start.sh
 .codex/
+.zcode/
 
 # Apple Wallet test passes (generated locally)
 *.pkpass


### PR DESCRIPTION
`.zcode/plans/` holds per-session planning notes written by the coding agent — the same class of local artifact as `.claude/`, `.codex/` and `.aider*`, all of which are already in `.gitignore`. `.zcode/` was simply never added.

Without the rule the directory shows as an untracked change in every working tree:

```
?? .zcode/plans/plan-sess_be08286a-....md
?? .zcode/plans/plan-sess_fcdb8399-....md
```

...which is noise at best and an accidental commit at worst.

**Ignore only — nothing is deleted.** Both files are live working state for in-flight sessions (one is the plan behind PR #732), so removing them would destroy another session's context.

Verified:

```
$ git check-ignore -v .zcode/plans/probe.md
.gitignore:173:.zcode/   .zcode/plans/probe.md
```

One line, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
