### PR TITLE
fix(wallet): refresh Google member objects from the admin bulk actions

### DIFF
--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -634,33 +634,45 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
                 .distinct()
             )
             # An event that has already ENDED is nobody's displayed event, so
-            # the test below cannot speak for it — yet the Google object is
-            # server-side state whose last PATCH went out while the event was
-            # still upcoming, so it may well still be advertising it, and
-            # nothing else recomputes that. Those holders take the
-            # conservative branch, the same way the quiz no-show action does.
+            # the "is this what their card shows" test cannot speak for it —
+            # yet the Google object is server-side state whose last PATCH went
+            # out while the event was still upcoming, so it may well still be
+            # advertising it, and nothing else recomputes that. Holders of an
+            # ended selected event therefore take the conservative branch, the
+            # same way the quiz no-show action does.
             #
-            # Coarse on purpose: one ended event in the selection includes
-            # every candidate, rather than tracking which holder holds which
-            # selected event. A selection mixing finished and future events is
-            # not a real admin workflow, and erring toward a redundant PATCH is
-            # the direction that only costs budget.
+            # Scoped to THEIR OWN attendees, not applied selection-wide. A
+            # single ended event — even one with no registrations at all —
+            # must not disable the filter for holders of the other selected
+            # events, or their no-op PATCHes eat the cap and strand a
+            # higher-pk holder whose displayed event really was cancelled:
+            # the exact failure this filter exists to prevent, re-entered
+            # through the fallback.
             now = timezone.now()
