### PR TITLE
Close the delete-path races Codex found after #800 merged

### DIFF
--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -957,6 +957,22 @@ def withdraw_event(event, client=None, dry_run=False, explicit=False):
         event.refresh_from_db()
         event.echo_sync = sync
 
+        # The re-read can also say the take-down is not wanted at all any
+        # more. An automatic withdrawal decided from an older save can queue
+        # behind a sync that republished the listing and left it correct;
+        # going ahead unpublishes what that newer save just put up and writes
+        # WITHDRAWN over its SYNCED, so the listing stays missing until the
+        # next hourly sweep notices. This is the mirror of the publish path's
+        # own "no longer ours to publish" check, which this side lacked.
+        #
+        # Only automatic take-downs abort. An `explicit` one is a person
+        # removing a listing whose event still qualifies — that is precisely
+        # what it is for — and `removal_requested` is that same instruction
+        # surviving a failed attempt, so neither may be talked out of it by
+        # eligibility coming back.
+        if not explicit and not sync.removal_requested and should_publish(event):
+            return "skipped"
+
         # `explicit` overrides the cancellation notice as well. Somebody asking
         # to remove a listing means remove it — leaving a public notice up
         # because the event also happens to be cancelled ignores the

--- a/crush_lu/signals.py
+++ b/crush_lu/signals.py
@@ -1055,15 +1055,45 @@ def withdraw_from_echo_lu_before_delete(sender, instance, **kwargs):
 
     So the id is captured here, where it is readable, and the take-down itself
     happens after the delete commits — see
-    :func:`_withdraw_deleted_echo_listing`. Nothing here touches the network
-    or the database: this fires once per instance for *any* delete reaching
-    this model, including Django's stock bulk action and any cascade from
-    somewhere else, so it has to stay cheap.
+    :func:`_withdraw_deleted_echo_listing`. No network here; this fires once
+    per instance for *any* delete reaching this model, including Django's
+    stock bulk action and any cascade from somewhere else.
+
+    The row is read **under its own lock**, not off the instance. Two things
+    went wrong with the plain attribute read:
+
+    * ``instance.echo_sync`` can be a cached copy from whenever the event was
+      loaded, and an id written since would not be on it.
+    * Even a fresh unlocked read sees only committed state. A first publish
+      holds this row locked across its POST, so a delete racing it reads the
+      pre-create blank id, concludes there is no listing, and schedules
+      nothing — then the cascade waits for that lock, deletes the row the
+      winner just wrote the id into, and the new listing is public with
+      nothing left that can name it. The lock is not an extra cost: the
+      cascade's own DELETE takes it moments later regardless, so this only
+      moves the wait earlier, to where the answer still matters.
     """
+    from .models.echo_lu import EchoExperienceSync
     from .services import echo_lu
 
-    sync = getattr(instance, "echo_sync", None)
+    sync = EchoExperienceSync.objects.select_for_update().filter(event=instance).first()
     if sync is None or not sync.experience_id:
+        return
+    # Already confirmed down, and the id is kept on purpose so a republish
+    # reuses the listing — so there is nothing to take down and dialling anyway
+    # spends the batch's shared budget on a no-op. That is not merely wasteful:
+    # enough already-down events ahead of a live one in a bulk delete push its
+    # callback past the budget, and its row is gone by then.
+    #
+    # CANCELLED is deliberately NOT in this set. That listing is still on
+    # display — a public notice with title, venue and date — and the delete is
+    # the last moment anything can take it down. FAILED is not either: the last
+    # attempt failed, so whether the listing is up is exactly what we do not
+    # know, and a failed take-down means it certainly is.
+    if sync.status in (
+        EchoExperienceSync.Status.WITHDRAWN,
+        EchoExperienceSync.Status.SUPPRESSED,
+    ):
         return
     if not echo_lu.is_sync_enabled():
         logger.warning(

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -2060,6 +2060,64 @@ class WithdrawnThenCancelledTests(TestCase):
 
 
 @override_settings(**ENABLED)
+class StaleWithdrawalTests(TestCase):
+    """The withdraw path lacked the publish path's own "never mind" check."""
+
+    def test_an_automatic_withdrawal_aborts_if_the_event_became_eligible(self):
+        # An automatic take-down decided from an older save can queue behind a
+        # sync that republished the listing and left it correct. Going ahead
+        # unpublishes what that newer save just put up and writes WITHDRAWN
+        # over its SYNCED, so the listing stays missing for up to an hour.
+        event = make_event()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+
+        # Stand in for the caller that decided to withdraw: its copy says
+        # unpublished, while the winner has since republished the event.
+        stale = MeetupEvent.objects.get(pk=event.pk)
+        stale.is_published = False
+        self.assertTrue(MeetupEvent.objects.get(pk=event.pk).is_published)
+
+        client = FakeClient()
+        self.assertEqual(echo_lu.withdraw_event(stale, client=client), "skipped")
+        self.assertEqual(client.calls, [])
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.SYNCED)
+
+    def test_an_explicit_withdrawal_is_not_talked_out_of_it(self):
+        # The whole point of an explicit take-down is that it removes a
+        # listing whose event still qualifies, so eligibility must not abort
+        # it — otherwise the coach's Remove action would become a no-op on
+        # exactly the events they use it for.
+        event = make_event()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+
+        client = FakeClient()
+        self.assertEqual(
+            echo_lu.withdraw_event(event, client=client, explicit=True),
+            "withdrawn",
+        )
+        self.assertEqual([call[0] for call in client.calls], ["unpublish"])
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.SUPPRESSED)
+
+    def test_a_pending_removal_still_goes_through(self):
+        # `removal_requested` is an explicit instruction that survived a failed
+        # attempt. The retry arrives with the event still saying "publish me" —
+        # that is the state the flag exists for — so it must not abort either.
+        event = make_event()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+        EchoExperienceSync.objects.filter(event=event).update(removal_requested=True)
+        event = MeetupEvent.objects.select_related("echo_sync").get(pk=event.pk)
+
+        client = FakeClient()
+        self.assertEqual(echo_lu.withdraw_event(event, client=client), "withdrawn")
+        self.assertEqual([call[0] for call in client.calls], ["unpublish"])
+
+
+@override_settings(**ENABLED)
 class DeleteEventTests(TestCase):
     """Deleting the event destroys the only record of the listing's id."""
 
