### PR TITLE
fix(wallet): refresh Google member passes when an event changes

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -501,6 +501,23 @@ WALLET_GOOGLE_KEY_ID = os.getenv("WALLET_GOOGLE_KEY_ID", "")
 WALLET_GOOGLE_EVENT_TICKET_ENABLED = _env_bool(
     "WALLET_GOOGLE_EVENT_TICKET_ENABLED", default=True
 )
+# How many Google Wallet member objects one event-level refresh may PATCH
+# synchronously. Same shape as PASSKIT_BULK_PUSH_LIMIT below, but a stricter
+# meaning: an Apple pass past its cap still updates on Wallet's next poll,
+# whereas Google objects only ever change when we PATCH them — anything skipped
+# here stays stale until that profile is saved again. Sized to cover a full
+# event rather than a typical one, and every skip is logged at WARNING.
+WALLET_GOOGLE_BULK_UPDATE_LIMIT = int(
+    os.getenv("WALLET_GOOGLE_BULK_UPDATE_LIMIT", "50")
+)
+# Wall-clock budget for that fan-out. The count above does not bound the work:
+# each pass is an HTTPS PATCH, and the whole batch runs inline in the admin
+# request via on_commit (there is no background worker). Requests are clamped
+# to whatever is left of this, so a slow Google API cannot hold the request for
+# the per-request 30s ceiling times the number of attendees.
+WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS = float(
+    os.getenv("WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS", "10")
+)
 
 # Pre-screening questionnaire (Crush.lu). Off by default; enable in production
 # after all Phases have shipped and the Coach-facing rollout is ready.

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -532,7 +532,7 @@ def reset_reminders_on_reschedule(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=MeetupEvent)
 def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
-    """Push installed Apple tickets when the EVENT itself changes.
+    """Refresh installed wallet passes when the EVENT itself changes.
 
     The pass embeds the event's date, time, location and address, so a
     reschedule or relocation leaves every installed ticket showing details that
@@ -549,6 +549,19 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
     the start time: retitling, moving venue, correcting the address or
     coordinates, or changing the duration all rewrite the pass just as surely
     as a reschedule does.
