### PR TITLE
fix(payments): make a failed Premium confirmation findable instead of silent

### DIFF
--- a/crush_lu/tests/test_sumup_payments.py
+++ b/crush_lu/tests/test_sumup_payments.py
@@ -677,6 +677,132 @@ class PaymentCompletionRevalidationTests(SiteTestMixin, TestCase):
 
 
 @override_settings(ROOT_URLCONF="azureproject.urls_crush")
+class PremiumCompletionRevalidationTests(SiteTestMixin, TestCase):
+    """The same in-flight problem on the Premium side.
+
+    ``PremiumMembership.confirm()`` re-checks the coach's capacity under a row
+    lock and raises ValueError if it is gone. The completion handler cannot let
+    that pass silently: SumUp has captured the money by then.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(
+            username="prem-race@crush.lu",
+            email="prem-race@crush.lu",
+            password="password123",
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user, gender="F", location="Luxembourg"
+        )
+        coach_user = User.objects.create_user(
+            username="coach-race@crush.lu",
+            email="coach-race@crush.lu",
+            password="password123",
+            first_name="Robin",
+        )
+        # One seat only, so a single rival membership fills it.
+        self.coach = CrushCoach.objects.create(
+            user=coach_user,
+            is_active=True,
+            accepting_premium=True,
+            max_premium_members=1,
+        )
+        self.membership = PremiumMembership.objects.create(
+            user=self.user, coach=self.coach, status="pending"
+        )
+
+    def _tx(self, ref):
+        return PaymentTransaction.objects.create(
+            transaction_reference=ref,
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id=f"CHK_{ref}",
+            amount=Decimal("10.00"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PENDING,
+            purpose=PaymentTransaction.Purpose.PREMIUM_MEMBERSHIP,
+            user=self.user,
+            premium_membership=self.membership,
+        )
+
+    def _fill_the_coach(self):
+        rival = User.objects.create_user(
+            username="rival@crush.lu", email="rival@crush.lu", password="password123"
+        )
+        CrushProfile.objects.create(user=rival, gender="M")
+        PremiumMembership.objects.create(
+            user=rival, coach=self.coach, status="active", payment_confirmed=True
+        )
+
+    def test_payment_for_a_coach_that_filled_up_does_not_grant_premium(self):
+        """Charged, but the seat is gone — the money must stay on record and the
+        failure must be loud, because it needs a human to reassign or refund."""
+        from crush_lu.views_payments import _apply_paid_checkout
+
+        tx = self._tx("PREMFULL")
+        self._fill_the_coach()
+
+        with self.assertLogs("crush_lu.views_payments", level="ERROR") as logs:
+            with self.captureOnCommitCallbacks(execute=True):
+                _apply_paid_checkout(tx, {"status": "PAID"})
+
+        self.membership.refresh_from_db()
+        self.profile.refresh_from_db()
+        tx.refresh_from_db()
+
+        # Premium was NOT granted.
+        self.assertEqual(self.membership.status, "pending")
+        self.assertFalse(self.membership.payment_confirmed)
+        self.assertIsNone(self.profile.assigned_coach_id)
+        # ...but the charge is still on record so staff can act on it.
+        self.assertEqual(tx.status, PaymentTransaction.Status.PAID)
+        # ...and it is loud enough to find.
+        self.assertTrue(
+            any("Premium NOT granted" in line for line in logs.output),
+            logs.output,
+        )
+
+    def test_payment_on_a_cancelled_request_does_not_grant_premium(self):
+        """A request cancelled before the money lands must not be resurrected.
+
+        This one is caught by the outer ``status == "pending"`` guard rather
+        than by confirm(), so it logs nothing — confirm()'s own "only a pending
+        membership" ValueError is reachable only in a genuine race, where the
+        status flips between this read and confirm()'s locked re-read.
+        """
+        from crush_lu.views_payments import _apply_paid_checkout
+
+        tx = self._tx("PREMCANCEL")
+        self.membership.status = "cancelled"
+        self.membership.save(update_fields=["status"])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            _apply_paid_checkout(tx, {"status": "PAID"})
+
+        self.membership.refresh_from_db()
+        self.profile.refresh_from_db()
+        tx.refresh_from_db()
+        self.assertEqual(self.membership.status, "cancelled")
+        self.assertIsNone(self.profile.assigned_coach_id)
+        self.assertEqual(tx.status, PaymentTransaction.Status.PAID)
+
+    def test_normal_premium_payment_still_confirms(self):
+        """The ordinary path must still activate and assign the coach."""
+        from crush_lu.views_payments import _apply_paid_checkout
+
+        tx = self._tx("PREMHAPPY")
+        with self.captureOnCommitCallbacks(execute=True):
+            _apply_paid_checkout(tx, {"status": "PAID"})
+
+        self.membership.refresh_from_db()
+        self.profile.refresh_from_db()
+        self.assertEqual(self.membership.status, "active")
+        self.assertTrue(self.membership.payment_confirmed)
+        self.assertIsNotNone(self.membership.payment_date)
+        self.assertEqual(self.profile.assigned_coach_id, self.coach.id)
+
+
+@override_settings(ROOT_URLCONF="azureproject.urls_crush")
 class PaymentRaceAndStaleStateTests(SiteTestMixin, TestCase):
     """Round-4 Codex findings: stale reads, downgrades and stale amounts."""
 

--- a/crush_lu/views_payments.py
+++ b/crush_lu/views_payments.py
@@ -391,13 +391,42 @@ def _apply_paid_checkout(tx_obj, data):
         ):
             pm = locked.premium_membership
             if pm.status == "pending":
-                pm.payment_confirmed = True
-                pm.payment_date = timezone.now()
+                # No pre-setting of payment_confirmed/payment_date here.
+                # ``confirm()`` sets both itself on success, and on failure it
+                # raises *before* its own save(), so assigning them first only
+                # ever produced in-memory values that were silently discarded —
+                # which read like the money had been recorded on the membership
+                # when it had not. The charge is recorded on this
+                # PaymentTransaction either way; that is the money's home.
                 try:
                     pm.confirm()
                     logger.info("Confirmed PremiumMembership %s via SumUp", pm.id)
                 except ValueError as exc:
-                    logger.error("Could not confirm PremiumMembership %s: %s", pm.id, exc)
+                    # Same contract as the event-registration branch above:
+                    # SumUp has already captured the money by the time this
+                    # runs, so the transaction stays PAID — dropping it would
+                    # lose the only record of a real charge. What we refuse to
+                    # do is grant Premium.
+                    #
+                    # confirm() raises for two distinct reasons, and the
+                    # remedies differ: the chosen coach filled up while the
+                    # payment was in flight (reassign the member to a coach with
+                    # capacity — that keeps the sale), or the request stopped
+                    # being pending mid-flight, i.e. it was cancelled (refund).
+                    # Both need a human, so this is logged at error level with
+                    # the same "payment recorded, NOT granted" phrasing the
+                    # seat path uses, and carries the ids needed to act on it.
+                    logger.error(
+                        "SumUp payment %s completed for PremiumMembership %s "
+                        "(user=%s, coach=%s) but it could not be confirmed: %s "
+                        "— payment recorded, Premium NOT granted, coach "
+                        "reassignment or refund required.",
+                        locked.transaction_reference,
+                        pm.id,
+                        pm.user_id,
+                        pm.coach_id,
+                        exc,
+                    )
 
 
 def _sync_checkout_with_sumup(tx_obj):


### PR DESCRIPTION
## Purpose

* **A member could be charged for Premium and receive nothing, with no signal anyone would notice.** When SumUp reports a Premium checkout `PAID`, `_apply_paid_checkout` calls `PremiumMembership.confirm()`, which re-checks the coach's capacity under a row lock and raises `ValueError` if the seat went while the payment was in flight. The handler caught that into a bare one-line log and moved on.

* This became worth fixing now because #769 made the path *reachable*. Before it, `PREMIUM_REDIRECTS_TO_BETA` meant nobody could buy Premium at all, so only event seats could hit this class of failure. The first hand-picked tester to buy is the first real money through here.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

The path already refused to grant Premium and already kept the transaction `PAID`. What was missing was any way to find out it had happened.

## Pull Request Type

```
[x] Bugfix
```

## How to Test

```
git fetch origin
git checkout fix/premium-confirm-silent-failure
.venv/Scripts/Activate.ps1
```

```
pytest crush_lu/tests/test_sumup_payments.py --create-db
```

43 passed locally, exit 0. `ruff check` clean on both files.

## What to Check

* **The dead assignments are the subtler half.** `payment_confirmed` / `payment_date` were assigned on the instance immediately before `confirm()`. `confirm()` sets both itself on success, and on failure raises *before* its own `save()` — so those assignments only ever produced in-memory values that were discarded. Reading the old code it looked as though the payment had been recorded against the membership on the failure path; it never was. They're removed rather than persisted, because the charge's home is the `PaymentTransaction` row, which is unchanged.

* **The message now matches the convention already used ten lines above.** The event-registration branch handles the identical situation with an explicit *"payment recorded, seat NOT restored, refund required"* at error level. The Premium branch now says the same thing in the same shape and carries the checkout reference plus user and coach ids — acting on one of these means finding the charge in SumUp, which the old message gave you no way to do.

* **The two causes need different remedies, and the text says which.** A coach that filled up is fixable by reassigning the member to one with capacity, which keeps the sale. A request cancelled mid-flight needs a refund. Previously both produced the same opaque line.

* **New tests mirror the seat-side ones.** `PremiumCompletionRevalidationTests` is deliberately shaped like the existing `PaymentCompletionRevalidationTests`: a payment against a filled coach leaves the membership `pending` with no coach assigned, keeps the transaction `PAID`, and logs an error containing "Premium NOT granted"; the ordinary path still activates and assigns. Note the behavioural assertions would have passed before this change too — the one that discriminates is the log assertion, because the old text did not say that.

## Other Information

* The cancelled-request test is honest about its own limits: that case is caught by the outer `status == "pending"` guard rather than by `confirm()`, so it logs nothing. `confirm()`'s own *"only a pending membership"* `ValueError` is reachable only in a genuine race, where the status flips between that read and `confirm()`'s locked re-read — noted in the test docstring rather than faked.
* **Not addressed here, deliberately:** there is still no *alert*, only a log line. Matching the existing convention was the right scope for a fix; routing money-loss errors somewhere a human actually watches is a separate question that applies equally to the event-seat path.
* Related: #769, which opened Premium purchase to hand-picked beta testers.
