### PR TITLE
fix(wallet): stop every SSO login refreshing the member pass

### DIFF
--- a/crush_lu/api_referral.py
+++ b/crush_lu/api_referral.py
@@ -16,7 +16,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from .models import CrushProfile, ReferralCode
-from .referrals import get_referral_stats
+from .referrals import get_referral_stats, refresh_passes_after_points_change
 from .qr_utils import generate_qr_code_base64
 
 logger = logging.getLogger(__name__)
@@ -188,6 +188,12 @@ def redeem_points(request):
             referral_points=F("referral_points") - points_required
         )
         profile.refresh_from_db()
+
+        # Spending points lowers the balance printed on both passes, and the
+        # deduction above is a QuerySet.update() — no signal. Deferred to
+        # commit inside, so the select_for_update above is released before any
+        # network call.
+        refresh_passes_after_points_change(profile)
 
         # Record the redemption (for auditing)
         # Note: In a full implementation, you'd create a PointsRedemption model

--- a/crush_lu/referrals.py
+++ b/crush_lu/referrals.py
@@ -187,6 +187,8 @@ def refresh_passes_after_points_change(profile):
     """
     from .signals import _trigger_google_wallet_object_update
 
+    # One try/except per wallet, not one around both: neither may swallow the
+    # other, and either way a wallet push must never cost somebody their points.
     try:
         if profile.apple_pass_serial:
             from .wallet.passkit_service import refresh_ticket_serials
@@ -195,11 +197,18 @@ def refresh_passes_after_points_change(profile):
                 [profile.apple_pass_serial],
                 context=f"Points change for user {profile.user_id}",
             )
+    except Exception as e:
+        logger.error(
+            "Error refreshing Apple pass after a points change for user %s: %s",
+            profile.user_id,
+            e,
+        )
+
+    try:
         _trigger_google_wallet_object_update(profile)
     except Exception as e:
-        # A wallet push must never cost somebody their points.
         logger.error(
-            "Error refreshing wallet passes after a points change for user %s: %s",
+            "Error refreshing Google pass after a points change for user %s: %s",
             profile.user_id,
             e,
         )

--- a/crush_lu/referrals.py
+++ b/crush_lu/referrals.py
@@ -169,11 +169,33 @@ def refresh_passes_after_points_change(profile):
     counts as a change, so the refresh has to be asked for explicitly. Both
     halves defer to ``transaction.on_commit``, so this is safe to call from
     inside the surrounding atomic block — no network runs under the lock.
+
+    Apple goes through ``refresh_ticket_serials`` rather than the generic
+    trigger, because these callers are request paths — a referral award fires
+    from coach approval, event check-in and login signals, and redemption from
+    an API call — and ``on_commit`` runs before the response returns. That
+    helper is the bounded form AGENTS.md asks for: it advances the update
+    marker in one query with no network (guaranteed, so the pass still
+    refreshes on Wallet's next poll) and caps the pushes by both count and
+    wall clock. The generic path instead pushes to every registered device
+    with a 10s timeout each and no deadline, which can outlast the request
+    *after* the points have already committed — leaving the caller a failure
+    it may retry against work that actually succeeded.
+
+    Google has no equivalent bound: it is still a token exchange plus a PATCH
+    at 30s each. Worth knowing before adding more callers.
     """
-    from .signals import trigger_wallet_pass_updates
+    from .signals import _trigger_google_wallet_object_update
 
     try:
-        trigger_wallet_pass_updates(profile)
+        if profile.apple_pass_serial:
+            from .wallet.passkit_service import refresh_ticket_serials
+
+            refresh_ticket_serials(
+                [profile.apple_pass_serial],
+                context=f"Points change for user {profile.user_id}",
+            )
+        _trigger_google_wallet_object_update(profile)
     except Exception as e:
         # A wallet push must never cost somebody their points.
         logger.error(

--- a/crush_lu/referrals.py
+++ b/crush_lu/referrals.py
@@ -154,6 +154,35 @@ def update_membership_tier(profile):
     return False
 
 
+def refresh_passes_after_points_change(profile):
+    """Push a points-only change to the holder's installed wallet passes.
+
+    The balance is printed on both passes (``apple_pass.py`` field value,
+    ``google_api.py`` POINTS module), but every points mutation in this module
+    is a ``QuerySet.update()`` carrying an ``F()`` expression — deliberately,
+    since that is what closes the concurrent-award race — and
+    ``QuerySet.update()`` emits no signals. A points-only change therefore
+    reaches neither the pre_save snapshot nor the post_save receiver.
+
+    It used to self-heal on the holder's next bare ``profile.save()`` (the
+    Microsoft sign-in path saved on every login), but that save no longer
+    counts as a change, so the refresh has to be asked for explicitly. Both
+    halves defer to ``transaction.on_commit``, so this is safe to call from
+    inside the surrounding atomic block — no network runs under the lock.
+    """
+    from .signals import trigger_wallet_pass_updates
+
+    try:
+        trigger_wallet_pass_updates(profile)
+    except Exception as e:
+        # A wallet push must never cost somebody their points.
+        logger.error(
+            "Error refreshing wallet passes after a points change for user %s: %s",
+            profile.user_id,
+            e,
+        )
+
+
 def apply_referral_reward(attribution, reward_type="signup"):
     """
     Apply referral reward points to the referrer.
@@ -214,7 +243,12 @@ def apply_referral_reward(attribution, reward_type="signup"):
         attribution.referrer.refresh_from_db()
 
         # Check for tier upgrade
-        update_membership_tier(attribution.referrer)
+        upgraded = update_membership_tier(attribution.referrer)
+
+        # An upgrade saved the profile, which already fired the wallet
+        # receiver; refreshing again would push a byte-identical package.
+        if not upgraded:
+            refresh_passes_after_points_change(attribution.referrer)
 
         logger.info(
             "Awarded %d points to user %s for referral %s (%s). New total: %d",
@@ -300,7 +334,10 @@ def check_and_apply_profile_approved_reward(profile):
 
         attribution.refresh_from_db()
         attribution.referrer.refresh_from_db()
-        update_membership_tier(attribution.referrer)
+        upgraded = update_membership_tier(attribution.referrer)
+
+        if not upgraded:
+            refresh_passes_after_points_change(attribution.referrer)
 
         logger.info(
             "Awarded %d bonus points to user %s for referred profile approval",

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -183,12 +183,23 @@ def _trigger_google_wallet_object_update(profile):
             # the write carries what the database actually says.
             #
             # This narrows the window rather than closing it: two overlapping
-            # callbacks can still complete their network calls out of order.
-            # Closing that needs a per-profile mutex or server-side versioning,
-            # both of which put blocking back in the request (on_commit runs
-            # inline) — not worth it for a payload that only changes on a tier
-            # upgrade, since points move via QuerySet.update() and emit no
-            # signal at all.
+            # callbacks can still finish their network calls out of order, and
+            # the loser is whichever re-read first — it lands last and writes
+            # the older balance.
+            #
+            # Do NOT reason about this as a rare case. An earlier version of
+            # this comment argued the payload only changes on a tier upgrade,
+            # since points move via QuerySet.update() and emit no signal; that
+            # stopped being true when refresh_passes_after_points_change()
+            # started scheduling one for every award and redemption. Any two
+            # overlapping points transactions for the same profile can hit it.
+            #
+            # Closing it needs per-profile serialization or server-side
+            # versioning: a mutex puts blocking back in the request (on_commit
+            # runs inline), and a queue is not available — production leaves
+            # DJANGO_TASKS_BACKEND unset, so .enqueue() would run inline too.
+            # Left open deliberately, and written down rather than assumed
+            # away.
             fresh = CrushProfile.objects.filter(pk=profile.pk).first()
             if fresh is None or not fresh.google_wallet_object_id:
                 # Deleted, or the object was unlinked, while the callback was

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2661,7 +2661,7 @@ def remember_previous_member_pass_fields(sender, instance, update_fields=None, *
 def refresh_wallet_passes_on_user_rename(
     sender, instance, created, update_fields, **kwargs
 ):
-    """Refresh Apple passes when the holder's actual name changes.
+    """Refresh both wallets when the holder's actual name changes.
 
     The name printed on both the member pass and every event ticket comes from
     ``CrushProfile.display_name``, which reads ``User.first_name`` /
@@ -2703,6 +2703,27 @@ def refresh_wallet_passes_on_user_rename(
         refresh_ticket_serials(serials, context=f"User {instance.pk} rename")
     except Exception as e:
         logger.error(f"Error refreshing wallet passes for user {instance.pk}: {e}")
+
+    # Google prints display_name too (google_api._build_generic_object_payload
+    # puts it in the subheader), and refresh_ticket_serials above is Apple-only
+    # — it pushes PassKit serials. Nothing else will bring the Google object up
+    # to date either: display_name is a property, so it can never reach a
+    # profile update_fields nor the persisted snapshot the profile receiver
+    # compares. This used to ride on the next bare profile.save() reaching
+    # trigger_wallet_pass_updates, which is exactly the save that no longer
+    # counts as a change, so without this a renamed member's Google card kept
+    # the old name indefinitely.
+    #
+    # Its own try/except: an APNs failure above must not swallow this, and vice
+    # versa. The call no-ops for a profile with no Google object.
+    try:
+        profile = getattr(instance, "crushprofile", None)
+        if profile is not None:
+            _trigger_google_wallet_object_update(profile)
+    except Exception as e:
+        logger.error(
+            f"Error scheduling Google Wallet rename update for user {instance.pk}: {e}"
+        )
 
 
 def _refresh_user_event_tickets(profile):

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -56,7 +56,13 @@ _thread_local = threading.local()
 # WALLET PASS UPDATE TRIGGERS
 # =============================================================================
 
-# Fields that should trigger a wallet pass update when changed
+# Every input a wallet pass renders from, INCLUDING the three that are
+# properties rather than columns. No receiver reads this set any more — they
+# gate on the two subsets below, which are what can actually be compared — so
+# treat it as the inventory the subsets are checked against:
+# test_member_pass_fields_are_real_columns asserts the split, which turns
+# "added a field here and forgot the subset" into a failing test rather than a
+# pass that silently never refreshes.
 WALLET_UPDATE_PROFILE_FIELDS = {
     "referral_points",
     "membership_tier",

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -74,6 +74,21 @@ WALLET_UPDATE_PROFILE_FIELDS = {
 # and User renames are handled by refresh_wallet_passes_on_user_rename.
 WALLET_TICKET_IDENTITY_FIELDS = {"show_full_name"}
 
+# The subset that is a real model field, and therefore the only part of the set
+# a change can be *proven* against: `display_name`/`first_name`/`last_name` are
+# PROPERTIES reading the User, so they can neither reach a profile
+# `update_fields` nor be fetched with .values() — renames arrive through
+# refresh_wallet_passes_on_user_rename instead. Everything else the member pass
+# prints is derived from these (tier_display), owned by another model (the
+# referral code, the next event) or immutable (member_since).
+WALLET_MEMBER_PASS_FIELDS = {
+    "referral_points",
+    "membership_tier",
+    "show_photo_on_wallet",
+    "photo_1",
+    "show_full_name",
+}
+
 
 def _trigger_apple_pass_refresh(profile):
     """
@@ -146,25 +161,44 @@ def _trigger_google_wallet_object_update(profile):
     if not profile.google_wallet_object_id:
         return
 
+    def _after_commit():
+        try:
+            from .wallet.google_api import update_google_wallet_pass
+
+            result = update_google_wallet_pass(profile)
+
+            if result["success"]:
+                logger.info(
+                    f"Google Wallet pass updated for user {profile.user_id}: "
+                    f"object_id={profile.google_wallet_object_id}"
+                )
+            else:
+                logger.warning(
+                    f"Google Wallet pass update failed for user {profile.user_id}: "
+                    f"{result['message']}"
+                )
+
+        except Exception as e:
+            logger.error(
+                f"Error updating Google Wallet pass for user {profile.user_id}: {e}"
+            )
+
     try:
-        from .wallet.google_api import update_google_wallet_pass
-
-        result = update_google_wallet_pass(profile)
-
-        if result["success"]:
-            logger.info(
-                f"Google Wallet pass updated for user {profile.user_id}: "
-                f"object_id={profile.google_wallet_object_id}"
-            )
-        else:
-            logger.warning(
-                f"Google Wallet pass update failed for user {profile.user_id}: "
-                f"{result['message']}"
-            )
-
+        # Deferred to commit like the Apple half above, for two reasons of its
+        # own. This one is not a "come back for the new package" push — it
+        # PATCHes the content straight onto Google, so a caller that rolls back
+        # afterwards leaves Google showing state that never existed, and the
+        # payload comes from build_wallet_pass_data(), which re-queries for the
+        # next event and should read committed rows. It is also two HTTP calls
+        # (token exchange, then the PATCH) at a 30s timeout each, and callers
+        # such as referrals.update_membership_tier() save inside
+        # transaction.atomic() holding a select_for_update — up to a minute of
+        # network with the row locked. on_commit runs inline when there is no
+        # transaction, so every other caller is unaffected.
+        transaction.on_commit(_after_commit)
     except Exception as e:
         logger.error(
-            f"Error updating Google Wallet pass for user {profile.user_id}: {e}"
+            f"Error scheduling Google Wallet update for user {profile.user_id}: {e}"
         )
 
 
@@ -2548,26 +2582,46 @@ def remember_previous_user_name(sender, instance, update_fields=None, **kwargs):
     )
 
 
