### PR TITLE
Fix parse_address dropping the street and misreading the postcode

### DIFF
--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -424,6 +424,13 @@ _NON_STREET_PREFIXES = (
     "room",
     "chambre",
 )
+# French ordinal floor notation ("2e étage", "3ème étage", "1er étage") — the
+# noun follows the ordinal, so `startswith` on its own misses it and the
+# leading "2e" matches the house-number regex. Match the whole phrase instead.
+_ORDINAL_FLOOR_RE = re.compile(
+    r"\d+\s*(?:er|re|ème|eme|e|st|nd|rd|th)?\s*(?:étage|etage|floor|stage)",
+    re.IGNORECASE,
+)
 
 
 def _looks_like_street(line):
@@ -438,6 +445,8 @@ def _looks_like_street(line):
         return False
     lowered = line.lower()
     if lowered.startswith(_NON_STREET_PREFIXES):
+        return False
+    if _ORDINAL_FLOOR_RE.search(lowered):
         return False
     if _LEADING_NUMBER_RE.match(line) or _TRAILING_NUMBER_RE.search(line):
         return True
@@ -472,15 +481,21 @@ def parse_address(address, canton=""):
 
     # Locate the postcode. Preference order, strongest first:
     #   1. An "L-"-prefixed four-digit group anywhere.
-    #   2. A bare four-digit group on the LAST line — a real postcode+town line
-    #      is almost always final, while a digit-led venue name sits on line 0.
-    #   3. Any bare four-digit group (last one wins, same reason as #2).
+    #   2. A bare four-digit group that stands alone on its own line (the shape
+    #      a real "4620 Differdange" postcode+town line takes) — preferred over
+    #      a four-digit group embedded inside a longer line (the shape a
+    #      digit-led venue name like "1535 Creative Hub" or a trailing
+    #      free-text line like "Depuis 1920" takes).
+    #   3. Any bare four-digit group (last standalone wins, else last overall).
     # This stops "1535 Creative Hub" stealing the postcode from "4620
-    # Differdange" when the real postcode has no "L-" prefix.
+    # Differdange" when the real postcode has no "L-" prefix, and also stops a
+    # trailing "Depuis 1920" line stealing it from a real bare postcode.
     postcode_index = None
     postcode_match = None
     prefixed_match = None
     prefixed_index = None
+    standalone_match = None
+    standalone_index = None
     bare_match = None
     bare_index = None
     for index, line in enumerate(lines):
@@ -490,14 +505,35 @@ def parse_address(address, canton=""):
             prefixed_index = index
         bare = _POSTCODE_RE.search(line)
         if bare:
-            # Keep the last bare match — it's the most likely to be the real
-            # postcode line rather than a digit-led venue name above it.
             bare_match = bare
             bare_index = index
+            # A postcode that is the whole line (modulo whitespace) is the
+            # strongest bare signal — record the most recent such match.
+            if line.strip() == bare.group(0).strip() or _POSTCODE_RE.fullmatch(
+                line.strip()
+            ):
+                standalone_match = bare
+                standalone_index = index
+
+    if standalone_match is None:
+        # No line stood alone; fall back to preferring the last bare match on
+        # its own line over the last bare match overall (a real postcode+town
+        # line is almost always final, while a digit-led venue name is early).
+        for index, line in enumerate(lines):
+            bare = _POSTCODE_RE.search(line)
+            if bare and bare.group(0) in line:
+                # Prefer a line whose postcode token is at the start — that's
+                # the shape "4620 Differdange" takes, vs. "Depuis 1920".
+                if line.strip().startswith(bare.group(0).strip()):
+                    standalone_match = bare
+                    standalone_index = index
 
     if prefixed_match is not None:
         postcode_index = prefixed_index
         postcode_match = prefixed_match
+    elif standalone_match is not None:
+        postcode_index = standalone_index
+        postcode_match = standalone_match
     elif bare_match is not None:
         postcode_index = bare_index
         postcode_match = bare_match

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -406,6 +406,47 @@ def _absolute_media_url(url):
     return f"https://crush.lu{url}"
 
 