+
+    Named for Apple because that is all it used to cover, but it now drives
+    three fan-outs, each bounded and each isolated from the others' failures:
+    Apple event tickets, Apple member passes, and Google member objects (which
+    print the same "Next Event" block).
+
+    The Google half was never handled here because it appeared to fix itself:
+    any bare profile.save() — the Microsoft SSO login path does one on every
+    sign-in — reaches trigger_wallet_pass_update_on_profile_change, which treats
+    an update_fields-less save as "refresh everything". That is an accident of
+    an over-broad receiver, not a mechanism, it only ever healed members who
+    happened to log in, and narrowing that receiver to real field changes
+    removes it entirely. The refresh belongs on the event change either way.
     """
     if created:
         return
@@ -601,6 +614,37 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
     except Exception as e:
         logger.error(
             f"Error refreshing Apple event tickets for event {instance.pk}: {e}"
+        )
+
+    # Google member objects print the same "Next Event" block, and there is no
+    # Google ticket to carry the change instead — the member object is the only
+    # Google surface this event appears on.
+    #
+    # Its own try/except, not the Apple block's: these are independent
+    # fan-outs over independent APIs, and a Google outage must not skip the
+    # Apple refresh (nor be reported as an Apple failure).
+    try:
+        from .wallet.google_api import refresh_google_wallet_objects
+
+        google_profiles = list(
+            CrushProfile.objects.filter(user__eventregistration__event=instance)
+            .exclude(google_wallet_object_id="")
+            .distinct()
+        )
+        scheduled = refresh_google_wallet_objects(
+            google_profiles, context=f"Event {instance.pk} Google member passes"
+        )
+        if scheduled:
+            logger.info(
+                "Scheduled Google refresh for %s member object(s) on event %s "
+                "(changed: %s)",
+                scheduled,
+                instance.pk,
+                ", ".join(changed),
+            )
+    except Exception as e:
+        logger.error(
+            f"Error refreshing Google Wallet objects for event {instance.pk}: {e}"
         )
 
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -503,6 +503,20 @@ def auto_create_event_ticket_class_on_publish(sender, instance, created, **kwarg
     if not getattr(settings, "WALLET_GOOGLE_ISSUER_ID", ""):
         return
 
+    # create_event_ticket_class persists the new class id with
+    # event.save(update_fields=[...]) on THIS instance, and that nested save
+    # re-runs remember_previous_event_start — which re-reads the row the outer
+    # save has already written and overwrites the "before" snapshot with the
+    # new values. Every later receiver then compares new against new: reminder
+    # markers are not cleared on a reschedule, and no wallet refresh is
+    # scheduled at all. It bites precisely the first edit of a published event
+    # that has no class yet, which is exactly when a coach reschedules one.
+    #
+    # Preserving it across the call also keeps the nested receiver chain inert
+    # (it sees the clobbered snapshot, finds nothing changed, and no-ops), so
+    # the outer chain still schedules exactly ONE fan-out rather than two.
+    snapshot_fields = getattr(instance, "_previous_ticket_fields", None)
+    snapshot_start = getattr(instance, "_previous_date_time", None)
     try:
         from .wallet.google_event_ticket_api import create_event_ticket_class
 
@@ -517,6 +531,9 @@ def auto_create_event_ticket_class_on_publish(sender, instance, created, **kwarg
             )
     except Exception as e:
         logger.error(f"Error creating EventTicketClass for event {instance.id}: {e}")
+    finally:
+        instance._previous_ticket_fields = snapshot_fields
+        instance._previous_date_time = snapshot_start
 
 
 # Every MeetupEvent field the Apple Wallet ticket payload embeds. A change to
@@ -546,6 +563,26 @@ _TICKET_PAYLOAD_FIELDS = _TICKET_PAYLOAD_BASE_FIELDS + tuple(
     f"{field}_{code.replace('-', '_')}"
     for field in _TICKET_TRANSLATED_FIELDS
     for code, _label in settings.LANGUAGES
+)
+
+# The subset of the above that can actually change the GOOGLE member object.
+# _build_generic_object_payload renders only the next event's title and date,
+# so a venue move, address fix, coordinate correction, event-type change or
+# duration edit rewrites the Apple ticket while leaving the Google object
+# byte-identical — and paying an OAuth exchange plus up to
+# WALLET_GOOGLE_BULK_UPDATE_LIMIT synchronous PATCHes to write an unchanged
+# object is exactly the budget spend the cap exists to protect.
+#
+# `is_cancelled` belongs here: get_next_event_for_pass drops a cancelled event,
+# so the block flips to "Browse events on crush.lu". The translated title
+# columns belong here for the reason given above — the card renders whichever
+# language its holder reads. Keep in sync with
+# google_api._build_generic_object_payload.
+_GOOGLE_PAYLOAD_FIELDS = frozenset(
+    ("date_time", "is_cancelled")
+    + tuple(
+        f"title_{code.replace('-', '_')}" for code, _label in settings.LANGUAGES
+    )
 )
 
 # Registration statuses under which an event can appear on a MEMBER card.
@@ -716,9 +753,18 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
     # Google ticket to carry the change instead — the member object is the only
     # Google surface this event appears on.
     #
+    # Gated on its OWN field subset, not the Apple one: the Google object
+    # renders far less of the event, so most edits that rewrite a ticket leave
+    # it identical, and this fan-out is far more expensive per pass than
+    # advancing an Apple update tag.
+    #
     # Its own try/except, not the Apple block's: these are independent
     # fan-outs over independent APIs, and a Google outage must not skip the
     # Apple refresh (nor be reported as an Apple failure).
+    google_changed = [field for field in changed if field in _GOOGLE_PAYLOAD_FIELDS]
+    if not google_changed:
+        return
+
     try:
         from .wallet.google_api import refresh_google_wallet_objects
 
@@ -734,7 +780,7 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
                 "(changed: %s)",
                 scheduled,
                 instance.pk,
-                ", ".join(changed),
+                ", ".join(google_changed),
             )
     except Exception as e:
         logger.error(

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -548,6 +548,12 @@ _TICKET_PAYLOAD_FIELDS = _TICKET_PAYLOAD_BASE_FIELDS + tuple(
     for code, _label in settings.LANGUAGES
 )
 
+# Registration statuses under which an event can appear on a MEMBER card.
+# Keep in sync with wallet_pass.get_next_event_for_pass, which is what actually
+# decides whether the card renders this event — anything outside this set is a
+# holder the event-change fan-outs must not spend their budget on.
+_NEXT_EVENT_STATUSES = (*SEAT_HOLDING_STATUSES, "waitlist")
+
 
 @receiver(pre_save, sender=MeetupEvent)
 def remember_previous_event_start(sender, instance, **kwargs):
@@ -655,6 +661,22 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
     if not changed:
         return
 
+    # Members whose card can actually show this event. get_next_event_for_pass
+    # only ever considers seat-holding or waitlisted registrations, so a
+    # cancelled or no-show attendee's card does not display this event and
+    # rebuilding it achieves nothing. That is not merely wasted work: both
+    # fan-outs below are capped, and on the Google side the cap is a hard loss
+    # (no poll heals what it skips), so an ineligible profile taking a slot
+    # leaves someone whose card IS wrong stale for good.
+    #
+    # Lazy, so it costs nothing until each branch narrows and evaluates it, and
+    # defined outside both try blocks so a failure in one cannot NameError the
+    # other.
+    attendee_profiles = CrushProfile.objects.filter(
+        user__eventregistration__event=instance,
+        user__eventregistration__status__in=_NEXT_EVENT_STATUSES,
+    )
+
     try:
         from .wallet.passkit_service import (
             refresh_event_tickets,
@@ -668,10 +690,7 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
         # they carry a different serial, so refreshing only the ticket serials
         # leaves every attendee's member pass showing the old details.
         member_serials = list(
-            CrushProfile.objects.filter(
-                user__eventregistration__event=instance
-            )
-            .exclude(apple_pass_serial="")
+            attendee_profiles.exclude(apple_pass_serial="")
             .values_list("apple_pass_serial", flat=True)
             .distinct()
         )
@@ -704,9 +723,7 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
         from .wallet.google_api import refresh_google_wallet_objects
 
         google_profiles = list(
-            CrushProfile.objects.filter(user__eventregistration__event=instance)
-            .exclude(google_wallet_object_id="")
-            .distinct()
+            attendee_profiles.exclude(google_wallet_object_id="").distinct()
         )
         scheduled = refresh_google_wallet_objects(
             google_profiles, context=f"Event {instance.pk} Google member passes"

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1085,6 +1085,419 @@ class TestEventLevelTicketRefresh:
         return out[:count]
 
 
+@pytest.fixture
+def _google_identity(settings):
+    """The settings a Google member-object refresh reads (no service-account key).
+
+    Both bounds are pinned rather than inherited so a change to the production
+    defaults cannot quietly turn a capped test into an uncapped one.
+    """
+    settings.WALLET_GOOGLE_CLASS_ID = "3388000000022222222.crush_member"
+    settings.WALLET_GOOGLE_BULK_UPDATE_LIMIT = 50
+    settings.WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS = 10.0
+
+
+class TestTimeoutKwargs:
+    """httpx reads an explicit timeout=None as 'no timeout at all', so an unset
+    override has to be omitted rather than forwarded."""
+
+    def test_unset_timeout_is_omitted(self):
+        from crush_lu.wallet.google_api import _timeout_kwargs
+
+        assert _timeout_kwargs(None) == {}
+
+    def test_explicit_timeout_is_forwarded(self):
+        from crush_lu.wallet.google_api import _timeout_kwargs
+
+        assert _timeout_kwargs(2.5) == {"timeout": 2.5}
+
+
+@pytest.mark.django_db
+class TestEventLevelGoogleRefresh:
+    """The GOOGLE member object prints the same "Next Event" block as the Apple
+    member pass, and nothing refreshed it when the event changed.
+
+    It differs from the Apple path in the one way that matters here: a Google
+    object is server-side state that only ever changes when we PATCH it. There
+    is no equivalent of Wallet's periodic poll, so anything the budget skips
+    stays wrong rather than merely arriving late.
+    """
+
+    def _google_holder(self, event_with_registrations, object_id="google-obj-1"):
+        event, registrations = event_with_registrations
+        profile = registrations[0].user.crushprofile
+        profile.google_wallet_object_id = object_id
+        # update_fields deliberately names only a field outside
+        # WALLET_UPDATE_PROFILE_FIELDS, so this setup save does not itself fire
+        # a wallet refresh and pollute the call counts below.
+        profile.save(update_fields=["google_wallet_object_id"])
+        return event, profile
+
+    def _extra_google_holders(self, event, count):
+        """`count` further attendees, each with a profile and an installed pass."""
+        from datetime import date
+
+        from django.contrib.auth import get_user_model
+
+        from crush_lu.models import CrushProfile, EventRegistration
+
+        User = get_user_model()
+        profiles = []
+        for i in range(count):
+            user = User.objects.create_user(
+                username=f"gbulk{i}@example.com",
+                email=f"gbulk{i}@example.com",
+                password="x",
+            )
+            # Registration first, profile second: the registration receiver
+            # bails on a profile-less user, so setup stays free of wallet calls.
+            EventRegistration.objects.create(
+                event=event, user=user, status="confirmed"
+            )
+            profile = CrushProfile.objects.create(
+                user=user,
+                date_of_birth=date(1995, 5, 15),
+                gender="M",
+                location="Luxembourg City",
+                is_approved=True,
+                verification_status="verified",
+                is_active=True,
+            )
+            profile.google_wallet_object_id = f"google-obj-extra-{i}"
+            profile.save(update_fields=["google_wallet_object_id"])
+            profiles.append(profile)
+        return profiles
+
+    def test_event_change_patches_the_member_object(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        event, profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        assert patch_object.call_count == 1
+        assert patch_object.call_args.args[0].pk == profile.pk
+        assert patch_object.call_args.args[2] == "tok"
+        assert token.call_count == 1
+
+    def test_one_token_exchange_serves_the_whole_batch(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # The per-profile entry point mints a token per call, so a fan-out cost
+        # two round trips per attendee. Sharing one exchange halves that.
+        event, _profile = self._google_holder(event_with_registrations)
+        self._extra_google_holders(event, 2)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        assert patch_object.call_count == 3
+        assert token.call_count == 1
+
+    def test_attendee_without_a_google_pass_costs_nothing(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # Not merely "no PATCH": with nothing to update there must be no token
+        # exchange either, so an event edit stays free for Apple-only crowds.
+        event, _registrations = event_with_registrations
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        assert token.call_count == 0
+        assert patch_object.call_count == 0
+
+    def test_no_payload_change_does_not_patch(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        event, _profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                # Not embedded in the pass payload.
+                event.is_published = not event.is_published
+                event.save()
+
+        patch_object.assert_not_called()
+
+    def test_nothing_runs_before_the_event_change_commits(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # Same reason as the Apple path: a PATCH sent before commit would
+        # publish details that a rollback then un-does.
+        event, _profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=False) as callbacks:
+                event.location = "A different bar"
+                event.save()
+
+            assert patch_object.call_count == 0
+            for callback in callbacks:
+                callback()
+            assert patch_object.call_count == 1
+
+    def test_fanout_is_capped_and_the_stale_passes_are_named(
+        self, _google_identity, settings, event_with_registrations,
+        django_capture_on_commit_callbacks, caplog,
+    ):
+        import logging
+
+        event, profile = self._google_holder(event_with_registrations)
+        extra = self._extra_google_holders(event, 2)
+        all_ids = {profile.google_wallet_object_id} | {
+            p.google_wallet_object_id for p in extra
+        }
+
+        settings.WALLET_GOOGLE_BULK_UPDATE_LIMIT = 2
+
+        with caplog.at_level(logging.WARNING, logger="crush_lu.wallet.google_api"):
+            with mock.patch(
+                "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+            ), mock.patch(
+                "crush_lu.wallet.google_api._patch_generic_object",
+                return_value={"success": True, "message": "Pass updated successfully"},
+            ) as patch_object:
+                with django_capture_on_commit_callbacks(execute=True):
+                    event.location = "A different bar"
+                    event.save()
+
+        assert patch_object.call_count == 2
+        patched = {
+            call.args[0].google_wallet_object_id
+            for call in patch_object.call_args_list
+        }
+        stale = all_ids - patched
+        assert len(stale) == 1
+        # Google has no poll to heal the skipped one, so the cap must never be
+        # silent — the warning has to name what was left wrong.
+        assert "STALE" in caplog.text
+        assert stale.pop() in caplog.text
+
+    def test_budget_stops_the_batch_mid_way(
+        self, _google_identity, settings, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # The count limit is not a bound on the work — each pass is an HTTPS
+        # PATCH, and this whole loop runs inline in the admin request. Only the
+        # wall clock actually stops a slow Google API.
+        import time as time_module
+
+        event, _profile = self._google_holder(event_with_registrations)
+        self._extra_google_holders(event, 2)
+
+        settings.WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS = 0.1
+
+        def _slow_patch(*args, **kwargs):
+            time_module.sleep(0.15)
+            return {"success": True, "message": "Pass updated successfully"}
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            side_effect=_slow_patch,
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        # One overran the budget, so the remaining two are never started —
+        # under the limit of 50, purely on time.
+        assert patch_object.call_count == 1
+
+    def test_each_request_is_clamped_to_the_remaining_budget(
+        self, _google_identity, settings, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # A 30s per-request default is not a bound on a 2s batch: without the
+        # clamp, one hung PATCH holds the request far past the budget.
+        event, _profile = self._google_holder(event_with_registrations)
+
+        settings.WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS = 2.0
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        timeout = patch_object.call_args.kwargs["timeout"]
+        assert 0 < timeout <= 2.0
+        # The token exchange is inside the same budget — a hanging OAuth
+        # endpoint would otherwise burn 30s before a single pass was touched.
+        assert 0 < token.call_args.kwargs["timeout"] <= 2.0
+
+    def test_one_failing_object_does_not_strand_the_rest(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        event, _profile = self._google_holder(event_with_registrations)
+        self._extra_google_holders(event, 2)
+
+        ok = {"success": True, "message": "Pass updated successfully"}
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            side_effect=[RuntimeError("boom"), ok, ok],
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        assert patch_object.call_count == 3
+
+    def test_token_failure_is_swallowed_and_reported(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks, caplog,
+    ):
+        import logging
+
+        # Nothing can be PATCHed without a token, so this takes the batch with
+        # it — but it runs from on_commit inside a request whose write already
+        # succeeded, so it must never propagate.
+        event, profile = self._google_holder(event_with_registrations)
+
+        with caplog.at_level(logging.WARNING, logger="crush_lu.wallet.google_api"):
+            with mock.patch(
+                "crush_lu.wallet.google_api._get_access_token",
+                side_effect=RuntimeError("oauth down"),
+            ), mock.patch(
+                "crush_lu.wallet.google_api._patch_generic_object"
+            ) as patch_object:
+                with django_capture_on_commit_callbacks(execute=True):
+                    event.location = "A different bar"
+                    event.save()
+
+        patch_object.assert_not_called()
+        assert "STALE" in caplog.text
+        assert profile.google_wallet_object_id in caplog.text
+
+    def test_missing_class_id_schedules_nothing(
+        self, _google_identity, settings, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        event, _profile = self._google_holder(event_with_registrations)
+        settings.WALLET_GOOGLE_CLASS_ID = ""
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        assert token.call_count == 0
+        assert patch_object.call_count == 0
+
+    def test_google_still_runs_when_the_apple_half_fails(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # Two independent APIs: an Apple outage must not skip the Google
+        # refresh, which is why they no longer share one try block.
+        event, _profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_event_tickets",
+            side_effect=RuntimeError("apns down"),
+        ), mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        assert patch_object.call_count == 1
+
+    def test_returns_the_number_scheduled_and_ignores_passless_profiles(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from crush_lu.wallet.google_api import refresh_google_wallet_objects
+
+        event, profile = self._google_holder(event_with_registrations)
+        other = self._extra_google_holders(event, 1)[0]
+        other.google_wallet_object_id = ""
+        other.save(update_fields=["google_wallet_object_id"])
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                assert refresh_google_wallet_objects([profile, other]) == 1
+
+        assert patch_object.call_count == 1
+
+    def test_single_profile_path_still_mints_its_own_token(
+        self, _google_identity, event_with_registrations
+    ):
+        # The batch borrows a token and a client; the per-profile entry point
+        # still owns both, so extracting the PATCH must not have changed it.
+        from crush_lu.wallet.google_api import update_google_wallet_pass
+
+        _event, profile = self._google_holder(event_with_registrations)
+        result = {"success": True, "message": "Pass updated successfully"}
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object", return_value=result
+        ) as patch_object:
+            assert update_google_wallet_pass(profile) == result
+
+        assert token.call_count == 1
+        assert patch_object.call_args.args[2] == "tok"
+
+
 @pytest.mark.django_db
 class TestAppleEventTicketRefreshSignal:
     """Every repo-wide Apple refresh path went through the MEMBER pass serial,

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1636,6 +1636,63 @@ class TestEventLevelGoogleRefresh:
 
         assert patch_object.call_count == 1
 