+def _normalized_member_pass_values(values):
+    """Flatten a member-pass field mapping so a row and an instance compare equal.
+
+    Only ``photo_1`` needs it: ``.values()`` yields the stored file name while
+    the instance holds a FieldFile, and an empty photo is NULL on some rows and
+    "" on others (the column is both null and blank), which would otherwise read
+    as a change on every save.
+    """
+    if values is None:
+        return None
+    normalized = dict(values)
+    photo = normalized.get("photo_1")
+    normalized["photo_1"] = getattr(photo, "name", photo) or ""
+    return normalized
+
+
 @receiver(pre_save, sender=CrushProfile)
-def remember_previous_ticket_identity(sender, instance, update_fields=None, **kwargs):
-    """Snapshot the profile input to the ticket's attendee name.
+def remember_previous_member_pass_fields(sender, instance, update_fields=None, **kwargs):
+    """Snapshot the persisted fields both wallet passes are rendered from.
 
     Mirrors remember_previous_user_name, and for the same reason: a bare
-    ``profile.save()`` is not evidence of an identity change. The Microsoft
-    sign-in path saves the profile on every login without touching
-    ``show_full_name``, and treating that as a change refreshed every
-    historical ticket the user owns — synchronous fan-out hung off a login.
+    ``profile.save()`` is not evidence of a change. The Microsoft sign-in path
+    saves the profile on every login without touching any of these, and treating
+    that as a change refreshed every historical ticket the user owns *and* made
+    each of those logins wait on a Google Wallet round trip.
+
+    One indexed primary-key lookup, and only when a relevant field could have
+    moved at all: an onboarding step saving ``update_fields=["bio"]`` pays
+    nothing.
     """
-    instance._previous_show_full_name = None
+    instance._previous_member_pass_fields = None
     if not instance.pk:
         return
     if update_fields is not None and not (
-        set(update_fields) & WALLET_TICKET_IDENTITY_FIELDS
+        set(update_fields) & WALLET_MEMBER_PASS_FIELDS
     ):
         return
-    instance._previous_show_full_name = (
+    instance._previous_member_pass_fields = _normalized_member_pass_values(
         CrushProfile.objects.filter(pk=instance.pk)
-        .values_list("show_full_name", flat=True)
+        .values(*WALLET_MEMBER_PASS_FIELDS)
         .first()
     )
 
@@ -2651,37 +2705,51 @@ def trigger_wallet_pass_update_on_profile_change(
     """
     Trigger wallet pass updates when relevant profile fields change.
 
-    This signal fires on CrushProfile save and checks if any wallet-relevant
-    fields were updated. If so, it triggers push notifications to Apple Wallet
-    devices and updates Google Wallet objects.
+    This signal fires on CrushProfile save and compares the fields the passes
+    are rendered from against the pre_save snapshot. If one actually moved, it
+    triggers push notifications to Apple Wallet devices and updates Google
+    Wallet objects.
 
-    Wallet-relevant fields include:
+    Wallet-relevant fields (WALLET_MEMBER_PASS_FIELDS) are:
     - referral_points, membership_tier (rewards/status)
     - show_photo_on_wallet, photo_1 (appearance)
