### PR TITLE
fix(mobile): let the check-in QR scanner reach the camera

### DIFF
--- a/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
+++ b/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
@@ -3,6 +3,16 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- The coach check-in page scans QR codes with getUserMedia() inside the
+         WebView. Without this declaration the runtime request is auto-denied and
+         no system prompt is ever shown. -->
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <!-- Declaring CAMERA implies a *required* camera feature, which would hide
+         the app on Play from camera-less devices. Everything but the scanner
+         works without one, so keep distribution open. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
     <application
         android:allowBackup="false"

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.webkit.CookieManager;
+import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
@@ -41,6 +42,7 @@ import android.os.Build;
 public class MainActivity extends AppCompatActivity {
     private static final int FILE_CHOOSER_REQUEST = 1001;
     private static final int NOTIFICATION_PERMISSION_REQUEST = 1002;
+    private static final int CAMERA_PERMISSION_REQUEST = 1003;
     private static final String BASE_URL = BuildConfig.BASE_URL;
     private static final String START_URL = BASE_URL + "/en/dashboard/?source=android_app";
     private static final String AUTH_SCHEME = BuildConfig.AUTH_SCHEME;
@@ -52,6 +54,9 @@ public class MainActivity extends AppCompatActivity {
     private SwipeRefreshLayout swipeRefresh;
     private View offlineView;
     private ValueCallback<Uri[]> filePathCallback;
+    // Held while the OS camera prompt is up: the WebView's request must stay
+    // un-answered until the user decides, then be granted or denied.
+    private PermissionRequest pendingCameraRequest;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -199,7 +204,66 @@ public class MainActivity extends AppCompatActivity {
                 }
                 return true;
             }
+
+            @Override
+            public void onPermissionRequest(PermissionRequest request) {
+                // WebChromeClient's default implementation denies outright, so
+                // without this override getUserMedia() in the check-in scanner
+                // fails with NotAllowedError and no prompt is ever shown.
+                boolean wantsCamera = false;
+                for (String resource : request.getResources()) {
+                    if (PermissionRequest.RESOURCE_VIDEO_CAPTURE.equals(resource)) {
+                        wantsCamera = true;
+                    }
+                }
+                // Only our own pages may reach the camera; anything else (an
+                // embedded third-party frame) is refused.
+                if (!wantsCamera || !isInternal(request.getOrigin())) {
+                    request.deny();
+                    return;
+                }
+
+                if (checkSelfPermission(android.Manifest.permission.CAMERA)
+                        == PackageManager.PERMISSION_GRANTED) {
+                    request.grant(new String[]{PermissionRequest.RESOURCE_VIDEO_CAPTURE});
+                    return;
+                }
+
+                if (pendingCameraRequest != null) {
+                    // A prompt is already up (e.g. Start tapped twice); leaving
+                    // the newer request unanswered would wedge the scanner.
+                    request.deny();
+                    return;
+                }
+                pendingCameraRequest = request;
+                requestPermissions(
+                        new String[]{android.Manifest.permission.CAMERA},
+                        CAMERA_PERMISSION_REQUEST);
+            }
+
+            @Override
+            public void onPermissionRequestCanceled(PermissionRequest request) {
+                if (request.equals(pendingCameraRequest)) {
+                    pendingCameraRequest = null;
+                }
+            }
         });
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode != CAMERA_PERMISSION_REQUEST || pendingCameraRequest == null) {
+            return;
+        }
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            pendingCameraRequest.grant(new String[]{PermissionRequest.RESOURCE_VIDEO_CAPTURE});
+        } else {
+            // Denying (rather than dropping it) lets the page surface its
+            // "camera permission denied" message instead of hanging.
+            pendingCameraRequest.deny();
+        }
+        pendingCameraRequest = null;
     }
 
     private void configureSwipeRefresh() {

--- a/mobile/ios/CrushLU/CrushLU/CrushWebView.swift
+++ b/mobile/ios/CrushLU/CrushLU/CrushWebView.swift
@@ -13,6 +13,10 @@ struct CrushWebView: UIViewRepresentable {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .default()
         configuration.allowsInlineMediaPlayback = true
+        // The scanner's <video> is fed by a MediaStream and started from inside a
+        // promise chain, so the tap's user-gesture no longer counts by the time
+        // play() runs. Mirrors setMediaPlaybackRequiresUserGesture(false) on Android.
+        configuration.mediaTypesRequiringUserActionForPlayback = []
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
@@ -129,8 +133,29 @@ struct CrushWebView: UIViewRepresentable {
             appState.load(completeURL)
         }
 
+        func webView(
+            _ webView: WKWebView,
+            requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+            initiatedByFrame frame: WKFrameInfo,
+            type: WKMediaCaptureType,
+            decisionHandler: @escaping (WKPermissionDecision) -> Void
+        ) {
+            // Only the check-in scanner needs capture, and only our own pages may
+            // ask. Granting here skips WebKit's redundant in-page prompt; iOS still
+            // shows the system alert on first use (NSCameraUsageDescription).
+            guard type == .camera, isInternalHost(origin.host) else {
+                decisionHandler(.deny)
+                return
+            }
+            decisionHandler(.grant)
+        }
+
         private func isInternal(_ url: URL) -> Bool {
-            guard let host = url.host?.lowercased() else { return false }
+            isInternalHost(url.host)
+        }
+
+        private func isInternalHost(_ host: String?) -> Bool {
+            guard let host = host?.lowercased() else { return false }
             return host == "crush.lu" || host == "www.crush.lu" || host == "test.crush.lu"
         }
     }

--- a/mobile/ios/CrushLU/CrushLU/Info.plist
+++ b/mobile/ios/CrushLU/CrushLU/Info.plist
@@ -27,6 +27,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Crush.lu uses the camera so coaches can scan attendee QR codes at event check-in.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIRequiresFullScreen</key>


### PR DESCRIPTION
## Problem

The coach check-in scanner never asked for camera permission in the Android app. The page itself is fine — `getUserMedia()` was being refused by the native shell before any prompt could appear.

Because qr-scanner collapses *every* `getUserMedia` failure into the string `"Camera not found"`, the door saw **"No camera found on this device"** rather than a permission error — which sent the diagnosis in the wrong direction.

## Root cause — two independent Android blockers

Either one alone is fatal.

**1. `WebChromeClient.onPermissionRequest()` was not overridden.** `MainActivity` installed a `WebChromeClient` with only `onProgressChanged` and `onShowFileChooser`. Per the Android contract, if `onPermissionRequest` isn't overridden the permission is **denied** — silently, with no OS dialog. The promise rejected instantly.

**2. `android.permission.CAMERA` was not declared.** The manifest carried only `INTERNET`, `ACCESS_NETWORK_STATE`, `POST_NOTIFICATIONS`. With `targetSdk = 35`, an undeclared runtime permission returns `PERMISSION_DENIED` immediately and shows no dialog — so even after fixing (1), the app itself held no camera access to hand on.

## Changes

### Android
- **`AndroidManifest.xml`** — declare `CAMERA`; declare `camera` / `camera.autofocus` as `required="false"`. That second part matters: declaring `CAMERA` alone implies a *required* camera feature, which would have hidden the app on Play from camera-less devices.
- **`MainActivity.java`** — override `onPermissionRequest()`, hold the `PermissionRequest` across the runtime prompt, resolve it in a new `onRequestPermissionsResult()`, and clear it in `onPermissionRequestCanceled()`. Grants only `RESOURCE_VIDEO_CAPTURE` from a crush.lu origin; a denial is passed through explicitly so the page renders its "camera permission denied" message instead of hanging. A second request arriving while a prompt is up is denied rather than left unanswered — leaving it dangling would wedge the scanner button.

### iOS (same flow, same gap)
- **`Info.plist`** — add `NSCameraUsageDescription`. Its absence is a **hard crash** on first camera access, not a denial.
- **`CrushWebView.swift`** — add `requestMediaCapturePermissionFor` (origin- and type-checked), and clear `mediaTypesRequiringUserActionForPlayback` so the MediaStream `<video>` autoplays. That mirrors `setMediaPlaybackRequiresUserGesture(false)`, which Android already had.

## Verification

- `processDebugMainManifest` + `compileDebugJavaWithJavac` — **BUILD SUCCESSFUL**. The three warnings (source/target 8 obsolete, deprecated `onBackPressed()`) are pre-existing on `main`.
- Merged manifest confirmed to carry `CAMERA` with both camera features still `required="false"`.
- **iOS is unverified** — no Xcode on the dev box, so the Swift/plist changes are reviewed but not compiled. Please build before the next TestFlight push.
- **Not yet walked on a device.** Needs an install + one real scan at the check-in page to confirm the prompt appears and the stream starts.

## Notes for the reviewer

- **Device testing needs HTTPS.** Against the emulator's `http://10.0.2.2` dev origin this will still fail — `getUserMedia` requires a secure context, and a plain-HTTP LAN IP doesn't qualify (only `localhost`/`127.0.0.1` are exempt). Test against `test.crush.lu`.
- **No Play declaration form required.** `CAMERA` is an ordinary dangerous permission, not a restricted one. Data Safety is unaffected — QR decoding is entirely on-device and no frames leave the phone.
- Shipping this needs a new Android build; `versionCode` is auto-derived from commit count, so the normal CI path covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