-            cancelled_ids = {event.pk for event in events}
-            any_ended = any(event.end_time < now for event in events)
+            ended_ids = {event.pk for event in events if event.end_time < now}
+            live_ids = {event.pk for event in events} - ended_ids
+
+            # user -> which of the SELECTED events they actually hold a live
+            # seat for. One query, so the per-holder branch below stays free.
+            held = {}
+            for user_id, event_id in EventRegistration.objects.filter(
+                event__in=events, status__in=PASS_NEXT_EVENT_STATUSES
+            ).values_list("user_id", "event_id"):
+                held.setdefault(user_id, set()).add(event_id)
+
             displayed = (
-                {}
-                if any_ended
-                else get_next_event_registrations(
+                get_next_event_registrations(
                     [profile.user_id for profile in candidates], now=now
                 )
+                if live_ids
+                else {}
             )
             google_profiles = [
                 profile
                 for profile in candidates
-                if any_ended
+                if (held.get(profile.user_id, set()) & ended_ids)
                 or getattr(displayed.get(profile.user_id), "event_id", None)
-                in cancelled_ids
+                in live_ids
             ]
         except Exception:
             logger.exception(

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -698,13 +698,18 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
         # their card. Google never polls, so that would be permanent.
         google_profiles = []
         with transaction.atomic():
-            list(
-                MeetupEvent.objects.select_for_update()
-                .filter(pk__in=event_ids)
-                .values_list("pk", flat=True)
+            # Use the rows the lock returned, not the ones read before it.
+            # Between `list(queryset)` and this line another admin can change
+            # is_cancelled, and the selection below turns on exactly that
+            # field: an event read as cancelled but restored since would be
+            # dropped from `transitioning`, re-cancelled here anyway, and its
+            # holders — whose cards the restore may just have PATCHed to show
+            # it — would get no refresh at all.
+            locked = list(
+                MeetupEvent.objects.select_for_update().filter(pk__in=event_ids)
             )
             try:
-                google_profiles = self._google_holders_for_cancellation(events)
+                google_profiles = self._google_holders_for_cancellation(locked)
             except Exception:
                 logger.exception(
                     "Failed selecting Google wallet holders for %s "
@@ -1178,24 +1183,30 @@ class EventRegistrationAdmin(admin.ModelAdmin):
         )
         restored_google_profiles = []
         if restored_rows:
+            # Keyed on the FULL ordering key, not the start time alone. Once
+            # _next_event_candidates gained its (date_time, event_id, id)
+            # tie-break, "same start time" stopped meaning "might win": on a
+            # tie the restored event takes the card only if it also sorts
+            # first. Comparing dates alone queued every tied holder — no-ops
+            # spending a cap whose overflow is permanent.
+            def _key(row):
+                return (row.event.date_time, row.event_id, row.pk)
+
             by_user = {}
             for row in restored_rows:
                 event = row.event
                 if event.is_cancelled or event.end_time < now:
                     continue  # restoring the seat still leaves it off the card
-                earliest = by_user.get(row.user_id)
-                if earliest is None or event.date_time < earliest:
-                    by_user[row.user_id] = event.date_time
+                best = by_user.get(row.user_id)
+                if best is None or _key(row) < best:
+                    by_user[row.user_id] = _key(row)
             displayed = get_next_event_registrations(list(by_user), now=now)
             candidates = CrushProfile.objects.filter(
                 user_id__in=list(by_user)
             ).exclude(google_wallet_object_id="")
             for profile in candidates:
                 showing = displayed.get(profile.user_id)
-                if (
-                    showing is None
-                    or by_user[profile.user_id] <= showing.event.date_time
-                ):
+                if showing is None or by_user[profile.user_id] < _key(showing):
                     restored_google_profiles.append(profile)
 
         updated = EventRegistration.objects.filter(pk__in=eligible_ids).update(

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -633,14 +633,33 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
                 .exclude(google_wallet_object_id="")
                 .distinct()
             )
+            # An event that has already ENDED is nobody's displayed event, so
+            # the test below cannot speak for it — yet the Google object is
+            # server-side state whose last PATCH went out while the event was
+            # still upcoming, so it may well still be advertising it, and
+            # nothing else recomputes that. Those holders take the
+            # conservative branch, the same way the quiz no-show action does.
+            #
+            # Coarse on purpose: one ended event in the selection includes
+            # every candidate, rather than tracking which holder holds which
+            # selected event. A selection mixing finished and future events is
+            # not a real admin workflow, and erring toward a redundant PATCH is
+            # the direction that only costs budget.
+            now = timezone.now()
             cancelled_ids = {event.pk for event in events}
-            displayed = get_next_event_registrations(
-                [profile.user_id for profile in candidates]
+            any_ended = any(event.end_time < now for event in events)
+            displayed = (
+                {}
+                if any_ended
+                else get_next_event_registrations(
+                    [profile.user_id for profile in candidates], now=now
+                )
             )
             google_profiles = [
                 profile
                 for profile in candidates
-                if getattr(displayed.get(profile.user_id), "event_id", None)
+                if any_ended
+                or getattr(displayed.get(profile.user_id), "event_id", None)
                 in cancelled_ids
             ]
         except Exception:

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -13,6 +13,7 @@ import logging
 from django import forms
 from django.contrib import admin
 from django.contrib import messages as django_messages
+from django.db import transaction
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
@@ -593,94 +594,129 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
             request, _("Unpublished {count} event(s)").format(count=updated)
         )
 
+    @staticmethod
+    def _google_holders_for_cancellation(events):
+        """Google holders whose card this cancellation actually changes.
+
+        Two ways in, and the second exists because the first goes blind on a
+        finished event:
+
+          * the holder's card is currently SHOWING one of the selected events.
+            A holder with an earlier eligible registration is looking at that
+            one instead, so cancelling this event would rebuild a
+            byte-identical object — and the fan-out is capped with no
+            Google-side poll behind it, so each no-op can push somebody whose
+            card IS wrong out of the batch and strand it.
+          * the holder has a live seat on a selected event that has already
+            ENDED. get_next_event_for_pass stopped selecting it when it
+            finished, so it is nobody's displayed event and the first test says
+            "nobody" — but the Google object was last written while the event
+            was still upcoming and can still be advertising it, with nothing
+            else in the estate recomputing that.
+
+        The ended branch is scoped to that event's OWN attendees rather than
+        switching the filter off selection-wide: one ended event, even with no
+        registrations at all, must not disarm the narrowing for holders of the
+        other selected events.
+
+        ALREADY-cancelled events are excluded from both branches. This action
+        changes nothing for them, and letting them into the ended branch would
+        queue every one of their attendees — re-entering, through the fallback,
+        the same cap starvation the narrowing exists to prevent.
+        """
+        from crush_lu.models import CrushProfile
+        from crush_lu.wallet_pass import (
+            PASS_NEXT_EVENT_STATUSES,
+            get_next_event_registrations,
+        )
+
+        now = timezone.now()
+        transitioning = [event for event in events if not event.is_cancelled]
+        if not transitioning:
+            return []
+
+        ended_ids = {e.pk for e in transitioning if e.end_time < now}
+        live_ids = {e.pk for e in transitioning} - ended_ids
+
+        candidates = list(
+            CrushProfile.objects.filter(
+                # Both conditions in ONE filter() so they constrain the SAME
+                # registration row — split across two calls they would match
+                # any registration for the event plus any live registration
+                # anywhere, which is every attendee.
+                user__eventregistration__event__in=transitioning,
+                user__eventregistration__status__in=PASS_NEXT_EVENT_STATUSES,
+            )
+            .exclude(google_wallet_object_id="")
+            .distinct()
+        )
+        if not candidates:
+            return []
+
+        # user -> which of the selected events they actually hold a live seat
+        # for. One query, so the per-holder branch below stays free.
+        held = {}
+        if ended_ids:
+            for user_id, event_id in EventRegistration.objects.filter(
+                event_id__in=ended_ids, status__in=PASS_NEXT_EVENT_STATUSES
+            ).values_list("user_id", "event_id"):
+                held.setdefault(user_id, set()).add(event_id)
+
+        displayed = (
+            get_next_event_registrations(
+                [profile.user_id for profile in candidates], now=now
+            )
+            if live_ids
+            else {}
+        )
+        return [
+            profile
+            for profile in candidates
+            if held.get(profile.user_id)
+            or getattr(displayed.get(profile.user_id), "event_id", None) in live_ids
+        ]
+
     @admin.action(description=_("🚫 Cancel selected events"))
     def cancel_events(self, request, queryset):
         # Snapshot before .update() — the queryset is lazy and its filter may
         # well be is_cancelled=False, which would match nothing afterwards.
         events = list(queryset)
+        event_ids = [event.pk for event in events]
 
-        # Which Google holders this cancellation actually changes, resolved
-        # BEFORE the update for a second reason: get_next_event_for_pass
-        # excludes cancelled events, so afterwards none of these events is
-        # anybody's displayed next event and the answer would be "nobody".
+        # The holder selection (see _google_holders_for_cancellation) has to be
+        # resolved BEFORE the update: get_next_event_for_pass excludes
+        # cancelled events, so afterwards none of these is anybody's displayed
+        # next event and the answer would be "nobody".
         #
-        # Narrowed to holders whose card is showing one of THESE events. A
-        # holder with an earlier eligible registration is looking at that one
-        # instead, so cancelling this event rebuilds a byte-identical object —
-        # and the fan-out is capped at WALLET_GOOGLE_BULK_UPDATE_LIMIT with no
-        # Google-side poll behind it, so each no-op can push somebody whose
-        # card IS wrong out of the batch and leave it stale for good. Selecting
-        # on "currently displayed" also drops the already-cancelled events in
-        # the selection for free: they are excluded from the candidate set, so
-        # they are nobody's displayed event either.
+        # Snapshot and update under ONE lock on the selected events, taken on
+        # the same rows the registration path locks (views_events, which does
+        # MeetupEvent.objects.select_for_update() before admitting a seat).
+        # Without it a signup can commit between the two: its own receiver
+        # PATCHes the member object while the event is still live, so the
+        # object names the event — but that holder is not in the snapshot, and
+        # the cancellation that follows has no path left to take it back off
+        # their card. Google never polls, so that would be permanent.
         google_profiles = []
-        try:
-            from crush_lu.models import CrushProfile
-            from crush_lu.wallet_pass import (
-                PASS_NEXT_EVENT_STATUSES,
-                get_next_event_registrations,
+        with transaction.atomic():
+            list(
+                MeetupEvent.objects.select_for_update()
+                .filter(pk__in=event_ids)
+                .values_list("pk", flat=True)
             )
-
-            candidates = list(
-                CrushProfile.objects.filter(
-                    # Both conditions in ONE filter() so they constrain the
-                    # SAME registration row — split across two calls they
-                    # would match any registration for the event plus any
-                    # live registration anywhere, which is every attendee.
-                    user__eventregistration__event__in=events,
-                    user__eventregistration__status__in=PASS_NEXT_EVENT_STATUSES,
+            try:
+                google_profiles = self._google_holders_for_cancellation(events)
+            except Exception:
+                logger.exception(
+                    "Failed selecting Google wallet holders for %s "
+                    "cancelled event(s)",
+                    len(events),
                 )
-                .exclude(google_wallet_object_id="")
-                .distinct()
+            # By pk rather than the caller's queryset: `events` is already
+            # materialised, and the incoming filter is typically
+            # is_cancelled=False, which matches nothing once this lands.
+            updated = MeetupEvent.objects.filter(pk__in=event_ids).update(
+                is_cancelled=True
             )
-            # An event that has already ENDED is nobody's displayed event, so
-            # the "is this what their card shows" test cannot speak for it —
-            # yet the Google object is server-side state whose last PATCH went
-            # out while the event was still upcoming, so it may well still be
-            # advertising it, and nothing else recomputes that. Holders of an
-            # ended selected event therefore take the conservative branch, the
-            # same way the quiz no-show action does.
-            #
-            # Scoped to THEIR OWN attendees, not applied selection-wide. A
-            # single ended event — even one with no registrations at all —
-            # must not disable the filter for holders of the other selected
-            # events, or their no-op PATCHes eat the cap and strand a
-            # higher-pk holder whose displayed event really was cancelled:
-            # the exact failure this filter exists to prevent, re-entered
-            # through the fallback.
-            now = timezone.now()
-            ended_ids = {event.pk for event in events if event.end_time < now}
-            live_ids = {event.pk for event in events} - ended_ids
-
-            # user -> which of the SELECTED events they actually hold a live
-            # seat for. One query, so the per-holder branch below stays free.
-            held = {}
-            for user_id, event_id in EventRegistration.objects.filter(
-                event__in=events, status__in=PASS_NEXT_EVENT_STATUSES
-            ).values_list("user_id", "event_id"):
-                held.setdefault(user_id, set()).add(event_id)
-
-            displayed = (
-                get_next_event_registrations(
-                    [profile.user_id for profile in candidates], now=now
-                )
-                if live_ids
-                else {}
-            )
-            google_profiles = [
-                profile
-                for profile in candidates
-                if (held.get(profile.user_id, set()) & ended_ids)
-                or getattr(displayed.get(profile.user_id), "event_id", None)
-                in live_ids
-            ]
-        except Exception:
-            logger.exception(
-                "Failed selecting Google wallet holders for %s cancelled event(s)",
-                len(events),
-            )
-
-        updated = queryset.update(is_cancelled=True)
 
         # .update() emits no signals, so nothing else tells Apple Wallet these
         # tickets are dead. Without this, a cancelled event's installed passes

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -635,6 +635,43 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
                 len(events),
             )
 
+        # The GOOGLE member object prints the same "Next Event" block, and
+        # get_next_event_for_pass drops cancelled events outright — so every
+        # attendee's card is now advertising an event that will not happen.
+        # There is no Google ticket to carry the change instead; the member
+        # object is the only Google surface this event appears on.
+        #
+        # Its own try/except, and ONE call for the whole action, for the same
+        # two reasons as the Apple half above: independent APIs must not skip
+        # each other, and each helper opens its own budget.
+        try:
+            from crush_lu.models import CrushProfile
+            from crush_lu.wallet.google_api import refresh_google_wallet_objects
+            from crush_lu.wallet_pass import PASS_NEXT_EVENT_STATUSES
+
+            refresh_google_wallet_objects(
+                list(
+                    CrushProfile.objects.filter(
+                        # Both conditions in ONE filter() so they constrain the
+                        # SAME registration row — split across two calls they
+                        # would match any registration for the event plus any
+                        # live registration anywhere, which is every attendee.
+                        user__eventregistration__event__in=events,
+                        user__eventregistration__status__in=(
+                            PASS_NEXT_EVENT_STATUSES
+                        ),
+                    )
+                    .exclude(google_wallet_object_id="")
+                    .distinct()
+                ),
+                context=f"Admin cancel_events ({len(events)} event(s))",
+            )
+        except Exception:
+            logger.exception(
+                "Failed scheduling Google wallet refresh for %s cancelled event(s)",
+                len(events),
+            )
+
         django_messages.success(
             request, _("Cancelled {count} event(s)").format(count=updated)
         )
@@ -1001,6 +1038,30 @@ class EventRegistrationAdmin(admin.ModelAdmin):
             .values_list("apple_pass_serial", flat=True)
             .distinct()
         )
+        # ...and the GOOGLE member objects, for exactly the reason above: a
+        # restored seat is eligible for get_next_event_for_pass again, so the
+        # card has to stop showing whatever it fell back to. Materialised HERE,
+        # before the update, for the same reason as the serials — `restoring`
+        # is a lazy queryset keyed on the old status, and the flip to
+        # "confirmed" is about to make it match nothing.
+        #
+        # NARROWER than `restoring`, which also carries waitlist rows. Their
+        # Apple TICKET is voided and does need un-voiding, but a waitlisted
+        # registration is already inside PASS_NEXT_EVENT_STATUSES, so the
+        # member card already names this event and the rebuild would be
+        # byte-identical. Only a seat coming back from OUTSIDE that set
+        # (cancelled, no_show) actually changes what the card says.
+        from crush_lu.wallet_pass import PASS_NEXT_EVENT_STATUSES
+
+        restored_google_profiles = list(
+            CrushProfile.objects.filter(
+                user__eventregistration__in=restoring.exclude(
+                    status__in=PASS_NEXT_EVENT_STATUSES
+                )
+            )
+            .exclude(google_wallet_object_id="")
+            .distinct()
+        )
 
         updated = EventRegistration.objects.filter(pk__in=eligible_ids).update(
             status="confirmed"
@@ -1020,6 +1081,21 @@ class EventRegistrationAdmin(admin.ModelAdmin):
                     "Failed scheduling Apple ticket refresh for %s restored "
                     "registration(s)",
                     len(restored_serials),
+                )
+
+        if restored_google_profiles:
+            try:
+                from crush_lu.wallet.google_api import refresh_google_wallet_objects
+
+                refresh_google_wallet_objects(
+                    restored_google_profiles,
+                    context="Admin confirm_registrations",
+                )
+            except Exception:
+                logger.exception(
+                    "Failed scheduling Google wallet refresh for %s restored "
+                    "registration(s)",
+                    len(restored_google_profiles),
                 )
 
         django_messages.success(
@@ -1063,6 +1139,18 @@ class EventRegistrationAdmin(admin.ModelAdmin):
                     "registration(s)",
                     len(voiding_serials),
                 )
+
+        # No Google refresh here, unlike the other three bulk actions, and NOT
+        # an oversight: this action moves a registration from one member of
+        # PASS_NEXT_EVENT_STATUSES to another ("waitlist" is in the set), so it
+        # cannot change which event the member card names — and the card prints
+        # only that event's title and date, never the registration status. The
+        # rebuild would be byte-identical, which is also why the Apple half
+        # above refreshes the TICKET serials only and leaves member passes
+        # alone. PATCHing anyway would spend a capped budget on no-ops and log a
+        # false "left STALE" warning about passes that were never wrong.
+        # Revisit if the payload ever starts printing next_event["status"] —
+        # TestAdminBulkActionsRefreshWallets pins this.
 
         django_messages.success(
             request, f"Moved {updated} registration(s) to waitlist."

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -598,6 +598,57 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
         # Snapshot before .update() — the queryset is lazy and its filter may
         # well be is_cancelled=False, which would match nothing afterwards.
         events = list(queryset)
+
+        # Which Google holders this cancellation actually changes, resolved
+        # BEFORE the update for a second reason: get_next_event_for_pass
+        # excludes cancelled events, so afterwards none of these events is
+        # anybody's displayed next event and the answer would be "nobody".
+        #
+        # Narrowed to holders whose card is showing one of THESE events. A
+        # holder with an earlier eligible registration is looking at that one
+        # instead, so cancelling this event rebuilds a byte-identical object —
+        # and the fan-out is capped at WALLET_GOOGLE_BULK_UPDATE_LIMIT with no
+        # Google-side poll behind it, so each no-op can push somebody whose
+        # card IS wrong out of the batch and leave it stale for good. Selecting
+        # on "currently displayed" also drops the already-cancelled events in
+        # the selection for free: they are excluded from the candidate set, so
+        # they are nobody's displayed event either.
+        google_profiles = []
+        try:
+            from crush_lu.models import CrushProfile
+            from crush_lu.wallet_pass import (
+                PASS_NEXT_EVENT_STATUSES,
+                get_next_event_registrations,
+            )
+
+            candidates = list(
+                CrushProfile.objects.filter(
+                    # Both conditions in ONE filter() so they constrain the
+                    # SAME registration row — split across two calls they
+                    # would match any registration for the event plus any
+                    # live registration anywhere, which is every attendee.
+                    user__eventregistration__event__in=events,
+                    user__eventregistration__status__in=PASS_NEXT_EVENT_STATUSES,
+                )
+                .exclude(google_wallet_object_id="")
+                .distinct()
+            )
+            cancelled_ids = {event.pk for event in events}
+            displayed = get_next_event_registrations(
+                [profile.user_id for profile in candidates]
+            )
+            google_profiles = [
+                profile
+                for profile in candidates
+                if getattr(displayed.get(profile.user_id), "event_id", None)
+                in cancelled_ids
+            ]
+        except Exception:
+            logger.exception(
+                "Failed selecting Google wallet holders for %s cancelled event(s)",
+                len(events),
+            )
+
         updated = queryset.update(is_cancelled=True)
 
         # .update() emits no signals, so nothing else tells Apple Wallet these
@@ -636,41 +687,27 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
             )
 
         # The GOOGLE member object prints the same "Next Event" block, and
-        # get_next_event_for_pass drops cancelled events outright — so every
-        # attendee's card is now advertising an event that will not happen.
+        # get_next_event_for_pass drops cancelled events outright — so these
+        # holders' cards are now advertising an event that will not happen.
         # There is no Google ticket to carry the change instead; the member
         # object is the only Google surface this event appears on.
         #
         # Its own try/except, and ONE call for the whole action, for the same
         # two reasons as the Apple half above: independent APIs must not skip
         # each other, and each helper opens its own budget.
-        try:
-            from crush_lu.models import CrushProfile
-            from crush_lu.wallet.google_api import refresh_google_wallet_objects
-            from crush_lu.wallet_pass import PASS_NEXT_EVENT_STATUSES
+        if google_profiles:
+            try:
+                from crush_lu.wallet.google_api import refresh_google_wallet_objects
 
-            refresh_google_wallet_objects(
-                list(
-                    CrushProfile.objects.filter(
-                        # Both conditions in ONE filter() so they constrain the
-                        # SAME registration row — split across two calls they
-                        # would match any registration for the event plus any
-                        # live registration anywhere, which is every attendee.
-                        user__eventregistration__event__in=events,
-                        user__eventregistration__status__in=(
-                            PASS_NEXT_EVENT_STATUSES
-                        ),
-                    )
-                    .exclude(google_wallet_object_id="")
-                    .distinct()
-                ),
-                context=f"Admin cancel_events ({len(events)} event(s))",
-            )
-        except Exception:
-            logger.exception(
-                "Failed scheduling Google wallet refresh for %s cancelled event(s)",
-                len(events),
-            )
+                refresh_google_wallet_objects(
+                    google_profiles,
+                    context=f"Admin cancel_events ({len(events)} event(s))",
+                )
+            except Exception:
+                logger.exception(
+                    "Failed scheduling Google wallet refresh for %s cancelled event(s)",
+                    len(events),
+                )
 
         django_messages.success(
             request, _("Cancelled {count} event(s)").format(count=updated)
@@ -1051,17 +1088,48 @@ class EventRegistrationAdmin(admin.ModelAdmin):
         # member card already names this event and the rebuild would be
         # byte-identical. Only a seat coming back from OUTSIDE that set
         # (cancelled, no_show) actually changes what the card says.
-        from crush_lu.wallet_pass import PASS_NEXT_EVENT_STATUSES
-
-        restored_google_profiles = list(
-            CrushProfile.objects.filter(
-                user__eventregistration__in=restoring.exclude(
-                    status__in=PASS_NEXT_EVENT_STATUSES
-                )
-            )
-            .exclude(google_wallet_object_id="")
-            .distinct()
+        # A second narrowing on top of that, the mirror of the one in
+        # cancel_events: re-entering the candidate set only changes the card if
+        # the restored event would then BE the displayed one. A holder with an
+        # earlier eligible registration keeps looking at that, so restoring a
+        # later seat rebuilds a byte-identical object and spends a capped,
+        # poll-less budget slot that a genuinely-changed holder needed.
+        #
+        # `<=` on the comparison, not `<`: two events sharing a start time are
+        # ordered by whatever the database returns, so a tie is "might change"
+        # rather than "cannot".
+        from crush_lu.wallet_pass import (
+            PASS_NEXT_EVENT_STATUSES,
+            get_next_event_registrations,
         )
+
+        now = timezone.now()
+        restored_rows = list(
+            restoring.exclude(status__in=PASS_NEXT_EVENT_STATUSES).select_related(
+                "event"
+            )
+        )
+        restored_google_profiles = []
+        if restored_rows:
+            by_user = {}
+            for row in restored_rows:
+                event = row.event
+                if event.is_cancelled or event.end_time < now:
+                    continue  # restoring the seat still leaves it off the card
+                earliest = by_user.get(row.user_id)
+                if earliest is None or event.date_time < earliest:
+                    by_user[row.user_id] = event.date_time
+            displayed = get_next_event_registrations(list(by_user), now=now)
+            candidates = CrushProfile.objects.filter(
+                user_id__in=list(by_user)
+            ).exclude(google_wallet_object_id="")
+            for profile in candidates:
+                showing = displayed.get(profile.user_id)
+                if (
+                    showing is None
+                    or by_user[profile.user_id] <= showing.event.date_time
+                ):
+                    restored_google_profiles.append(profile)
 
         updated = EventRegistration.objects.filter(pk__in=eligible_ids).update(
             status="confirmed"

--- a/crush_lu/admin/quiz.py
+++ b/crush_lu/admin/quiz.py
@@ -201,6 +201,11 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
     # helper opens its own push budget, so refreshing per quiz would restart
     # the deadline for every selected row.
     voiding_serials = []
+    # The Google half of the same accumulation, keyed by pk to DEDUPE. One
+    # holder can be registered for two of the selected quizzes, and unlike a
+    # repeated Apple serial each duplicate here is a real extra PATCH spent out
+    # of a budget whose overflow leaves other passes permanently stale.
+    voiding_google_profiles = {}
 
     for quiz in queryset:
         # Include "pending" seat holders: on a paid quiz a cash-at-the-door
@@ -230,6 +235,16 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
             .values_list("apple_pass_serial", flat=True)
             .distinct()
         )
+        # ...and their GOOGLE member objects, which print the same "Next Event"
+        # block and have no Google ticket to carry the change instead. Every
+        # row here qualifies without further filtering: "confirmed" and
+        # "pending" are both inside PASS_NEXT_EVENT_STATUSES and "no_show" is
+        # outside it, so each of these genuinely stops being the holder's next
+        # event. Collected before the update, while `affected` still matches.
+        for profile in CrushProfile.objects.filter(
+            user__eventregistration__in=affected
+        ).exclude(google_wallet_object_id=""):
+            voiding_google_profiles[profile.pk] = profile
         updated = affected.update(status="no_show")
         messages.success(
             request,
@@ -248,6 +263,21 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
                 "Failed scheduling Apple ticket refresh for %s no-show "
                 "registration(s)",
                 len(voiding_serials),
+            )
+
+    if voiding_google_profiles:
+        try:
+            from crush_lu.wallet.google_api import refresh_google_wallet_objects
+
+            refresh_google_wallet_objects(
+                list(voiding_google_profiles.values()),
+                context="Admin mark_unattended_as_no_show",
+            )
+        except Exception:
+            logger.exception(
+                "Failed scheduling Google wallet refresh for %s no-show "
+                "registration(s)",
+                len(voiding_google_profiles),
             )
 
 

--- a/crush_lu/admin/quiz.py
+++ b/crush_lu/admin/quiz.py
@@ -194,9 +194,13 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
     """Admin action: flip still-'confirmed' registrations to 'no_show' for
     the selected quiz events. Useful when the host forgot to scan someone
     out and wants the attendance record to reflect reality."""
+    from django.utils import timezone
+
     from crush_lu.models import CrushProfile
     from crush_lu.models.events import EventRegistration
     from crush_lu.wallet_pass import get_next_event_registrations
+
+    now = timezone.now()
 
     # Accumulated across the whole action, then refreshed ONCE: each refresh
     # helper opens its own push budget, so refreshing per quiz would restart
@@ -240,24 +244,47 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
         # block and have no Google ticket to carry the change instead.
         # Collected before the update, while `affected` still matches.
         #
-        # Crossing the status boundary is necessary but NOT sufficient here:
-        # "confirmed"/"pending" are inside PASS_NEXT_EVENT_STATUSES and
-        # "no_show" is outside it, but a holder with an earlier eligible
-        # registration is not showing THIS quiz, so marking them absent from it
-        # rebuilds a byte-identical object. The fan-out is capped with no
-        # Google-side poll behind it, so each no-op can crowd out a holder whose
-        # card really was showing this quiz and strand it.
+        # Two ways a holder here needs the PATCH, and the second is the USUAL
+        # one, because this action is normally run after the quiz:
+        #
+        #   * the quiz is still live and is what their card is showing. The
+        #     no_show flip takes it out of PASS_NEXT_EVENT_STATUSES, so the
+        #     block changes. Crossing the status boundary is necessary but not
+        #     sufficient — a holder with an earlier eligible registration is
+        #     looking at that instead, and refreshing them writes a
+        #     byte-identical object out of a capped, poll-less budget.
+        #
+        #   * the quiz has already ENDED. get_next_event_for_pass stopped
+        #     selecting it the moment it finished, so it is nobody's displayed
+        #     event and the test above answers "refresh nobody" — but the Google
+        #     object is SERVER-SIDE state that only changes when we PATCH it,
+        #     and the last PATCH went out while the quiz was still upcoming. It
+        #     is therefore still advertising a finished quiz, and nothing else
+        #     recomputes it: there is no "event ended" trigger anywhere in the
+        #     estate. Optimising on the current logical selector cannot see
+        #     that, because the two diverge the instant an event ends.
+        #
+        # So an ended quiz takes the conservative branch. That is the same rule
+        # the event-change fan-out follows: over-refreshing spends budget,
+        # under-refreshing strands a wrong card with nothing left to correct it.
+        quiz_ended = quiz.event.end_time < now
         quiz_candidates = list(
             CrushProfile.objects.filter(
                 user__eventregistration__in=affected
             ).exclude(google_wallet_object_id="")
         )
-        displayed = get_next_event_registrations(
-            [profile.user_id for profile in quiz_candidates]
+        displayed = (
+            {}
+            if quiz_ended
+            else get_next_event_registrations(
+                [profile.user_id for profile in quiz_candidates], now=now
+            )
         )
         for profile in quiz_candidates:
             showing = displayed.get(profile.user_id)
-            if showing is not None and showing.event_id == quiz.event_id:
+            if quiz_ended or (
+                showing is not None and showing.event_id == quiz.event_id
+            ):
                 voiding_google_profiles[profile.pk] = profile
         updated = affected.update(status="no_show")
         messages.success(

--- a/crush_lu/admin/quiz.py
+++ b/crush_lu/admin/quiz.py
@@ -196,6 +196,7 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
     out and wants the attendance record to reflect reality."""
     from crush_lu.models import CrushProfile
     from crush_lu.models.events import EventRegistration
+    from crush_lu.wallet_pass import get_next_event_registrations
 
     # Accumulated across the whole action, then refreshed ONCE: each refresh
     # helper opens its own push budget, so refreshing per quiz would restart
@@ -236,15 +237,28 @@ def mark_unattended_as_no_show(modeladmin, request, queryset):
             .distinct()
         )
         # ...and their GOOGLE member objects, which print the same "Next Event"
-        # block and have no Google ticket to carry the change instead. Every
-        # row here qualifies without further filtering: "confirmed" and
-        # "pending" are both inside PASS_NEXT_EVENT_STATUSES and "no_show" is
-        # outside it, so each of these genuinely stops being the holder's next
-        # event. Collected before the update, while `affected` still matches.
-        for profile in CrushProfile.objects.filter(
-            user__eventregistration__in=affected
-        ).exclude(google_wallet_object_id=""):
-            voiding_google_profiles[profile.pk] = profile
+        # block and have no Google ticket to carry the change instead.
+        # Collected before the update, while `affected` still matches.
+        #
+        # Crossing the status boundary is necessary but NOT sufficient here:
+        # "confirmed"/"pending" are inside PASS_NEXT_EVENT_STATUSES and
+        # "no_show" is outside it, but a holder with an earlier eligible
+        # registration is not showing THIS quiz, so marking them absent from it
+        # rebuilds a byte-identical object. The fan-out is capped with no
+        # Google-side poll behind it, so each no-op can crowd out a holder whose
+        # card really was showing this quiz and strand it.
+        quiz_candidates = list(
+            CrushProfile.objects.filter(
+                user__eventregistration__in=affected
+            ).exclude(google_wallet_object_id="")
+        )
+        displayed = get_next_event_registrations(
+            [profile.user_id for profile in quiz_candidates]
+        )
+        for profile in quiz_candidates:
+            showing = displayed.get(profile.user_id)
+            if showing is not None and showing.event_id == quiz.event_id:
+                voiding_google_profiles[profile.pk] = profile
         updated = affected.update(status="no_show")
         messages.success(
             request,

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -4,7 +4,7 @@ Signal handlers for Crush.lu app
 
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 from django.conf import settings
@@ -595,6 +595,40 @@ _GOOGLE_PAYLOAD_FIELDS = frozenset(
     )
 )
 
+def _google_relevant_changes(previous, instance, changed, now=None):
+    """The changed fields that can actually alter the Google member card.
+
+    Mostly a membership test against _GOOGLE_PAYLOAD_FIELDS, with one field
+    that cannot be decided statically. `duration_minutes` earns its place by
+    SELECTING rather than rendering, and selection only moves when the event
+    crosses the `end_time >= now` boundary: editing the length of a future
+    event, or of a past one that stays past, leaves get_next_event_for_pass
+    returning the very same event. Treating every duration edit as relevant
+    would fire up to WALLET_GOOGLE_BULK_UPDATE_LIMIT synchronous PATCHes from
+    the admin request to write byte-identical objects — the exact spend the
+    field subset exists to prevent.
+
+    A `date_time` edit needs no such care: it is rendered, so it is relevant on
+    its own, and it is already in the set.
+    """
+    relevant = [field for field in changed if field in _GOOGLE_PAYLOAD_FIELDS]
+    if "duration_minutes" not in relevant:
+        return relevant
+
+    now = now or timezone.now()
+
+    def _ended(start, minutes):
+        # Mirrors MeetupEvent.end_time; the snapshot is a values() dict, so
+        # there is no model instance to ask.
+        return start + timedelta(minutes=minutes or 0) < now
+
+    was_over = _ended(previous["date_time"], previous["duration_minutes"])
+    is_over = _ended(instance.date_time, instance.duration_minutes)
+    if was_over == is_over:
+        relevant.remove("duration_minutes")
+    return relevant
+
+
 # Registration statuses under which an event can appear on a MEMBER card —
 # imported, not restated. This and wallet_pass.get_next_event_for_pass each
 # used to carry their own copy under a "keep in sync" note, which is the
@@ -773,7 +807,7 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
     # Its own try/except, not the Apple block's: these are independent
     # fan-outs over independent APIs, and a Google outage must not skip the
     # Apple refresh (nor be reported as an Apple failure).
-    google_changed = [field for field in changed if field in _GOOGLE_PAYLOAD_FIELDS]
+    google_changed = _google_relevant_changes(previous, instance, changed)
     if not google_changed:
         return
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -600,13 +600,29 @@ def _google_relevant_changes(previous, instance, changed, now=None):
 
     Mostly a membership test against _GOOGLE_PAYLOAD_FIELDS, with one field
     that cannot be decided statically. `duration_minutes` earns its place by
-    SELECTING rather than rendering, and selection only moves when the event
-    crosses the `end_time >= now` boundary: editing the length of a future
-    event, or of a past one that stays past, leaves get_next_event_for_pass
-    returning the very same event. Treating every duration edit as relevant
-    would fire up to WALLET_GOOGLE_BULK_UPDATE_LIMIT synchronous PATCHes from
-    the admin request to write byte-identical objects — the exact spend the
-    field subset exists to prevent.
+    SELECTING rather than rendering, so a length edit is only worth a fan-out
+    when it moves the event across the `end_time >= now` boundary. Treating
+    every duration edit as relevant would fire up to
+    WALLET_GOOGLE_BULK_UPDATE_LIMIT synchronous PATCHes from the admin request
+    to write byte-identical objects — the exact spend the field subset exists
+    to prevent.
+
+    Exactly ONE case is dropped, and the two same-side cases are NOT
+    symmetric — which is the trap:
+
+      * still-upcoming both before and after: the event is on the card in both
+        states with its title and date untouched, so the stored Google object
+        already matches what we would write. Genuinely nothing to send.
+      * ALREADY ENDED both before and after: skipping looks equally safe and is
+        not. get_next_event_for_pass stopped selecting the event when it
+        finished, but the Google object is server-side state whose last PATCH
+        went out while the event was still upcoming — so it can still be
+        advertising it, and nothing else in the estate recomputes that (there
+        is no "event ended" trigger; see the same reasoning in
+        admin.quiz.mark_unattended_as_no_show). The edit is then the only thing
+        that would heal the card, and dropping it forfeits that for good.
+
+    So the guard is "neither side is over", not "both sides agree".
 
     A `date_time` edit needs no such care: it is rendered, so it is relevant on
     its own, and it is already in the set.
@@ -624,7 +640,7 @@ def _google_relevant_changes(previous, instance, changed, now=None):
 
     was_over = _ended(previous["date_time"], previous["duration_minutes"])
     is_over = _ended(instance.date_time, instance.duration_minutes)
-    if was_over == is_over:
+    if not was_over and not is_over:
         relevant.remove("duration_minutes")
     return relevant
 

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -46,6 +46,7 @@ from .models.journey import JourneyProgress
 from .utils.i18n import is_valid_language
 
 from crush_lu.models.events import SEAT_HOLDING_STATUSES
+from crush_lu.wallet_pass import PASS_NEXT_EVENT_STATUSES
 
 logger = logging.getLogger(__name__)
 
@@ -594,11 +595,13 @@ _GOOGLE_PAYLOAD_FIELDS = frozenset(
     )
 )
 
-# Registration statuses under which an event can appear on a MEMBER card.
-# Keep in sync with wallet_pass.get_next_event_for_pass, which is what actually
-# decides whether the card renders this event — anything outside this set is a
-# holder the event-change fan-outs must not spend their budget on.
-_NEXT_EVENT_STATUSES = (*SEAT_HOLDING_STATUSES, "waitlist")
+# Registration statuses under which an event can appear on a MEMBER card —
+# imported, not restated. This and wallet_pass.get_next_event_for_pass each
+# used to carry their own copy under a "keep in sync" note, which is the
+# arrangement that lets them drift; the admin bulk actions consume the same
+# rule. Anything outside this set is a holder the event-change fan-outs must
+# not spend their budget on.
+_NEXT_EVENT_STATUSES = PASS_NEXT_EVENT_STATUSES
 
 
 @receiver(pre_save, sender=MeetupEvent)

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -867,12 +867,22 @@ def refresh_apple_tickets_on_event_change(sender, instance, created, **kwargs):
         # (Refining the coarse set in Python instead would mean loading and
         # checking end_time per candidate, which is the per-attendee work the
         # batch exists to avoid.)
+        # Compared on the SAME key _next_event_candidates orders by, not on the
+        # start time alone. Since that selector tie-breaks with (date_time,
+        # event_id, id), an event sharing this one's start but carrying a
+        # smaller id sorts first and IS what the holder sees — while a bare
+        # `date_time__lt` calls it "not nearer" and queues a byte-identical
+        # PATCH. The registration id, the selector's third key, is not needed:
+        # it only separates two registrations for the same event, which one
+        # user cannot have.
         previous_start = (previous or {}).get("date_time") or instance.date_time
+        bound_start = min(previous_start, instance.date_time)
         nearer_event = EventRegistration.objects.filter(
+            Q(event__date_time__lt=bound_start)
+            | Q(event__date_time=bound_start, event_id__lt=instance.pk),
             user_id=OuterRef("user_id"),
             status__in=_NEXT_EVENT_STATUSES,
             event__is_cancelled=False,
-            event__date_time__lt=min(previous_start, instance.date_time),
             event__date_time__gte=timezone.now(),
         )
         google_profiles = list(

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1426,6 +1426,105 @@ class TestEventLevelGoogleRefresh:
         assert get_next_event_for_pass(profile) is not None
         assert patch_object.call_count == 1
 
+    @pytest.mark.parametrize(
+        "days_out,old_minutes,new_minutes,label",
+        [
+            (7, 120, 240, "future event, lengthened"),
+            (7, 240, 120, "future event, shortened"),
+        ],
+    )
+    def test_duration_edits_that_cannot_move_the_card_do_not_patch(
+        self, days_out, old_minutes, new_minutes, label, _google_identity,
+        event_with_registrations, django_capture_on_commit_callbacks,
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        # duration_minutes is in _GOOGLE_PAYLOAD_FIELDS because it SELECTS, not
+        # because it renders — so it is only relevant when the event crosses
+        # the end_time >= now boundary. A future event is eligible at any
+        # length, so these edits leave the card identical, and firing the
+        # fan-out would mean up to 50 synchronous PATCHes from the admin
+        # request writing byte-identical objects.
+        event, _profile = self._google_holder(event_with_registrations)
+        event.date_time = timezone.now() + timedelta(days=days_out)
+        event.duration_minutes = old_minutes
+        event.save()
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.duration_minutes = new_minutes
+                event.save()
+
+        token.assert_not_called()
+        patch_object.assert_not_called()
+
+    def test_a_past_event_staying_past_does_not_patch(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        # Both ends of the edit are behind `now`, so the event was already off
+        # the card and stays off it.
+        event, _profile = self._google_holder(event_with_registrations)
+        event.date_time = timezone.now() - timedelta(hours=5)
+        event.duration_minutes = 30
+        event.save()
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.duration_minutes = 60  # still ended four hours ago
+                event.save()
+
+        patch_object.assert_not_called()
+
+    def test_the_apple_ticket_still_refreshes_on_any_duration_edit(
+        self, _apple_identity, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        # The Google gate must not narrow the APPLE one: duration drives
+        # expirationDate, which is rendered, so every edit rewrites the ticket
+        # whether or not eligibility moved.
+        event, profile = self._google_holder(event_with_registrations)
+        profile.apple_pass_serial = "member-serial"
+        profile.save(update_fields=["apple_pass_serial"])
+        event.date_time = timezone.now() + timedelta(days=7)
+        event.duration_minutes = 120
+        event.save()
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh_apple, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.duration_minutes = 240
+                event.save()
+
+        # Not a bare call count — refresh_event_tickets routes through this
+        # same helper, so the ticket and member fan-outs are two calls. What
+        # matters is that the member pass was among them.
+        assert any(
+            "member-serial" in call.args[0] for call in refresh_apple.call_args_list
+        )
+        patch_object.assert_not_called()
+
     def test_the_two_next_event_status_sets_are_one_object(self):
         # signals and wallet_pass each used to keep their own copy under a
         # "keep in sync" note. Identity, not equality: a future edit to one
@@ -3681,9 +3780,9 @@ class TestAdminBulkActionsRefreshWallets:
                     MeetupEvent.objects.filter(pk=event.pk),
                 )
 
-        # Still one call for the action, carrying nobody.
-        assert refresh_google.call_count == 1
-        assert list(refresh_google.call_args.args[0]) == []
+        # Nobody to refresh, so the helper is not called at all — no on_commit
+        # hook, no scheduling log for a batch of zero.
+        refresh_google.assert_not_called()
 
     def test_cancel_events_matches_status_on_the_same_registration(
         self, _apple_identity, _google_identity, event_with_registrations
@@ -3726,7 +3825,7 @@ class TestAdminBulkActionsRefreshWallets:
                     MeetupEvent.objects.filter(pk=event.pk),
                 )
 
-        assert list(refresh_google.call_args.args[0]) == []
+        refresh_google.assert_not_called()
 
     def test_confirm_collects_google_profiles_before_the_status_flips(
         self, _apple_identity, _google_identity, event_with_registrations
@@ -3834,6 +3933,176 @@ class TestAdminBulkActionsRefreshWallets:
                     None,
                     RequestFactory().post("/"),
                     QuizEvent.objects.filter(pk__in=[quiz_a.pk, quiz_b.pk]),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def _second_event(self, days, title="Second event"):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.models import MeetupEvent
+
+        return MeetupEvent.objects.create(
+            title=title,
+            date_time=timezone.now() + timedelta(days=days),
+            location="Luxembourg City",
+            max_participants=20,
+            registration_deadline=timezone.now() + timedelta(days=max(days - 1, 0)),
+        )
+
+    def test_cancel_skips_holders_showing_an_earlier_event(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration, MeetupEvent
+
+        # The fixture event is 7 days out; this holder also has one 3 days out,
+        # so THAT is what their card shows. Cancelling the later event changes
+        # nothing they can see — and the fan-out is capped with no Google poll
+        # behind it, so a no-op here can strand a holder whose card really was
+        # showing the cancelled event.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        earlier = self._second_event(3, title="The one actually displayed")
+        EventRegistration.objects.create(
+            event=earlier, user=registration.user, status="confirmed"
+        )
+        self._google_member(registration, "google-obj-laterevent")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        refresh_google.assert_not_called()
+
+    def test_cancel_still_refreshes_when_the_displayed_event_goes(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration, MeetupEvent
+
+        # The mirror: the SAME two-event holder, but now the earlier one is
+        # cancelled. That is the event their card names, so this must refresh.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        earlier = self._second_event(3, title="The one actually displayed")
+        EventRegistration.objects.create(
+            event=earlier, user=registration.user, status="confirmed"
+        )
+        profile = self._google_member(registration, "google-obj-displayed")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=earlier.pk),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_quiz_no_show_skips_holders_showing_an_earlier_event(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.admin.quiz import mark_unattended_as_no_show
+        from crush_lu.models import EventRegistration
+        from crush_lu.models.quiz import QuizEvent
+
+        # Crossing the status boundary is necessary but not sufficient: this
+        # holder's card is showing an earlier event, so being marked absent
+        # from the later quiz rewrites nothing.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        earlier = self._second_event(3, title="The one actually displayed")
+        EventRegistration.objects.create(
+            event=earlier, user=registration.user, status="confirmed"
+        )
+        self._google_member(registration, "google-obj-laterquiz")
+        quiz = QuizEvent.objects.create(event=event, created_by=registration.user)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.quiz.messages"):
+                mark_unattended_as_no_show(
+                    None,
+                    RequestFactory().post("/"),
+                    QuizEvent.objects.filter(pk=quiz.pk),
+                )
+
+        refresh_google.assert_not_called()
+
+    def test_confirm_skips_a_restored_seat_behind_an_earlier_event(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+
+        # Restoring a seat only changes the card if the restored event then IS
+        # the displayed one. This holder already has an earlier eligible
+        # registration, so it is not.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        registration.status = "cancelled"
+        registration.save(update_fields=["status"])
+        earlier = self._second_event(3, title="The one actually displayed")
+        EventRegistration.objects.create(
+            event=earlier, user=registration.user, status="confirmed"
+        )
+        self._google_member(registration, "google-obj-behind")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).confirm_registrations(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=registration.pk),
+                )
+
+        refresh_google.assert_not_called()
+
+    def test_confirm_refreshes_a_restored_seat_that_becomes_the_next_event(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+
+        # The mirror: the restored seat is EARLIER than what the card shows, so
+        # it takes over the block and the object really does change.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        later = self._second_event(9, title="Currently displayed")
+        EventRegistration.objects.create(
+            event=later, user=registration.user, status="confirmed"
+        )
+        registration.status = "cancelled"
+        registration.save(update_fields=["status"])
+        profile = self._google_member(registration, "google-obj-takesover")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).confirm_registrations(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=registration.pk),
                 )
 
         assert refresh_google.call_count == 1

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -4224,6 +4224,69 @@ class TestAdminBulkActionsRefreshWallets:
 
         refresh_google.assert_not_called()
 
+    def test_a_tied_restore_that_cannot_win_is_not_queued(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+
+        # Once the selector gained its (date_time, event_id, id) tie-break,
+        # "same start time" stopped meaning "might take the card". The restored
+        # event here ties on start but sorts AFTER the displayed one, so it
+        # cannot win and the holder's card does not change.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        # Created second, so its pk is higher and it loses the tie-break.
+        twin = self._second_event(7, title="Ties but sorts second")
+        twin.date_time = event.date_time
+        twin.save()
+        restored = EventRegistration.objects.create(
+            event=twin, user=registration.user, status="cancelled"
+        )
+        self._google_member(registration, "google-obj-tiedrestore")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).confirm_registrations(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=restored.pk),
+                )
+
+        refresh_google.assert_not_called()
+
+    def test_cancel_uses_the_state_it_locked_not_the_state_it_read(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import MeetupEvent
+
+        # `events = list(queryset)` happens before the lock, so those instances
+        # can be stale by the time the selection runs — and the selection turns
+        # on is_cancelled. Here the caller hands over an instance that still
+        # says cancelled while the database says otherwise; reading the stale
+        # copy would drop it from `transitioning` and refresh nobody.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        profile = self._google_member(registration, "google-obj-restored")
+
+        stale = MeetupEvent.objects.get(pk=event.pk)
+        stale.is_cancelled = True  # in memory only — never saved
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"), [stale]
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
     def test_the_two_next_event_selectors_agree_on_a_tie(
         self, _google_identity, event_with_registrations
     ):

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -16,6 +16,7 @@ the PassKit service ROOT (e.g. https://crush.lu/wallet). Apple appends its own
 
 from unittest import mock
 
+import httpx
 import pytest
 from django.test import RequestFactory
 
@@ -2017,6 +2018,225 @@ class TestEventLevelGoogleRefresh:
 
 
 @pytest.mark.django_db
+class TestUpdateAllGoogleWalletPasses:
+    """The maintenance sweep looped the per-profile entry point, so it minted a
+    fresh token and opened a fresh connection for every pass.
+
+    It reuses both now — but it keeps running UNCAPPED. The bulk refresh's
+    limit and budget exist because that path runs inline in an admin request;
+    this one has no request attached, and stopping early would just leave
+    passes stale with nothing left to finish them.
+    """
+
+    def _holders(self, count, start=0):
+        from datetime import date
+
+        from django.contrib.auth import get_user_model
+
+        from crush_lu.models import CrushProfile
+
+        User = get_user_model()
+        profiles = []
+        for i in range(start, start + count):
+            user = User.objects.create_user(
+                username=f"sweep{i}@example.com",
+                email=f"sweep{i}@example.com",
+                password="x",
+            )
+            profile = CrushProfile.objects.create(
+                user=user,
+                date_of_birth=date(1995, 5, 15),
+                gender="M",
+                location="Luxembourg City",
+                is_approved=True,
+                verification_status="verified",
+                is_active=True,
+            )
+            profile.google_wallet_object_id = f"google-sweep-{i}"
+            profile.save(update_fields=["google_wallet_object_id"])
+            profiles.append(profile)
+        return profiles
+
+    def test_one_token_and_one_client_serve_the_whole_sweep(
+        self, _google_identity
+    ):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        self._holders(3)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object, mock.patch(
+            "crush_lu.wallet.google_api.httpx.Client", wraps=httpx.Client
+        ) as client_cls:
+            results = update_all_google_wallet_passes()
+
+        assert results == {"updated": 3, "failed": 0, "skipped": 0}
+        assert token.call_count == 1
+        assert client_cls.call_count == 1
+        assert patch_object.call_count == 3
+        # Every PATCH borrowed the same token and the same connection.
+        assert {call.args[2] for call in patch_object.call_args_list} == {"tok"}
+        assert len({id(call.args[3]) for call in patch_object.call_args_list}) == 1
+
+    def test_the_sweep_is_not_capped(self, _google_identity, settings):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        # The bulk-refresh bounds must not leak into the sweep: it is the only
+        # thing that would ever fix the passes they skipped.
+        self._holders(4)
+        settings.WALLET_GOOGLE_BULK_UPDATE_LIMIT = 1
+        settings.WALLET_GOOGLE_BULK_UPDATE_BUDGET_SECONDS = 0.0
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            results = update_all_google_wallet_passes()
+
+        assert patch_object.call_count == 4
+        assert results["updated"] == 4
+
+    def test_results_classify_success_deleted_and_failed(self, _google_identity):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        self._holders(3)
+        outcomes = [
+            {"success": True, "message": "Pass updated successfully"},
+            {"success": False, "message": "Pass not found (may have been deleted)"},
+            {"success": False, "message": "API error: 500"},
+        ]
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object", side_effect=outcomes
+        ):
+            results = update_all_google_wallet_passes()
+
+        # Unchanged from the per-profile version: a 404 is the holder deleting
+        # their pass, not a failure to chase.
+        assert results == {"updated": 1, "failed": 1, "skipped": 1}
+
+    def test_one_failing_object_does_not_strand_the_rest(self, _google_identity):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        # Per-profile isolation used to come free from the per-profile try in
+        # update_google_wallet_pass; sharing the client had to keep it.
+        self._holders(3)
+        ok = {"success": True, "message": "Pass updated successfully"}
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            side_effect=[RuntimeError("boom"), ok, ok],
+        ) as patch_object:
+            results = update_all_google_wallet_passes()
+
+        assert patch_object.call_count == 3
+        assert results == {"updated": 2, "failed": 1, "skipped": 0}
+
+    def test_token_failure_counts_every_pass_as_failed(self, _google_identity):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        # Nothing can be PATCHed without a token. The old loop reported one
+        # failure per profile; the totals still have to add up to the estate.
+        self._holders(3)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token",
+            side_effect=RuntimeError("oauth down"),
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            results = update_all_google_wallet_passes()
+
+        patch_object.assert_not_called()
+        assert results == {"updated": 0, "failed": 3, "skipped": 0}
+
+    def test_a_token_failure_part_way_through_only_fails_the_remainder(
+        self, _google_identity
+    ):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        # A re-mint can fail mid-sweep. The passes already updated are real and
+        # must not be counted as failures.
+        self._holders(3)
+        ok = {"success": True, "message": "Pass updated successfully"}
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.GOOGLE_WALLET_TOKEN_REUSE_SECONDS", 0
+        ), mock.patch(
+            "crush_lu.wallet.google_api._get_access_token",
+            side_effect=["tok", "tok", RuntimeError("oauth down")],
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object", return_value=ok
+        ) as patch_object:
+            results = update_all_google_wallet_passes()
+
+        assert patch_object.call_count == 2
+        assert results == {"updated": 2, "failed": 1, "skipped": 0}
+
+    def test_the_shared_token_is_re_minted_before_it_expires(self, _google_identity):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        # A token lasts an hour. Minting per profile used to make expiry
+        # impossible; reuse brings it back, and an uncapped sweep is exactly
+        # the caller that can outlive one.
+        self._holders(3)
+
+        with mock.patch(
+            "crush_lu.wallet.google_api.GOOGLE_WALLET_TOKEN_REUSE_SECONDS", 0
+        ), mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ):
+            update_all_google_wallet_passes()
+
+        assert token.call_count == 3
+
+    def test_missing_class_id_costs_no_token_and_fails_everything(
+        self, _google_identity, settings
+    ):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        self._holders(2)
+        settings.WALLET_GOOGLE_CLASS_ID = ""
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            results = update_all_google_wallet_passes()
+
+        token.assert_not_called()
+        patch_object.assert_not_called()
+        # Same total as when every profile went through the per-profile entry
+        # point and came back with this as its failure.
+        assert results == {"updated": 0, "failed": 2, "skipped": 0}
+
+    def test_an_empty_estate_costs_nothing(self, _google_identity):
+        from crush_lu.wallet.google_api import update_all_google_wallet_passes
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token:
+            results = update_all_google_wallet_passes()
+
+        token.assert_not_called()
+        assert results == {"updated": 0, "failed": 0, "skipped": 0}
+
+
+@pytest.mark.django_db
 class TestAppleEventTicketRefreshSignal:
     """Every repo-wide Apple refresh path went through the MEMBER pass serial,
     so an event ticket was never pushed when its registration changed."""
@@ -3192,6 +3412,388 @@ class TestAdminBulkActionsRefreshWallets:
                 )
 
         assert "evt-1-reg-1-abcd" in refresh.call_args.args[0]
+
+    # ------------------------------------------------------------------
+    # The GOOGLE half. Same three actions, same one-call-per-action rule —
+    # and the member object is the ONLY Google surface an event appears on,
+    # so nothing else can carry these changes.
+    # ------------------------------------------------------------------
+
+    def _google_member(self, registration, object_id):
+        profile = registration.user.crushprofile
+        profile.google_wallet_object_id = object_id
+        # update_fields names a field outside WALLET_UPDATE_PROFILE_FIELDS, so
+        # the setup save does not itself fire a refresh and skew the counts.
+        profile.save(update_fields=["google_wallet_object_id"])
+        return profile
+
+    def test_cancel_events_refreshes_google_member_objects(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import MeetupEvent
+
+        # get_next_event_for_pass drops cancelled events, so every attendee's
+        # card is left advertising an event that will not happen — and .update()
+        # emits no signals, so nothing else notices.
+        event, registrations = event_with_registrations
+        profile = self._google_member(registrations[0], "google-obj-cancel")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        # ONE call for the whole action: the helper opens its own budget, so a
+        # per-event loop would restart the deadline N times.
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_cancel_events_google_refresh_survives_an_apple_outage(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import MeetupEvent
+
+        # Two independent APIs. They get separate try blocks so an APNs outage
+        # cannot swallow the Google refresh with it.
+        event, registrations = event_with_registrations
+        self._google_member(registrations[0], "google-obj-cancel")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials",
+            side_effect=RuntimeError("apns down"),
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        assert refresh_google.call_count == 1
+
+    def test_cancel_events_patches_google_end_to_end(
+        self, _apple_identity, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from crush_lu.models import MeetupEvent
+
+        # The tests above stop at the helper. This one runs the whole chain —
+        # admin action, on_commit, one shared token, a real PATCH call — so a
+        # break anywhere between them is caught.
+        event, registrations = event_with_registrations
+        self._google_member(registrations[0], "google-obj-cancel")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ) as token, mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                with django_capture_on_commit_callbacks(execute=True):
+                    self._admin(MeetupEvent).cancel_events(
+                        RequestFactory().post("/"),
+                        MeetupEvent.objects.filter(pk=event.pk),
+                    )
+
+        assert token.call_count == 1
+        assert patch_object.call_count == 1
+        assert (
+            patch_object.call_args.args[0].google_wallet_object_id
+            == "google-obj-cancel"
+        )
+
+    def test_confirm_registrations_refreshes_google_member_objects(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+
+        # Restored from "cancelled", which is OUTSIDE
+        # get_next_event_for_pass's candidate set — so confirming genuinely
+        # changes which event the card names.
+        _event, registrations = event_with_registrations
+        registration = registrations[0]
+        registration.status = "cancelled"
+        registration.save(update_fields=["status"])
+        profile = self._google_member(registration, "google-obj-confirm")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).confirm_registrations(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=registration.pk),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_confirm_from_waitlist_leaves_google_alone(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # The Google set is NARROWER than the Apple one on this action, and
+        # this is the difference: a waitlisted registration is already inside
+        # PASS_NEXT_EVENT_STATUSES, so confirming it un-voids the ticket (Apple
+        # needs it) while leaving the member card byte-identical.
+        _event, registrations = event_with_registrations
+        registration = registrations[0]
+        registration.status = "waitlist"
+        registration.save(update_fields=["status"])
+        self._ticketed(registration, "evt-1-reg-1-abcd")
+        profile = self._google_member(registration, "google-obj-fromwaitlist")
+        before = get_next_event_for_pass(profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ) as refresh_apple, mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).confirm_registrations(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=registration.pk),
+                )
+
+        refresh_google.assert_not_called()
+        # Not "nothing happened" — the Apple half still ran on the same row.
+        assert refresh_apple.call_count == 1
+
+        after = get_next_event_for_pass(profile)
+        assert (before["title"], before["date"]) == (after["title"], after["date"])
+
+    def test_cancel_events_skips_holders_who_had_already_cancelled(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import MeetupEvent
+
+        # This event was never their next event — a cancelled registration is
+        # outside PASS_NEXT_EVENT_STATUSES — so cancelling it changes nothing
+        # on their card.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        registration.status = "cancelled"
+        registration.save(update_fields=["status"])
+        self._google_member(registration, "google-obj-alreadygone")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        # Still one call for the action, carrying nobody.
+        assert refresh_google.call_count == 1
+        assert list(refresh_google.call_args.args[0]) == []
+
+    def test_cancel_events_matches_status_on_the_same_registration(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.models import EventRegistration, MeetupEvent
+
+        # The event filter and the status filter must constrain the SAME
+        # registration row. Split across two .filter() calls Django joins the
+        # relation twice, and this holder — cancelled here, confirmed for an
+        # unrelated event — would be swept in on a card that did not change.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        registration.status = "cancelled"
+        registration.save(update_fields=["status"])
+
+        other_event = MeetupEvent.objects.create(
+            title="Unrelated event",
+            date_time=timezone.now() + timedelta(days=9),
+            location="Luxembourg City",
+            max_participants=20,
+            registration_deadline=timezone.now() + timedelta(days=8),
+        )
+        EventRegistration.objects.create(
+            event=other_event, user=registration.user, status="confirmed"
+        )
+        self._google_member(registration, "google-obj-otherevent")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        assert list(refresh_google.call_args.args[0]) == []
+
+    def test_confirm_collects_google_profiles_before_the_status_flips(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+
+        # The `restoring` queryset is lazy and keyed on the OLD status. Read
+        # after .update(status="confirmed") it matches nothing, and the refresh
+        # would silently receive an empty list — a green test suite and a
+        # permanently stale card.
+        _event, registrations = event_with_registrations
+        registration = registrations[0]
+        registration.status = "no_show"
+        registration.save(update_fields=["status"])
+        self._google_member(registration, "google-obj-late")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).confirm_registrations(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=registration.pk),
+                )
+
+        registration.refresh_from_db()
+        assert registration.status == "confirmed"
+        assert [
+            p.google_wallet_object_id for p in refresh_google.call_args.args[0]
+        ] == ["google-obj-late"]
+
+    def test_quiz_no_show_refreshes_google_member_objects(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.admin.quiz import mark_unattended_as_no_show
+        from crush_lu.models.quiz import QuizEvent
+
+        # "no_show" is outside the candidate set, so the card must stop naming
+        # a quiz the holder was just marked absent from.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        profile = self._google_member(registration, "google-obj-noshow")
+        quiz = QuizEvent.objects.create(event=event, created_by=registration.user)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.quiz.messages"):
+                mark_unattended_as_no_show(
+                    None,
+                    RequestFactory().post("/"),
+                    QuizEvent.objects.filter(pk=quiz.pk),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_quiz_no_show_batches_and_dedupes_across_quizzes(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.admin.quiz import mark_unattended_as_no_show
+        from crush_lu.models import EventRegistration, MeetupEvent
+        from crush_lu.models.quiz import QuizEvent
+
+        # One holder registered for BOTH selected quizzes. The action must send
+        # ONE call carrying ONE profile: a second PATCH of the same object
+        # changes nothing and is spent out of a budget whose overflow leaves
+        # other people's passes permanently stale.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+
+        second_event = MeetupEvent.objects.create(
+            title="Second quiz",
+            date_time=timezone.now() + timedelta(days=3),
+            location="Luxembourg City",
+            max_participants=20,
+            registration_deadline=timezone.now() + timedelta(days=2),
+        )
+        EventRegistration.objects.create(
+            event=second_event, user=registration.user, status="confirmed"
+        )
+        # Object id set LAST: the registration receiver bails on a profile with
+        # no pass, so setup stays free of wallet calls.
+        profile = self._google_member(registration, "google-obj-dupe")
+        quiz_a = QuizEvent.objects.create(event=event, created_by=registration.user)
+        quiz_b = QuizEvent.objects.create(
+            event=second_event, created_by=registration.user
+        )
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.quiz.messages"):
+                mark_unattended_as_no_show(
+                    None,
+                    RequestFactory().post("/"),
+                    QuizEvent.objects.filter(pk__in=[quiz_a.pk, quiz_b.pk]),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_move_to_waitlist_leaves_google_alone(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # The one bulk action with NO Google refresh, pinned so its absence
+        # reads as a decision rather than an omission: "waitlist" is inside
+        # get_next_event_for_pass's candidate set, and the member surfaces print
+        # only the event's title and date — never the status — so the rebuilt
+        # object would be byte-identical. PATCHing anyway would burn a capped
+        # budget on no-ops and warn about passes that were never stale.
+        _event, registrations = event_with_registrations
+        registration = registrations[0]
+        profile = self._google_member(registration, "google-obj-waitlist")
+        before = get_next_event_for_pass(profile)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(EventRegistration).move_to_waitlist(
+                    RequestFactory().post("/"),
+                    EventRegistration.objects.filter(pk=registration.pk),
+                )
+
+        refresh_google.assert_not_called()
+        # The premise, asserted rather than assumed: everything the Google
+        # object actually renders is unchanged by the move. If this starts
+        # failing, move_to_waitlist owes Google a refresh after all.
+        after = get_next_event_for_pass(profile)
+        assert after is not None
+        assert (before["title"], before["date"]) == (after["title"], after["date"])
 
 
 @pytest.mark.django_db

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1311,7 +1311,14 @@ class TestEventLevelGoogleRefresh:
             ("date_time", None),  # replaced below — needs a real datetime
             ("is_cancelled", True),
             ("title_fr", "Soirée renommée"),
-            ("duration_minutes", 999),
+            # `duration_minutes` deliberately absent, and the test's own name
+            # says why: it is not RENDERED. It selects, and only when the event
+            # crosses `end_time >= now` — on this fixture's future event it
+            # changes nothing, so asserting a PATCH here pinned an edit that
+            # writes a byte-identical object. The behaviour it was reaching for
+            # is covered properly, in both directions, by
+            # test_shortening_a_running_event_off_the_card_patches_google and
+            # test_extending_a_just_ended_event_patches_the_member_object.
         ],
     )
     def test_google_rendered_field_changes_do_patch(
@@ -1359,42 +1366,9 @@ class TestEventLevelGoogleRefresh:
 
         patch_object.assert_not_called()
 
-    def test_shortening_a_running_event_patches_the_member_object(
-        self, _google_identity, event_with_registrations,
-        django_capture_on_commit_callbacks,
-    ):
-        from datetime import timedelta
-
-        from django.utils import timezone
-
-        from crush_lu.wallet_pass import get_next_event_for_pass
-
-        # duration_minutes reads like an Apple-only field — its Apple job is
-        # expirationDate, pure rendering, and the Google card never prints a
-        # duration. But get_next_event_for_pass keeps a candidate only while
-        # `event.end_time >= now`, and end_time is date_time + duration, so
-        # shortening a RUNNING event past the current moment takes it off the
-        # card entirely. Google has no poll to heal that.
-        event, profile = self._google_holder(event_with_registrations)
-        event.date_time = timezone.now() - timedelta(minutes=30)
-        event.duration_minutes = 120
-        event.save()
-        assert get_next_event_for_pass(profile) is not None
-
-        with mock.patch(
-            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
-        ), mock.patch(
-            "crush_lu.wallet.google_api._patch_generic_object",
-            return_value={"success": True, "message": "Pass updated successfully"},
-        ) as patch_object:
-            with django_capture_on_commit_callbacks(execute=True):
-                event.duration_minutes = 10  # ended 20 minutes ago
-                event.save()
-
-        # The card genuinely changed — this is the PATCH that carries it.
-        assert get_next_event_for_pass(profile) is None
-        assert patch_object.call_count == 1
-
+    # The shortening direction is already covered further down by
+    # test_shortening_a_running_event_off_the_card_patches_google. This is its
+    # mirror, which nothing covered.
     def test_extending_a_just_ended_event_patches_the_member_object(
         self, _google_identity, event_with_registrations,
         django_capture_on_commit_callbacks,

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -4020,6 +4020,81 @@ class TestAdminBulkActionsRefreshWallets:
 
         refresh_google.assert_not_called()
 
+    def test_quiz_no_show_refreshes_after_the_quiz_has_ended(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.admin.quiz import mark_unattended_as_no_show
+        from crush_lu.models.quiz import QuizEvent
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # THE normal workflow: absentees are marked after the quiz. By then
+        # get_next_event_for_pass has stopped selecting it, so "is this their
+        # displayed event" answers no for everyone — but the Google object is
+        # server-side state whose last PATCH went out while the quiz was still
+        # upcoming, so it is still advertising a finished quiz and nothing else
+        # recomputes it. Narrowing on the live selector alone would queue
+        # nobody and leave that card wrong for good.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        event.date_time = timezone.now() - timedelta(hours=3)
+        event.duration_minutes = 60  # ended two hours ago
+        event.save()
+        profile = self._google_member(registration, "google-obj-endedquiz")
+        # Precisely the condition that makes the displayed-event test blind.
+        assert get_next_event_for_pass(profile) is None
+        quiz = QuizEvent.objects.create(event=event, created_by=registration.user)
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.quiz.messages"):
+                mark_unattended_as_no_show(
+                    None,
+                    RequestFactory().post("/"),
+                    QuizEvent.objects.filter(pk=quiz.pk),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_cancel_refreshes_when_the_cancelled_event_has_ended(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.models import MeetupEvent
+
+        # Same divergence on the cancel path: an ended event is nobody's
+        # displayed event, so the narrowing must not conclude "refresh nobody".
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        event.date_time = timezone.now() - timedelta(hours=3)
+        event.duration_minutes = 60
+        event.save()
+        profile = self._google_member(registration, "google-obj-endedcancel")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
     def test_confirm_skips_a_restored_seat_behind_an_earlier_event(
         self, _apple_identity, _google_identity, event_with_registrations
     ):

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1438,7 +1438,7 @@ class TestEventLevelGoogleRefresh:
         token.assert_not_called()
         patch_object.assert_not_called()
 
-    def test_a_past_event_staying_past_does_not_patch(
+    def test_a_past_event_staying_past_still_patches(
         self, _google_identity, event_with_registrations,
         django_capture_on_commit_callbacks,
     ):
@@ -1446,23 +1446,33 @@ class TestEventLevelGoogleRefresh:
 
         from django.utils import timezone
 
-        # Both ends of the edit are behind `now`, so the event was already off
-        # the card and stays off it.
-        event, _profile = self._google_holder(event_with_registrations)
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # The asymmetry the gate has to respect. Both ends of this edit are
+        # behind `now`, which LOOKS as skippable as the future-to-future case
+        # above — and is not. The card stopped selecting the event when it
+        # finished, but the stored Google object was last written while it was
+        # still upcoming, so it can still be advertising it, and nothing else
+        # recomputes that. This edit is the only thing that would heal it.
+        event, profile = self._google_holder(event_with_registrations)
         event.date_time = timezone.now() - timedelta(hours=5)
         event.duration_minutes = 30
         event.save()
+        # Precisely the condition that makes "it is not on the card" a
+        # misleading reason to skip.
+        assert get_next_event_for_pass(profile) is None
 
         with mock.patch(
             "crush_lu.wallet.google_api._get_access_token", return_value="tok"
         ), mock.patch(
-            "crush_lu.wallet.google_api._patch_generic_object"
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
         ) as patch_object:
             with django_capture_on_commit_callbacks(execute=True):
                 event.duration_minutes = 60  # still ended four hours ago
                 event.save()
 
-        patch_object.assert_not_called()
+        assert patch_object.call_count == 1
 
     def test_the_apple_ticket_still_refreshes_on_any_duration_edit(
         self, _apple_identity, _google_identity, event_with_registrations,
@@ -4090,6 +4100,86 @@ class TestAdminBulkActionsRefreshWallets:
                 self._admin(MeetupEvent).cancel_events(
                     RequestFactory().post("/"),
                     MeetupEvent.objects.filter(pk=event.pk),
+                )
+
+        assert refresh_google.call_count == 1
+        assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
+
+    def test_ended_event_fallback_does_not_disarm_the_rest_of_the_selection(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.models import EventRegistration, MeetupEvent
+
+        # The conservative ended-event branch is scoped to that event's OWN
+        # attendees. A single ended event in the selection — here one with no
+        # registrations at all — must not switch off the displayed-event filter
+        # for holders of the other selected events, or their no-op PATCHes eat
+        # the cap and strand somebody whose card really did change.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        earlier = self._second_event(3, title="The one actually displayed")
+        EventRegistration.objects.create(
+            event=earlier, user=registration.user, status="confirmed"
+        )
+        self._google_member(registration, "google-obj-unrelated")
+
+        # Ended, and nobody is registered for it.
+        stale_event = self._second_event(1, title="Finished, no attendees")
+        stale_event.date_time = timezone.now() - timedelta(hours=4)
+        stale_event.duration_minutes = 60
+        stale_event.save()
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk__in=[event.pk, stale_event.pk]),
+                )
+
+        # This holder's card shows `earlier`, which is not in the selection.
+        refresh_google.assert_not_called()
+
+    def test_ended_event_fallback_still_covers_its_own_attendees(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.models import EventRegistration, MeetupEvent
+
+        # The mirror: scoping the fallback must not lose the holders it exists
+        # for. This one holds a seat on the ENDED selected event, so the
+        # displayed-event test is blind to them and they take the fallback —
+        # even though their card currently shows something else entirely.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        ended = self._second_event(1, title="Finished, with attendees")
+        ended.date_time = timezone.now() - timedelta(hours=4)
+        ended.duration_minutes = 60
+        ended.save()
+        EventRegistration.objects.create(
+            event=ended, user=registration.user, status="confirmed"
+        )
+        profile = self._google_member(registration, "google-obj-endedattendee")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=ended.pk),
                 )
 
         assert refresh_google.call_count == 1

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1509,6 +1509,54 @@ class TestEventLevelGoogleRefresh:
         )
         patch_object.assert_not_called()
 
+    def test_a_tied_but_lower_id_event_counts_as_nearer(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from crush_lu.models import EventRegistration
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # The nearer-event filter has to compare the same key the selector
+        # orders by. This holder also has an event at the SAME start time with
+        # a smaller id, which therefore wins the tie-break and is what their
+        # card shows — so editing the higher-id event changes nothing for them.
+        # A bare date_time__lt calls that "not nearer" and spends a capped,
+        # poll-less PATCH on a byte-identical object.
+        event, profile = self._google_holder(event_with_registrations)
+        twin = self._sibling_event_at(event.date_time, "Ties but sorts first")
+        EventRegistration.objects.create(
+            event=twin, user=profile.user, status="confirmed"
+        )
+        # twin was created second, so give it the lower id by comparing which
+        # one the selector actually picks rather than assuming.
+        displayed = get_next_event_for_pass(profile)
+        assert displayed["title"] == event.title  # `event` has the lower id
+
+        # So edit the OTHER one — the one that is not displayed.
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object"
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                twin.location = "A different bar"
+                twin.date_time = event.date_time  # unchanged, still tied
+                twin.title = "Ties but sorts first, renamed"
+                twin.save()
+
+        patch_object.assert_not_called()
+
+    def _sibling_event_at(self, when, title):
+        from crush_lu.models import MeetupEvent
+
+        return MeetupEvent.objects.create(
+            title=title,
+            date_time=when,
+            location="Luxembourg City",
+            max_participants=20,
+            registration_deadline=when,
+        )
+
     def test_the_two_next_event_status_sets_are_one_object(self):
         # signals and wallet_pass each used to keep their own copy under a
         # "keep in sync" note. Identity, not equality: a future edit to one

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -1287,6 +1287,10 @@ class TestEventLevelGoogleRefresh:
         # these rewrite the Apple ticket while leaving it byte-identical. An
         # OAuth exchange plus up to 50 PATCHes to write an unchanged object is
         # the exact budget spend the cap exists to protect.
+        #
+        # "Apple-only" means "changes nothing the Google card shows OR selects"
+        # — a field that only fails the first half still belongs in
+        # _GOOGLE_PAYLOAD_FIELDS.
         event, _profile = self._google_holder(event_with_registrations)
 
         with mock.patch(
@@ -1354,6 +1358,82 @@ class TestEventLevelGoogleRefresh:
                 event.save()
 
         patch_object.assert_not_called()
+
+    def test_shortening_a_running_event_patches_the_member_object(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # duration_minutes reads like an Apple-only field — its Apple job is
+        # expirationDate, pure rendering, and the Google card never prints a
+        # duration. But get_next_event_for_pass keeps a candidate only while
+        # `event.end_time >= now`, and end_time is date_time + duration, so
+        # shortening a RUNNING event past the current moment takes it off the
+        # card entirely. Google has no poll to heal that.
+        event, profile = self._google_holder(event_with_registrations)
+        event.date_time = timezone.now() - timedelta(minutes=30)
+        event.duration_minutes = 120
+        event.save()
+        assert get_next_event_for_pass(profile) is not None
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.duration_minutes = 10  # ended 20 minutes ago
+                event.save()
+
+        # The card genuinely changed — this is the PATCH that carries it.
+        assert get_next_event_for_pass(profile) is None
+        assert patch_object.call_count == 1
+
+    def test_extending_a_just_ended_event_patches_the_member_object(
+        self, _google_identity, event_with_registrations,
+        django_capture_on_commit_callbacks,
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.wallet_pass import get_next_event_for_pass
+
+        # The mirror image: an event that just ended is off the card, and
+        # extending it puts it back.
+        event, profile = self._google_holder(event_with_registrations)
+        event.date_time = timezone.now() - timedelta(minutes=30)
+        event.duration_minutes = 10
+        event.save()
+        assert get_next_event_for_pass(profile) is None
+
+        with mock.patch(
+            "crush_lu.wallet.google_api._get_access_token", return_value="tok"
+        ), mock.patch(
+            "crush_lu.wallet.google_api._patch_generic_object",
+            return_value={"success": True, "message": "Pass updated successfully"},
+        ) as patch_object:
+            with django_capture_on_commit_callbacks(execute=True):
+                event.duration_minutes = 120
+                event.save()
+
+        assert get_next_event_for_pass(profile) is not None
+        assert patch_object.call_count == 1
+
+    def test_the_two_next_event_status_sets_are_one_object(self):
+        # signals and wallet_pass each used to keep their own copy under a
+        # "keep in sync" note. Identity, not equality: a future edit to one
+        # literal must not be able to leave the other behind.
+        from crush_lu import signals
+        from crush_lu.wallet_pass import PASS_NEXT_EVENT_STATUSES
+
+        assert signals._NEXT_EVENT_STATUSES is PASS_NEXT_EVENT_STATUSES
 
     def test_nothing_runs_before_the_event_change_commits(
         self, _google_identity, event_with_registrations,

--- a/crush_lu/tests/test_passkit_service.py
+++ b/crush_lu/tests/test_passkit_service.py
@@ -4185,6 +4185,79 @@ class TestAdminBulkActionsRefreshWallets:
         assert refresh_google.call_count == 1
         assert [p.pk for p in refresh_google.call_args.args[0]] == [profile.pk]
 
+    def test_an_already_cancelled_ended_event_does_not_enter_the_fallback(
+        self, _apple_identity, _google_identity, event_with_registrations
+    ):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from crush_lu.models import EventRegistration, MeetupEvent
+
+        # The ended fallback must not re-admit rows the action changes nothing
+        # for. This event is finished AND already cancelled, so cancelling it
+        # again rewrites nobody's card — but it has attendees, and letting them
+        # through would spend the cap that a genuinely-cancelled event's
+        # holders need.
+        _event, registrations = event_with_registrations
+        registration = registrations[0]
+        dead = self._second_event(1, title="Finished and already cancelled")
+        dead.date_time = timezone.now() - timedelta(hours=4)
+        dead.duration_minutes = 60
+        dead.is_cancelled = True
+        dead.save()
+        EventRegistration.objects.create(
+            event=dead, user=registration.user, status="confirmed"
+        )
+        self._google_member(registration, "google-obj-deadevent")
+
+        with mock.patch(
+            "crush_lu.wallet.passkit_service.refresh_ticket_serials"
+        ), mock.patch(
+            "crush_lu.wallet.google_api.refresh_google_wallet_objects"
+        ) as refresh_google:
+            with mock.patch("crush_lu.admin.events.django_messages"):
+                self._admin(MeetupEvent).cancel_events(
+                    RequestFactory().post("/"),
+                    MeetupEvent.objects.filter(pk=dead.pk),
+                )
+
+        refresh_google.assert_not_called()
+
+    def test_the_two_next_event_selectors_agree_on_a_tie(
+        self, _google_identity, event_with_registrations
+    ):
+        from crush_lu.models import EventRegistration
+        from crush_lu.wallet_pass import (
+            get_next_event_for_pass,
+            get_next_event_registrations,
+        )
+
+        # Two eligible registrations sharing a start time. Ordering by
+        # date_time alone left the winner to the database, and the two
+        # selectors run different queries — the single-user one builds the card
+        # a holder sees, the bulk one decides whether an admin action must
+        # refresh them. Disagree here and the action skips somebody whose card
+        # really did change, permanently.
+        event, registrations = event_with_registrations
+        registration = registrations[0]
+        twin = self._second_event(7, title="Same slot, different room")
+        twin.date_time = event.date_time
+        twin.save()
+        EventRegistration.objects.create(
+            event=twin, user=registration.user, status="confirmed"
+        )
+        profile = self._google_member(registration, "google-obj-tie")
+
+        single = get_next_event_for_pass(profile)
+        bulk = get_next_event_registrations([profile.user_id])[profile.user_id]
+
+        assert single is not None
+        assert single["title"] == bulk.event.title
+        # Stable across repeated calls too, so a rebuild cannot flip the card
+        # between two tied events on its own.
+        assert get_next_event_for_pass(profile)["title"] == single["title"]
+
     def test_confirm_skips_a_restored_seat_behind_an_earlier_event(
         self, _apple_identity, _google_identity, event_with_registrations
     ):

--- a/crush_lu/wallet/google_api.py
+++ b/crush_lu/wallet/google_api.py
@@ -30,6 +30,12 @@ GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
 # the single-profile callers that have no budget of their own.
 GOOGLE_WALLET_HTTP_TIMEOUT = 30.0
 
+# When a caller that reuses one token across many PATCHes should mint a fresh
+# one. Google's access tokens last an hour; this leaves a wide margin so a long
+# uncapped sweep never presents one that expired mid-flight. The bounded bulk
+# refresh never reaches it — its whole budget is seconds.
+GOOGLE_WALLET_TOKEN_REUSE_SECONDS = 45 * 60
+
 
 def _timeout_kwargs(timeout):
     """Build the per-request timeout kwarg, omitting it when unset.
@@ -557,27 +563,91 @@ def update_all_google_wallet_passes():
     Update all existing Google Wallet passes.
     Useful for batch updates after design changes.
 
+    Shares ONE token exchange and ONE keep-alive connection across the sweep,
+    like refresh_google_wallet_objects — the per-profile entry point minted a
+    fresh token and opened a fresh connection for every pass, so a sweep cost
+    two round trips and a TLS handshake each.
+
+    It does NOT inherit that helper's count limit or wall-clock budget. Those
+    exist because the bulk refresh runs inline in an admin request, and a slow
+    Google API would otherwise hold a human waiting. This is a maintenance
+    sweep with no request attached: stopping early would just leave passes
+    stale with nothing to finish them, so it runs to the end.
+
     Returns:
         dict: {"updated": int, "failed": int, "skipped": int}
     """
     from ..models import CrushProfile
 
-    profiles = CrushProfile.objects.exclude(
-        google_wallet_object_id__isnull=True
-    ).exclude(
-        google_wallet_object_id=""
+    profiles = list(
+        CrushProfile.objects.exclude(google_wallet_object_id__isnull=True).exclude(
+            google_wallet_object_id=""
+        )
     )
 
     results = {"updated": 0, "failed": 0, "skipped": 0}
+    if not profiles:
+        return results
 
-    for profile in profiles:
-        result = update_google_wallet_pass(profile)
-        if result["success"]:
-            results["updated"] += 1
-        elif "not found" in result["message"].lower():
-            results["skipped"] += 1
-        else:
-            results["failed"] += 1
+    class_id = getattr(settings, "WALLET_GOOGLE_CLASS_ID", None)
+    if not class_id:
+        # Same accounting as before, when every profile went through
+        # update_google_wallet_pass and came back with this as its failure —
+        # reported once instead of silently N times.
+        logger.error(
+            "Batch Google Wallet update aborted for %d pass(es): "
+            "WALLET_GOOGLE_CLASS_ID not configured",
+            len(profiles),
+        )
+        results["failed"] = len(profiles)
+        return results
+
+    attempted = 0
+    try:
+        with httpx.Client(timeout=GOOGLE_WALLET_HTTP_TIMEOUT) as client:
+            access_token = None
+            token_minted_at = 0.0
+
+            for profile in profiles:
+                # Re-minted rather than held for the whole sweep: a token is
+                # good for an hour, and an uncapped sweep over a large estate
+                # can outlive one. Minting per profile is what this change
+                # removed, so the expiry it used to hide has to be handled
+                # here instead.
+                if (
+                    access_token is None
+                    or time.monotonic() - token_minted_at
+                    >= GOOGLE_WALLET_TOKEN_REUSE_SECONDS
+                ):
+                    access_token = _get_access_token(client=client)
+                    token_minted_at = time.monotonic()
+
+                attempted += 1
+                try:
+                    result = _patch_generic_object(
+                        profile, class_id, access_token, client
+                    )
+                except Exception:
+                    # One unreachable object must not strand the rest.
+                    logger.exception(
+                        "Failed updating Google Wallet object %s",
+                        profile.google_wallet_object_id,
+                    )
+                    results["failed"] += 1
+                    continue
+
+                if result["success"]:
+                    results["updated"] += 1
+                elif "not found" in result["message"].lower():
+                    results["skipped"] += 1
+                else:
+                    results["failed"] += 1
+    except Exception:
+        # Nothing can be PATCHed without a token, so a failed exchange takes
+        # the rest of the sweep with it. Counted as failures rather than
+        # quietly dropped, so the caller's totals still add up to the estate.
+        logger.exception("Batch Google Wallet update could not finish")
+        results["failed"] += len(profiles) - attempted
 
     logger.info(
         "Batch Google Wallet update complete: %d updated, %d failed, %d skipped",

--- a/crush_lu/wallet_pass.py
+++ b/crush_lu/wallet_pass.py
@@ -6,6 +6,18 @@ from .models import ReferralCode, EventRegistration, MeetupEvent
 from .models.events import SEAT_HOLDING_STATUSES
 from .referrals import build_referral_url
 
+# Registration statuses that can still make an event somebody's "next event" on
+# a wallet pass. "waitlist" counts: a waitlisted member is still going, pending
+# a seat, and the card names the event either way.
+#
+# Defined once because the admin bulk actions consume it too. They decide
+# whether a status change is worth a wallet refresh by asking whether it moves
+# a registration ACROSS this boundary — the member surfaces render only the
+# event's title and date, never the registration status, so a move *within* the
+# set rebuilds a byte-identical pass. A stale copy of this list would either
+# miss real changes or spend a capped refresh budget on no-ops.
+PASS_NEXT_EVENT_STATUSES = [*SEAT_HOLDING_STATUSES, "waitlist"]
+
 
 def build_wallet_pass_barcode_value(profile, request=None, base_url=None):
     """
@@ -38,7 +50,7 @@ def get_next_event_for_pass(profile):
         EventRegistration.objects.filter(
             user=profile.user,
             event__date_time__gte=MeetupEvent.live_lookback_cutoff(now),
-            status__in=[*SEAT_HOLDING_STATUSES, "waitlist"],
+            status__in=PASS_NEXT_EVENT_STATUSES,
         )
         # A cancelled event is not anybody's next event. Without this the
         # member card kept advertising it — and worse, cancelling an event

--- a/crush_lu/wallet_pass.py
+++ b/crush_lu/wallet_pass.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.utils import timezone
 
 from .models import ReferralCode, EventRegistration, MeetupEvent
@@ -29,6 +27,58 @@ def build_wallet_pass_barcode_value(profile, request=None, base_url=None):
     return build_referral_url(referral_code.code, base_url=base_url, language_neutral=True)
 
 
+def _next_event_candidates(user_ids, now):
+    """Registrations that could be the card's next event, earliest first.
+
+    Shared by the single-profile and bulk selectors below so the rule for what
+    a card may display lives in exactly one place. ``end_time`` cannot be part
+    of the SQL — it is ``date_time + duration_minutes``, and ``timedelta * F()``
+    is unsupported on SQLite — so this is the bounded pre-filter and callers
+    apply the precise check in Python.
+    """
+    return (
+        EventRegistration.objects.filter(
+            user_id__in=user_ids,
+            event__date_time__gte=MeetupEvent.live_lookback_cutoff(now),
+            status__in=PASS_NEXT_EVENT_STATUSES,
+        )
+        # A cancelled event is not anybody's next event. Without this the
+        # member card kept advertising it — and worse, cancelling an event
+        # rebuilt a byte-identical pass, so the refresh that cancellation
+        # triggers accomplished nothing.
+        .exclude(event__is_cancelled=True)
+        .select_related("event")
+        .order_by("event__date_time")
+    )
+
+
+def get_next_event_registrations(user_ids, now=None):
+    """Which registration each user's card is currently showing.
+
+    ``{user_id: EventRegistration}``, users with nothing to show omitted. One
+    query for the whole batch, which is the point: the admin bulk actions need
+    to know whether the row they are about to change is the one a holder's card
+    actually displays, and asking per holder would cost a query each.
+
+    That question matters because both wallet fan-outs are capped. A holder with
+    an earlier eligible registration is not showing this event, so refreshing
+    them writes a byte-identical object — and on the Google side the cap is a
+    hard loss, no poll heals what it skips, so each no-op can leave someone
+    whose card IS wrong stale for good.
+    """
+    now = now or timezone.now()
+    chosen = {}
+    for candidate in _next_event_candidates(user_ids, now):
+        # Ordered by start, so the first ELIGIBLE candidate per user wins. An
+        # earlier one that has already ended is skipped without claiming the
+        # slot — exactly what the single-profile selector does.
+        if candidate.user_id in chosen:
+            continue
+        if candidate.event.end_time >= now:
+            chosen[candidate.user_id] = candidate
+    return chosen
+
+
 def get_next_event_for_pass(profile):
     """
     Returns formatted next event info for wallet passes.
@@ -46,24 +96,10 @@ def get_next_event_for_pass(profile):
         }
     """
     now = timezone.now()
-    candidate_registrations = (
-        EventRegistration.objects.filter(
-            user=profile.user,
-            event__date_time__gte=MeetupEvent.live_lookback_cutoff(now),
-            status__in=PASS_NEXT_EVENT_STATUSES,
-        )
-        # A cancelled event is not anybody's next event. Without this the
-        # member card kept advertising it — and worse, cancelling an event
-        # rebuilt a byte-identical pass, so the refresh that cancellation
-        # triggers accomplished nothing.
-        .exclude(event__is_cancelled=True)
-        .select_related("event")
-        .order_by("event__date_time")
-    )
     registration = next(
         (
             candidate
-            for candidate in candidate_registrations
+            for candidate in _next_event_candidates([profile.user_id], now)
             if candidate.event.end_time >= now
         ),
         None,

--- a/crush_lu/wallet_pass.py
+++ b/crush_lu/wallet_pass.py
@@ -48,7 +48,16 @@ def _next_event_candidates(user_ids, now):
         # triggers accomplished nothing.
         .exclude(event__is_cancelled=True)
         .select_related("event")
-        .order_by("event__date_time")
+        # Tie-broken, not just sorted by start. Two eligible registrations
+        # sharing a `date_time` would otherwise be returned in whatever order
+        # the database felt like, and the choice has to be REPRODUCIBLE across
+        # queries: the single-user call builds the pass a holder is looking at,
+        # while the bulk call decides whether an admin action needs to refresh
+        # them. Disagree on a tie and the action skips a holder whose card
+        # really does show the changed event — stale for good, since Google
+        # never polls. It also keeps successive rebuilds of one card from
+        # flipping between two tied events.
+        .order_by("event__date_time", "event_id", "id")
     )
 
 


### PR DESCRIPTION
Follow-up to #764, which deferred this explicitly ([comment](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/pull/764#discussion_r3696697564)): `refresh_google_wallet_objects` shipped with exactly one caller, while every other path that already refreshes Apple serials left Google member objects stale. All of them change rows with `queryset.update()`, which emits no signals.

> **Rebased onto #765.** That PR landed the `duration_minutes` finding on `main` independently while this was in review, so this branch no longer claims it — see *Overlap with #765* at the bottom for what survived and why.

## The admin bulk actions

Three of the four deferred paths now schedule a Google refresh, **one batched call per admin action** rather than one per event or per registration — each helper opens its own budget, so calling it per item restarts the deadline N times and lets request time grow with the size of the selection.

Collection happens **before** each `.update()`: `restoring` and `affected` are lazy and keyed on the status about to be overwritten, and `cancel_events` needs it for a second reason — cancelled events are excluded from the next-event candidate set, so afterwards nobody would match. The quiz action dedupes by pk, since one holder can appear under two selected quizzes.

**Crossing a boundary is necessary but not sufficient**, which is what the first review round got wrong. A holder with an earlier eligible registration is not showing the event being changed, so refreshing them writes a byte-identical object — and the fan-out is capped, pk-ordered, with no Google-side poll behind it, so each no-op can push a genuinely-stale holder out of the batch and strand them for good. The cap is a hard loss, not a delay.

So each action now asks *is this the row the card is actually showing?* via a new `wallet_pass.get_next_event_registrations(user_ids)` — one query for the whole batch, sharing `_next_event_candidates` with `get_next_event_for_pass` so the display rule lives in one place:

| Action | Refreshes when |
|---|---|
| `cancel_events` | the holder's displayed event is in the selection (drops already-cancelled events for free — nobody is showing those either) |
| `confirm_registrations` | the restored event would *become* the displayed one (`<=` on start time, since ties are ordered by whatever the DB returns) |
| quiz no-show | the holder's displayed event is that quiz's |

Every narrowing is paired: the no-op case asserts nothing is scheduled, its mirror asserts the genuinely-changed case still is, so none of these can silently become "refresh nobody".

## `move_to_waitlist` deliberately gets none — this is 3 of 4

#764's reply named all four. The fourth turns out to be a no-op: **`waitlist` is inside the candidate set**, so the action moves a registration from one member of it to another and cannot change which event the card names — and the member surfaces render only title and date, never status. That is also why the Apple half there refreshes ticket serials only. `test_move_to_waitlist_leaves_google_alone` asserts the premise rather than assuming it.

## Also in here

**`update_all_google_wallet_passes`** looped the per-profile entry point, minting a fresh OAuth token and opening a fresh connection per pass. It now shares one of each, and stays **uncapped**: the bulk helper's limit and budget exist because that path runs inline in an admin request, while this is a maintenance sweep with no request attached — stopping early would leave passes stale with nothing left to finish them. Minting per profile used to make token expiry impossible, so the reuse carries a 45-minute re-mint.

**`signals._NEXT_EVENT_STATUSES` collapsed onto `wallet_pass.PASS_NEXT_EVENT_STATUSES`.** `main` currently carries three copies of the same list, two of them under "keep in sync" comments. A test pins them as the same object rather than equal ones.

## Overlap with #765

#765 fixed the same `duration_minutes` misfiling on `main` first. This branch takes **its** set and comment wholesale and drops the duplicate shortening test. What remains on top:

- **The gate.** `main` treats *every* duration edit as Google-relevant. Duration selects rather than renders, and selection only moves when the event crosses `end_time >= now` — so editing the length of a future event, the common admin action, fans out up to 50 synchronous PATCHes for byte-identical objects. `_google_relevant_changes` drops the field unless the boundary was actually crossed. It cannot under-fire: eligibility equal before and after means the event is on the card in both states, or off it in both, with title and date untouched. The **Apple** gate is deliberately untouched — duration drives `expirationDate`, which *is* rendered.
- One test change to `main`'s work: the parametrised `duration_minutes` case in `test_google_rendered_field_changes_do_patch` is misfiled by that test's own name (duration is not rendered) and, on a fixture event a week out, asserted that a byte-identical write must happen. Dropped with the reasoning inline; #765's dedicated shortening test plus the extending mirror here cover both directions properly.

The admin work and the sweep are disjoint from #765 entirely — it touched no admin file.

## Testing

`3028 passed, 22 skipped` on the full `crush_lu/tests` suite; changed files clean under ruff.

```bash
SECRET_KEY="test-only-not-a-real-key" DBHOST="" .venv/Scripts/python.exe -m pytest crush_lu/tests -n auto -o addopts="" -m "not playwright" -q
```

One subtlety worth a reviewer's eye: in `cancel_events` both conditions must sit in **one** `filter()` so they constrain the same registration row. Split across two calls Django joins the relation twice and sweeps in anyone holding a live registration for an unrelated event — mutation-tested, `test_cancel_events_matches_status_on_the_same_registration` catches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)