-    - display_name, first_name, last_name, show_full_name (identity)
+    - show_full_name (identity; the User half is the rename receiver above)
     """
-    # Narrower than WALLET_UPDATE_PROFILE_FIELDS on purpose: that set also
-    # carries member-pass-only fields (referral_points, membership_tier,
-    # show_photo_on_wallet, photo_1), none of which appears in a ticket. Gating
-    # tickets on it meant a tier bump or a photo upload refreshed every
-    # historical ticket the user owns and burned the APNs budget downloading
-    # byte-identical packages. The only profile input to a ticket is the
-    # attendee name; the User half of that is handled by the rename receiver
-    # above.
-    #
-    # Compares the PERSISTED value rather than trusting update_fields: a bare
+    # What actually MOVED, from the pre_save snapshot — never "update_fields
+    # says so", and never "a full save must mean something changed". A bare
     # profile.save() carries update_fields=None, and the Microsoft sign-in path
-    # does exactly that on every login without touching show_full_name.
+    # does exactly that on every login without editing a single field; reading
+    # that as a change put an APNs fan-out and a synchronous Google Wallet round
+    # trip (two HTTP calls, 30s timeouts) on the critical path of every login by
+    # a member who has installed a pass.
+    #
+    # An empty snapshot (no relevant field in update_fields, or the row is gone)
+    # reads as "nothing moved" — same fail-closed shape as the User receiver —
+    # and short-circuits before touching the instance, so the saves that skipped
+    # the snapshot query pay nothing here either.
+    previous = getattr(instance, "_previous_member_pass_fields", None)
+    changed = set()
+    if previous is not None:
+        current = _normalized_member_pass_values(
+            {name: getattr(instance, name) for name in WALLET_MEMBER_PASS_FIELDS}
+        )
+        changed = {
+            name for name, value in current.items() if previous[name] != value
+        }
+
+    # Tickets are gated on a strictly narrower set than the member pass: the
+    # only profile input to a ticket is the attendee name, so a tier bump or a
+    # photo upload must not refresh every historical ticket the user owns and
+    # burn the APNs budget downloading byte-identical packages. The User half of
+    # the name is handled by the rename receiver above.
     #
     # `created` counts as a change in its own right: an open-event attendee can
     # install a ticket with no profile at all (the name falls back to the bare
     # username), and creating the profile switches display_name to
     # username.split("@")[0]. There is no previous value to compare on that
     # path, so the persisted-value guard alone would suppress it.
-    previous_show_full_name = getattr(instance, "_previous_show_full_name", None)
-    ticket_identity_changed = created or (
-        previous_show_full_name is not None
-        and previous_show_full_name != instance.show_full_name
+    ticket_identity_changed = created or bool(
+        changed & WALLET_TICKET_IDENTITY_FIELDS
     )
 
     # Event tickets print the holder's name and carry their own evt-* serials,
@@ -2704,34 +2772,20 @@ def trigger_wallet_pass_update_on_profile_change(
     if not instance.apple_pass_serial and not instance.google_wallet_object_id:
         return
 
-    # Check if any wallet-relevant fields were updated
-    should_update = False
+    if not changed:
+        return
 
-    if update_fields is not None:
-        # Specific fields were updated - check if any are wallet-relevant
-        updated_fields = set(update_fields)
-        if updated_fields & WALLET_UPDATE_PROFILE_FIELDS:
-            should_update = True
-            logger.debug(
-                f"Wallet-relevant fields updated for user {instance.user_id}: "
-                f"{updated_fields & WALLET_UPDATE_PROFILE_FIELDS}"
-            )
-    else:
-        # Full save - trigger update to be safe
-        # This happens when save() is called without update_fields
-        should_update = True
-        logger.debug(
-            f"Full profile save for user {instance.user_id}, triggering wallet update"
+    logger.debug(
+        f"Wallet-relevant fields changed for user {instance.user_id}: {changed}"
+    )
+
+    try:
+        trigger_wallet_pass_updates(instance)
+    except Exception as e:
+        # Don't fail the save if wallet update fails
+        logger.error(
+            f"Error triggering wallet update for user {instance.user_id}: {e}"
         )
-
-    if should_update:
-        try:
-            trigger_wallet_pass_updates(instance)
-        except Exception as e:
-            # Don't fail the save if wallet update fails
-            logger.error(
-                f"Error triggering wallet update for user {instance.user_id}: {e}"
-            )
 
 
 @receiver(pre_save, sender=EventRegistration)

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -171,16 +171,41 @@ def _trigger_google_wallet_object_update(profile):
         try:
             from .wallet.google_api import update_google_wallet_pass
 
-            result = update_google_wallet_pass(profile)
+            # Re-read rather than PATCH from the instance captured at save
+            # time. Unlike the Apple half — which pushes a content-free "come
+            # back for it" and lets the device fetch from the web service, so
+            # it always renders current rows — this call ships the payload
+            # itself, built from whatever the instance holds. Deferring to
+            # commit releases the profile row lock first, so between scheduling
+            # and running, another transaction can have committed a newer tier
+            # or point total; sending the captured copy would put Google back
+            # on the older one indefinitely. Reading committed state here means
+            # the write carries what the database actually says.
+            #
+            # This narrows the window rather than closing it: two overlapping
+            # callbacks can still complete their network calls out of order.
+            # Closing that needs a per-profile mutex or server-side versioning,
+            # both of which put blocking back in the request (on_commit runs
+            # inline) — not worth it for a payload that only changes on a tier
+            # upgrade, since points move via QuerySet.update() and emit no
+            # signal at all.
+            fresh = CrushProfile.objects.filter(pk=profile.pk).first()
+            if fresh is None or not fresh.google_wallet_object_id:
+                # Deleted, or the object was unlinked, while the callback was
+                # queued. cleanup_passkit_registrations_on_profile_delete owns
+                # that teardown; there is nothing left to PATCH.
+                return
+
+            result = update_google_wallet_pass(fresh)
 
             if result["success"]:
                 logger.info(
-                    f"Google Wallet pass updated for user {profile.user_id}: "
-                    f"object_id={profile.google_wallet_object_id}"
+                    f"Google Wallet pass updated for user {fresh.user_id}: "
+                    f"object_id={fresh.google_wallet_object_id}"
                 )
             else:
                 logger.warning(
-                    f"Google Wallet pass update failed for user {profile.user_id}: "
+                    f"Google Wallet pass update failed for user {fresh.user_id}: "
                     f"{result['message']}"
                 )
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2610,27 +2610,23 @@ def refresh_member_pass_on_registration_delete(
     equivalent, and used to be picked up by the holder's next bare
     profile.save().
 
-    Scoped to a DIRECT delete of one registration — an admin object delete —
-    using the signal's `origin`. A cascade (deleting the event, or the user)
-    fires this per row, and one bounded refresh per row is not bounded in
-    aggregate: each call starts its own push budget, so N rows multiply the
-    deadline N times. That is the same pathology cancel_events was already
-    fixed for by batching into a single refresh. Deleting a user makes the
-    refresh pointless anyway, and deleting an event is better served by a
-    batched path at the event level than by this receiver.
+    A direct delete of one registration — an admin object delete — pushes.
+    Anything else reaches this per row (an event cascade, a user cascade, a
+    bulk queryset), and one push per row is not bounded in aggregate: each
+    carries its own budget, so N rows multiply the deadline N times. That is
+    the pathology cancel_events was already fixed for by batching into a single
+    refresh. Those rows get the marker advance instead — one query, no network,
+    and the card still rebuilds on Wallet's next poll rather than advertising
+    an event that no longer exists.
     """
-    if not isinstance(origin, EventRegistration):
-        # Never silent about skipped work.
-        logger.info(
-            "Registration %s deleted via %s; member-pass refresh skipped "
-            "(cascade/bulk deletes need a batched path, not one per row)",
-            instance.pk,
-            type(origin).__name__,
-        )
+    context = f"Registration {instance.pk} deleted"
+    profile = CrushProfile.objects.filter(user_id=instance.user_id).first()
+
+    if isinstance(origin, EventRegistration):
+        _refresh_member_pass(profile, context)
         return
 
-    profile = CrushProfile.objects.filter(user_id=instance.user_id).first()
-    _refresh_member_pass(profile, f"Registration {instance.pk} deleted")
+    _mark_member_pass_stale(profile, f"{context} ({type(origin).__name__})")
 
 
 # `username` counts: CrushProfile.display_name falls back to it in BOTH
@@ -2800,6 +2796,37 @@ def _refresh_member_pass(profile, context):
         logger.error(f"Error refreshing Google member pass ({context}): {e}")
 
 
+def _mark_member_pass_stale(profile, context):
+    """Advance the Apple update marker WITHOUT pushing.
+
+    For bulk and cascade paths, where one refresh per row is not bounded in
+    aggregate — each push carries its own budget, so N rows multiply the
+    deadline N times. This is the guaranteed half of that work on its own: one
+    indexed write, no network, so it cannot fan out, and the pass still
+    rebuilds on Wallet's next periodic poll instead of staying wrong forever.
+
+    Google has no marker equivalent — its card is only ever corrected by an
+    explicit PATCH — so a bulk path leaves it until the next real refresh.
+    """
+    if profile is None or not profile.apple_pass_serial:
+        return
+    pass_type_id = getattr(settings, "WALLET_APPLE_PASS_TYPE_IDENTIFIER", None)
+    if not pass_type_id:
+        return
+    try:
+        from .wallet.passkit_apns import mark_passes_updated_bulk
+
+        mark_passes_updated_bulk(pass_type_id, [profile.apple_pass_serial])
+        logger.info(
+            "%s: marked member pass %s for Wallet's next poll (no push — bulk "
+            "path, one push per row is not bounded in aggregate)",
+            context,
+            profile.apple_pass_serial,
+        )
+    except Exception as e:
+        logger.error(f"Error marking member pass stale ({context}): {e}")
+
+
 # The QR on the member pass is the referrer's link, and all three of these
 # change what it resolves to: the code is the URL, capture filters on
 # is_active (referrals.py:52 and :86) so a deactivated code renders a QR that
