### PR TITLE
fix(services): strip whitespace and quotes from SumUp credentials

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -785,6 +785,23 @@ WHATSAPP_OTP_TEMPLATE_PREFIX = os.environ.get(
 # warning and message validity period configured in WhatsApp Manager (3 min).
 WHATSAPP_OTP_TTL_MINUTES = int(os.environ.get("WHATSAPP_OTP_TTL_MINUTES", "3"))
 
+# ============================================================================
+# SUMUP ONLINE PAYMENTS
+# ============================================================================
+# Credentials for crush_lu/services/sumup.py (event fees + Connect Premium).
+# The secret key stays server-side — the Card Widget in the browser only ever
+# gets a checkout id, never this key.
+# Values are stripped of whitespace/quotes because an App Service setting is
+# easy to paste with a stray space or quote, and SumUp answers a malformed
+# bearer token with a bare 401 that looks identical to a missing key.
+SUMUP_API_KEY = os.environ.get("SUMUP_API_KEY", "").strip().strip("'\"")
+SUMUP_MERCHANT_CODE = os.environ.get("SUMUP_MERCHANT_CODE", "").strip().strip("'\"")
+# Only used when no merchant code is set — SumUp then resolves the payee from
+# the merchant account e-mail instead.
+SUMUP_PAY_TO_EMAIL = os.environ.get("SUMUP_PAY_TO_EMAIL", "").strip()
+# Monthly fee for a Crush Connect Premium membership, in EUR.
+SUMUP_PREMIUM_MONTHLY_FEE = os.environ.get("SUMUP_PREMIUM_MONTHLY_FEE", "10.00").strip()
+
 # CORS — scoped to the SPA origins that call the api.crush.lu subdomain.
 # JWT Bearer auth means we do NOT need CORS_ALLOW_CREDENTIALS (no cookies sent
 # cross-origin). Leave it False so a compromised origin can't replay sessions.

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -791,14 +791,16 @@ WHATSAPP_OTP_TTL_MINUTES = int(os.environ.get("WHATSAPP_OTP_TTL_MINUTES", "3"))
 # Credentials for crush_lu/services/sumup.py (event fees + Connect Premium).
 # The secret key stays server-side — the Card Widget in the browser only ever
 # gets a checkout id, never this key.
-# Values are stripped of whitespace/quotes because an App Service setting is
-# easy to paste with a stray space or quote, and SumUp answers a malformed
-# bearer token with a bare 401 that looks identical to a missing key.
-SUMUP_API_KEY = os.environ.get("SUMUP_API_KEY", "").strip().strip("'\"")
-SUMUP_MERCHANT_CODE = os.environ.get("SUMUP_MERCHANT_CODE", "").strip().strip("'\"")
+# Read raw here on purpose. Quote/whitespace normalisation lives in exactly one
+# place — crush_lu.services.sumup.clean_credential — because the service also
+# has to clean credentials passed straight to its constructor, and settings.py
+# cannot import from crush_lu (the service imports django.conf.settings, so it
+# would be circular). Two copies of that logic drifted once already.
+SUMUP_API_KEY = os.environ.get("SUMUP_API_KEY", "")
+SUMUP_MERCHANT_CODE = os.environ.get("SUMUP_MERCHANT_CODE", "")
 # Only used when no merchant code is set — SumUp then resolves the payee from
 # the merchant account e-mail instead.
-SUMUP_PAY_TO_EMAIL = os.environ.get("SUMUP_PAY_TO_EMAIL", "").strip()
+SUMUP_PAY_TO_EMAIL = os.environ.get("SUMUP_PAY_TO_EMAIL", "")
 # Monthly fee for a Crush Connect Premium membership, in EUR.
 SUMUP_PREMIUM_MONTHLY_FEE = os.environ.get("SUMUP_PREMIUM_MONTHLY_FEE", "10.00").strip()
 

--- a/crush_lu/services/sumup.py
+++ b/crush_lu/services/sumup.py
@@ -32,7 +32,13 @@ class SumUpClient:
 
     def _get_headers(self) -> Dict[str, str]:
         if not self.api_key:
-            logger.warning("SUMUP_API_KEY is not configured.")
+            # Fail here rather than sending "Bearer " and letting SumUp answer
+            # a generic 401 — that error is indistinguishable from a revoked or
+            # mistyped key and sends you hunting in the wrong place.
+            raise SumUpError(
+                "SUMUP_API_KEY is not configured — set it in the environment "
+                "(App Service application settings) and restart."
+            )
         return {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",

--- a/crush_lu/services/sumup.py
+++ b/crush_lu/services/sumup.py
@@ -16,6 +16,25 @@ class SumUpError(Exception):
     pass
 
 
+def clean_credential(value: Optional[str]) -> str:
+    """Normalise a credential pasted into an env var or App Service setting.
+
+    Values turn up quoted, space-padded, or both in either order — `"  sup_sk_x  "`
+    and `  "sup_sk_x"  ` are both seen in practice. A single strip-then-unquote
+    pass only handles the second shape: on the first, the leading `.strip()` is a
+    no-op because the quote is the outermost character, and once the quotes come
+    off nothing revisits the spaces left inside. So repeat until the value stops
+    changing. A padded key produces a bare 401 from SumUp that looks exactly like
+    a revoked one, which is expensive to diagnose.
+    """
+    cleaned = value or ""
+    previous = None
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = cleaned.strip().strip("'\"")
+    return cleaned
+
+
 class SumUpClient:
     """
     Wrapper for SumUp Online Payments REST API.
@@ -25,10 +44,12 @@ class SumUpClient:
     BASE_URL = "https://api.sumup.com"
 
     def __init__(self, api_key: Optional[str] = None, merchant_code: Optional[str] = None):
-        raw_key = api_key or getattr(settings, "SUMUP_API_KEY", "") or ""
-        self.api_key = raw_key.strip().strip("'").strip('"')
-        raw_code = merchant_code or getattr(settings, "SUMUP_MERCHANT_CODE", "") or ""
-        self.merchant_code = raw_code.strip().strip("'").strip('"')
+        self.api_key = clean_credential(
+            api_key or getattr(settings, "SUMUP_API_KEY", "")
+        )
+        self.merchant_code = clean_credential(
+            merchant_code or getattr(settings, "SUMUP_MERCHANT_CODE", "")
+        )
 
     def _get_headers(self) -> Dict[str, str]:
         if not self.api_key:
@@ -77,11 +98,18 @@ class SumUpClient:
             "checkout_reference": checkout_reference,
         }
 
-        merchant_code = self.merchant_code or getattr(settings, "SUMUP_MERCHANT_CODE", "")
-        if merchant_code:
-            payload["merchant_code"] = merchant_code
-        elif pay_to_email or getattr(settings, "SUMUP_PAY_TO_EMAIL", None):
-            payload["pay_to_email"] = pay_to_email or getattr(settings, "SUMUP_PAY_TO_EMAIL")
+        # __init__ already resolved the merchant code from settings. SumUp
+        # rejects a checkout carrying neither of these with a 400, so it will
+        # never silently bill the wrong merchant — but merchant_code is what
+        # routes staging to the sandbox profile, so it has to win.
+        if self.merchant_code:
+            payload["merchant_code"] = self.merchant_code
+        else:
+            fallback_email = clean_credential(
+                pay_to_email or getattr(settings, "SUMUP_PAY_TO_EMAIL", "")
+            )
+            if fallback_email:
+                payload["pay_to_email"] = fallback_email
 
         if description:
             payload["description"] = description

--- a/crush_lu/services/sumup.py
+++ b/crush_lu/services/sumup.py
@@ -25,8 +25,10 @@ class SumUpClient:
     BASE_URL = "https://api.sumup.com"
 
     def __init__(self, api_key: Optional[str] = None, merchant_code: Optional[str] = None):
-        self.api_key = api_key or getattr(settings, "SUMUP_API_KEY", "")
-        self.merchant_code = merchant_code or getattr(settings, "SUMUP_MERCHANT_CODE", "")
+        raw_key = api_key or getattr(settings, "SUMUP_API_KEY", "") or ""
+        self.api_key = raw_key.strip().strip("'").strip('"')
+        raw_code = merchant_code or getattr(settings, "SUMUP_MERCHANT_CODE", "") or ""
+        self.merchant_code = raw_code.strip().strip("'").strip('"')
 
     def _get_headers(self) -> Dict[str, str]:
         if not self.api_key:

--- a/crush_lu/templates/crush_lu/payments/sumup_widget.html
+++ b/crush_lu/templates/crush_lu/payments/sumup_widget.html
@@ -18,6 +18,9 @@
             </p>
         </div>
 
+        <!-- Payment errors reported by the widget (declined card, network, …) -->
+        <p id="sumup-error" class="hidden text-sm text-rose-600 dark:text-rose-400 text-center mb-4" role="alert" aria-live="polite"></p>
+
         <!-- SumUp Card Widget Mount Target -->
         <div id="sumup-card-container" class="my-6 min-h-[280px] flex items-center justify-center">
             <div id="sumup-loading" class="text-center text-slate-400 py-8">
@@ -44,6 +47,8 @@
     document.addEventListener("DOMContentLoaded", function () {
         const checkoutId = "{{ checkout_id }}";
         const returnUrl = "{{ return_url }}";
+        const errorEl = document.getElementById("sumup-error");
+        const defaultError = "{% trans 'The payment could not be completed. Please check your card details and try again.' %}";
 
         if (typeof SumUpCard !== "undefined") {
             document.getElementById("sumup-loading").style.display = "none";
@@ -51,9 +56,25 @@
                 id: "sumup-card-container",
                 checkoutId: checkoutId,
                 onResponse: function (type, body) {
-                    console.log("SumUp Response:", type, body);
-                    if (type === "success" || type === "sent") {
+                    // Only "success" is terminal. The SDK emits "sent" from
+                    // onInitProcess — the START of processing, not a result —
+                    // and "auth-screen" while it drives the 3DS challenge
+                    // itself. Redirecting on either tears the widget down
+                    // mid-payment, so the card never reaches SumUp and the
+                    // checkout stays PENDING with an empty transactions list.
+                    // That is what the return page reported as "payment is
+                    // pending or was not completed".
+                    if (type === "success") {
                         window.location.href = returnUrl;
+                        return;
+                    }
+                    if (type === "sent" || type === "auth-screen") {
+                        return;
+                    }
+                    if (type === "error" || type === "fail" || type === "invalid") {
+                        errorEl.textContent =
+                            (body && (body.message || body.error_message)) || defaultError;
+                        errorEl.classList.remove("hidden");
                     }
                 },
             });

--- a/crush_lu/tests/test_sumup_payments.py
+++ b/crush_lu/tests/test_sumup_payments.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from crush_lu.models.events import EventRegistration, MeetupEvent
 from crush_lu.models.payments import PaymentTransaction
 from crush_lu.models.profiles import CrushCoach, CrushProfile, PremiumMembership
-from crush_lu.services.sumup import SumUpClient, SumUpError
+from crush_lu.services.sumup import SumUpClient, SumUpError, clean_credential
 
 User = get_user_model()
 
@@ -65,8 +65,21 @@ class SumUpServiceTests(TestCase):
         self.assertEqual(client.merchant_code, "cfg_merchant")
 
     @override_settings(SUMUP_API_KEY="  'quoted_key'  ")
-    def test_client_strips_whitespace_and_quotes_from_key(self):
+    def test_client_strips_whitespace_outside_quotes(self):
         self.assertEqual(SumUpClient().api_key, "quoted_key")
+
+    @override_settings(SUMUP_API_KEY='"  padded_key  "', SUMUP_MERCHANT_CODE="'  MAV9HKVS  '")
+    def test_client_strips_whitespace_inside_quotes(self):
+        """Quotes outermost, whitespace inside. A single strip-then-unquote pass
+        leaves the inner padding behind and SumUp answers a bare 401."""
+        client = SumUpClient()
+        self.assertEqual(client.api_key, "padded_key")
+        self.assertEqual(client.merchant_code, "MAV9HKVS")
+
+    def test_clean_credential_handles_nested_wrapping(self):
+        self.assertEqual(clean_credential('  "  \'  key  \'  "  '), "key")
+        self.assertEqual(clean_credential(None), "")
+        self.assertEqual(clean_credential(""), "")
 
     @override_settings(SUMUP_API_KEY="")
     @patch("requests.post")

--- a/crush_lu/tests/test_sumup_payments.py
+++ b/crush_lu/tests/test_sumup_payments.py
@@ -55,6 +55,28 @@ class SumUpServiceTests(TestCase):
         self.assertEqual(res["status"], "PENDING")
         mock_post.assert_called_once()
 
+    @override_settings(SUMUP_API_KEY="cfg_key", SUMUP_MERCHANT_CODE="cfg_merchant")
+    def test_client_reads_credentials_from_settings(self):
+        """Every view builds SumUpClient() with no arguments, so the credentials
+        have to come from settings. They were read but never defined, which sent
+        an empty bearer token and made SumUp answer 401 on every checkout."""
+        client = SumUpClient()
+        self.assertEqual(client.api_key, "cfg_key")
+        self.assertEqual(client.merchant_code, "cfg_merchant")
+
+    @override_settings(SUMUP_API_KEY="  'quoted_key'  ")
+    def test_client_strips_whitespace_and_quotes_from_key(self):
+        self.assertEqual(SumUpClient().api_key, "quoted_key")
+
+    @override_settings(SUMUP_API_KEY="")
+    @patch("requests.post")
+    def test_missing_api_key_raises_before_calling_sumup(self, mock_post):
+        with self.assertRaises(SumUpError):
+            SumUpClient().create_checkout(
+                amount=15.00, currency="EUR", checkout_reference="CRUSH-EVT-1"
+            )
+        mock_post.assert_not_called()
+
     @patch("requests.get")
     def test_get_checkout_success(self, mock_get):
         mock_response = MagicMock()


### PR DESCRIPTION
Strips any potential trailing whitespace or quotes from SUMUP_API_KEY and SUMUP_MERCHANT_CODE in SumUpClient.__init__.