@@ -2213,6 +2271,67 @@ class DeleteEventTests(TestCase):
         with mock.patch.object(echo_lu, "EchoLuClient", return_value=client):
             self._delete(event)
         self.assertEqual(client.calls, [])
+
+    def test_an_already_withdrawn_listing_is_not_taken_down_again(self):
+        # The id is kept on a withdrawn row on purpose, so "has an id" is not
+        # "is up". Dialling anyway spends the batch's shared budget on a no-op,
+        # and in a bulk delete enough of them push a live listing's callback
+        # past the budget — after its row is gone.
+        event = make_event()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+        event.is_published = False
+        event.save()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.WITHDRAWN)
+
+        client = FakeClient()
+        with mock.patch.object(echo_lu, "EchoLuClient", return_value=client):
+            self._delete(event)
+        self.assertEqual(client.calls, [])
+
+    def test_a_cancelled_notice_is_still_taken_down_on_delete(self):
+        # The counter-case, and the reason the skip above is a two-item list
+        # rather than "anything not synced": a cancelled listing is still on
+        # public display, and the delete is the last moment anything can reach
+        # it. Miss this and the country keeps a cancellation notice for an
+        # event that no longer exists.
+        event = make_event()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+        MeetupEvent.objects.filter(pk=event.pk).update(is_cancelled=True)
+        event.refresh_from_db()
+        echo_lu.sync_event(event, client=FakeClient())
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.CANCELLED)
+
+        client = FakeClient()
+        with mock.patch.object(echo_lu, "EchoLuClient", return_value=client):
+            self._delete(event)
+        self.assertEqual([call[0] for call in client.calls], ["unpublish"])
+
+    def test_an_id_written_since_the_event_was_loaded_is_still_found(self):
+        # The receiver used to read `instance.echo_sync`, which can be a copy
+        # cached when the event was loaded. A first publish that lands after
+        # that — it holds the row locked across its POST, so a racing delete
+        # reads the pre-create blank id — left the receiver concluding there
+        # was no listing, and the cascade then deleted the row the winner had
+        # just written the id into. Reading the row fresh, under its lock, is
+        # what makes the answer current.
+        event = make_event()
+        stale = EchoExperienceSync.objects.create(event=event)
+        event.echo_sync = stale  # the copy from before the create landed
+        EchoExperienceSync.objects.filter(pk=stale.pk).update(
+            experience_id="exp-late", status=EchoExperienceSync.Status.SYNCED
+        )
+        self.assertEqual(event.echo_sync.experience_id, "")
+
+        client = FakeClient()
+        with mock.patch.object(echo_lu, "EchoLuClient", return_value=client):
+            self._delete(event)
+
+        self.assertEqual(client.calls, [("unpublish", "exp-late")])
 
     @override_settings(ECHO_LU_SYNC_ENABLED=False)
     def test_a_disabled_environment_still_names_the_stranded_listing(self):