+    def test_payload_comes_from_committed_state_not_the_captured_instance(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # This call ships the payload itself, so PATCHing from the instance
+        # captured at schedule time would put Google back on a stale tier or
+        # point total that another transaction has since moved. Same rule the
+        # per-profile path follows in _trigger_google_wallet_object_update.
+        from crush_lu.models import CrushProfile
+        from crush_lu.wallet.google_api import refresh_google_wallet_objects
+
+        _event, profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                refresh_google_wallet_objects([profile])
+                # Committed after the batch was scheduled, exactly the window
+                # the re-read exists to cover.
+                CrushProfile.objects.filter(pk=profile.pk).update(
+                    membership_tier="gold"
+                )
+
+        assert patch_object.call_args.args[0].membership_tier == "gold"
+
+    def test_a_profile_that_vanishes_before_commit_is_skipped(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # Unlinked (or deleted) between scheduling and running: there is
+        # nothing left to PATCH, and the captured object id would target a
+        # pass the holder no longer has.
+        from crush_lu.models import CrushProfile
+        from crush_lu.wallet.google_api import refresh_google_wallet_objects
+
+        _event, profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                # Still reports 1 scheduled — the row was there at the time.
+                assert refresh_google_wallet_objects([profile]) == 1
+                CrushProfile.objects.filter(pk=profile.pk).update(
+                    google_wallet_object_id=""
+                )
+
+        patch_object.assert_not_called()
+        # Not even a token: the batch finds nothing to do and stops first.
+        token.assert_not_called()
+
     def test_single_profile_path_still_mints_its_own_token(
         self, _google_identity, event_with_registrations
     ):

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -940,6 +940,35 @@ class TestEventLevelTicketRefresh:
         pushed = {call.args[1] for call in refresh.call_args_list}
         assert pushed == {"evt-1-reg-1-abcd", "member-serial"}
 
+    def test_cancelled_attendees_member_pass_is_not_pushed(
+        self, _apple_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # Same reasoning as the Google half: get_next_event_for_pass ignores a
+        # cancelled registration, so this card is not showing this event and
+        # pushing it only spends the capped push budget on a no-op rebuild.
+        # The TICKET still refreshes — that one has to go `voided`.
+        from crush_lu.models import EventRegistration
+
+        event, registration = self._ticketed(event_with_registrations)
+        profile = registration.user.crushprofile
+        profile.apple_pass_serial = "member-serial"
+        profile.save(update_fields=["apple_pass_serial"])
+        # .update() so the per-registration receiver does not fire during setup.
+        EventRegistration.objects.filter(pk=registration.pk).update(
+            status="cancelled"
+        )
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.trigger_pass_refresh"
+        ) as refresh:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        pushed = {call.args[1] for call in refresh.call_args_list}
+        assert pushed == {"evt-1-reg-1-abcd"}
+
     def test_no_payload_change_does_not_push(
         self, _apple_identity, event_with_registrations, django_capture_on_commit_callbacks
     ):
@@ -1107,9 +1136,11 @@ class TestTimeoutKwargs:
         assert _timeout_kwargs(None) == {}
 
     def test_explicit_timeout_is_forwarded(self):
+        import httpx
+
         from crush_lu.wallet.google_api import _timeout_kwargs
 
-        assert _timeout_kwargs(2.5) == {"timeout": 2.5}
+        assert _timeout_kwargs(2.5) == {"timeout": httpx.Timeout(2.5)}
 
 
 @pytest.mark.django_db
@@ -1345,8 +1376,7 @@ class TestEventLevelGoogleRefresh:
         self, _google_identity, settings, event_with_registrations,
         django_capture_on_commit_callbacks,
     ):
-        # A 30s per-request default is not a bound on a 2s batch: without the
-        # clamp, one hung PATCH holds the request far past the budget.
+        # A 30s per-phase default is no kind of bound inside a 2s batch.
         event, _profile = self._google_holder(event_with_registrations)
 
         settings.WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS = 2.0
@@ -1361,11 +1391,140 @@ class TestEventLevelGoogleRefresh:
                 event.location = "A different bar"
                 event.save()
 
-        timeout = patch_object.call_args.kwargs["timeout"]
-        assert 0 < timeout <= 2.0
-        # The token exchange is inside the same budget — a hanging OAuth
+        assert 0 < patch_object.call_args.kwargs["timeout"] <= 2.0
+        # The token exchange is inside the same budget — a stalled OAuth
         # endpoint would otherwise burn 30s before a single pass was touched.
         assert 0 < token.call_args.kwargs["timeout"] <= 2.0
+
+    def test_every_timeout_phase_is_lowered_not_just_the_default(self):
+        # httpx applies a timeout PER PHASE, and a bare float only reads as
+        # "all four" through its own coercion. Build the Timeout explicitly so
+        # a connect/read/write/pool phase cannot silently keep the 30s default.
+        import httpx
+
+        from crush_lu.wallet.google_api import _timeout_kwargs
+
+        timeout = _timeout_kwargs(1.5)["timeout"]
+        assert isinstance(timeout, httpx.Timeout)
+        assert (timeout.connect, timeout.read, timeout.write, timeout.pool) == (
+            1.5,
+            1.5,
+            1.5,
+            1.5,
+        )
+
+    def test_payload_is_built_in_the_holders_language(
+        self, _google_identity, event_with_registrations
+    ):
+        # The next-event title is modeltranslated and the admin is forced to
+        # English, so without an override a coach editing an event rewrites a
+        # French holder's card in English. Asserted on _patch_generic_object
+        # directly, so it covers the single-profile path too.
+        from django.utils import translation
+
+        from crush_lu.wallet import google_api
+
+        _event, profile = self._google_holder(event_with_registrations)
+        profile.preferred_language = "fr"
+        # Not a WALLET_UPDATE_PROFILE_FIELDS member, so this save fires nothing.
+        profile.save(update_fields=["preferred_language"])
+
+        seen = {}
+
+        def _capture(_profile, object_id, _class_id):
+            seen["language"] = translation.get_language()
+            return {"id": object_id}
+
+        class _Response:
+            status_code = 200
+
+        class _Client:
+            def patch(self, *_args, **_kwargs):
+                return _Response()
+
+        with translation.override("en"):
+            with mock.patch.object(
+                google_api, "_build_generic_object_payload", side_effect=_capture
+            ):
+                result = google_api._patch_generic_object(
+                    profile, "class-id", "tok", _Client()
+                )
+
+        assert result["success"] is True
+        # Built as "fr" despite the caller running under "en".
+        assert seen["language"] == "fr"
+
+    def test_holder_without_a_language_does_not_inherit_the_callers(
+        self, _google_identity, event_with_registrations
+    ):
+        # override(None) deactivates translations rather than keeping the
+        # ambient language, so a holder with no stated preference gets the
+        # project default deterministically instead of whichever language the
+        # staff member editing the event happened to be browsing in. Same
+        # semantics as the Apple member-pass rebuild.
+        from django.utils import translation
+
+        from crush_lu.wallet import google_api
+
+        _event, profile = self._google_holder(event_with_registrations)
+        profile.preferred_language = ""
+        profile.save(update_fields=["preferred_language"])
+
+        seen = {}
+
+        def _capture(_profile, object_id, _class_id):
+            seen["language"] = translation.get_language()
+            return {"id": object_id}
+
+        class _Response:
+            status_code = 200
+
+        class _Client:
+            def patch(self, *_args, **_kwargs):
+                return _Response()
+
+        with translation.override("de"):
+            with mock.patch.object(
+                google_api, "_build_generic_object_payload", side_effect=_capture
+            ):
+                google_api._patch_generic_object(
+                    profile, "class-id", "tok", _Client()
+                )
+
+        assert seen["language"] is None
+
+    def test_a_cancelled_attendee_does_not_consume_the_budget(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # get_next_event_for_pass ignores cancelled registrations, so this
+        # holder's card cannot be showing this event at all. Refreshing it is
+        # not merely wasted work: the cap is a hard loss on the Google side, so
+        # a slot spent here leaves someone whose card IS wrong stale for good.
+        from crush_lu.models import EventRegistration
+
+        event, profile = self._google_holder(event_with_registrations)
+        cancelled = self._extra_google_holders(event, 1)[0]
+        # .update() so the per-registration receiver does not fire during setup.
+        EventRegistration.objects.filter(user=cancelled.user, event=event).update(
+            status="cancelled"
+        )
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.location = "A different bar"
+                event.save()
+
+        patched = {
+            call.args[0].google_wallet_object_id
+            for call in patch_object.call_args_list
+        }
+        assert patched == {profile.google_wallet_object_id}
 
     def test_one_failing_object_does_not_strand_the_rest(
         self, _google_identity, event_with_registrations,

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1154,6 +1154,16 @@ class TestEventLevelGoogleRefresh:
     stays wrong rather than merely arriving late.
     """
 
+    def _retitle(self, event):
+        """Make an edit the Google member object actually renders, and save.
+
+        The card prints only the next event's title and date, so a venue or
+        address edit deliberately does NOT reach Google (see
+        _GOOGLE_PAYLOAD_FIELDS) — these tests need one that does.
+        """
+        event.title_en = f"{event.title_en or event.title} (renamed)"
+        event.save()
+
     def _google_holder(self, event_with_registrations, object_id="google-obj-1"):
         event, registrations = event_with_registrations
         profile = registrations[0].user.crushprofile
@@ -1212,8 +1222,7 @@ class TestEventLevelGoogleRefresh:
             return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert patch_object.call_count == 1
         assert patch_object.call_args.args[0].pk == profile.pk
@@ -1236,8 +1245,7 @@ class TestEventLevelGoogleRefresh:
             return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert patch_object.call_count == 3
         assert token.call_count == 1
@@ -1256,11 +1264,76 @@ class TestEventLevelGoogleRefresh:
             "crush_lu.wallet.google_api._patch_generic_object"
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert token.call_count == 0
         assert patch_object.call_count == 0
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("location", "A different bar"),
+            ("address", "1 New Street"),
+            ("latitude", 49.61),
+            ("duration_minutes", 999),
+        ],
+    )
+    def test_apple_only_field_changes_do_not_patch_google(
+        self, field, value, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # The Google object renders only the next event's title and date, so
+        # these rewrite the Apple ticket while leaving it byte-identical. An
+        # OAuth exchange plus up to 50 PATCHes to write an unchanged object is
+        # the exact budget spend the cap exists to protect.
+        event, _profile = self._google_holder(event_with_registrations)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                setattr(event, field, value)
+                event.save()
+
+        token.assert_not_called()
+        patch_object.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("date_time", None),  # replaced below — needs a real datetime
+            ("is_cancelled", True),
+            ("title_fr", "Soirée renommée"),
+        ],
+    )
+    def test_google_rendered_field_changes_do_patch(
+        self, field, value, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # The other half of the gate: what the card actually prints must still
+        # reach Google. is_cancelled counts because get_next_event_for_pass
+        # drops a cancelled event, flipping the block to "Browse events".
+        from datetime import timedelta
+
+        from django.utils import timezone as dj_timezone
+
+        event, _profile = self._google_holder(event_with_registrations)
+        if field == "date_time":
+            value = dj_timezone.now() + timedelta(days=21)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                setattr(event, field, value)
+                event.save()
+
+        assert patch_object.call_count == 1
 
     def test_no_payload_change_does_not_patch(
         self, _google_identity, event_with_registrations,
@@ -1295,8 +1368,7 @@ class TestEventLevelGoogleRefresh:
             return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=False) as callbacks:
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
             assert patch_object.call_count == 0
             for callback in callbacks:
@@ -1325,7 +1397,7 @@ class TestEventLevelGoogleRefresh:
                 return_value={"success": True, "message": "Pass updated successfully"},
             ) as patch_object:
                 with django_capture_on_commit_callbacks(execute=True):
-                    event.location = "A different bar"
+                    self._retitle(event)
                     event.save()
 
         assert patch_object.call_count == 2
@@ -1365,8 +1437,7 @@ class TestEventLevelGoogleRefresh:
             side_effect=_slow_patch,
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         # One overran the budget, so the remaining two are never started —
         # under the limit of 50, purely on time.
@@ -1388,8 +1459,7 @@ class TestEventLevelGoogleRefresh:
             return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert 0 < patch_object.call_args.kwargs["timeout"] <= 2.0
         # The token exchange is inside the same budget — a stalled OAuth
@@ -1517,8 +1587,7 @@ class TestEventLevelGoogleRefresh:
             return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         patched = {
             call.args[0].google_wallet_object_id
@@ -1541,8 +1610,7 @@ class TestEventLevelGoogleRefresh:
             side_effect=[RuntimeError("boom"), ok, ok],
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert patch_object.call_count == 3
 
@@ -1565,7 +1633,7 @@ class TestEventLevelGoogleRefresh:
                 "crush_lu.wallet.google_api._patch_generic_object"
             ) as patch_object:
                 with django_capture_on_commit_callbacks(execute=True):
-                    event.location = "A different bar"
+                    self._retitle(event)
                     event.save()
 
         patch_object.assert_not_called()
@@ -1585,8 +1653,7 @@ class TestEventLevelGoogleRefresh:
             "crush_lu.wallet.google_api._patch_generic_object"
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert token.call_count == 0
         assert patch_object.call_count == 0
@@ -1609,8 +1676,7 @@ class TestEventLevelGoogleRefresh:
             return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
-                event.location = "A different bar"
-                event.save()
+                self._retitle(event)
 
         assert patch_object.call_count == 1
 
@@ -1634,6 +1700,57 @@ class TestEventLevelGoogleRefresh:
             with django_capture_on_commit_callbacks(execute=True):
                 assert refresh_google_wallet_objects([profile, other]) == 1
 
+        assert patch_object.call_count == 1
+
+    def test_nested_class_creation_does_not_swallow_the_refresh(
+        self, _google_identity, settings, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        # auto_create_event_ticket_class_on_publish runs FIRST and persists the
+        # new class id with a nested event.save() on the same instance. That
+        # save re-runs remember_previous_event_start, which re-reads the row
+        # this save has already written — so without preserving the snapshot,
+        # every later receiver compares new against new, finds nothing changed,
+        # and silently skips the whole fan-out. It bites the first edit of a
+        # published event with no class yet: exactly a coach rescheduling one.
+        from datetime import timedelta
+
+        from django.utils import timezone as dj_timezone
+
+        event, _profile = self._google_holder(event_with_registrations)
+
+        def _fake_create_class(target):
+            # The real create_event_ticket_class does exactly this after its
+            # HTTP call; the nested save is the whole point of the test.
+            target.google_wallet_event_class_id = "class-1"
+            target.save(update_fields=["google_wallet_event_class_id"])
+            return {"success": True, "message": "Class created", "class_id": "class-1"}
+
+        # Set only now: with the issuer unset, the setup saves above returned
+        # early and never reached the class-creation branch.
+        settings.WALLET_GOOGLE_ISSUER_ID = "3388000000022222222"
+        settings.WALLET_GOOGLE_EVENT_TICKET_ENABLED = True
+        assert not event.google_wallet_event_class_id and event.is_published
+
+        with mock.patch(
+            "crush_lu.wallet.google_event_ticket_api.create_event_ticket_class",
+            side_effect=_fake_create_class,
+        ), mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.date_time = dj_timezone.now() + timedelta(days=21)
+                event.save()
+
+        event.refresh_from_db()
+        # The nested save really happened...
+        assert event.google_wallet_event_class_id == "class-1"
+        # ...and the refresh survived it — exactly once, not twice: the nested
+        # receiver chain sees the clobbered snapshot and no-ops, so only the
+        # outer one schedules a fan-out.
         assert patch_object.call_count == 1
 
     def test_payload_comes_from_committed_state_not_the_captured_instance(

--- a/crush_lu/wallet/google_api.py
+++ b/crush_lu/wallet/google_api.py
@@ -409,10 +409,17 @@ def refresh_google_wallet_objects(profiles, context=""):
     request either way — production leaves DJANGO_TASKS_BACKEND unset, so TASKS
     falls back to ImmediateBackend and enqueuing would not move the work off it.
 
-    Returns the number of profiles scheduled; the work itself runs on commit.
+    Takes profiles but keeps only their pks, re-reading committed rows in the
+    callback — see there for why a captured instance is the wrong thing to
+    PATCH from.
+
+    Returns the number of profiles scheduled; the work itself runs on commit,
+    by which point some of them may legitimately no longer need it.
     """
-    profiles = [p for p in profiles if getattr(p, "google_wallet_object_id", "")]
-    if not profiles:
+    profile_ids = [
+        p.pk for p in profiles if getattr(p, "google_wallet_object_id", "")
+    ]
+    if not profile_ids:
         return 0
 
     class_id = getattr(settings, "WALLET_GOOGLE_CLASS_ID", None)
@@ -421,7 +428,7 @@ def refresh_google_wallet_objects(profiles, context=""):
             "%s: skipping Google Wallet refresh for %s pass(es) — "
             "WALLET_GOOGLE_CLASS_ID is not configured",
             context or "bulk refresh",
-            len(profiles),
+            len(profile_ids),
         )
         return 0
 
@@ -431,6 +438,28 @@ def refresh_google_wallet_objects(profiles, context=""):
     )
 
     def _after_commit():
+        from ..models import CrushProfile
+
+        # Re-read from COMMITTED state instead of PATCHing the instances the
+        # caller captured, for the reason spelled out in
+        # signals._trigger_google_wallet_object_update: this call ships the
+        # payload itself, and between scheduling and running here another
+        # transaction can have committed a newer tier or point total — or
+        # deleted the profile outright, or unlinked its object — and the
+        # captured copy would put Google back on the older state indefinitely.
+        # ONE query for the whole batch, so the correctness the per-profile
+        # path pays a query each for is actually cheaper here.
+        #
+        # Ordered by pk so the cap below and the stale report are reproducible
+        # rather than dependent on however the database returned the rows.
+        profiles = list(
+            CrushProfile.objects.filter(pk__in=profile_ids)
+            .exclude(google_wallet_object_id="")
+            .order_by("pk")
+        )
+        if not profiles:
+            return
+
         deadline = time.monotonic() + update_budget
         updated = 0
         failed = 0
@@ -520,7 +549,7 @@ def refresh_google_wallet_objects(profiles, context=""):
             )
 
     transaction.on_commit(_after_commit)