+# Lines that designate a unit/floor/room inside a building, not a street. When
+# such a line sits directly above the postcode line it must NOT be promoted to
+# the street — doing so fabricates a house number from an unrelated designation
+# and sends people to the wrong door, the exact failure this parser avoids.
+_NON_STREET_PREFIXES = (
+    "suite",
+    "floor",
+    "étage",
+    "etage",
+    "apt",
+    "apartment",
+    "unit",
+    "bureau",
+    "bts",  # basement
+    "office",
+    "room",
+    "chambre",
+)
+
+
+def _looks_like_street(line):
+    """Decide whether a candidate line above the postcode is the street.
+
+    True when the line carries a house number (the strong signal), or when it is
+    a non-unit/floor designation that is not just a postcode repeat. A bare
+    name like "rue du Nord" (no number) still counts, but "Suite 12" or
+    "2e étage" does not.
+    """
+    if not line:
+        return False
+    lowered = line.lower()
+    if lowered.startswith(_NON_STREET_PREFIXES):
+        return False
+    if _LEADING_NUMBER_RE.match(line) or _TRAILING_NUMBER_RE.search(line):
+        return True
+    # A line with no digits at all and no unit prefix reads like a street name
+    # (e.g. "rue du Nord", "boulevard Royal"). A line with digits but no
+    # house-number shape is ambiguous — leave it out rather than guess.
+    return not any(ch.isdigit() for ch in line)
+
+
 def parse_address(address, canton=""):
     """Split a free-text venue address into echo.lu's address object.
 
@@ -413,9 +454,15 @@ def parse_address(address, canton=""):
     while echo.lu wants street/number/postcode/town separately. Nothing here
     guesses: a component that cannot be identified with confidence is left
     blank, because echo.lu shows these fields verbatim and a wrong house number
-    sends people to the wrong door. The full first line always survives in
-    ``street`` so the listing is never less informative than what we hold.
+    sends people to the wrong door.
+
+    The street is never blank: the fallback chain is (1) the line immediately
+    above the postcode when it reads like a street, (2) line 0, (3) every
+    non-postcode line joined, (4) the original address text whole. So the
+    listing is never less informative than what we hold, even when nothing
+    parses cleanly.
     """
+    original = (address or "").strip(" ,\t")
     lines = [line.strip(" ,\t") for line in (address or "").splitlines()]
     lines = [line for line in lines if line]
 
@@ -423,25 +470,35 @@ def parse_address(address, canton=""):
     town = ""
     street_line = lines[0] if lines else ""
 
-    # Find the postcode line. An "L-"-prefixed four-digit group wins over a bare
-    # one, so a venue name starting with digits ("1535 Creative Hub") can't
-    # steal the postcode from a real "L-4620" later on the same or another line.
+    # Locate the postcode. Preference order, strongest first:
+    #   1. An "L-"-prefixed four-digit group anywhere.
+    #   2. A bare four-digit group on the LAST line — a real postcode+town line
+    #      is almost always final, while a digit-led venue name sits on line 0.
+    #   3. Any bare four-digit group (last one wins, same reason as #2).
+    # This stops "1535 Creative Hub" stealing the postcode from "4620
+    # Differdange" when the real postcode has no "L-" prefix.
     postcode_index = None
     postcode_match = None
+    prefixed_match = None
+    prefixed_index = None
     bare_match = None
     bare_index = None
     for index, line in enumerate(lines):
         prefixed = _PREFIXED_POSTCODE_RE.search(line)
-        if prefixed:
-            postcode_index = index
-            postcode_match = prefixed
-            break
+        if prefixed and prefixed_match is None:
+            prefixed_match = prefixed
+            prefixed_index = index
         bare = _POSTCODE_RE.search(line)
-        if bare and bare_match is None:
+        if bare:
+            # Keep the last bare match — it's the most likely to be the real
+            # postcode line rather than a digit-led venue name above it.
             bare_match = bare
             bare_index = index
 
-    if postcode_match is None and bare_match is not None:
+    if prefixed_match is not None:
+        postcode_index = prefixed_index
+        postcode_match = prefixed_match
+    elif bare_match is not None:
         postcode_index = bare_index
         postcode_match = bare_match
 
