### PR TITLE
fix(payments): stop the global loading overlay burying the SumUp card form

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -1188,6 +1188,11 @@ SECURE_CSP_REPORT_ONLY = {
         "https://login.microsoftonline.com",
         # Azure Application Insights SDK
         "https://js.monitor.azure.com",
+        # SumUp card widget SDK — loaded by crush_lu/templates/crush_lu/
+        # payments/sumup_widget.html. Absent until 2026-08-02, which was
+        # invisible only because this policy is report-only; enforcing it
+        # without this line takes payments down.
+        "https://gateway.sumup.com",
     ],
     # Workers: qr-scanner's decode worker is spawned from a blob: URL
     # (vendored under crush_lu/static/crush_lu/vendor/qr-scanner/). Without
@@ -1271,6 +1276,9 @@ SECURE_CSP_REPORT_ONLY = {
         "https://*.fbcdn.net",
         # Apple Sign In
         "https://appleid.apple.com",
+        # SumUp — the widget calls the gateway directly from the browser
+        "https://gateway.sumup.com",
+        "https://api.sumup.com",
         # WebSocket for HTMX
         "wss:",
     ],
@@ -1290,6 +1298,14 @@ SECURE_CSP_REPORT_ONLY = {
         "https://player.vimeo.com",
         "https://open.spotify.com",
         "https://w.soundcloud.com",
+        # SumUp card widget: the card fields and the 3DS step are iframed.
+        # ⚠️ A 3DS challenge can hand off to the card issuer's own ACS domain,
+        # which is per-bank and cannot be enumerated here. So this line makes
+        # the widget work but does NOT prove 3DS survives enforcement — walk a
+        # real 3DS payment with the policy enforced before switching
+        # SECURE_CSP_REPORT_ONLY over to CONTENT_SECURITY_POLICY. Same caveat
+        # applies to "form-action", which is still CSP.SELF below.
+        "https://gateway.sumup.com",
     ],
     "form-action": [CSP.SELF],
     "base-uri": [CSP.SELF],

--- a/crush_lu/static/crush_lu/js/page-loading.js
+++ b/crush_lu/static/crush_lu/js/page-loading.js
@@ -14,6 +14,17 @@
     let isShowing = false;
     let lastHideTime = 0;
     const DEBOUNCE_TIME = 100; // ms to ignore rapid show calls after hide