-    return len(profiles)
+    return len(profile_ids)
 
 
 def update_all_google_wallet_passes():

--- a/crush_lu/wallet/google_api.py
+++ b/crush_lu/wallet/google_api.py
@@ -13,6 +13,7 @@ import uuid
 import httpx
 from django.conf import settings
 from django.db import transaction
+from django.utils import translation
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -24,10 +25,9 @@ logger = logging.getLogger(__name__)
 GOOGLE_WALLET_API_BASE = "https://walletobjects.googleapis.com/walletobjects/v1"
 GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
 
-# Per-request ceiling for every call in this module. It is NOT what bounds a
-# bulk refresh — refresh_google_wallet_objects clamps each request to whatever
-# is left of its wall-clock budget, and this only caps the single-profile
-# callers that have no budget of their own.
+# Per-phase ceiling for every call in this module. A bulk refresh lowers it to
+# whatever is left of its wall-clock budget; this is the floor-level cap for
+# the single-profile callers that have no budget of their own.
 GOOGLE_WALLET_HTTP_TIMEOUT = 30.0
 
 
@@ -36,14 +36,32 @@ def _timeout_kwargs(timeout):
 
     httpx reads an explicit ``timeout=None`` as "no timeout at all", so an
     absent override must be left out entirely rather than forwarded as None —