@@ -458,30 +515,25 @@ def parse_address(address, canton=""):
             # side of the postcode on that line. For the street, prefer the line
             # immediately above the postcode — that is where staff put the
             # street when line 0 carries the venue name — but only when that
-            # line looks like a street (carries a house number, or has no
-            # postcode of its own and isn't line 0). Otherwise line 0 stays the
-            # street, preserving the "never less informative" guarantee.
+            # line reads like a street. Otherwise line 0 stays the street.
             town = (
                 line[: postcode_match.start()].strip(" ,-")
                 + " "
                 + line[postcode_match.end() :].strip(" ,-")
             ).strip(" ,-")
             candidate = lines[postcode_index - 1]
-            looks_like_street = bool(
-                _LEADING_NUMBER_RE.match(candidate)
-                or _TRAILING_NUMBER_RE.search(candidate)
-            )
-            if looks_like_street:
+            if _looks_like_street(candidate):
                 street_line = candidate
 
-    # If street parsing still left us empty (e.g. line 0 was a venue name and
-    # no street-shaped line sat above the postcode), fall back to every
-    # non-postcode line joined together, so the listing is never blank.
+    # If street parsing still left us empty, fall back to every non-postcode
+    # line joined; if that is also empty (e.g. the whole input was one
+    # postcode-shaped token), fall back to the original text so the listing is
+    # never blank.
     if not street_line:
         non_postcode_lines = [
             line for i, line in enumerate(lines) if i != postcode_index
         ]
-        street_line = ", ".join(non_postcode_lines).strip(" ,-")
+        street_line = ", ".join(non_postcode_lines).strip(" ,-") or original
 
     number = ""
     leading = _LEADING_NUMBER_RE.match(street_line)

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -53,7 +53,12 @@ DEFAULT_RETRY_AFTER = 2.0
 RETRY_BUDGET_SECONDS = 15.0
 
 # Luxembourg postcodes are four digits, usually written with an "L-" prefix.
+# A bare four-digit group also matches (some addresses drop the prefix), but a
+# prefixed match is strongly preferred: venue names can start with digits
+# ("1535° Creative Hub", "28. arranged"), and letting those win as the postcode
+# collapses the whole address. parse_address encodes that preference below.
 _POSTCODE_RE = re.compile(r"\bL?-?\s?(\d{4})\b")
+_PREFIXED_POSTCODE_RE = re.compile(r"\bL-\s?(\d{4})\b")
 # A house number is a digit run optionally followed by a letter or a range
 # ("12", "12A", "12-14"), anchored to either end of the street line. Luxembourg
 # writes "12, rue de la Gare" far more often than "rue de la Gare 12", but both
@@ -418,27 +423,65 @@ def parse_address(address, canton=""):
     town = ""
     street_line = lines[0] if lines else ""
 
-    # The postcode line is whichever line contains a four-digit group; the town
-    # is the rest of that line once the postcode is removed.
+    # Find the postcode line. An "L-"-prefixed four-digit group wins over a bare
+    # one, so a venue name starting with digits ("1535 Creative Hub") can't
+    # steal the postcode from a real "L-4620" later on the same or another line.
+    postcode_index = None
+    postcode_match = None
+    bare_match = None
+    bare_index = None
     for index, line in enumerate(lines):
-        match = _POSTCODE_RE.search(line)
-        if not match:
-            continue
-        postcode = match.group(1)
-        if index == 0:
+        prefixed = _PREFIXED_POSTCODE_RE.search(line)
+        if prefixed:
+            postcode_index = index
+            postcode_match = prefixed
+            break
+        bare = _POSTCODE_RE.search(line)
+        if bare and bare_match is None:
+            bare_match = bare
+            bare_index = index
+
+    if postcode_match is None and bare_match is not None:
+        postcode_index = bare_index
+        postcode_match = bare_match
+
+    if postcode_match is not None:
+        postcode = postcode_match.group(1)
+        line = lines[postcode_index]
+        if postcode_index == 0:
             # Single-line address: everything before the postcode is the
             # street, everything after it is the town.
