### PR TITLE
fix(dashboard): read an explicit no_show as "Missed", not "Past"

### DIFF
--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -96,9 +96,12 @@
                                 {% comment %}
                                 The event is over and the seat was never scanned. A no-show
                                 keeps `confirmed` forever, so status alone would render it
-                                "Confirmed" -- live-looking -- months afterwards.
+                                "Confirmed" -- live-looking -- months afterwards. `no_show`
+                                is the same fact stated explicitly, set by the admin action
+                                mark_unattended_as_no_show, so both read "Missed" -- which is
+                                also what my_events calls it (views_events.py, entry.no_show).
                                 {% endcomment %}
-                                {% if registration.status == 'confirmed' %}
+                                {% if registration.status == 'confirmed' or registration.status == 'no_show' %}
                                     <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">{% trans "Missed" %}</span>
                                 {% else %}
                                     <span class="inline-flex items-center px-2.5 py-1 text-xs font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full">{% trans "Past" %}</span>

--- a/crush_lu/tests/test_dashboard_event_status.py
+++ b/crush_lu/tests/test_dashboard_event_status.py
@@ -11,7 +11,8 @@ Two defects these lock down (see crush_lu/templates/crush_lu/dashboard.html):
 
   2. The ticket CTA tested status but never the date. A no-show keeps
      ``confirmed`` forever, so an event months past kept rendering "Confirmed"
-     plus a live ticket button.
+     plus a live ticket button. A seat the admin explicitly flipped to
+     ``no_show`` reads "Missed" alongside it, the same word my_events uses.
 """
 
 from datetime import timedelta
@@ -105,6 +106,25 @@ class DashboardEventStatusTests(TestCase):
         response = self._get()
         self.assertContains(response, _badge("Missed"))
         self.assertNotContains(response, _badge("Confirmed"))
+        self.assertNotContains(
+            response, reverse("crush_lu:event_ticket", args=[event.id])
+        )
+
+    def test_past_no_show_reads_missed(self):
+        """`no_show` is the same fact as an unscanned `confirmed`, said aloud.
+
+        The admin action mark_unattended_as_no_show (crush_lu/admin/quiz.py)
+        flips still-`confirmed` and `pending` seats to `no_show` once the host
+        confirms nobody arrived. Falling through to "Past" here would tell the
+        member less than the untouched row next to it, and my_events already
+        calls this exact status "Missed" (views_events.py, entry.no_show).
+        """
+        event = _make_event("Marked absent", days_from_now=-60)
+        self._register(event, "no_show")
+
+        response = self._get()
+        self.assertContains(response, _badge("Missed"))
+        self.assertNotContains(response, _badge("Past"))
         self.assertNotContains(
             response, reverse("crush_lu:event_ticket", args=[event.id])
         )


### PR DESCRIPTION
## Purpose
* The past-event branch in the dashboard's "Your Events" list (`crush_lu/templates/crush_lu/dashboard.html`) mapped only `confirmed` to **"Missed"** and let every other status fall through to the vaguer **"Past"**. That swept up `no_show` — the status the admin action `mark_unattended_as_no_show` (`crush_lu/admin/quiz.py`) sets *deliberately*, once a host confirms nobody arrived. The row where staff recorded the absence therefore told the member **less** than the untouched `confirmed` row beside it.
* It also disagreed with `my_events.html`, which already calls this exact status "Missed" (`crush_lu/views_events.py`: `entry["no_show"] = reg.status == "no_show"`). Two surfaces, same registration, different words.
* The condition now reads `confirmed or no_show` → "Missed". `"Missed"` is already in the FR and DE catalogues (the `confirmed` branch uses the same string), so there is no new translation work and no `.po`/`.mo` churn.

Based on `fix/dashboard-registration-status` (#783), which introduced the `is_past` branch this refines.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout claude/dashboard-registration-status-ye0qjd
```

* Test the code

```
pytest crush_lu/tests/test_dashboard_event_status.py
```

Manually: register a member for an event whose `end_time` is in the past, run the **"Mark unattended as no-show"** admin action on it (or set `status="no_show"` directly), then load `/dashboard/`.

## What to Check
Verify that the following are valid
* A past registration with `status="no_show"` renders the **"Missed"** pill, not "Past", and offers no ticket button — covered by the new `test_past_no_show_reads_missed`.
* A past `confirmed` registration still reads "Missed" (unchanged), and past `pending` / `waitlist` still read "Past" — the existing cases in the same file are untouched and still pass.
* The dashboard and `my_events` now use the same word for the same registration.

## Other Information
* The Django suite could not be run in this environment — PyPI is blocked by the network policy (`pip install` returns 403), so Django isn't installable here. Both files were validated statically instead: `py_compile` on the test module, and a tag-balance check on the template confirming the `{% if %}`/`{% endif %}`/`{% comment %}` nesting is intact and no multi-line `{# #}` was introduced (the existing `test_no_template_comment_leaks_into_the_page` guards this at runtime). CI runs the real suite.
* Out of scope, noted while working: a `no_show` on an event that is **not yet** past falls through every badge branch and renders no pill at all. That predates this change and isn't reachable via the admin action in normal use, so it's left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCvMcVFAyTaEAXYWTtd6fH)_