### PR TITLE
docs: correct the background-tasks claim — production runs inline, no db_worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ DRF + SimpleJWT JSON API backing the external `hub.crush.lu` CRM SPA. JWT Bearer
 
 ### Background tasks
 
-Uses Django 6.0's native `TASKS` framework. Default `ImmediateBackend` runs inline (safe for dev). Production sets `DJANGO_TASKS_BACKEND` to the DB backend and runs `manage.py db_worker`. **conftest.py forces `ImmediateBackend` in tests regardless of env.**
+Uses Django 6.0's native `TASKS` framework — but **production runs on the default `ImmediateBackend`, inline**. `DJANGO_TASKS_BACKEND` is unset on the App Service and no `manage.py db_worker` runs anywhere (`azureproject/production.py`: *"no separate db_worker process is running on Azure"*). So **`.enqueue()` defers nothing** — the task body executes synchronously inside the calling request, and `@task` buys you only a named unit with its own error handling. Never move slow work (network fan-out, email, APNs pushes) into a task expecting it to leave the request: bound it in-request instead (e.g. `PASSKIT_BULK_PUSH_LIMIT` / `PASSKIT_BULK_PUSH_BUDGET_SECONDS`), or drive it from an Azure Function timer hitting an admin endpoint the way `CampaignDispatch` does. **conftest.py forces `ImmediateBackend` in tests regardless of env.**
 
 ### Multi-channel campaigns (crush_lu Coach Panel)
 

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1351,6 +1351,30 @@ class TestProfileRenameRefreshesTickets:
         pushed = {c.args[1] for c in refresh.call_args_list}
         assert pushed == {"evt-1-reg-1-abcd", "member-serial"}
 
+    def test_profile_creation_refreshes_an_existing_ticket(
+        self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
+    ):
+        from datetime import date
+
+        from crush_lu.models import CrushProfile
+
+        # An open-event attendee can install a ticket with NO profile — the
+        # name falls back to the bare username. Creating the profile switches
+        # display_name to username.split("@")[0], so the installed ticket goes
+        # stale. There is no previous value to compare on this path, so the
+        # persisted-value guard has to treat `created` as a change in itself.
+        registration = self._ticketed(event_with_registrations)
+        user = registration.user
+        CrushProfile.objects.filter(user=user).delete()
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.trigger_pass_refresh"
+        ) as refresh:
+            with django_capture_on_commit_callbacks(execute=True):
+                CrushProfile.objects.create(user=user, date_of_birth=date(1995, 5, 15))
+
+        assert "evt-1-reg-1-abcd" in {c.args[1] for c in refresh.call_args_list}
+
     def test_bare_profile_save_does_not_refresh(
         self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
     ):


### PR DESCRIPTION
## Purpose

`AGENTS.md:76` described the Django 6.0 `TASKS` setup with:

> Production sets `DJANGO_TASKS_BACKEND` to the DB backend and runs `manage.py db_worker`.

Both halves are false. Verified against the live App Service (`django-app-ajfffwjb5ie3s-app-service`, RG `django-app-rg`): there is **no app setting matching `*TASK*`**, so `DJANGO_TASKS_BACKEND` is unset and `azureproject/settings.py`'s `TASKS` config falls back to `ImmediateBackend`. There is also no `db_worker` invocation anywhere in the repo's startup scripts, workflows or bicep.

The repo already said the right thing in three places — this line was contradicting the very settings module it describes:

* `azureproject/production.py:647-652` — *"Inherits ImmediateBackend from settings.py (tasks run synchronously). This is intentional — no separate db_worker process is running on Azure."*
* `docs/specs/campaign-dashboard.md:83` — *"Production runs Django tasks on `ImmediateBackend` with no `db_worker`"*
* a comment in `crush_lu/signals.py` (Google Wallet event-ticket handler) — *"production has no task worker"*

**Why it matters:** the claim invites moving slow or blocking work (network fan-out, email, APNs pushes) into `.enqueue()` believing it will run out of band. It will not — the task body executes synchronously inside the calling request, so the latency is unchanged and the code is now harder to follow. This already came up while bounding the Apple Wallet APNs fan-out, which had to be capped in-request (`PASSKIT_BULK_PUSH_LIMIT` / `PASSKIT_BULK_PUSH_BUDGET_SECONDS`) rather than queued.

The corrected line states that production runs inline on `ImmediateBackend` with no `db_worker`, that `.enqueue()` defers nothing, and points at the two patterns that *do* work (bound in-request, or drive it from an Azure Function timer the way `CampaignDispatch` does). The note that `conftest.py` forces `ImmediateBackend` in tests is preserved.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

No behaviour changes. The factual claims can be re-verified:

```bash
# 1. No TASKS-related app setting exists on the live App Service
az webapp config appsettings list \
  -n django-app-ajfffwjb5ie3s-app-service -g django-app-rg \
  --query "[?contains(name,'TASK')]"        # -> []

# 2. No db_worker is started anywhere
grep -rn "db_worker" . --exclude-dir=.git   # only comments + docs, no invocation
```

## What to Check

* `AGENTS.md:76` now agrees with `azureproject/production.py:647-652` instead of contradicting it.
* The `conftest.py` / `ImmediateBackend`-in-tests note is still present on the line.

## Other Information

**`CLAUDE.md` is not in this PR — it cannot be.** It is gitignored (`.gitignore:204`) and exists only at the repo root, never inside a worktree. Its identical line 76 has been corrected locally with the same text, but that fix is machine-local and cannot travel in a PR. Anyone relying on `CLAUDE.md` will need the same one-line edit applied on their own checkout. The two files have also drifted in size (9.3 KB vs 11.5 KB), though line 76 was identical in both.

**This PR also carries one pre-existing unmerged commit**, `test(wallet): cover profile creation refreshing an installed ticket` — a 24-line test-only addition to `crush_lu/tests/test_passkit_service.py` that was left on this branch after #761 merged. It closes the one gap review flagged in `51f4e3e0`: the `created=True` branch was fixed but never directly tested. It is mutation-checked (reverting `created or` to `False and` fails the test), and contains no logic change.

### Follow-ups found while auditing `.enqueue()` (not fixed here)

Auditing the call sites surfaced a real latent bug worth its own PR. `ImmediateBackend.enqueue()` catches `BaseException` and records a FAILED `TaskResult` — **it never re-raises** (`django/tasks/backends/immediate.py:57`).

* `crush_lu/api_admin_hybrid.py:109-137` — the comment claims *"if enqueue raises, the savepoint rolls back, so the submission stays eligible for the next sweep"*. That safety net **cannot fire**. A failed send still commits `fallback_offered_at`, increments `processed`, logs `fallback_offered` to the audit trail and returns `202 {"failed": 0}` — after which the submission is permanently excluded by the `fallback_offered_at__isnull=True` filter and the user never receives their booking link.
* `crush_lu/views_coach.py:1669` — same swallow, so the `except Exception` → 500 *"Could not send the booking offer"* path is unreachable for send failures and the coach sees success regardless.
* `crush_lu/management/commands/sla_tick.py:102` — dev-only by its own docstring; prints `SUCCESS` even when the send failed. Cosmetic.

**Latent, not currently firing:** all three sit behind `HYBRID_COACH_SYSTEM_ENABLED`, which defaults to `False` and is unset on prod, so `sla_sweep` returns `{"skipped": true}` before reaching the enqueue. It becomes live the moment the hybrid coach system is switched on.

Two module docstrings also still repeat the corrected claim and are the most likely thing a developer reads right before enqueuing: `crush_lu/tasks.py:7-8` and `crush_lu/api_admin_hybrid.py:12-14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
