### PR TITLE
fix(dashboard): stop the lobby CTA overflowing its card on mobile

### DIFF
--- a/crush_lu/templates/crush_lu/components/event_lobby_cta.html
+++ b/crush_lu/templates/crush_lu/components/event_lobby_cta.html
@@ -8,28 +8,38 @@ per-user state computed by services.event_lobby.lobby_cta():
                       the static feature promo is a separate component
                       (event_lobby_promo.html).
   event  (required) — the MeetupEvent (drives the lobby URL).
-  block  (optional) — truthy: full-width hero style for event detail / ticket
+  hero   (optional) — truthy: full-width hero style for event detail / ticket
                       pages; omitted: compact list-card button.
+
+NEVER rename `hero` back to `block`. Django's {% block %} tag puts the
+BlockNode itself into the context under the name `block` (that is what makes
+{{ block.super }} work), so inside any {% block content %} — i.e. on every page
+that extends base.html — {% if hero %} is unconditionally TRUE. Under that name
+the compact branch was dead code on every real surface: the hero button rendered
+in the dashboard/my_events/attendees list cards and overflowed the card on
+mobile. Rendering this component standalone via render_to_string() does NOT
+reproduce it, because there is no enclosing {% block %} — so component-level
+tests pass while the page is broken. Assert on the rendered PAGE.
 
 Disclosure rules (§5.3 as amended 2026-07-18) live entirely in the service —
 callers pass the computed state through and never re-derive eligibility.
 {% endcomment %}
 {% if cta == "enter_live" %}
     <a href="{% url 'crush_lu:event_lobby' event.id %}"
-       class="{% if block %}flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-crush-purple to-crush-pink text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base{% else %}btn-crush-solid inline-flex items-center justify-center gap-2 text-sm px-3 py-2{% endif %}">
-        <span class="inline-block w-2 h-2 rounded-full {% if block %}bg-white{% else %}bg-crush-pink{% endif %} animate-pulse" aria-hidden="true"></span>
-        {% if block %}{% trans "Event Lobby is live" %}{% else %}{% trans "Event Lobby" %}{% endif %}
+       class="{% if hero %}flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-crush-purple to-crush-pink text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base{% else %}btn-crush-solid inline-flex items-center justify-center gap-2 text-sm px-3 py-2{% endif %}">
+        <span class="inline-block w-2 h-2 rounded-full {% if hero %}bg-white{% else %}bg-crush-pink{% endif %} animate-pulse" aria-hidden="true"></span>
+        {% if hero %}{% trans "Event Lobby is live" %}{% else %}{% trans "Event Lobby" %}{% endif %}
     </a>
 {% elif cta == "enter_recap" %}
     <a href="{% url 'crush_lu:event_lobby' event.id %}"
-       class="{% if block %}flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-crush-purple to-crush-pink text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base{% else %}btn-crush-solid inline-flex min-w-0 w-40 max-w-full items-center justify-center gap-2 px-3 py-2 text-center text-sm sm:w-auto sm:max-w-none{% endif %}">
+       class="{% if hero %}flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-crush-purple to-crush-pink text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base{% else %}btn-crush-solid inline-flex min-w-0 w-40 max-w-full items-center justify-center gap-2 px-3 py-2 text-center text-sm sm:w-auto sm:max-w-none{% endif %}">
         {% include "shared/icons/heart.html" with class="w-4 h-4 shrink-0" %}
         {% trans "Confirm who you met" %}
     </a>
 {% elif cta == "finish_connect" %}
     <a href="{% url 'crush_lu:crush_connect_onboarding' %}?event_id={{ event.pk }}"
-       class="{% if block %}flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-crush-purple to-crush-pink text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base{% else %}btn-crush-solid inline-flex items-center justify-center gap-2 text-sm px-3 py-2{% endif %}">
+       class="{% if hero %}flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-crush-purple to-crush-pink text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base{% else %}btn-crush-solid inline-flex items-center justify-center gap-2 text-sm px-3 py-2{% endif %}">
         {% include "shared/icons/sparkles.html" with class="w-4 h-4" %}
-        {% if block %}{% trans "Finish Crush Connect to join the Event Lobby" %}{% else %}{% trans "Finish Crush Connect" %}{% endif %}
+        {% if hero %}{% trans "Finish Crush Connect to join the Event Lobby" %}{% else %}{% trans "Finish Crush Connect" %}{% endif %}
     </a>
 {% endif %}