@@ -2885,15 +2912,25 @@ def refresh_member_pass_on_referral_code_delete(
     QR scans and attributes nothing — and the next build mints a different
     code, so the installed pass never converges on its own.
 
-    Scoped to a direct delete via `origin`. Django deletes children before
-    parents, so on a cascade from profile.delete() the profile row is still
-    there when this fires and would happily schedule a refresh for a pass that
-    is about to stop existing.
+    A direct delete pushes. The admin's default "Delete selected" action calls
+    QuerySet.delete(), so `origin` is the queryset, not each row — pushing per
+    row there is not bounded in aggregate, so those rows get the marker advance
+    only and rebuild on Wallet's next poll.
+
+    A cascade from anything else is a profile going away underneath its own
+    codes. Django deletes children before parents, so the profile row is still
+    readable here — refreshing a pass that is about to stop existing is the
+    trap, hence the explicit model check rather than "not a queryset".
     """
-    if not isinstance(origin, ReferralCode):
-        return
+    context = f"Referral code {instance.pk} deleted"
     profile = CrushProfile.objects.filter(pk=instance.referrer_id).first()
-    _refresh_member_pass(profile, f"Referral code {instance.pk} deleted")
+
+    if isinstance(origin, ReferralCode):
+        _refresh_member_pass(profile, context)
+        return
+
+    if getattr(origin, "model", None) is ReferralCode:
+        _mark_member_pass_stale(profile, f"{context} (bulk)")
 
 
 def _refresh_user_event_tickets(profile):

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -40,6 +40,7 @@ from .models import (
     CrushCoach,
     CrushSpark,
     ProfileSubmission,
+    ReferralCode,
 )
 from .models.journey import JourneyProgress
 from .utils.i18n import is_valid_language
@@ -2734,6 +2735,73 @@ def refresh_wallet_passes_on_user_rename(
     except Exception as e:
         logger.error(
             f"Error scheduling Google Wallet rename update for user {instance.pk}: {e}"
+        )
+
+
+# The QR on the member pass is the referrer's link, and BOTH of these change
+# what it resolves to: the code is the URL, and capture filters on is_active
+# (referrals.py:52 and :86), so a deactivated code renders a QR that scans but
+# attributes nothing. Staff can edit either through ReferralCodeAdmin.
+_REFERRAL_CODE_PASS_FIELDS = ("code", "is_active")
+
+
+@receiver(pre_save, sender=ReferralCode)
+def remember_previous_referral_code(sender, instance, update_fields=None, **kwargs):
+    """Snapshot the code fields the member pass barcode is built from."""
+    instance._previous_referral_code = None
+    if not instance.pk:
+        return
+    if update_fields is not None and not (
+        set(update_fields) & set(_REFERRAL_CODE_PASS_FIELDS)
+    ):
+        return
+    instance._previous_referral_code = (
+        ReferralCode.objects.filter(pk=instance.pk)
+        .values_list(*_REFERRAL_CODE_PASS_FIELDS)
+        .first()
+    )
+
+
+@receiver(post_save, sender=ReferralCode)
+def refresh_member_pass_on_referral_code_change(sender, instance, created, **kwargs):
+    """Rebuild the member pass when its QR stops meaning what it did.
+
+    build_wallet_pass_barcode_value() embeds this code, and nothing else
+    notices when it moves: the code lives on another model, so it reaches
+    neither WALLET_MEMBER_PASS_FIELDS nor any profile save. Deactivating a code
+    is the case that actually bites — get_or_create_for_profile only returns
+    active ones, so the next build mints a *different* code while every
+    installed pass keeps scanning to the dead one, silently attributing
+    nothing.
+
+    Deliberately does not fire on `created`: the only thing that creates a code
+    is get_or_create_for_profile, which is called *from the pass build itself*,
+    so refreshing here would push a notification at the device that just
+    downloaded the pass. A code is only ever created when no active one
+    remains, and the deactivation that got it there already refreshed.
+    """
+    if created:
+        return
+    previous = getattr(instance, "_previous_referral_code", None)
+    if previous is None or previous == (instance.code, instance.is_active):
+        return
+
+    try:
+        profile = instance.referrer
+        if not profile.apple_pass_serial and not profile.google_wallet_object_id:
+            return
+
+        if profile.apple_pass_serial:
+            from .wallet.passkit_service import refresh_ticket_serials
+
+            refresh_ticket_serials(
+                [profile.apple_pass_serial],
+                context=f"Referral code change for user {profile.user_id}",
+            )
+        _trigger_google_wallet_object_update(profile)
+    except Exception as e:
+        logger.error(
+            f"Error refreshing member pass for referral code {instance.pk}: {e}"
         )
 
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -2599,6 +2599,40 @@ def cleanup_passkit_registrations_on_registration_delete(sender, instance, **kwa
     _delete_passkit_registrations(instance.apple_wallet_ticket_serial)
 
 
+@receiver(post_delete, sender=EventRegistration)
+def refresh_member_pass_on_registration_delete(
+    sender, instance, origin=None, **kwargs
+):
+    """The member card prints the holder's NEXT event, so deleting the row that
+    supplied it leaves the card advertising an event they are not going to.
+
+    The post_save receiver covers create and status changes; deletion had no
+    equivalent, and used to be picked up by the holder's next bare
+    profile.save().
+
+    Scoped to a DIRECT delete of one registration — an admin object delete —
+    using the signal's `origin`. A cascade (deleting the event, or the user)
+    fires this per row, and one bounded refresh per row is not bounded in
+    aggregate: each call starts its own push budget, so N rows multiply the
+    deadline N times. That is the same pathology cancel_events was already
+    fixed for by batching into a single refresh. Deleting a user makes the
+    refresh pointless anyway, and deleting an event is better served by a
+    batched path at the event level than by this receiver.
+    """
+    if not isinstance(origin, EventRegistration):
+        # Never silent about skipped work.
+        logger.info(
+            "Registration %s deleted via %s; member-pass refresh skipped "
+            "(cascade/bulk deletes need a batched path, not one per row)",
+            instance.pk,
+            type(origin).__name__,
+        )
+        return
+
+    profile = CrushProfile.objects.filter(user_id=instance.user_id).first()
+    _refresh_member_pass(profile, f"Registration {instance.pk} deleted")
+
+
 # `username` counts: CrushProfile.display_name falls back to it in BOTH
 # branches (get_full_name() or username, and first_name or username), so a
 # user with no first name has their username printed on the pass and on every
@@ -2738,11 +2772,49 @@ def refresh_wallet_passes_on_user_rename(
         )
 
 
-# The QR on the member pass is the referrer's link, and BOTH of these change
-# what it resolves to: the code is the URL, and capture filters on is_active
-# (referrals.py:52 and :86), so a deactivated code renders a QR that scans but
-# attributes nothing. Staff can edit either through ReferralCodeAdmin.
-_REFERRAL_CODE_PASS_FIELDS = ("code", "is_active")
+def _refresh_member_pass(profile, context):
+    """Bounded refresh of ONE member pass on both wallets.
+
+    Apple goes through refresh_ticket_serials rather than the generic trigger
+    for the reason AGENTS.md gives: these are request paths, so the work has to
+    advance the update marker in one no-network query (guaranteed — the pass
+    still refreshes on Wallet's next poll) and cap the push by count and wall
+    clock. One try/except per wallet: neither may swallow the other.
+    """
+    if profile is None:
+        return
+    if not profile.apple_pass_serial and not profile.google_wallet_object_id:
+        return
+
+    try:
+        if profile.apple_pass_serial:
+            from .wallet.passkit_service import refresh_ticket_serials
+
+            refresh_ticket_serials([profile.apple_pass_serial], context=context)
+    except Exception as e:
+        logger.error(f"Error refreshing Apple member pass ({context}): {e}")
+
+    try:
+        _trigger_google_wallet_object_update(profile)
+    except Exception as e:
+        logger.error(f"Error refreshing Google member pass ({context}): {e}")
+
+
+# The QR on the member pass is the referrer's link, and all three of these
+# change what it resolves to: the code is the URL, capture filters on
+# is_active (referrals.py:52 and :86) so a deactivated code renders a QR that
+# scans but attributes nothing, and `referrer` decides WHOSE link it is — staff
+# reassigning it leaves the old holder's pass crediting somebody else. All
+# three are editable through ReferralCodeAdmin.
+_REFERRAL_CODE_PASS_FIELDS = ("code", "is_active", "referrer_id")
+
+# What `update_fields` may legitimately name for those columns. A FK can arrive
+# as either the field name or its attname, and save(update_fields=["referrer"])
+# is what admin and ordinary code actually write — gating on "referrer_id"
+# alone skipped the snapshot and made reassignment a silent no-op.
+_REFERRAL_CODE_UPDATE_FIELD_NAMES = frozenset(
+    {"code", "is_active", "referrer", "referrer_id"}
+)
 
 
 @receiver(pre_save, sender=ReferralCode)
@@ -2752,7 +2824,7 @@ def remember_previous_referral_code(sender, instance, update_fields=None, **kwar
     if not instance.pk:
         return
     if update_fields is not None and not (
-        set(update_fields) & set(_REFERRAL_CODE_PASS_FIELDS)
+        set(update_fields) & _REFERRAL_CODE_UPDATE_FIELD_NAMES
     ):
         return
     instance._previous_referral_code = (
@@ -2783,26 +2855,45 @@ def refresh_member_pass_on_referral_code_change(sender, instance, created, **kwa
     if created:
         return
     previous = getattr(instance, "_previous_referral_code", None)
-    if previous is None or previous == (instance.code, instance.is_active):
+    if previous is None:
+        return
+    previous_code, previous_active, previous_referrer_id = previous
+    if previous == (instance.code, instance.is_active, instance.referrer_id):
         return
 
-    try:
-        profile = instance.referrer
-        if not profile.apple_pass_serial and not profile.google_wallet_object_id:
-            return
+    context = f"Referral code {instance.pk} change"
+    _refresh_member_pass(
+        CrushProfile.objects.filter(pk=instance.referrer_id).first(), context
+    )
 
-        if profile.apple_pass_serial:
-            from .wallet.passkit_service import refresh_ticket_serials
-
-            refresh_ticket_serials(
-                [profile.apple_pass_serial],
-                context=f"Referral code change for user {profile.user_id}",
-            )
-        _trigger_google_wallet_object_update(profile)
-    except Exception as e:
-        logger.error(
-            f"Error refreshing member pass for referral code {instance.pk}: {e}"
+    # A reassignment has two victims, and the one that actually matters is the
+    # OLD holder: their installed QR now credits somebody else entirely.
+    if previous_referrer_id != instance.referrer_id:
+        _refresh_member_pass(
+            CrushProfile.objects.filter(pk=previous_referrer_id).first(),
+            f"{context} (previous holder)",
         )
+
+
+@receiver(post_delete, sender=ReferralCode)
+def refresh_member_pass_on_referral_code_delete(
+    sender, instance, origin=None, **kwargs
+):
+    """Deleting the code strands every pass that embeds it.
+
+    capture_referral() needs a matching active row, so once the row is gone the
+    QR scans and attributes nothing — and the next build mints a different
+    code, so the installed pass never converges on its own.
+
+    Scoped to a direct delete via `origin`. Django deletes children before
+    parents, so on a cascade from profile.delete() the profile row is still
+    there when this fires and would happily schedule a refresh for a pass that
+    is about to stop existing.
+    """
+    if not isinstance(origin, ReferralCode):
+        return
+    profile = CrushProfile.objects.filter(pk=instance.referrer_id).first()
+    _refresh_member_pass(profile, f"Referral code {instance.pk} deleted")
 
 
 def _refresh_user_event_tickets(profile):

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1589,6 +1589,62 @@ class TestMemberPassUpdateNeedsARealChange:
 
         assert google_patch.call_count == 1
 
+    def test_google_wallet_update_sends_committed_state_not_the_snapshot(
+        self, test_user_with_profile, django_capture_on_commit_callbacks
+    ):
+        from crush_lu.models import CrushProfile
+        from crush_lu.signals import trigger_wallet_pass_updates
+
+        # Deferring releases the profile row lock before the PATCH, so another
+        # transaction can commit a newer tier while this callback is queued.
+        # The PATCH ships the payload itself (Apple only pushes "come back for
+        # it"), so sending the instance captured at save time would put Google
+        # back on the older tier indefinitely.
+        profile = self._with_member_pass(test_user_with_profile)
+        profile.membership_tier = "bronze"
+        profile.save(update_fields=["membership_tier"])
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.update_google_wallet_pass",
+            return_value={"success": True, "message": "ok"},
+        ) as google_patch, mock.patch(
+            "crush_lu.wallet.passkit_apns.send_passkit_push_notifications",
+            return_value={"success": 0, "failed": 0, "total": 0},
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                trigger_wallet_pass_updates(profile)
+                # A concurrent award commits a higher tier first.
+                CrushProfile.objects.filter(pk=profile.pk).update(
+                    membership_tier="silver"
+                )
+
+        assert google_patch.call_args.args[0].membership_tier == "silver"
+        # ...and the captured instance really was stale, so this is not a
+        # tautology.
+        assert profile.membership_tier == "bronze"
+
+    def test_google_wallet_update_skips_a_profile_deleted_before_commit(
+        self, test_user_with_profile, django_capture_on_commit_callbacks
+    ):
+        from crush_lu.models import CrushProfile
+        from crush_lu.signals import trigger_wallet_pass_updates
+
+        # Re-reading has to tolerate the row being gone: the delete receiver
+        # owns that teardown, and there is nothing left to PATCH.
+        profile = self._with_member_pass(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.update_google_wallet_pass"
+        ) as google_patch, mock.patch(
+            "crush_lu.wallet.passkit_apns.send_passkit_push_notifications",
+            return_value={"success": 0, "failed": 0, "total": 0},
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                trigger_wallet_pass_updates(profile)
+                CrushProfile.objects.filter(pk=profile.pk).delete()
+
+        google_patch.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestTicketStampsAreSignalFree:

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1462,6 +1462,134 @@ class TestProfileRenameRefreshesTickets:
         refresh.assert_not_called()
 
 
+def test_member_pass_fields_are_real_columns():
+    from crush_lu.models import CrushProfile
+    from crush_lu.signals import (
+        WALLET_MEMBER_PASS_FIELDS,
+        WALLET_UPDATE_PROFILE_FIELDS,
+    )
+
+    # Everything in the member set is snapshotted with .values() and matched
+    # against update_fields, so a property in here would raise FieldError on
+    # every profile save. The leftovers are exactly the three that ARE
+    # properties — the User's name read through the profile, which reaches
+    # Wallet via refresh_wallet_passes_on_user_rename instead.
+    concrete = {f.name for f in CrushProfile._meta.concrete_fields}
+    assert WALLET_MEMBER_PASS_FIELDS <= concrete
+    assert WALLET_MEMBER_PASS_FIELDS <= WALLET_UPDATE_PROFILE_FIELDS
+    assert WALLET_UPDATE_PROFILE_FIELDS - WALLET_MEMBER_PASS_FIELDS == {
+        "display_name",
+        "first_name",
+        "last_name",
+    }
+
+
+@pytest.mark.django_db
+class TestMemberPassUpdateNeedsARealChange:
+    """The MEMBER-pass half of the same receiver, which used to read every
+    ``update_fields=None`` save as a change "to be safe". The Microsoft
+    sign-in path calls a bare ``profile.save()`` on every login, so each login
+    by a member with an installed pass paid for an APNs fan-out plus a Google
+    Wallet round trip (token exchange, then a PATCH, 30s timeout each)."""
+
+    def _with_member_pass(self, test_user_with_profile):
+        _user, profile = test_user_with_profile
+        profile.apple_pass_serial = "member-serial"
+        profile.google_wallet_object_id = "issuer.member-1"
+        profile.save(update_fields=["apple_pass_serial", "google_wallet_object_id"])
+        return profile
+
+    def test_bare_profile_save_does_not_refresh(self, test_user_with_profile):
+        profile = self._with_member_pass(test_user_with_profile)
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            profile.save()
+
+        update.assert_not_called()
+
+    def test_rewriting_the_same_value_does_not_refresh(self, test_user_with_profile):
+        # update_fields naming a wallet field is not evidence either: the value
+        # is what it already was, so a rebuild would be byte-identical.
+        profile = self._with_member_pass(test_user_with_profile)
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            profile.save(update_fields=["membership_tier"])
+
+        update.assert_not_called()
+
+    def test_an_existing_photo_does_not_read_as_a_change(
+        self, test_user_with_profile
+    ):
+        from crush_lu.models import CrushProfile
+
+        # photo_1 is the one field where the row and the instance hold
+        # different types — the stored name vs a FieldFile — and an empty one
+        # is NULL on some rows and "" on others. Unnormalised, a member with a
+        # photo would refresh on every single save. Written with .update() so
+        # no storage backend is touched.
+        profile = self._with_member_pass(test_user_with_profile)
+        CrushProfile.objects.filter(pk=profile.pk).update(
+            photo_1="users/1/photos/a.jpg"
+        )
+        profile.refresh_from_db()
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            profile.save()
+
+        update.assert_not_called()
+
+    def test_a_real_change_in_a_bare_save_still_refreshes(
+        self, test_user_with_profile
+    ):
+        # The guard has to be a comparison, not a blanket "full saves don't
+        # count": the profile form posts every field, so a genuine tier or
+        # privacy edit arrives with update_fields=None too.
+        profile = self._with_member_pass(test_user_with_profile)
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            profile.membership_tier = "gold"
+            profile.save()
+
+        update.assert_called_once_with(profile)
+
+    def test_a_new_photo_refreshes(self, test_user_with_profile):
+        profile = self._with_member_pass(test_user_with_profile)
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            # Assigning a name (rather than an upload) keeps storage out of it;
+            # the FieldFile is created already-committed, so save() writes the
+            # string straight through.
+            profile.photo_1 = "users/1/photos/b.jpg"
+            profile.save(update_fields=["photo_1"])
+
+        update.assert_called_once_with(profile)
+
+    def test_google_wallet_update_waits_for_commit(
+        self, test_user_with_profile, django_capture_on_commit_callbacks
+    ):
+        from crush_lu.signals import trigger_wallet_pass_updates
+
+        # The Google half PATCHes content straight onto Google — there is no
+        # device coming back for it — so a caller that rolls back afterwards
+        # would leave Google showing state that never existed. And
+        # referrals.update_membership_tier() saves from inside atomic() holding
+        # a select_for_update, where two 30s HTTP calls sit on the lock.
+        profile = self._with_member_pass(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.update_google_wallet_pass",
+            return_value={"success": True, "message": "ok"},
+        ) as google_patch, mock.patch(
+            "crush_lu.wallet.passkit_apns.send_passkit_push_notifications",
+            return_value={"success": 0, "failed": 0, "total": 0},
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                trigger_wallet_pass_updates(profile)
+                google_patch.assert_not_called()
+
+        assert google_patch.call_count == 1
+
+
 @pytest.mark.django_db
 class TestTicketStampsAreSignalFree:
     """Stamping ticket-only metadata must not emit post_save: the generic

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1732,14 +1732,20 @@ class TestPointsChangesReachThePasses:
 
         referrer, attribution = self._referred(test_user_with_profile)
 
-        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+        # Asserted at refresh_ticket_serials, not the generic trigger: these
+        # are request paths, so the refresh has to go through the bounded
+        # helper (guaranteed marker advance + capped push) that AGENTS.md
+        # calls for.
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
             apply_referral_reward(attribution, "signup")
 
         # No tier boundary crossed, so nothing saved the profile — without an
         # explicit refresh the pass keeps the old balance.
         referrer.refresh_from_db()
         assert referrer.membership_tier == "basic"
-        assert update.call_count == 1
+        assert "member-serial" in set(refresh.call_args.args[0])
 
     def test_a_tier_upgrade_refreshes_exactly_once(
         self, test_user_with_profile, settings
@@ -1753,12 +1759,19 @@ class TestPointsChangesReachThePasses:
         settings.MEMBERSHIP_TIER_THRESHOLDS = {"bronze": 1, "silver": 2, "gold": 3}
         referrer, attribution = self._referred(test_user_with_profile)
 
-        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+        with mock.patch(
+            "crush_lu.signals.trigger_wallet_pass_updates"
+        ) as update, mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
             apply_referral_reward(attribution, "signup")
 
         referrer.refresh_from_db()
         assert referrer.membership_tier != "basic"
+        # The tier save fired the receiver; the points path must then stay out
+        # of the way rather than adding a second, byte-identical push.
         assert update.call_count == 1
+        refresh.assert_not_called()
 
     def test_the_profile_approval_bonus_refreshes_the_passes(
         self, test_user_with_profile, settings
@@ -1787,14 +1800,16 @@ class TestPointsChangesReachThePasses:
             user=attribution.referred_user, date_of_birth=date(1995, 5, 15)
         )
 
-        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
             check_and_apply_profile_approved_reward(referred_profile)
 
         referrer.refresh_from_db()
         assert referrer.referral_points == 50
         # Well short of bronze, so no tier save fired the receiver for us.
         assert referrer.membership_tier == "basic"
-        assert update.call_count == 1
+        assert "member-serial" in set(refresh.call_args.args[0])
 
     def test_redeeming_points_refreshes_the_passes(self, test_user_with_profile):
         from crush_lu.referrals import refresh_passes_after_points_change
@@ -1805,10 +1820,12 @@ class TestPointsChangesReachThePasses:
         profile.apple_pass_serial = "member-serial"
         profile.save(update_fields=["apple_pass_serial"])
 
-        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
             refresh_passes_after_points_change(profile)
 
-        update.assert_called_once_with(profile)
+        assert "member-serial" in set(refresh.call_args.args[0])
 
     def test_a_failing_push_never_costs_the_points(self, test_user_with_profile):
         from crush_lu.referrals import apply_referral_reward
@@ -1818,7 +1835,7 @@ class TestPointsChangesReachThePasses:
         referrer, attribution = self._referred(test_user_with_profile)
 
         with mock.patch(
-            "crush_lu.signals.trigger_wallet_pass_updates",
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials",
             side_effect=RuntimeError("APNs down"),
         ):
             points, _total = apply_referral_reward(attribution, "signup")
@@ -1826,6 +1843,104 @@ class TestPointsChangesReachThePasses:
         referrer.refresh_from_db()
         assert points > 0
         assert referrer.referral_points == points
+
+
+@pytest.mark.django_db
+class TestReferralCodeChangeRefreshesTheMemberPass:
+    """The member pass QR *is* the referral link. The code lives on another
+    model, so it reaches neither WALLET_MEMBER_PASS_FIELDS nor any profile
+    save — it was only ever picked up by the next bare profile.save()."""
+
+    def _with_code(self, test_user_with_profile):
+        from crush_lu.models import ReferralCode
+
+        _user, profile = test_user_with_profile
+        profile.apple_pass_serial = "member-serial"
+        profile.google_wallet_object_id = "issuer.member-1"
+        profile.save(update_fields=["apple_pass_serial", "google_wallet_object_id"])
+        return profile, ReferralCode.get_or_create_for_profile(profile)
+
+    def test_deactivating_a_code_refreshes(
+        self, _apple_identity, test_user_with_profile
+    ):
+        # The one that actually bites: get_or_create_for_profile only returns
+        # active codes, so the next build mints a different one while every
+        # installed pass keeps scanning to the dead code — which capture
+        # filters out, so it attributes nothing.
+        profile, code = self._with_code(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            code.is_active = False
+            code.save(update_fields=["is_active"])
+
+        assert "member-serial" in set(refresh.call_args.args[0])
+
+    def test_editing_the_code_refreshes(
+        self, _apple_identity, test_user_with_profile
+    ):
+        profile, code = self._with_code(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            code.code = "NEWCODE1"
+            code.save(update_fields=["code"])
+
+        assert "member-serial" in set(refresh.call_args.args[0])
+
+    def test_touching_an_unrelated_field_does_not_refresh(
+        self, _apple_identity, test_user_with_profile
+    ):
+        from django.utils import timezone as dj_timezone
+
+        # Capture stamps last_used_at on every scan. That must not fan out a
+        # push per scan.
+        profile, code = self._with_code(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            code.last_used_at = dj_timezone.now()
+            code.save(update_fields=["last_used_at"])
+
+        refresh.assert_not_called()
+
+    def test_creating_a_code_does_not_refresh(
+        self, _apple_identity, test_user_with_profile
+    ):
+        from crush_lu.models import ReferralCode
+
+        # get_or_create_for_profile is called FROM the pass build, so pushing
+        # here would notify the device that just downloaded the pass.
+        _user, profile = test_user_with_profile
+        profile.apple_pass_serial = "member-serial"
+        profile.save(update_fields=["apple_pass_serial"])
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            ReferralCode.objects.create(referrer=profile)
+
+        refresh.assert_not_called()
+
+    def test_a_holder_with_no_pass_costs_nothing(
+        self, _apple_identity, test_user_with_profile
+    ):
+        from crush_lu.models import ReferralCode
+
+        _user, profile = test_user_with_profile
+        assert not profile.apple_pass_serial
+        code = ReferralCode.get_or_create_for_profile(profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            code.is_active = False
+            code.save(update_fields=["is_active"])
+
+        refresh.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1351,6 +1351,30 @@ class TestProfileRenameRefreshesTickets:
         pushed = {c.args[1] for c in refresh.call_args_list}
         assert pushed == {"evt-1-reg-1-abcd", "member-serial"}
 
+    def test_profile_creation_refreshes_an_existing_ticket(
+        self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
+    ):
+        from datetime import date
+
+        from crush_lu.models import CrushProfile
+
+        # An open-event attendee can install a ticket with NO profile — the
+        # name falls back to the bare username. Creating the profile switches
+        # display_name to username.split("@")[0], so the installed ticket goes
+        # stale. There is no previous value to compare on this path, so the
+        # persisted-value guard has to treat `created` as a change in itself.
+        registration = self._ticketed(event_with_registrations)
+        user = registration.user
+        CrushProfile.objects.filter(user=user).delete()
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.trigger_pass_refresh"
+        ) as refresh:
+            with django_capture_on_commit_callbacks(execute=True):
+                CrushProfile.objects.create(user=user, date_of_birth=date(1995, 5, 15))
+
+        assert "evt-1-reg-1-abcd" in {c.args[1] for c in refresh.call_args_list}
+
     def test_bare_profile_save_does_not_refresh(
         self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
     ):

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1846,6 +1846,50 @@ class TestPointsChangesReachThePasses:
 
 
 @pytest.mark.django_db
+class TestRegistrationDeletionRefreshesTheMemberPass:
+    """The member card prints the holder's NEXT event. The post_save receiver
+    covers create and status changes; deletion had no equivalent and used to
+    ride on the holder's next bare profile.save()."""
+
+    def _member(self, event_with_registrations):
+        _event, registrations = event_with_registrations
+        registration = registrations[0]
+        profile = registration.user.crushprofile
+        profile.apple_pass_serial = "member-serial"
+        profile.save(update_fields=["apple_pass_serial"])
+        return registration, profile
+
+    def test_deleting_one_registration_refreshes(
+        self, _apple_identity, event_with_registrations
+    ):
+        registration, _profile = self._member(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            registration.delete()
+
+        pushed = {s for c in refresh.call_args_list for s in c.args[0]}
+        assert "member-serial" in pushed
+
+    def test_an_event_cascade_does_not_fan_out_per_row(
+        self, _apple_identity, event_with_registrations
+    ):
+        event, _registrations = event_with_registrations
+        _registration, _profile = self._member(event_with_registrations)
+
+        # One bounded refresh per row is not bounded in aggregate: each call
+        # starts its own push budget, so N rows multiply the deadline N times
+        # — the pathology cancel_events was already fixed for by batching.
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            event.delete()
+
+        refresh.assert_not_called()
+
+
+@pytest.mark.django_db
 class TestReferralCodeChangeRefreshesTheMemberPass:
     """The member pass QR *is* the referral link. The code lives on another
     model, so it reaches neither WALLET_MEMBER_PASS_FIELDS nor any profile
@@ -1939,6 +1983,66 @@ class TestReferralCodeChangeRefreshesTheMemberPass:
         ) as refresh:
             code.is_active = False
             code.save(update_fields=["is_active"])
+
+        refresh.assert_not_called()
+
+    def test_reassigning_the_owner_refreshes_both_holders(
+        self, _apple_identity, test_user_with_profile
+    ):
+        from datetime import date
+
+        from django.contrib.auth import get_user_model
+
+        from crush_lu.models import CrushProfile
+
+        # The old holder is the one that actually matters: their installed QR
+        # now credits somebody else entirely.
+        old_holder, code = self._with_code(test_user_with_profile)
+        new_user = get_user_model().objects.create_user(
+            username="new@example.com", email="new@example.com", password="x"
+        )
+        new_holder = CrushProfile.objects.create(
+            user=new_user, date_of_birth=date(1995, 5, 15)
+        )
+        new_holder.apple_pass_serial = "new-holder-serial"
+        new_holder.save(update_fields=["apple_pass_serial"])
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            code.referrer = new_holder
+            code.save(update_fields=["referrer"])
+
+        pushed = {s for c in refresh.call_args_list for s in c.args[0]}
+        assert pushed == {"member-serial", "new-holder-serial"}
+        assert old_holder.apple_pass_serial == "member-serial"
+
+    def test_deleting_a_code_refreshes(
+        self, _apple_identity, test_user_with_profile
+    ):
+        # capture_referral needs a matching row, so once it is gone the QR
+        # attributes nothing — and the next build mints a different code, so
+        # the installed pass never converges on its own.
+        profile, code = self._with_code(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            code.delete()
+
+        assert "member-serial" in set(refresh.call_args.args[0])
+
+    def test_deleting_the_profile_does_not_refresh_its_own_code(
+        self, _apple_identity, test_user_with_profile
+    ):
+        # The usual reason a code disappears is the profile going with it.
+        # Refreshing a pass whose profile no longer exists is pointless.
+        profile, _code = self._with_code(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh:
+            profile.delete()
 
         refresh.assert_not_called()
 

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1760,6 +1760,42 @@ class TestPointsChangesReachThePasses:
         assert referrer.membership_tier != "basic"
         assert update.call_count == 1
 
+    def test_the_profile_approval_bonus_refreshes_the_passes(
+        self, test_user_with_profile, settings
+    ):
+        from datetime import date
+
+        from crush_lu.models import CrushProfile
+        from crush_lu.referrals import check_and_apply_profile_approved_reward
+
+        # The bonus is a second QuerySet.update() site with the same shape as
+        # the award above. Pinning the point settings rather than inheriting
+        # them keeps the tier arithmetic below deterministic.
+        settings.REFERRAL_POINTS_PER_SIGNUP = 100
+        settings.REFERRAL_POINTS_PER_PROFILE_APPROVED = 50
+        settings.MEMBERSHIP_TIER_THRESHOLDS = {
+            "bronze": 200,
+            "silver": 500,
+            "gold": 1000,
+        }
+        referrer, attribution = self._referred(test_user_with_profile)
+        # Reached only once the signup reward has already landed.
+        attribution.reward_applied = True
+        attribution.reward_points = 100
+        attribution.save(update_fields=["reward_applied", "reward_points"])
+        referred_profile = CrushProfile.objects.create(
+            user=attribution.referred_user, date_of_birth=date(1995, 5, 15)
+        )
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            check_and_apply_profile_approved_reward(referred_profile)
+
+        referrer.refresh_from_db()
+        assert referrer.referral_points == 50
+        # Well short of bronze, so no tier save fired the receiver for us.
+        assert referrer.membership_tier == "basic"
+        assert update.call_count == 1
+
     def test_redeeming_points_refreshes_the_passes(self, test_user_with_profile):
         from crush_lu.referrals import refresh_passes_after_points_change
 

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1872,21 +1872,26 @@ class TestRegistrationDeletionRefreshesTheMemberPass:
         pushed = {s for c in refresh.call_args_list for s in c.args[0]}
         assert "member-serial" in pushed
 
-    def test_an_event_cascade_does_not_fan_out_per_row(
+    def test_an_event_cascade_marks_instead_of_pushing(
         self, _apple_identity, event_with_registrations
     ):
         event, _registrations = event_with_registrations
         _registration, _profile = self._member(event_with_registrations)
 
-        # One bounded refresh per row is not bounded in aggregate: each call
-        # starts its own push budget, so N rows multiply the deadline N times
-        # — the pathology cancel_events was already fixed for by batching.
+        # One push per row is not bounded in aggregate: each carries its own
+        # budget, so N rows multiply the deadline N times — the pathology
+        # cancel_events was already fixed for by batching. The marker advance
+        # is the guaranteed half on its own: one query, no network, and the
+        # card still rebuilds on Wallet's next poll.
         with mock.patch(
             "crush_lu.wallet.passkit_service.refresh_ticket_serials"
-        ) as refresh:
+        ) as refresh, mock.patch(
+            "crush_lu.wallet.passkit_apns.mark_passes_updated_bulk"
+        ) as mark:
             event.delete()
 
         refresh.assert_not_called()
+        assert "member-serial" in set(mark.call_args.args[1])
 
 
 @pytest.mark.django_db
@@ -2031,6 +2036,26 @@ class TestReferralCodeChangeRefreshesTheMemberPass:
             code.delete()
 
         assert "member-serial" in set(refresh.call_args.args[0])
+
+    def test_admin_bulk_delete_marks_instead_of_pushing(
+        self, _apple_identity, test_user_with_profile
+    ):
+        from crush_lu.models import ReferralCode
+
+        # ReferralCodeAdmin exposes Django's default "Delete selected", whose
+        # delete_queryset() calls QuerySet.delete() — so origin is the
+        # queryset, not each row, and pushing per row would fan out.
+        profile, code = self._with_code(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh, mock.patch(
+            "crush_lu.wallet.passkit_apns.mark_passes_updated_bulk"
+        ) as mark:
+            ReferralCode.objects.filter(pk=code.pk).delete()
+
+        refresh.assert_not_called()
+        assert "member-serial" in set(mark.call_args.args[1])
 
     def test_deleting_the_profile_does_not_refresh_its_own_code(
         self, _apple_identity, test_user_with_profile

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1696,6 +1696,103 @@ class TestMemberPassUpdateNeedsARealChange:
 
 
 @pytest.mark.django_db
+class TestPointsChangesReachThePasses:
+    """Both passes print the points balance, but every points mutation is a
+    QuerySet.update() carrying an F() expression — that is what closes the
+    concurrent-award race — and QuerySet.update() emits no signals. The
+    balance used to self-heal on the holder's next bare profile.save(); once
+    that stopped counting as a change, a points-only award left the installed
+    pass showing the old total indefinitely."""
+
+    def _referred(self, test_user_with_profile):
+        from django.contrib.auth import get_user_model
+
+        from crush_lu.models import ReferralAttribution, ReferralCode
+
+        _user, referrer = test_user_with_profile
+        referrer.apple_pass_serial = "member-serial"
+        referrer.save(update_fields=["apple_pass_serial"])
+
+        invitee = get_user_model().objects.create_user(
+            username="invitee@example.com",
+            email="invitee@example.com",
+            password="x",
+        )
+        code = ReferralCode.get_or_create_for_profile(referrer)
+        attribution = ReferralAttribution.objects.create(
+            referral_code=code,
+            referred_user=invitee,
+            referrer=referrer,
+            status=ReferralAttribution.Status.CONVERTED,
+        )
+        return referrer, attribution
+
+    def test_points_only_award_refreshes_the_passes(self, test_user_with_profile):
+        from crush_lu.referrals import apply_referral_reward
+
+        referrer, attribution = self._referred(test_user_with_profile)
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            apply_referral_reward(attribution, "signup")
+
+        # No tier boundary crossed, so nothing saved the profile — without an
+        # explicit refresh the pass keeps the old balance.
+        referrer.refresh_from_db()
+        assert referrer.membership_tier == "basic"
+        assert update.call_count == 1
+
+    def test_a_tier_upgrade_refreshes_exactly_once(
+        self, test_user_with_profile, settings
+    ):
+        from crush_lu.referrals import apply_referral_reward
+
+        # Crossing a threshold saves membership_tier, which fires the receiver
+        # on its own. Refreshing again on top of that would push a
+        # byte-identical package.
+        settings.REFERRAL_POINTS_PER_SIGNUP = 500
+        settings.MEMBERSHIP_TIER_THRESHOLDS = {"bronze": 1, "silver": 2, "gold": 3}
+        referrer, attribution = self._referred(test_user_with_profile)
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            apply_referral_reward(attribution, "signup")
+
+        referrer.refresh_from_db()
+        assert referrer.membership_tier != "basic"
+        assert update.call_count == 1
+
+    def test_redeeming_points_refreshes_the_passes(self, test_user_with_profile):
+        from crush_lu.referrals import refresh_passes_after_points_change
+
+        # The redemption endpoint deducts with QuerySet.update() too, so the
+        # balance drops on the pass with no signal behind it.
+        _user, profile = test_user_with_profile
+        profile.apple_pass_serial = "member-serial"
+        profile.save(update_fields=["apple_pass_serial"])
+
+        with mock.patch("crush_lu.signals.trigger_wallet_pass_updates") as update:
+            refresh_passes_after_points_change(profile)
+
+        update.assert_called_once_with(profile)
+
+    def test_a_failing_push_never_costs_the_points(self, test_user_with_profile):
+        from crush_lu.referrals import apply_referral_reward
+
+        # The award is the user's money; a wallet push is not. If the push
+        # raises, the points must still be committed.
+        referrer, attribution = self._referred(test_user_with_profile)
+
+        with mock.patch(
+            "crush_lu.signals.trigger_wallet_pass_updates",
+            side_effect=RuntimeError("APNs down"),
+        ):
+            points, _total = apply_referral_reward(attribution, "signup")
+
+        referrer.refresh_from_db()
+        assert points > 0
+        assert referrer.referral_points == points
+
+
+@pytest.mark.django_db
 class TestTicketStampsAreSignalFree:
     """Stamping ticket-only metadata must not emit post_save: the generic
     registration receiver treats any non-created save as a next-event change

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1446,6 +1446,55 @@ class TestProfileRenameRefreshesTickets:
 
         refresh.assert_not_called()
 
+    def test_user_rename_refreshes_the_google_member_object(
+        self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
+    ):
+        # Google prints display_name too, but refresh_ticket_serials is
+        # Apple-only. This used to ride on the next bare profile.save()
+        # reaching trigger_wallet_pass_updates — exactly the save that no
+        # longer counts as a change — so without an explicit call here a
+        # renamed member's Google card keeps the old name indefinitely.
+        registration = self._ticketed(event_with_registrations)
+        user = registration.user
+        profile = user.crushprofile
+        profile.google_wallet_object_id = "issuer.member-1"
+        profile.save(update_fields=["google_wallet_object_id"])
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.update_google_wallet_pass",
+            return_value={"success": True, "message": "ok"},
+        ) as google_patch, mock.patch(
+            "crush_lu.wallet.passkit_service.trigger_pass_refresh"
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                user.first_name = "Renamed"
+                user.save(update_fields=["first_name"])
+
+        assert google_patch.call_count == 1
+
+    def test_password_change_does_not_refresh_the_google_member_object(
+        self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
+    ):
+        # The Google half has to sit behind the same rename guard as the Apple
+        # half, or CrushSetPasswordForm.save() — a bare user.save() — starts
+        # PATCHing Google on every password change.
+        registration = self._ticketed(event_with_registrations)
+        user = registration.user
+        profile = user.crushprofile
+        profile.google_wallet_object_id = "issuer.member-1"
+        profile.save(update_fields=["google_wallet_object_id"])
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.update_google_wallet_pass"
+        ) as google_patch, mock.patch(
+            "crush_lu.wallet.passkit_service.trigger_pass_refresh"
+        ):
+            with django_capture_on_commit_callbacks(execute=True):
+                user.set_password("a-brand-new-password")
+                user.save()
+
+        google_patch.assert_not_called()
+
     def test_non_identity_save_does_not_refresh_tickets(
         self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
     ):


### PR DESCRIPTION
## Purpose

* Stop every Microsoft SSO login from paying for a wallet round trip. `trigger_wallet_pass_update_on_profile_change` (post_save on `CrushProfile`) treated **every** save carrying `update_fields=None` as wallet-relevant — *"Full save - trigger update to be safe"*. The social-login receiver (`crush_lu/signals.py:1592`) does a bare `profile.save()` on every Microsoft login with **no field changes at all**, so for any member who has installed a pass, each login paid for an APNs fan-out plus a **synchronous Google Wallet round trip** (a token exchange and a PATCH, 30s timeout each) inside the request.
* This is **pre-existing behaviour, not introduced by #761**, and no reviewer flagged it. It was found by sweeping for siblings of two bugs that PR *did* fix, where the same "a full save is not evidence of a change" mistake had been made — `refresh_wallet_passes_on_user_rename` (User) and the event-**ticket** half of this same receiver. This is the member-pass half, fixed with the same shape.
* Also moves the Google Wallet PATCH off the critical section of open transactions (see below).

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

One behaviour change worth knowing, though it is the point of the PR: `profile.save(update_fields=["membership_tier"])` that rewrites the **same** value no longer refreshes. The rebuild would have been byte-identical — but it is a case that used to fire.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What changed

**1. `pre_save` snapshot, widened rather than duplicated.** `remember_previous_ticket_identity` becomes `remember_previous_member_pass_fields` and snapshots all five member-pass fields — `referral_points`, `membership_tier`, `show_photo_on_wallet`, `photo_1`, `show_full_name` (`WALLET_MEMBER_PASS_FIELDS`) — in the *same* single indexed primary-key lookup that previously fetched only `show_full_name`. The ticket half reads `show_full_name` back out of it, so there is still **at most one snapshot query per save**, and still none at all when `update_fields` can't have moved anything relevant.

`display_name` / `first_name` / `last_name` are deliberately **not** in that set: they are *properties* reading the `User`, so they can neither reach a profile `update_fields` nor be fetched with `.values()`. Renames continue to arrive through `refresh_wallet_passes_on_user_rename`.

`photo_1` needs normalising or the fix would backfire: `.values()` yields the stored file name while the instance holds a `FieldFile`, and an empty photo is `NULL` on some rows and `""` on others (the column is both null and blank). Unnormalised, every member with a photo would read as changed on every save.

**2. `post_save` compares instead of assuming.** The `update_fields is None → should_update = True` branch is gone; `changed` is the set of fields that actually moved. An absent snapshot reads as "nothing moved" and short-circuits before touching the instance, so saves that skipped the snapshot query pay nothing in the receiver either.

**3. `_trigger_google_wallet_object_update` deferred with `transaction.on_commit`**, matching the Apple half — considered as asked, and it should be, for reasons beyond Apple's:

- It is not a "come back for the new package" push; it **PATCHes content straight onto Google**, so a caller that rolls back afterwards leaves Google showing state that never committed.
- Its payload comes from `build_wallet_pass_data()`, which re-queries for the next event and should read committed rows.
- It is two HTTP calls at a 30s timeout each, and `referrals.update_membership_tier()` saves the profile from **inside `transaction.atomic()` holding a `select_for_update()`** on the attribution row — up to a minute of network with that row locked.

`on_commit` runs inline when no transaction is open, so every other caller is unaffected. The admin action that actually *reports* Google results (`update_google_wallet_passes`) calls the API directly and is untouched.

**Not** moved to a background task, deliberately: production leaves `DJANGO_TASKS_BACKEND` unset, so the TASKS framework falls back to `ImmediateBackend` and `.enqueue()` would run inline in the request regardless.

**4. The deferred PATCH re-reads committed state** (`f424eaf5`, from Codex's P2). Deferring releases the profile row lock *before* the network call, so a newer tier can commit while the callback sits queued — and the callback shipped the instance captured at save time, which would put Google back on the older tier indefinitely. It now re-reads the row and PATCHes that, which also fixes the same staleness for callers that never held the lock and so were never serialized even before this PR (the admin bulk action, the `EventRegistration` receiver). Apple needs none of it: its push carries no content, so the device re-fetches current rows.

This **narrows the window rather than closing it** — two overlapping callbacks can still finish their HTTP calls out of order. Closing that needs a per-profile mutex or server-side versioning, both of which put blocking back into the request (`on_commit` runs inline), for a payload that only changes on a tier *upgrade*: points move via `QuerySet.update()` and emit no signal at all, and `update_membership_tier` never downgrades. Reverting the deferral is the worse trade — it puts two 30s HTTP calls back inside a lock held against every other writer of that profile row. Flagging it as an explicit trade you can reverse, not a hidden assumption.

**5. Two things were quietly relying on the removed fallback** — both found by Codex review, both regressions this PR introduced, both restored:

- **`907aeeec` — the Google member object on a User rename.** `_build_generic_object_payload` prints `display_name` in the subheader, but `refresh_wallet_passes_on_user_rename` only ever called `refresh_ticket_serials`, which is Apple-only. Google was catching renames purely by accident, via the next bare `profile.save()`. The rename receiver now schedules it explicitly, behind the same persisted-name guard (so a password change still doesn't fire) and in its own `try/except` so an APNs failure can't swallow it.
- **`0582b105` — the points balance.** Both passes print it, but every points mutation is a `QuerySet.update()` with an `F()` expression — that expression is what closes the concurrent-award race, so routing it through a signal-emitting save would trade this bug for a lost-update one. `refresh_passes_after_points_change()` asks for the refresh explicitly at the three sites that mutate points without a save (both award paths, plus redemption). Skipped when the award crossed a tier boundary, since that save already fired the receiver.

## Known remaining gap (deliberate, not an oversight)

`refresh_apple_tickets_on_event_change` refreshes Apple tickets **and** Apple member passes when an event is rescheduled, retitled or moved — but it is Apple-only, and the Google member object prints the same "Next Event" block. Like the two above, that used to self-heal on the holder's next bare `profile.save()`, so this PR makes it permanent.

I did not fix it here because the fix is a different shape, not a one-liner: Google needs two HTTP calls (token exchange + PATCH) **per attendee**, so scheduling one per registration on an admin event save would grow request time with attendee count — which is exactly why the Apple side goes through `refresh_ticket_serials` with a shared push budget. Doing it properly means giving the Google path the same batching/budget treatment. Flagging it rather than either shipping an unbounded fan-out or leaving it silent; happy to do it here if you'd prefer it in scope.

## How to Test

```bash
SECRET_KEY="test-only-not-a-real-key" DBHOST="" .venv/Scripts/python.exe -m pytest crush_lu/tests -n auto -o addopts="" -m "not playwright" -q
```

Result on this branch: **2948 passed, 22 skipped**. `ruff check` clean on both changed files.

The new coverage lives in `TestMemberPassUpdateNeedsARealChange` in `crush_lu/tests/test_passkit_service.py`:

```bash
SECRET_KEY="test-only-not-a-real-key" DBHOST="" .venv/Scripts/python.exe -m pytest crush_lu/tests/test_passkit_service.py -n 0 -o addopts="" -k "MemberPassUpdateNeedsARealChange or member_pass_fields_are_real_columns" -q
```

## What to Check

* **The tests are not vacuous.** Falsification-checked rather than assumed: run the new tests against the pre-change `signals.py` and the four behavioural ones fail (`test_bare_profile_save_does_not_refresh`, `test_rewriting_the_same_value_does_not_refresh`, `test_an_existing_photo_does_not_read_as_a_change`, `test_google_wallet_update_waits_for_commit`) while the constants test errors on import. The two *positive* guardrails — a real change still refreshes, through a bare save **and** through `update_fields`, since the profile form posts every field — pass on both sides, which is what makes them guardrails against over-correcting into "never fires". The two tests added with the re-read fix (`..._sends_committed_state_not_the_snapshot`, `..._skips_a_profile_deleted_before_commit`) likewise fail against `5e2a1875`; the first asserts *both* that the PATCH received the concurrently-committed tier **and** that the captured instance really was stale, so a no-op re-read would fail it.
* **`WALLET_MEMBER_PASS_FIELDS` is the complete set of member-pass inputs.** Everything else the pass prints is derived from these (`tier_display`), owned by another model (the referral code lives on `ReferralCode`, the next event on `EventRegistration` — handled by its own receiver) or immutable (`member_since`). `test_member_pass_fields_are_real_columns` pins the set to concrete columns and asserts the leftovers versus `WALLET_UPDATE_PROFILE_FIELDS` are exactly the three properties — a property in that set would raise `FieldError` on every profile save.
* **The `created` path is preserved.** An open-event attendee can install a ticket with no `CrushProfile` at all, and creating the profile is exactly when the printed name changes; there is no previous value to compare on that path, so `created` still counts as a change in its own right. Guarded by the first commit in this PR.
* The added query cost: one indexed PK lookup on `update_fields` saves that name a member-pass field (previously only bare saves and `show_full_name` paid it) — in exchange for removing up to two 30s HTTP calls from every SSO login.

## Other Information

The first commit (`6724ccc4`, test-only) predates this session — it covers the `created=True` branch of the ticket half and missed #761's merge, so it rides along here.

Commits, and what each round of review changed:

| Commit | What |
|---|---|
| `6724ccc4` | Test-only, pre-existing (see above) |
| `d9902d17` | The fix: compare persisted state; defer the Google PATCH |
| `5e2a1875` | Comment-only — `WALLET_UPDATE_PROFILE_FIELDS` no longer gates a receiver, and its comment said otherwise |
| `f424eaf5` | Codex P2: PATCH from committed state, not the captured snapshot |
| `907aeeec` | Codex P2: refresh the Google member object on a User rename |
| `0582b105` | Codex P2: refresh the passes after a points-only change |

Note that the bot reviews did **not** execute `pytest` or `ruff` — each says so explicitly. The counts above come from local runs and from CI's `Run Tests (Python 3.12)`, not from the reviewers.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