+    // Hard ceiling on how long the overlay may stay up. Every hide path here is
+    // tied to a top-level navigation (load / pageshow / DOMContentLoaded), so a
+    // submit handled in JavaScript instead — a third-party widget that calls
+    // preventDefault and works inside iframes — shows the overlay and then never
+    // fires anything that takes it down. That is what happened on the SumUp
+    // payment page: the overlay covered the live card form, 3DS included, with
+    // no way past it. The opt-out below is the real fix; this is the backstop,
+    // because a full-screen cover that never lifts is the worst thing this file
+    // can do and it must not depend on getting the opt-out right everywhere.
+    const MAX_VISIBLE_TIME = 15000;
+    let watchdogTimeout = null;
 
     /**
      * Show loading overlay with delay to avoid flashing on fast loads
@@ -50,6 +61,15 @@
                 loadingOverlay.classList.add("show");
             }
         }, LOADING_DELAY);
+
+        // Arm the watchdog from the moment we decide to show, not from page
+        // load — the pre-existing "hide after 10s" fallback listens on `load`,
+        // which has long since fired by the time a click or submit shows the
+        // overlay, so it never rescued this case.
+        if (watchdogTimeout) {
+            clearTimeout(watchdogTimeout);
+        }
+        watchdogTimeout = setTimeout(hideLoadingOverlay, MAX_VISIBLE_TIME);
     }
 
     /**
@@ -63,6 +83,11 @@
         if (loadingTimeout) {
             clearTimeout(loadingTimeout);
             loadingTimeout = null;
+        }
+
+        if (watchdogTimeout) {
+            clearTimeout(watchdogTimeout);
+            watchdogTimeout = null;
         }
 
         // Hide overlay
@@ -82,7 +107,7 @@
             !link.href.includes("#") &&
             !link.hasAttribute("download") &&
             link.target !== "_blank" &&
-            !link.classList.contains("no-loading")
+            !link.closest(".no-loading")
         ); // Allow opt-out
     }
 
@@ -130,8 +155,11 @@
                 return;
             }
 
-            // Allow opt-out via no-loading class on the form
-            if (form && form.classList.contains("no-loading")) {
+            // Allow opt-out via a no-loading class on the form OR any ancestor.
+            // Ancestor matters: a third-party SDK renders its own form inside a
+            // container we control, so the class can only be put on the
+            // container — checking the form alone never matches.
+            if (form && form.closest && form.closest(".no-loading")) {
                 return;
             }
 

--- a/crush_lu/templates/crush_lu/payments/sumup_widget.html
+++ b/crush_lu/templates/crush_lu/payments/sumup_widget.html
@@ -21,8 +21,12 @@
         <!-- Payment errors reported by the widget (declined card, network, …) -->
         <p id="sumup-error" class="hidden text-sm text-rose-600 dark:text-rose-400 text-center mb-4" role="alert" aria-live="polite"></p>
 
-        <!-- SumUp Card Widget Mount Target -->
-        <div id="sumup-card-container" class="my-6 min-h-[280px] flex items-center justify-center">
+        <!-- SumUp Card Widget Mount Target.
+             `no-loading` opts this subtree out of the global navigation overlay
+             (page-loading.js). The SDK renders its own form in here and handles
+             submission in JavaScript, so the overlay would otherwise appear on
+             Pay and never come down, covering the card form and the 3DS step. -->
+        <div id="sumup-card-container" class="no-loading my-6 min-h-[280px] flex items-center justify-center">
             <div id="sumup-loading" class="text-center text-slate-400 py-8">
                 <svg class="animate-spin h-8 w-8 mx-auto text-rose-500 mb-2" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>


### PR DESCRIPTION
## Purpose

* **The SumUp card form was buried under the site's own loading overlay.** Observed on staging while walking a real checkout: after reaching the card screen, the page sat on "Laden… / Einen Moment" forever. That is *not* the widget's loader — the widget's says *"Loading secure SumUp payment checkout…"*. It was `page-loading.js` covering a live payment form, 3DS step included, with no way past it.

* **SumUp is in no CSP directive at all.** The browser is logging `script-src`, `frame-src` and `connect-src` violations for `gateway.sumup.com` on every visit to the widget. Harmless today because the policy is report-only — and exactly the kind of thing that stays invisible until someone flips it to enforcing, which `production.py:609` already names as the plan, and payments die on the spot.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
```

## How to Test

```
git fetch origin
git checkout fix/sumup-widget-overlay-and-csp
.venv/Scripts/Activate.ps1
```

```
pytest crush_lu/tests/test_sumup_payments.py crush_lu/tests/test_premium_membership.py --create-db
```

61 passed, exit 0. `manage.py check` clean.

**The real test is a browser walk on staging**, since the widget needs a live SumUp checkout session that cannot be created locally: reach the card screen, click Pay, and confirm the overlay no longer appears over the form.

## What to Check

* **Why it hangs.** `page-loading.js` listens for `submit` on the document in the **capture** phase and shows the overlay for any non-HTMX form. Every path that hides it again is tied to a *top-level navigation* — `load`, `pageshow`, `DOMContentLoaded`. The SumUp SDK takes the submit, calls `preventDefault`, and does the work in JavaScript and iframes. The top document never navigates, so nothing ever lifts the overlay.

* **The pre-existing 10s fallback does not cover this**, which is why it never rescued the page: it is armed from the `load` event, which fired minutes earlier, not from when the overlay appears. The new watchdog arms at show time instead.

* **The opt-out had to become ancestor-aware to be usable at all.** It previously checked `classList.contains("no-loading")` on the form itself — but the SDK renders *its own* form inside our container, so the class can only go on the container. Now `closest(".no-loading")`, for links and forms alike.

* **The watchdog is a backstop, not the fix.** A full-screen cover that never lifts is the worst thing this file can do, and it shouldn't depend on every page remembering the opt-out. The `no-loading` class on `#sumup-card-container` is the actual fix.

* **⚠️ The CSP change makes the widget work but does not prove 3DS survives enforcement.** A 3DS challenge can hand off to the card issuer's own ACS domain, which is per-bank and cannot be enumerated in a static allowlist. `form-action` is also still `CSP.SELF`. Both caveats are noted inline in `settings.py` — walk a real 3DS payment under an *enforcing* policy before switching `SECURE_CSP_REPORT_ONLY` to `CONTENT_SECURITY_POLICY`.

## Other Information

* **Ops, applied separately, not in this diff:** staging had `PREMIUM_REDIRECTS_TO_BETA=False`, so the beta funnel was off there and the premium coach directory rendered for *any* logged-in member. That means the staging walk could not exercise #769's allowlist at all — the guard short-circuits on the flag before `selected_as_tester` is ever consulted. Now set to `True` on the staging slot. It is slot-sticky (confirmed against `slotConfigNames`), so it cannot ride a swap into production.
* The `E402` ruff warnings on `settings.py` are pre-existing module-level imports at lines 106/210/1165, untouched here; CI's blocking gate is `E9,F63,F7,F82`.
* Related: #769 (purchase allowlist), #770 (silent Premium confirmation failure).