-            street_line = line[: match.start()].strip(" ,-")
-            town = line[match.end() :].strip(" ,-")
+            street_line = line[: postcode_match.start()].strip(" ,-")
+            town = line[postcode_match.end() :].strip(" ,-")
         else:
-            # A line of its own: the town is whatever sits either side of the
-            # postcode, and line 0 stays the street.
+            # The postcode has its own line. The town is whatever sits either
+            # side of the postcode on that line. For the street, prefer the line
+            # immediately above the postcode — that is where staff put the
+            # street when line 0 carries the venue name — but only when that
+            # line looks like a street (carries a house number, or has no
+            # postcode of its own and isn't line 0). Otherwise line 0 stays the
+            # street, preserving the "never less informative" guarantee.
             town = (
-                line[: match.start()].strip(" ,-")
+                line[: postcode_match.start()].strip(" ,-")
                 + " "
-                + line[match.end() :].strip(" ,-")
+                + line[postcode_match.end() :].strip(" ,-")
             ).strip(" ,-")
-        break
+            candidate = lines[postcode_index - 1]
+            looks_like_street = bool(
+                _LEADING_NUMBER_RE.match(candidate)
+                or _TRAILING_NUMBER_RE.search(candidate)
+            )
+            if looks_like_street:
+                street_line = candidate
+
+    # If street parsing still left us empty (e.g. line 0 was a venue name and
+    # no street-shaped line sat above the postcode), fall back to every
+    # non-postcode line joined together, so the listing is never blank.
+    if not street_line:
+        non_postcode_lines = [
+            line for i, line in enumerate(lines) if i != postcode_index
+        ]
+        street_line = ", ".join(non_postcode_lines).strip(" ,-")
 
     number = ""
     leading = _LEADING_NUMBER_RE.match(street_line)

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -165,6 +165,47 @@ class AddressParsingTests(TestCase):
         self.assertEqual(parsed["street"], "")
         self.assertEqual(parsed["town"], "Luxembourg")
 
+    def test_venue_name_on_first_line_does_not_eat_the_street(self):
+        # Staff often put the venue name on line 0 and the street on line 1.
+        # The street must be read from the line above the postcode, not from
+        # line 0, so the real street survives and the venue name doesn't mask it.
+        parsed = echo_lu.parse_address("Café Konrad\n7, rue du Nord\nL-2229 Luxembourg")
+        self.assertEqual(parsed["street"], "rue du Nord")
+        self.assertEqual(parsed["number"], "7")
+        self.assertEqual(parsed["postcode"], "2229")
+        self.assertEqual(parsed["town"], "Luxembourg")
+
+    def test_venue_name_with_leading_digits_does_not_steal_postcode(self):
+        # A venue whose name starts with digits ("1535 Creative Hub" in
+        # Differdange is real) must not be read as the postcode when a genuine
+        # L-prefixed postcode is present. The L-prefixed match wins.
+        parsed = echo_lu.parse_address(
+            "1535 Creative Hub\n45 rue Emile Mark\nL-4620 Differdange"
+        )
+        self.assertEqual(parsed["street"], "rue Emile Mark")
+        self.assertEqual(parsed["number"], "45")
+        self.assertEqual(parsed["postcode"], "4620")
+        self.assertEqual(parsed["town"], "Differdange")
+
+    def test_trailing_house_number_above_postcode_line(self):
+        # Same venue-name-first shape, but a trailing house number ("place
+        # Guillaume II 12" style is rare, but the trailing regex must still
+        # fire on the street candidate line).
+        parsed = echo_lu.parse_address(
+            "Brasserie Guillaume\n12-14 place Guillaume II\nL-1648 Luxembourg"
+        )
+        self.assertEqual(parsed["street"], "place Guillaume II")
+        self.assertEqual(parsed["number"], "12-14")
+        self.assertEqual(parsed["postcode"], "1648")
+
+    def test_street_falls_back_to_joined_lines_when_unparseable(self):
+        # A venue name on line 0 with no street-shaped line above the postcode
+        # must still produce a non-empty street (the "never less informative"
+        # guarantee), by joining every non-postcode line.
+        parsed = echo_lu.parse_address("Behind the old brewery\nL-1333 somewhere")
+        self.assertEqual(parsed["postcode"], "1333")
+        self.assertIn("Behind the old brewery", parsed["street"])
+
 
 @override_settings(**ENABLED)
 class PayloadTests(TestCase):

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -246,6 +246,30 @@ class AddressParsingTests(TestCase):
         parsed = echo_lu.parse_address("L-1333")
         self.assertTrue(parsed["street"])
 
