### PR TITLE
chore(android): bump versionName to 1.0.3 for the camera-permission fix

### DIFF
--- a/mobile/android/CrushLU/app/build.gradle.kts
+++ b/mobile/android/CrushLU/app/build.gradle.kts
@@ -54,7 +54,7 @@ android {
         // concurrency group so Play always sees increasing codes. The literal
         // fallback is only for local builds, which never upload.
         versionCode = providers.gradleProperty("CRUSH_VERSION_CODE").map { it.toInt() }.getOrElse(4)
-        versionName = "1.0.2"
+        versionName = "1.0.3"
         buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
         buildConfigField("String", "AUTH_SCHEME", "\"$authScheme\"")
 

--- a/mobile/android/CrushLU/distribution/whatsnew/whatsnew-en-US
+++ b/mobile/android/CrushLU/distribution/whatsnew/whatsnew-en-US
@@ -1,7 +1,4 @@
 What's new in this update:
 
-• More reliable push notifications, with a heads-up banner for new matches and messages
-• Tapping a notification now opens the right page
-• Fixed the bottom bar overlapping your phone's navigation buttons
-• Smoother keyboard behaviour on forms
+• Coaches can now scan attendee QR codes at event check-in — the app asks for camera permission the first time you open the scanner
 • Stability and reliability improvements


### PR DESCRIPTION
Follow-up to #735, which fixed the coach check-in QR scanner being unable to reach the camera.

## Why bump versionName

`versionCode` is computed by CI at run time, so a release could go out without touching anything here. But it would still be labelled **1.0.2** — identical to the build already on open testing.

That matters right now: the fix has never been walked on a device, so someone has to verify it at the door. If both builds read 1.0.2, a coach has no way to tell whether their phone has the fix or the old shell that silently denies camera access. Bumping to **1.0.3** makes that check trivial.

## Changes

- `build.gradle.kts` — `versionName` 1.0.2 → 1.0.3. `versionCode` untouched (CI computes it; do not hand-edit).
- `whatsnew-en-US` — release notes rewritten for this release. The previous text described the build-4 notification/nav-overlap work, which is already on open testing.

## After merge

Per the release runbook: dispatch `android-release.yml` from `main` via `workflow_dispatch` (**not** a `v*` tag — that would also cut an iOS App Store release). That lands a signed AAB on the **internal** track, which needs no Google review and is installable immediately for a device check of the camera prompt.

Promotion internal → open testing is the manual gate afterwards, and that one does trigger review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