-    passing it through would remove the client default and let one hung request
+    passing it through would drop the client default and let one hung request
     hold the caller forever.
+
+    What a value here does and does NOT bound: httpx applies a timeout PER
+    PHASE — connect, write, pool, and read, the last of which restarts on every
+    chunk received — so this limits how long any single phase may stall, not
+    the end-to-end duration of a request. A batch's wall-clock budget is
+    therefore enforced by the loop that stops STARTING requests once the
+    deadline passes; one pathologically slow endpoint can still overrun that
+    budget by roughly a single request's phases.
+
+    That residual is accepted rather than fixed, because sync httpx offers no
+    total-deadline or cancellation knob: the alternative is running each PATCH
+    on a thread abandoned at the deadline, and a thread blocked on a socket
+    read leaks for the life of the worker — strictly worse than a bounded
+    overrun well inside gunicorn's 120s timeout.
     """
-    return {"timeout": timeout} if timeout is not None else {}
+    if timeout is None:
+        return {}
+    # Constructed explicitly so the per-phase semantics above are visible here
+    # rather than hidden inside httpx's float coercion.
+    return {"timeout": httpx.Timeout(timeout)}
 
 
 def _remaining_timeout(deadline):
-    """Seconds left before `deadline`, capped at the per-request ceiling.
+    """Seconds left before `deadline`, capped at the per-phase ceiling.
 
     Returns a non-positive value once the budget is spent, which callers treat
     as "stop" — never as "no timeout".
@@ -277,11 +295,18 @@ def _patch_generic_object(profile, class_id, access_token, client, timeout=None)
     point below still owns both when called on its own, so its behaviour and
     return shape are unchanged.
     """