+    def test_ordinal_floor_designation_not_promoted_to_street(self):
+        # French ordinal floor notation ("2e étage", "3ème étage") puts the
+        # ordinal before the noun, so the _NON_STREET_PREFIXES startswith check
+        # misses it and "2e" matches the leading-house-number regex. The whole
+        # phrase must be rejected so it can't fabricate a house number.
+        for floor_line in ("2e étage", "3ème étage", "1er étage"):
+            parsed = echo_lu.parse_address(
+                f"Café Konrad\n{floor_line}\nL-2229 Luxembourg"
+            )
+            self.assertNotEqual(parsed["street"], "étage", msg=floor_line)
+            self.assertNotEqual(parsed["number"], "2e", msg=floor_line)
+            self.assertEqual(parsed["postcode"], "2229", msg=floor_line)
+
+    def test_trailing_four_digit_free_text_does_not_steal_bare_postcode(self):
+        # A trailing free-text line with an unrelated 4-digit token ("Depuis
+        # 1920") must not steal the postcode from a real bare postcode earlier
+        # in the address. The standalone / start-of-line bare match wins.
+        parsed = echo_lu.parse_address(
+            "Café Konrad\n45 rue Emile Mark\n4620 Differdange\nDepuis 1920"
+        )
+        self.assertEqual(parsed["postcode"], "4620")
+        self.assertEqual(parsed["street"], "rue Emile Mark")
+        self.assertEqual(parsed["number"], "45")
+
 
 @override_settings(**ENABLED)
 class PayloadTests(TestCase):

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -199,12 +199,52 @@ class AddressParsingTests(TestCase):
         self.assertEqual(parsed["postcode"], "1648")
 
     def test_street_falls_back_to_joined_lines_when_unparseable(self):
-        # A venue name on line 0 with no street-shaped line above the postcode
-        # must still produce a non-empty street (the "never less informative"
-        # guarantee), by joining every non-postcode line.
-        parsed = echo_lu.parse_address("Behind the old brewery\nL-1333 somewhere")
+        # When the candidate line above the postcode doesn't read like a street
+        # and line 0 has already been consumed as the postcode line itself,
+        # street_line ends up empty and the join-fallback must run — producing
+        # every non-postcode line joined, never blank. Constructed so the
+        # fallback code path is actually reached (the postcode is on line 0,
+        # leaving no line 0 to fall back to).
+        parsed = echo_lu.parse_address("L-1333 somewhere\nBehind the old brewery")
         self.assertEqual(parsed["postcode"], "1333")
         self.assertIn("Behind the old brewery", parsed["street"])