### PR DESCRIPTION
## Purpose

Codex filed its review of `9e477541` **three minutes after #800 was merged**, so its last three findings landed on `main` unreviewed. This closes them.

All three are **inert today** — `ECHO_LU_SYNC_ENABLED` is false and `DJANGO_ECHO_SYNC_URL` is unset, so no entry point does anything. All three are also real; I reproduced each against `aacdffc8` before writing a line.

| | Finding | Consequence |
| --- | --- | --- |
| P1 | `pre_delete` scheduled a take-down for rows already `WITHDRAWN`/`SUPPRESSED` | those keep their id on purpose, so each no-op call spends the batch's shared budget — enough of them ahead of a live listing push its callback past the budget, after its row is gone |
| P1 | `pre_delete` read `instance.echo_sync` unlocked | a delete racing a first publish reads the pre-create blank id, schedules nothing, then the cascade deletes the row the winner just wrote the id into — listing public, no local handle |
| P2 | `withdraw_event` re-read the event under the lock but acted unconditionally | an automatic take-down could unpublish a listing a concurrent sync had just republished, writing `WITHDRAWN` over its `SYNCED` |

## What to check

- **The skip set is exactly `{WITHDRAWN, SUPPRESSED}`.** `CANCELLED` must still schedule — that listing is on public display as a notice with title, venue and date, and the delete is the last moment anything can reach it. `FAILED` must still schedule — whether the listing is up is precisely what a failure leaves unknown, and a failed take-down means it certainly is.
- **The lock in `pre_delete` is not new database work.** `getattr(instance, "echo_sync", None)` already queried unless cached; this replaces a plain SELECT with a locking one. The cascade's own DELETE takes that same row lock moments later regardless, so the wait only moves earlier — to where the answer still matters.
- **The withdrawal abort exempts `explicit` and `removal_requested`.** Removing a listing whose event still qualifies is exactly what the coach's Remove action is for, and `removal_requested` is that instruction surviving a failed attempt. Both would become no-ops if eligibility could veto them. Two tests guard this.

## Testing

```
pytest crush_lu/tests/test_echo_lu_sync.py
```

158 tests. Six are new; the three targeting these paths were each run against `aacdffc8` and fail there with the expected symptom (`'withdrawn' != 'skipped'`, a redundant `unpublish`, and a missed `exp-late`). The other three pin the exemptions above.

One pre-existing local failure, `test_coach_event_detail.py::TestCoachLobbyPreview::test_preview_can_load_roster_photos`, fails on unmodified `main` too and is unrelated.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
[ ] Feature
```

## Still open before `ECHO_LU_SYNC_ENABLED` goes true

Not in this PR, tracked from the #800 review: `--audit` does not paginate; `parse_address` can publish an empty street; `ECHO_LU_CONTACT_EMAIL` defaults to a mailbox that may not exist; `languages`/`tags` are sent unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)