### PR TITLE
fix(crush_lu): branch the Connect subnav on Premium, not assigned_coach

### DIFF
--- a/crush_lu/templates/crush_lu/crush_connect/_connect_subnav.html
+++ b/crush_lu/templates/crush_lu/crush_connect/_connect_subnav.html
@@ -1,9 +1,9 @@
 {% load i18n crush_connect_tags %}
 {% comment %}
-Crush Connect sub-navigation — the dedicated menu shown across all Connect pages.
-Track-aware (receiver -> Today's Drop, candidate -> In the Mix) and coach-aware
-(Curation). Active tab via request.resolver_match.url_name. Reuses existing
-chip/pill utility classes already in the Tailwind build.
+Crush Connect sub-navigation (receiver -> Today's Drop, candidate -> In the Mix,
+coach -> Curation). Currently included by NO template: d5a8a891 dropped it from
+_base_connect.html. The track test must stay crush_connect_is_receiver (Premium)
+and never assigned_coach. Active tab via request.resolver_match.url_name.
 {% endcomment %}
 {% if user|crush_connect_nav_visible %}
 <nav class="max-w-2xl mx-auto px-4 pt-5" aria-label="{% trans 'Crush Connect' %}">
@@ -15,7 +15,7 @@ chip/pill utility classes already in the Tailwind build.
       {% include "shared/icons/sparkles.html" with class="w-4 h-4" %}<span>{% trans "Home" %}</span>
     </a>
 
-    {% if user.crushprofile.assigned_coach_id %}
+    {% if user|crush_connect_is_receiver %}
     <a href="{% url 'crush_lu:crush_connect_home' %}"
        class="{{ base }} {% if active == 'crush_connect_home' %}{{ on }}{% else %}{{ off }}{% endif %}">
       {% include "shared/icons/heart.html" with class="w-4 h-4" %}<span>{% trans "Today's Drop" %}</span>

--- a/crush_lu/templatetags/crush_connect_tags.py
+++ b/crush_lu/templatetags/crush_connect_tags.py
@@ -68,6 +68,40 @@ def crush_connect_nav_visible(user):
     return candidate_access_open()
 
 
+@register.filter
+def crush_connect_is_receiver(user):
+    """
+    True if this user is on the RECEIVER track (Today's Drop) right now, as
+    opposed to the CANDIDATE track (In the Mix).
+
+    Mirrors the view layer's source of truth exactly — ``_user_can_receive_now``
+    (active ``PremiumMembership`` AND a phase that lets them receive) with the
+    same ``or user.is_staff`` preview bypass the views apply.
+
+    Never branch a Connect track on ``assigned_coach``: a coach is also assigned
+    WITHOUT payment (the 0150 backfill, ``assign_coach_on_first_attendance`` on
+    first event check-in), so a coach-based test offers Today's Drop to members
+    whom ``_connect_access_blocker`` then bounces to their catalogue status.
+
+    This lives here rather than in view context because the Connect sub-nav is a
+    shared partial — only ``crush_connect_hub`` supplies ``is_receiver``, so a
+    context variable would silently read as False on every other Connect page.
+    """
+    from crush_lu.views_crush_connect import _user_can_receive_now
+
+    if not user or not user.is_authenticated:
+        return False
+    try:
+        return bool(_user_can_receive_now(user) or user.is_staff)
+    except Exception:
+        # Same defensive stance as crush_connect_nav_visible: this runs DB
+        # queries (profile + PremiumMembership) during template rendering, and
+        # a backend fault must not 500 the page from the nav. Falling back to
+        # the candidate tab is the safe default — it points at the surface a
+        # non-receiver would be redirected to anyway.
+        return False
+
+
 @register.simple_tag
 def crush_connect_launched():
     """Raw flag accessor for templates that need it directly."""

--- a/crush_lu/tests/test_crush_connect_hub.py
+++ b/crush_lu/tests/test_crush_connect_hub.py
@@ -138,16 +138,19 @@ def test_hub_surfaces_pending_sparks(client, settings):
 
 
 # ---------------------------------------------------------------------------
-# Shared shell: member-facing pages render the Connect sub-nav
+# Shared shell: member-facing pages link back to the Connect hub
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_member_page_renders_connect_subnav(client, settings):
+def test_member_page_links_back_to_the_hub(client, settings):
     settings.CRUSH_CONNECT_LAUNCHED = True
     me = _make_user(username="me", onboarded=True, premium=True)
     _login_eligible(client, me)
-    # Today's Drop now extends the Connect shell → its sub-nav links to the hub.
+    # That link comes from the persistent navbar / bottom nav
+    # (crush_connect_nav_visible) — NOT from _connect_subnav.html, which no
+    # template has included since d5a8a891. The old name and comment here
+    # claimed the sub-nav, which is what made its stale predicate look live.
     resp = client.get(reverse("crush_lu:crush_connect_home"))
     assert resp.status_code == 200
     assert reverse("crush_lu:crush_connect_hub") in resp.content.decode()

--- a/crush_lu/tests/test_crush_connect_hub.py
+++ b/crush_lu/tests/test_crush_connect_hub.py
@@ -7,11 +7,15 @@ use ``/en/crush-connect/…`` URLs which only resolve under ``urls_crush``.
 """
 
 import pytest
+from django.template.loader import render_to_string
 from django.urls import reverse
 
 pytestmark = pytest.mark.urls("azureproject.urls_crush")
 
-from crush_lu.models import CuriositySpark  # noqa: E402
+from crush_lu.models import CuriositySpark, PremiumMembership  # noqa: E402
+from crush_lu.templatetags.crush_connect_tags import (  # noqa: E402
+    crush_connect_is_receiver,
+)
 from crush_lu.tests.test_crush_connect import (  # noqa: E402
     _login_eligible,
     _make_user,
@@ -147,3 +151,100 @@ def test_member_page_renders_connect_subnav(client, settings):
     resp = client.get(reverse("crush_lu:crush_connect_home"))
     assert resp.status_code == 200
     assert reverse("crush_lu:crush_connect_hub") in resp.content.decode()
+
+
+# ---------------------------------------------------------------------------
+# Sub-nav track tab: Premium entitlement, NOT assigned_coach
+#
+# The partial is rendered directly because no template includes it right now
+# (d5a8a891 dropped the include from _base_connect.html). These tests pin the
+# predicate so the coach-based test can't come back if it is ever wired in.
+# ---------------------------------------------------------------------------
+
+
+def _render_subnav(user):
+    return render_to_string(
+        "crush_lu/crush_connect/_connect_subnav.html", {"user": user}
+    )
+
+
+def _drop_coach_assigned_non_premium(username="coached"):
+    """A member the 0150 backfill / attendance auto-assign left with a coach but
+    no active PremiumMembership — the shape of every one of the ~464 affected
+    accounts on production (0 active memberships platform-wide)."""
+    user = _make_user(username=username, onboarded=True, premium=True)
+    PremiumMembership.objects.filter(user=user).delete()
+    user.crushprofile.refresh_from_db()
+    assert user.crushprofile.assigned_coach_id is not None
+    assert user.crushprofile.has_active_premium is False
+    return user
+
+
+@pytest.mark.django_db
+def test_subnav_shows_in_the_mix_for_coach_assigned_non_premium(settings):
+    """A coach without payment must NOT surface a 'Today's Drop' tab: it is
+    mislabeled and _connect_access_blocker bounces it straight back to the
+    catalogue status page."""
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    me = _drop_coach_assigned_non_premium()
+
+    body = _render_subnav(me)
+
+    assert reverse("crush_lu:crush_connect_catalogue_status") in body
+    assert reverse("crush_lu:crush_connect_home") not in body
+
+
+@pytest.mark.django_db
+def test_subnav_shows_todays_drop_for_premium_receiver(settings):
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    me = _make_user(username="me", onboarded=True, premium=True)
+
+    body = _render_subnav(me)
+
+    assert reverse("crush_lu:crush_connect_home") in body
+    assert reverse("crush_lu:crush_connect_catalogue_status") not in body
+
+
+@pytest.mark.django_db
+def test_subnav_track_tab_matches_the_hub(client, settings):
+    """The sub-nav filter and the hub's view-supplied ``is_receiver`` must agree
+    — a coach-assigned non-premium member is a candidate on both surfaces."""
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    me = _drop_coach_assigned_non_premium(username="me")
+    _login_eligible(client, me)
+
+    resp = client.get(HUB_URL)
+
+    assert resp.status_code == 200
+    assert resp.context["is_receiver"] is False
+    assert crush_connect_is_receiver(me) is False
+
+
+@pytest.mark.django_db
+def test_subnav_is_receiver_filter_tracks_membership_status(settings):
+    """Cancelling the membership revokes the receiver tab even though the coach
+    relationship survives — mirrors the view-layer gate."""
+    settings.CRUSH_CONNECT_LAUNCHED = True
+    me = _make_user(username="me", onboarded=True, premium=True)
+    assert crush_connect_is_receiver(me) is True
+
+    PremiumMembership.objects.filter(user=me).update(status="cancelled")
+
+    assert crush_connect_is_receiver(me) is False
+    assert me.crushprofile.assigned_coach_id is not None
+
+
+@pytest.mark.django_db
+def test_subnav_beta_premium_non_tester_is_a_candidate(settings):
+    """In beta the phase also gates the receiver track: a Premium member who
+    isn't a selected tester is a candidate, exactly as _user_can_receive_now
+    reports it."""
+    settings.CRUSH_CONNECT_LAUNCHED = False
+    settings.CRUSH_CONNECT_CANDIDATE_OPEN = True
+    me = _make_user(username="me", onboarded=True, premium=True)
+
+    body = _render_subnav(me)
+
+    assert crush_connect_is_receiver(me) is False
+    assert reverse("crush_lu:crush_connect_catalogue_status") in body
+    assert reverse("crush_lu:crush_connect_home") not in body


### PR DESCRIPTION
## Purpose

`_connect_subnav.html` chose its track tab with `user.crushprofile.assigned_coach_id`. That is **not** the Premium entitlement.

PR #629 established that premium = an active `PremiumMembership` (`CrushProfile.has_active_premium`), because a coach is also assigned **without payment** — by the `0150` backfill and by `assign_coach_on_first_attendance`, which fires on first event check-in. The access layer already uses the right predicate: `_user_is_connect_receiver_eligible` checks `has_active_premium`, and `_user_can_receive_now` ANDs it with `receiver_access_open`.

The mismatch would offer a **"Today's Drop"** tab to any coach-assigned member without an active membership. Clicking it hits `_connect_access_blocker`, which computes `_user_can_receive_now == False` and redirects to `crush_connect_catalogue_status` — a mislabeled tab that bounces, while the **"In the Mix"** tab describing their actual state never appears. On production that is the ~464 members the `0150` backfill touched, plus every new event attendee, against **0 active PremiumMemberships platform-wide**.

### Not currently user-visible

Worth knowing before review: **no template includes this partial.** Commit `d5a8a891` ("Simplify Crush Connect hub navigation", 2026-07-05) removed the only `{% include %}`, which lived in `_base_connect.html`. A repo-wide search for `connect_subnav` across every `.html` and `.py` finds nothing outside the file itself and one test function name.

So nothing renders the mislabeled tab today, and no member is being bounced. The predicate is fixed anyway so the trap cannot return if the partial is wired back in, and the file's header comment — which claimed it was "shown across all Connect pages", the wording that made this look live — now records that it is orphaned.

**Open question for a follow-up:** the partial is dead code. Re-include it in `_base_connect.html`, or delete it? This PR does neither.

### Why a template filter

`crush_connect_is_receiver` was added to `crush_connect_tags.py` rather than exposing `is_receiver` from each view. The subnav is a shared partial and only `crush_connect_hub` supplies `is_receiver` (`views_crush_connect.py:770`), so a context variable would silently read `False` on every other Connect page — the same class of quiet-wrong-default this PR is fixing.

The filter mirrors the hub exactly — `_user_can_receive_now(user) or user.is_staff` — and carries the same defensive `except` as the neighbouring `crush_connect_nav_visible`, because it runs profile + `PremiumMembership` queries during template rendering and a backend fault must not 500 a page from the nav. It falls back to the candidate tab, which points at the surface a non-receiver would be redirected to anyway.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

Inert on production: the partial renders nowhere, so this is a no-op at runtime. No new translatable strings, and the template edit preserves line counts so the existing `.po` line references stay valid — no i18n churn.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```bash
DBHOST='' SECRET_KEY='test-secret-key-for-local-pytest' pytest crush_lu/tests/test_crush_connect_hub.py -n 0 -q
```

`DBHOST=''` forces SQLite; `-n 0` disables xdist. A worktree has no `.env`, hence the explicit `SECRET_KEY`.

Full Connect suite — **207 passed**:

```bash
DBHOST='' SECRET_KEY='test-secret-key-for-local-pytest' pytest crush_lu/tests/test_crush_connect_hub.py crush_lu/tests/test_crush_connect.py crush_lu/tests/test_crush_connect_beta_phase.py crush_lu/tests/test_crush_connect_onboarding.py -n 0 -q
```

## What to Check

Five tests were added. They render the partial directly with `render_to_string`, since no page includes it:

* a coach-assigned member with **no** active membership sees "In the Mix", not "Today's Drop" — the production shape, built by deleting the `PremiumMembership` the helper creates
* a premium receiver sees "Today's Drop", not "In the Mix"
* the filter agrees with the hub's view-supplied `is_receiver` for the same user
* cancelling the membership revokes the tab while `assigned_coach_id` survives
* in beta, a premium **non-tester** reads as a candidate — the phase gate, not just the entitlement

The first and last **fail against the old predicate**; verified by reverting the template line, re-running, and restoring.

Every other Connect navigation surface was audited and is already correct:

| Surface | Predicate | Verdict |
|---|---|---|
| `base.html` ×4 (navbar + mobile) | links to `crush_connect_hub` | no track branch |
| `partials/bottom_nav.html:65` | links to `crush_connect_hub` | no track branch |
| `crush_connect/hub.html:20,77` | view-supplied `is_receiver` | correct |
| `_connect_subnav.html:18` | `assigned_coach_id` | **fixed here** |

Remaining `assigned_coach` hits in templates are coach *name* display and connection assignment, not entitlement gates.

## Other Information

Ruff clean on both changed Python files. `black --check` reports three pre-existing hunks in `test_crush_connect_hub.py` that this PR does not touch — the repo is not black-clean (~490 files), so they were left alone to keep the diff honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