-    object_payload = _build_generic_object_payload(
-        profile,
-        profile.google_wallet_object_id,
-        class_id,
-    )
+    # Render in the HOLDER's language, not the caller's. The next-event title
+    # is modeltranslated, and every path that reaches here in bulk runs from
+    # the admin — which is forced to English — so without this override a
+    # French or German holder's card is rewritten in English by an edit they
+    # had nothing to do with. Mirrors the Apple member-pass rebuild in
+    # apple_pass.provide_pass_for_serial; None leaves the active language.
+    with translation.override(getattr(profile, "preferred_language", "") or None):
+        object_payload = _build_generic_object_payload(
+            profile,
+            profile.google_wallet_object_id,
+            class_id,
+        )
 
     # URL encode the object ID (it contains dots)
     encoded_object_id = profile.google_wallet_object_id.replace(".", "%2E")
@@ -365,9 +390,12 @@ def refresh_google_wallet_objects(profiles, context=""):
     isolated — with two differences that come from Google's model, not ours:
 
       * ONE token exchange and ONE keep-alive client serve the whole batch, so
-        each extra pass costs a single PATCH rather than two requests. Every
-        request is also clamped to the remaining budget, because a 30s default
-        timeout is not a bound on a 10s batch.
+        each extra pass costs a single PATCH rather than two requests. Each
+        request's phase timeouts are also lowered to the remaining budget,
+        since a 30s default is no kind of bound inside a 10s batch — though
+        see _timeout_kwargs for what that does and does not guarantee: the
+        budget is enforced by refusing to START work past the deadline, not by
+        cancelling work already in flight.
       * There is NO Google equivalent of Wallet's periodic poll. An Apple pass
         that misses its push still updates, because the bulk query advanced its
         tag; a Google object that misses its PATCH stays stale until something
@@ -418,9 +446,10 @@ def refresh_google_wallet_objects(profiles, context=""):
         if token_timeout > 0:
             try:
                 with httpx.Client(timeout=GOOGLE_WALLET_HTTP_TIMEOUT) as client:
-                    # One exchange for the batch. Clamped to the budget too: a
-                    # hanging OAuth endpoint would otherwise burn the full 30s
-                    # before a single pass had been touched.
+                    # One exchange for the batch, and inside the budget as
+                    # well: a stalled OAuth endpoint left at the 30s default
+                    # would burn the whole allowance before a single pass had
+                    # been touched.
                     access_token = _get_access_token(
                         client=client, timeout=token_timeout
                     )

--- a/crush_lu/wallet/google_api.py
+++ b/crush_lu/wallet/google_api.py
@@ -12,6 +12,7 @@ import uuid
 
 import httpx
 from django.conf import settings
+from django.db import transaction
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -21,12 +22,47 @@ from ..wallet_pass import build_wallet_pass_data
 logger = logging.getLogger(__name__)
 
 GOOGLE_WALLET_API_BASE = "https://walletobjects.googleapis.com/walletobjects/v1"
+GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+# Per-request ceiling for every call in this module. It is NOT what bounds a
+# bulk refresh — refresh_google_wallet_objects clamps each request to whatever
+# is left of its wall-clock budget, and this only caps the single-profile
+# callers that have no budget of their own.
+GOOGLE_WALLET_HTTP_TIMEOUT = 30.0
 
 
-def _get_access_token():
+def _timeout_kwargs(timeout):
+    """Build the per-request timeout kwarg, omitting it when unset.
+
+    httpx reads an explicit ``timeout=None`` as "no timeout at all", so an
+    absent override must be left out entirely rather than forwarded as None —
+    passing it through would remove the client default and let one hung request
+    hold the caller forever.
+    """
+    return {"timeout": timeout} if timeout is not None else {}
+
+
+def _remaining_timeout(deadline):
+    """Seconds left before `deadline`, capped at the per-request ceiling.
+
+    Returns a non-positive value once the budget is spent, which callers treat
+    as "stop" — never as "no timeout".
+    """
+    return min(GOOGLE_WALLET_HTTP_TIMEOUT, deadline - time.monotonic())
+
+
+def _get_access_token(client=None, timeout=None):
     """
     Generate an OAuth2 access token using service account credentials.
     Uses JWT bearer token flow for server-to-server authentication.
+
+    Args:
+        client: optional httpx.Client to borrow. A batch mints ONE token for
+            its whole fan-out and reuses a single connection; without this,
+            every pass update paid for its own exchange plus its own handshake.
+        timeout: optional per-request timeout, so a caller working to a
+            wall-clock budget is not held for the full default by a hanging
+            OAuth endpoint.
     """
     service_account_email = getattr(settings, "WALLET_GOOGLE_SERVICE_ACCOUNT_EMAIL", None)
     if not service_account_email:
@@ -58,13 +94,18 @@ def _get_access_token():
     signed_jwt = b".".join([signing_input, _base64url_encode(signature)]).decode("utf-8")
 
     # Exchange JWT for access token
-    with httpx.Client(timeout=30.0) as client:
+    owned_client = None
+    if client is None:
+        owned_client = httpx.Client(timeout=GOOGLE_WALLET_HTTP_TIMEOUT)
+        client = owned_client
+    try:
         response = client.post(
-            "https://oauth2.googleapis.com/token",
+            GOOGLE_OAUTH_TOKEN_URL,
             data={
                 "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
                 "assertion": signed_jwt,
             },
+            **_timeout_kwargs(timeout),
         )
 
         if response.status_code != 200:
@@ -72,6 +113,9 @@ def _get_access_token():
             raise ValueError(f"Failed to get access token: {response.status_code}")
 
         return response.json()["access_token"]
+    finally:
+        if owned_client is not None:
+            owned_client.close()
 
 
 def _build_generic_object_payload(profile, object_id, class_id):
@@ -225,6 +269,59 @@ def _build_generic_object_payload(profile, object_id, class_id):
     return generic_object
 
 
+def _patch_generic_object(profile, class_id, access_token, client, timeout=None):
+    """PATCH one member object with a caller-supplied token and HTTP client.
+
+    Split out of update_google_wallet_pass so a batch can mint ONE token and
+    reuse ONE connection across its whole fan-out. The single-profile entry
+    point below still owns both when called on its own, so its behaviour and
+    return shape are unchanged.
+    """
+    object_payload = _build_generic_object_payload(
+        profile,
+        profile.google_wallet_object_id,
+        class_id,
+    )
+
+    # URL encode the object ID (it contains dots)
+    encoded_object_id = profile.google_wallet_object_id.replace(".", "%2E")
+    url = f"{GOOGLE_WALLET_API_BASE}/genericObject/{encoded_object_id}"
+
+    response = client.patch(
+        url,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        json=object_payload,
+        **_timeout_kwargs(timeout),
+    )
+
+    if response.status_code == 200:
+        logger.info(
+            "Updated Google Wallet pass for user %s (object: %s)",
+            profile.user_id,
+            profile.google_wallet_object_id,
+        )
+        return {"success": True, "message": "Pass updated successfully"}
+
+    if response.status_code == 404:
+        # Pass doesn't exist in Google's system (user may have deleted it)
+        logger.warning(
+            "Google Wallet pass not found for user %s (object: %s)",
+            profile.user_id,
+            profile.google_wallet_object_id,
+        )
+        return {"success": False, "message": "Pass not found (may have been deleted)"}
+
+    logger.error(
+        "Failed to update Google Wallet pass: %s - %s",
+        response.status_code,
+        response.text,
+    )
+    return {"success": False, "message": f"API error: {response.status_code}"}
+
+
 def update_google_wallet_pass(profile):
     """
     Update an existing Google Wallet pass for a user.
@@ -243,55 +340,158 @@ def update_google_wallet_pass(profile):
         return {"success": False, "message": "WALLET_GOOGLE_CLASS_ID not configured"}
 
     try:
-        access_token = _get_access_token()
-        object_payload = _build_generic_object_payload(
-            profile,
-            profile.google_wallet_object_id,
-            class_id
-        )
-
-        # URL encode the object ID (it contains dots)
-        encoded_object_id = profile.google_wallet_object_id.replace(".", "%2E")
-        url = f"{GOOGLE_WALLET_API_BASE}/genericObject/{encoded_object_id}"
-
-        with httpx.Client(timeout=30.0) as client:
-            response = client.patch(
-                url,
-                headers={
-                    "Authorization": f"Bearer {access_token}",
-                    "Content-Type": "application/json",
-                },
-                json=object_payload,
-            )
-
-            if response.status_code == 200:
-                logger.info(
-                    "Updated Google Wallet pass for user %s (object: %s)",
-                    profile.user_id,
-                    profile.google_wallet_object_id,
-                )
-                return {"success": True, "message": "Pass updated successfully"}
-
-            elif response.status_code == 404:
-                # Pass doesn't exist in Google's system (user may have deleted it)
-                logger.warning(
-                    "Google Wallet pass not found for user %s (object: %s)",
-                    profile.user_id,
-                    profile.google_wallet_object_id,
-                )
-                return {"success": False, "message": "Pass not found (may have been deleted)"}
-
-            else:
-                logger.error(
-                    "Failed to update Google Wallet pass: %s - %s",
-                    response.status_code,
-                    response.text,
-                )
-                return {"success": False, "message": f"API error: {response.status_code}"}
+        with httpx.Client(timeout=GOOGLE_WALLET_HTTP_TIMEOUT) as client:
+            access_token = _get_access_token(client=client)
+            return _patch_generic_object(profile, class_id, access_token, client)
 
     except Exception as e:
         logger.exception("Error updating Google Wallet pass for user %s: %s", profile.user_id, e)
         return {"success": False, "message": str(e)}
+
+
+def refresh_google_wallet_objects(profiles, context=""):
+    """Bulk-refresh Google Wallet member objects under ONE shared budget.
+
+    The member object prints the holder's next event (see the "Next Event" text
+    module in _build_generic_object_payload, fed by get_next_event_for_pass), so
+    an event-level change makes every attendee's card wrong. Nothing else fixes
+    it: a Google object is server-side state that only changes when we PATCH it,
+    and update_google_wallet_pass() mints its own OAuth token and opens its own
+    connection per profile — so a naive per-attendee fan-out cost two round
+    trips each and let request time grow with attendance.
+
+    This mirrors passkit_service.refresh_ticket_serials — deferred to commit,
+    bounded by BOTH a count limit and a wall-clock deadline, per-item failures
+    isolated — with two differences that come from Google's model, not ours:
+
+      * ONE token exchange and ONE keep-alive client serve the whole batch, so
+        each extra pass costs a single PATCH rather than two requests. Every
+        request is also clamped to the remaining budget, because a 30s default
+        timeout is not a bound on a 10s batch.
+      * There is NO Google equivalent of Wallet's periodic poll. An Apple pass
+        that misses its push still updates, because the bulk query advanced its
+        tag; a Google object that misses its PATCH stays stale until something
+        else saves that profile. The cap is therefore a real last-resort brake
+        rather than a downgrade to "slower" — it is logged at WARNING with the
+        object ids, and the default limit is sized for a full event.
+
+    Deferred to commit for the same reason as the Apple path: the update must
+    not be visible to Google before the event change itself has committed.
+    on_commit runs inline outside a transaction, and inline INSIDE the admin
+    request either way — production leaves DJANGO_TASKS_BACKEND unset, so TASKS
+    falls back to ImmediateBackend and enqueuing would not move the work off it.
+
+    Returns the number of profiles scheduled; the work itself runs on commit.
+    """
+    profiles = [p for p in profiles if getattr(p, "google_wallet_object_id", "")]
+    if not profiles:
+        return 0
+
+    class_id = getattr(settings, "WALLET_GOOGLE_CLASS_ID", None)
+    if not class_id:
+        logger.warning(
+            "%s: skipping Google Wallet refresh for %s pass(es) — "
+            "WALLET_GOOGLE_CLASS_ID is not configured",
+            context or "bulk refresh",
+            len(profiles),
+        )
+        return 0
+
+    update_limit = getattr(settings, "WALLET_GOOGLE_BULK_UPDATE_LIMIT", 50)
+    update_budget = getattr(
+        settings, "WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS", 10.0
+    )
+
+    def _after_commit():
+        deadline = time.monotonic() + update_budget
+        updated = 0
+        failed = 0
+        # 404 means the holder deleted the pass — classified apart from a real
+        # failure, matching update_all_google_wallet_passes.
+        not_found = 0
+        attempted = 0
+
+        # A non-positive budget means there is no room to start anything; fall
+        # straight through to the stale accounting rather than handing httpx a
+        # zero timeout.
+        token_timeout = _remaining_timeout(deadline)
+        if token_timeout > 0:
+            try:
+                with httpx.Client(timeout=GOOGLE_WALLET_HTTP_TIMEOUT) as client:
+                    # One exchange for the batch. Clamped to the budget too: a
+                    # hanging OAuth endpoint would otherwise burn the full 30s
+                    # before a single pass had been touched.
+                    access_token = _get_access_token(
+                        client=client, timeout=token_timeout
+                    )
+
+                    for profile in profiles[:update_limit]:
+                        remaining = _remaining_timeout(deadline)
+                        if remaining <= 0:
+                            break
+                        attempted += 1
+                        try:
+                            result = _patch_generic_object(
+                                profile,
+                                class_id,
+                                access_token,
+                                client,
+                                timeout=remaining,
+                            )
+                        except Exception:
+                            # One unreachable object must not strand the rest.
+                            failed += 1
+                            logger.exception(
+                                "Failed refreshing Google Wallet object %s",
+                                profile.google_wallet_object_id,
+                            )
+                            continue
+                        if result["success"]:
+                            updated += 1
+                        elif "not found" in result["message"].lower():
+                            not_found += 1
+                        else:
+                            failed += 1
+            except Exception:
+                # Nothing can be PATCHed without a token, so a failed exchange
+                # takes the whole batch with it. Never propagate — this runs
+                # from on_commit inside a request whose write already
+                # succeeded — and fall through, so the passes it could not
+                # reach are reported as stale like any other skipped ones.
+                logger.exception(
+                    "%s: Google Wallet refresh could not run",
+                    context or "bulk refresh",
+                )
+
+        logger.info(
+            "%s: updated %s of %s Google Wallet pass(es) "
+            "(%s failed, %s already deleted by their holder)",
+            context or "bulk refresh",
+            updated,
+            len(profiles),
+            failed,
+            not_found,
+        )
+
+        skipped = len(profiles) - attempted
+        if skipped > 0:
+            # Never silent, and never merely "delayed": unlike an Apple pass
+            # past the push cap, these do not heal on a later poll.
+            stale = [p.google_wallet_object_id for p in profiles[attempted:]]
+            logger.warning(
+                "%s: %s Google Wallet pass(es) left STALE (limit=%s, "
+                "budget=%ss) — Google has no client poll to heal them, so they "
+                "keep showing the old details until the profile changes again: "
+                "%s",
+                context or "bulk refresh",
+                skipped,
+                update_limit,
+                update_budget,
+                ", ".join(stale[:10]) + ("…" if len(stale) > 10 else ""),
+            )
+
+    transaction.on_commit(_after_commit)
+    return len(profiles)
 
 
 def update_all_google_wallet_passes():


### PR DESCRIPTION
## Purpose

* The **Google** member object prints the holder's next event — title, date, location (`_build_generic_object_payload`, fed by `get_next_event_for_pass`) — exactly like the Apple member pass does, but **nothing refreshed it when the event itself changed**. `refresh_apple_tickets_on_event_change` covered Apple tickets and Apple member passes only, so a reschedule or venue move left every attendee's Google card advertising details that were simply wrong.
* It *looked* self-healing and wasn't. Any bare `profile.save()` — the Microsoft SSO login path does one per sign-in — reaches `trigger_wallet_pass_update_on_profile_change`, which treats an `update_fields`-less save as "refresh everything". That is an accident of an over-broad receiver, not a mechanism: it only ever healed members who happened to log in, and narrowing that receiver (#763, still open) removes it entirely. The refresh belongs on the event change either way.
* The reason it was skipped when the Apple half was built is that the fix is a **fan-out, not a one-liner**: `update_google_wallet_pass()` mints its own OAuth token and opens its own connection per profile, so scheduling one per attendee on an admin save cost two round trips each and let request time grow with attendance.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What changed

**`refresh_google_wallet_objects(profiles, context="")`** — `crush_lu/wallet/google_api.py`. The Google mirror of `passkit_service.refresh_ticket_serials`: deferred to `transaction.on_commit`, bounded by both a count limit and a wall-clock deadline, per-profile failures isolated so one unreachable object cannot strand the rest.

**Cost per pass halved: 2 HTTP calls → 1.** `_get_access_token()` now takes an optional `client`, so the batch mints one token and reuses one keep-alive connection for the whole fan-out. That required splitting the PATCH into `_patch_generic_object(profile, class_id, access_token, client, timeout=None)`; `update_google_wallet_pass()` still owns its own token and client and is unchanged from the caller's side (covered by a test).

**Two new settings**, mirroring the PassKit pair: `WALLET_GOOGLE_BULK_UPDATE_LIMIT` (50) and `WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS` (10).

**Call site** — `crush_lu/signals.py`, inside `refresh_apple_tickets_on_event_change`, in **its own `try`/`except`** rather than the Apple block's: independent APIs, so a Google outage must not skip the Apple refresh nor be logged as an Apple failure. There is a test for exactly that.

## What to Check

Two things deliberately differ from the Apple path, and both come from Google's model rather than ours — this is the part worth reviewing:

* **Every request is clamped to the remaining budget.** A 30s per-request default is not a bound on a 10s batch. The token exchange is inside the budget too — a hanging OAuth endpoint would otherwise burn the full 30s before a single pass had been touched.
* **There is no Google equivalent of Wallet's periodic poll.** An Apple pass past the push cap still updates, because `mark_passes_updated_bulk` advanced its tag; a Google object that misses its PATCH stays stale until something else saves that profile. So the cap is a genuine last-resort brake rather than a downgrade to "slower": it is logged at **WARNING** naming the stale object ids, and the default limit is sized for a full event rather than a typical one.

Also worth a look:
* `_timeout_kwargs()` exists because httpx reads an explicit `timeout=None` as *no timeout at all*, so an unset override must be omitted rather than forwarded.
* A failed token exchange aborts the batch but never propagates — it runs from `on_commit` inside a request whose write already succeeded — and falls through to the same stale accounting, so those passes are reported like any other skipped ones.
* 404 (holder deleted the pass) is counted apart from a real failure, matching `update_all_google_wallet_passes`.

## How to Test

```bash
SECRET_KEY="test-only-not-a-real-key" DBHOST="" .venv/Scripts/python.exe -m pytest crush_lu/tests -n auto -o addopts="" -m "not playwright" -q
```

Full suite green: **2949 passed, 22 skipped**.

16 new tests (`TestEventLevelGoogleRefresh`, `TestTimeoutKwargs` in `crush_lu/tests/test_passkit_service.py`) cover: one token exchange per batch, the count cap plus the named stale passes, real-clock budget interruption mid-batch, per-request timeout clamping, per-item and token-exchange failure isolation, deferral until commit, no cost at all when no attendee has a Google pass, and Google still running when the Apple half raises.

Verified non-vacuous: with the `signals.py` change reverted, **9 of them fail**.

## Other Information

Out of scope, flagged as follow-up: the admin bulk actions that already refresh Apple explicitly — `cancel_events`, `confirm_registrations`, `move_to_waitlist` (`crush_lu/admin/events.py`) and the quiz no-show action (`crush_lu/admin/quiz.py`) — still leave Google member objects stale, because they change rows with `queryset.update()` and emit no signals. Each needs one `refresh_google_wallet_objects(...)` call per action (not per item: each helper opens its own budget). Separately, `update_all_google_wallet_passes()` can now reuse the shared token/client, though as an unattached maintenance sweep it should stay uncapped.

Note on the premise: PR #763 (which narrows the profile receiver) is **open, not merged**, so the accidental SSO self-heal technically still exists on `main` today. It does not change this fix — the receiver docstring here is worded to stay accurate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