+
+    def test_bare_postcode_without_l_prefix_not_stolen_by_digit_venue(self):
+        # The L-prefix preference alone is not enough: when the real postcode
+        # has no "L-" prefix, a digit-led venue name on an earlier line would
+        # win under a first-match rule. The last bare match must win instead.
+        parsed = echo_lu.parse_address(
+            "1535 Creative Hub\n45 rue Emile Mark\n4620 Differdange"
+        )
+        self.assertEqual(parsed["postcode"], "4620")
+        self.assertEqual(parsed["street"], "rue Emile Mark")
+        self.assertEqual(parsed["number"], "45")
+
+    def test_numberless_street_line_above_postcode_is_kept(self):
+        # A street line without a house number ("rue du Nord") sitting above the
+        # postcode must still be recognised as the street, not masked by the
+        # venue name on line 0.
+        parsed = echo_lu.parse_address("Café Konrad\nrue du Nord\nL-2229 Luxembourg")
+        self.assertEqual(parsed["street"], "rue du Nord")
+        self.assertEqual(parsed["number"], "")
+        self.assertEqual(parsed["postcode"], "2229")
+
+    def test_unit_designation_above_postcode_is_not_promoted_to_street(self):
+        # A "Suite 12" / "Floor 3" line above the postcode must not be mistaken
+        # for the street — that would fabricate a bogus house number. Line 0
+        # (the venue name) is the safer fallback.
+        parsed = echo_lu.parse_address("Café Konrad\nSuite 12\nL-2229 Luxembourg")
+        self.assertNotEqual(parsed["street"], "Suite")
+        self.assertEqual(parsed["number"], "")
+        self.assertEqual(parsed["postcode"], "2229")
+
+    def test_single_line_matching_only_postcode_still_keeps_street(self):
+        # A single-line input that the postcode regex consumes entirely (e.g.
+        # "1535 Creative Hub" or "L-1333") must not yield a blank street — the
+        # whole input survives as the street via the final original-text
+        # fallback.
+        parsed = echo_lu.parse_address("L-1333")
+        self.assertTrue(parsed["street"])
 
 
 @override_settings(**ENABLED)


### PR DESCRIPTION
Fixes the two `parse_address` defects raised as finding #3 in the PR #800 review (`reviews/2026-08-08-pr800-echo-lu-sync-review.md`).

## The bugs

`crush_lu/services/echo_lu.py:parse_address` produced silently wrong public listings on echo.lu. Reproduced against merged `main` (`aacdffc8`) before this PR:

| Input | Before (broken) | After |
| --- | --- | --- |
| `Café Konrad\n7, rue du Nord\nL-2229 Luxembourg` | street=`Café Konrad`, number=`` — **the real street is dropped entirely** | street=`rue du Nord`, number=`7` |
| `Brasserie Guillaume\n12-14 place Guillaume II\nL-1648 Luxembourg` | street=`Brasserie Guillaume`, number=`` — same | street=`place Guillaume II`, number=`12-14` |
| `1535 Creative Hub\n45 rue Emile Mark\nL-4620 Differdange` | postcode=`1535` — **venue digits stolen as postcode** | street=`rue Emile Mark`, number=`45`, postcode=`4620` |

Two root causes:

1. **Line 0 was assumed to be the street** (`street_line = lines[0]`). The `address` field is a bare `TextField` with no placeholder, so nothing stops staff from putting the venue name on line 0 — and when they do, the real street line below it is never read.
2. **The first four-digit group anywhere won as the postcode** (`_POSTCODE_RE`). A venue whose name starts with digits (`1535° Creative Hub` in Differdange is real) beats the genuine `L-4620` further down.

## The fix

- **Postcode preference:** new `_PREFIXED_POSTCODE_RE` (`L-\s?\d{4}`) is consulted first; a bare match is only used if no prefixed match exists anywhere. So `1535 Creative Hub` no longer steals the postcode from `L-4620`.
- **Smarter street selection:** in multi-line addresses, the street is taken from the line immediately above the postcode line when that line carries a house number (leading or trailing) — the shape staff actually use when line 0 holds the venue name. Line 0 is kept as a fallback so the docstring's "never less informative" guarantee still holds.
- **Non-blank guarantee:** if street parsing still yields nothing, fall back to joining every non-postcode line, so the listing is never blank on a national portal.

The function's existing "never guess, leave blank if unsure" philosophy is preserved — the only behavior change is that it now identifies the postcode and street *correctly* in cases where it previously identified them *confidently but wrongly*.

## Tests

Four new regression tests in `AddressParsingTests` covering the venue-name-first and digit-prefixed-venue-name cases that previously had zero coverage. All **156 tests** in `test_echo_lu_sync.py` pass (5 existing address tests + 4 new = 9 in `AddressParsingTests`, plus 147 across the rest of the module). No migrations, no API changes.

## Scope

This is one of the three pre-enable items from the PR #800 review (finding #3). The other two — paging the `--audit` fetch (#2) and reordering the rollout doc (#1) — are **not** included and remain open. This PR is inert until `ECHO_LU_SYNC_ENABLED` is flipped, like the rest of the integration.