--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -65,10 +65,12 @@
     {% for action in post_event_actions %}
     <div class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-crush-purple/40 bg-purple-50 dark:bg-purple-900/20 px-4 py-3">
         <p class="text-xs sm:text-sm font-semibold text-crush-purple dark:text-purple-200 mb-0 min-w-0 flex-1">{{ action.event.title }}</p>
-        {# No flex-shrink-0 here: it pins this group to its max-content width, so a
-           flex-wrap container never feels the pressure that makes it wrap and the
-           buttons run past the card edge on mobile (up to three of them + a long
-           localised label). Let it shrink and wrap instead. #}
+        {% comment %}
+        No flex-shrink-0 here: it pins this group to its max-content width, so a
+        flex-wrap container never feels the pressure that makes it wrap and the
+        buttons run past the card edge on mobile (up to three of them + a long
+        localised label). Let it shrink and wrap instead.
+        {% endcomment %}
         <div class="flex flex-wrap gap-2">
             {% include "crush_lu/components/event_lobby_cta.html" with cta=action.lobby_cta event=action.event %}
             {% if action.show_quiz %}

--- a/crush_lu/templates/crush_lu/dashboard.html
+++ b/crush_lu/templates/crush_lu/dashboard.html
@@ -65,7 +65,11 @@
     {% for action in post_event_actions %}
     <div class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-crush-purple/40 bg-purple-50 dark:bg-purple-900/20 px-4 py-3">
         <p class="text-xs sm:text-sm font-semibold text-crush-purple dark:text-purple-200 mb-0 min-w-0 flex-1">{{ action.event.title }}</p>
-        <div class="flex flex-wrap gap-2 flex-shrink-0">
+        {# No flex-shrink-0 here: it pins this group to its max-content width, so a
+           flex-wrap container never feels the pressure that makes it wrap and the
+           buttons run past the card edge on mobile (up to three of them + a long
+           localised label). Let it shrink and wrap instead. #}
+        <div class="flex flex-wrap gap-2">
             {% include "crush_lu/components/event_lobby_cta.html" with cta=action.lobby_cta event=action.event %}
             {% if action.show_quiz %}
             <a href="{% url 'crush_lu:quiz_live' action.event.id %}" class="inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm font-semibold bg-crush-purple hover:bg-crush-purple-dark text-white rounded-lg transition-all">

--- a/crush_lu/templates/crush_lu/event_detail.html
+++ b/crush_lu/templates/crush_lu/event_detail.html
@@ -380,7 +380,7 @@
                 {# Prominent action buttons for attended users #}
                 {% if user.is_authenticated and user_registration and user_registration.status == 'attended' %}
                 <div class="space-y-3 mb-6">
-                    {% include "crush_lu/components/event_lobby_cta.html" with cta=event_lobby_cta event=event block=True %}
+                    {% include "crush_lu/components/event_lobby_cta.html" with cta=event_lobby_cta event=event hero=True %}
                     {% if event.quiz_join_available %}
                     <a href="{% url 'crush_lu:quiz_live' event.id %}" class="flex items-center justify-center gap-2 w-full py-3 sm:py-4 px-4 bg-gradient-to-r from-purple-600 to-pink-500 text-white font-semibold rounded-lg transition-all hover:shadow-lg text-sm sm:text-base">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>

--- a/crush_lu/templates/crush_lu/event_ticket.html
+++ b/crush_lu/templates/crush_lu/event_ticket.html
@@ -80,7 +80,7 @@
                     </div>
                     {% if lobby_cta and lobby_cta != "promo_only" %}
                     <div class="mb-4">
-                        {% include "crush_lu/components/event_lobby_cta.html" with cta=lobby_cta event=event block=True %}
+                        {% include "crush_lu/components/event_lobby_cta.html" with cta=lobby_cta event=event hero=True %}
                     </div>
                     {% endif %}
                 {% endif %}

--- a/crush_lu/tests/test_event_lobby.py
+++ b/crush_lu/tests/test_event_lobby.py
@@ -1427,9 +1427,43 @@ class TestLobbyCta:
 
         full_width = render_to_string(
             "crush_lu/components/event_lobby_cta.html",
-            {"cta": lobby.CTA_ENTER_RECAP, "event": event, "block": True},
+            {"cta": lobby.CTA_ENTER_RECAP, "event": event, "hero": True},
         )
         assert "w-full" in full_width
+
+    def test_dashboard_recap_cta_is_the_compact_variant(self, client):
+        """The hero variant must not leak into the dashboard action strip.
+
+        This asserts on the rendered PAGE, not on the component: the flag that
+        selects the variant used to be called `block`, and Django puts a truthy
+        BlockNode in the context under that exact name inside every
+        {% block %}. render_to_string() has no enclosing block, so the
+        component-level test above kept passing while every real surface
+        rendered the full-width hero button and overflowed the card on mobile.
+        """
+        member = _make_member("cta_compact")
+        event = _make_event()
+        _join(member, event)
+        _end_event(event)  # recap phase — this is what yields enter_recap
+        _login(client, member)
+
+        response = client.get(reverse("crush_lu:dashboard"))
+
+        assert response.status_code == 200
+        lobby_url = reverse("crush_lu:event_lobby", kwargs={"event_id": event.pk})
+        anchor = re.search(
+            rf'<a[^>]*href="{re.escape(lobby_url)}"[^>]*>',
+            response.content.decode(),
+        )
+        assert anchor is not None, "recap CTA missing from the dashboard strip"
+        tag = anchor.group(0)
+        # "w-full" is useless as a discriminator here — the compact variant
+        # carries max-w-full. Match on the markers unique to each variant.
+        assert "btn-crush-solid" in tag, f"expected the compact variant, got: {tag}"
+        assert "w-40" in tag, f"expected the compact variant, got: {tag}"
+        assert (
+            "bg-gradient-to-r" not in tag
+        ), f"hero variant leaked onto the dashboard: {tag}"
 
     def test_dashboard_attendee_action_is_labelled_my_crush(self, client):
         member = _make_member("cta_dashboard", membership=False, luxid=False)


### PR DESCRIPTION
## Purpose

The recap CTA ("Confirm who you met") ran ~57px past the right edge of the dashboard action strip on a 444px viewport, and gave the whole page a 25px horizontal scroll. Two independent causes.

**1. `block` is a reserved name in the template context.**

Django's `{% block %}` tag puts the BlockNode into the context under the name `block` — that is what makes `{{ block.super }}` work — so inside `{% block content %}`, i.e. on every page extending `base.html`, `{% if block %}` is **unconditionally true**.

`event_lobby_cta.html` used `block` to choose between a full-width hero button and a compact list-card button, so **the compact branch was dead code on every real surface**: dashboard, my_events and event_attendees all rendered the hero. Renamed the parameter to `hero`.

This also explains 3c457e85 ("fix crush mobile CTA"), which added `w-40 max-w-full sm:w-auto` to the compact branch — a fix to a branch that never executed. It is on prod today, doing nothing.

It hid because `render_to_string()` renders the component with **no enclosing `{% block %}`**, so `block` really is absent there and the compact branch renders. The component-level test passed while every page was broken. Replaced with a test that asserts on the rendered dashboard **page**.

**2. `flex-wrap` + `flex-shrink-0` on the same element never wraps.**

`flex-shrink-0` pins the button group to its max-content width, so it never feels the pressure that would make it wrap. Renaming alone still left 37px hanging off the card.

Measured on staging (`test.crush.lu`) at 444px:

| | overflow | page h-scroll |
|---|---|---|
| As deployed | 57.5px | 25px |
| Rename only | 37.3px | 6px |
| Both fixes | **-0.5px** | **0** |

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
git checkout fix/lobby-cta-block-context-collision
pytest crush_lu/tests/test_event_lobby.py crush_lu/tests/test_lobby_funnel.py crush_lu/tests/test_dashboard_event_status.py
```

`154 passed` locally (deselecting `TestLobbyPhoto`, which reaches real Azure Blob storage when `.env` carries live credentials — unrelated to this change).

Manually: open the dashboard at a ~450px viewport as a member with an attended event whose recap window is still open, so the post-event action strip renders.

## What to Check

* The dashboard action strip keeps all of its buttons inside the card at mobile widths, and the page has no horizontal scroll.
* **`my_events` and `event_attendees` were also rendering the hero button and now get the compact one.** That is the component's documented intent, but it is a visible change on those two pages and worth a look.
* `event_detail` and `event_ticket` still get the full-width hero button — they are the two call sites that legitimately pass the flag (now `hero=True`).

## Other Information

The new test `test_dashboard_recap_cta_is_the_compact_variant` deliberately asserts against the rendered page rather than the component, because the component renders correctly in isolation. `max-w-full` contains the substring `w-full`, so the two variants are discriminated on `btn-crush-solid` (compact) vs `bg-gradient-to-r` (hero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
