### PR TITLE
Delete the unused event flyer renderer

### DIFF
--- a/hub/image_generator.py
+++ b/hub/image_generator.py
@@ -6,13 +6,11 @@ import io
 import logging
 import os
 from pathlib import Path
-from urllib.parse import urlparse
 
-import requests
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import storages
-from PIL import Image, ImageDraw, ImageEnhance, ImageFilter, ImageFont
+from PIL import Image, ImageDraw, ImageFont
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +20,9 @@ PURPLE = (147, 51, 234)
 WHITE = (255, 255, 255)
 MUTED = (188, 190, 207)
 CARD = (31, 29, 49, 225)
-MAX_BACKGROUND_BYTES = 12 * 1024 * 1024
 CARD_COPY = {
     "fr": {
         "tagline": "RENCONTRES AUTHENTIQUES",
-        "event_badge": "ÉVÉNEMENT CRUSH.LU",
-        "event_cta": "RÉSERVER MA PLACE",
         "community_badge": "COMMUNAUTÉ CRUSH.LU",
         "kpi_title": "CHIFFRES DE LA SEMAINE",
         "kpi_subtitle": "Les données réelles de notre communauté",
@@ -37,8 +32,6 @@ CARD_COPY = {
     },
     "en": {
         "tagline": "AUTHENTIC CONNECTIONS",
-        "event_badge": "CRUSH.LU EVENT",
-        "event_cta": "RESERVE MY SPOT",
         "community_badge": "CRUSH.LU COMMUNITY",
         "kpi_title": "THIS WEEK'S NUMBERS",
         "kpi_subtitle": "Real data from our community",
@@ -48,8 +41,6 @@ CARD_COPY = {
     },
     "de": {
         "tagline": "ECHTE BEGEGNUNGEN",
-        "event_badge": "CRUSH.LU EVENT",
-        "event_cta": "PLATZ RESERVIEREN",
         "community_badge": "CRUSH.LU COMMUNITY",
         "kpi_title": "ZAHLEN DER WOCHE",
         "kpi_subtitle": "Echte Daten aus unserer Community",
@@ -117,47 +108,8 @@ def _gradient() -> Image.Image:
     return image.convert("RGBA")
 
 
-def _background_image(url: str | None) -> Image.Image | None:
-    parsed = urlparse(url or "")
-    if parsed.scheme not in {"http", "https"}:
-        return None
-    response = None
-    try:
-        response = requests.get(url, timeout=6, stream=True)
-        response.raise_for_status()
-        content_length = int(response.headers.get("content-length") or 0)
-        if content_length > MAX_BACKGROUND_BYTES:
-            raise ValueError("background image exceeds 12 MB")
-        content = bytearray()
-        for chunk in response.iter_content(chunk_size=64 * 1024):
-            if not chunk:
-                continue
-            content.extend(chunk)
-            if len(content) > MAX_BACKGROUND_BYTES:
-                raise ValueError("background image exceeds 12 MB")
-        image = Image.open(io.BytesIO(content)).convert("RGBA")
-        scale = max(SIZE / image.width, SIZE / image.height)
-        resized = image.resize(
-            (round(image.width * scale), round(image.height * scale)),
-            Image.Resampling.LANCZOS,
-        )
-        left = (resized.width - SIZE) // 2
-        top = (resized.height - SIZE) // 2
-        return resized.crop((left, top, left + SIZE, top + SIZE))
-    except (requests.RequestException, OSError, ValueError):
-        logger.warning("Could not load event background image", exc_info=True)
-        return None
-    finally:
-        if response is not None:
-            response.close()
-
-
-def _canvas(background_url: str | None = None) -> Image.Image:
-    background = _background_image(background_url) or _gradient()
-    if background_url and background:
-        background = ImageEnhance.Brightness(background).enhance(0.38)
-        background = background.filter(ImageFilter.GaussianBlur(radius=1.2))
-        background.alpha_composite(Image.new("RGBA", background.size, (10, 8, 25, 125)))
+def _canvas() -> Image.Image:
+    background = _gradient()
     draw = ImageDraw.Draw(background, "RGBA")
     draw.ellipse((-180, -220, 520, 480), fill=(*PURPLE, 52))
     draw.ellipse((690, 700, 1290, 1300), fill=(*ROSE, 55))
@@ -200,41 +152,6 @@ def _save(image: Image.Image, prefix: str) -> str:
     if url.startswith("/"):
         return f"{settings.BACKEND_BASE_URL.rstrip('/')}{url}"
     return url
-
-
-def generate_event_flyer(
-    title="Soirée rencontre Crush.lu",
-    date_str="Jeudi · 19:30",
-    location="Luxembourg",
-    background_url: str | None = None,
-    language: str = "fr",
-) -> str:
-    copy = _card_copy(language)
-    image = _canvas(background_url)
-    draw = ImageDraw.Draw(image, "RGBA")
-    draw.rounded_rectangle((55, 55, 1025, 970), radius=44, fill=(15, 13, 30, 178))
-    _pill(draw, (92, 92), copy["event_badge"], fill=(*ROSE, 205), font_size=25)
-
-    title_font = _font(73, bold=True)
-    lines = _wrap(draw, title, title_font, 870)[:4]
-    y = 250
-    for line in lines:
-        draw.text((92, y), line, font=title_font, fill=WHITE)
-        y += 91
-
-    draw.rounded_rectangle((92, 680, 988, 855), radius=30, fill=CARD)
-    draw.text((130, 714), date_str, font=_font(36, bold=True), fill=WHITE)
-    draw.text((130, 775), location, font=_font(31), fill=MUTED)
-    draw.rounded_rectangle((92, 885, 450, 950), radius=30, fill=(*ROSE, 255))
-    draw.text(
-        (271, 916),
-        copy["event_cta"],
-        font=_font(24, bold=True),
-        fill=WHITE,
-        anchor="mm",
-    )
-    _brand_footer(draw, language=language)
-    return _save(image, "event_flyer")
 
 
 def generate_kpi_card(title=None, stats=None, *, language: str = "fr") -> str:

--- a/hub/tests/test_social.py
+++ b/hub/tests/test_social.py
@@ -27,7 +27,7 @@ from hub.claude_service import (
     GeneratedArticle,
     generate_social_copy,
 )
-from hub.image_generator import _background_image, generate_kpi_card
+from hub.image_generator import generate_kpi_card
 from hub.models import HubResource, SocialPost
 
 User = get_user_model()
@@ -1182,22 +1182,6 @@ class ClaudeServiceTests(SimpleTestCase):
 
 
 class ImageGeneratorTests(SimpleTestCase):
-    @patch("hub.image_generator.requests.get")
-    def test_remote_background_stops_streaming_at_size_limit(self, get):
-        response = Mock()
-        response.headers = {}
-        response.iter_content.return_value = [b"1234", b"5"]
-        get.return_value = response
-
-        with patch("hub.image_generator.MAX_BACKGROUND_BYTES", 4):
-            image = _background_image("https://media.test/oversized.png")
-
-        self.assertIsNone(image)
-        get.assert_called_once_with(
-            "https://media.test/oversized.png", timeout=6, stream=True
-        )
-        response.close.assert_called_once()
-
     def test_pillow_renderer_creates_public_png_without_browser_runtime(self):
         with TemporaryDirectory() as media_root:
             with self.settings(


### PR DESCRIPTION
## Purpose
* Removes `generate_event_flyer` from `hub/image_generator.py`, which has had no callers since #799. That PR made event promotions reuse stored event copy and skip graphic generation, dropping both the import in `hub/views_social.py` and the `partial(generate_event_flyer, ...)` builder that was its only call site. A bot review on #799 flagged the leftover, and it was deferred there to keep that PR scoped to the promotion workflow.
* Deleting the flyer also strips the remote-background path it was the only user of. `_canvas()` took an optional `background_url`, and only the flyer ever passed one — so `_background_image`, `MAX_BACKGROUND_BYTES`, the `requests`/`urlparse` imports and Pillow's `ImageEnhance`/`ImageFilter` were reachable only through it. The `event_badge` and `event_cta` `CARD_COPY` strings were flyer-only chrome and go too.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

`generate_kpi_card` and `generate_profile_card` always called `_canvas()` bare, so they still render over the same gradient with identical output. No API surface, model, or migration is touched.

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code

```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform
cd Multi-Domain-Django-Platform
git checkout claude/intelligent-cray-7whzva
```

* Test the code

```
DBHOST= SECRET_KEY=test-secret-key-for-local-pytest .venv/Scripts/python.exe -m pytest hub/ -n 0
black --check hub/image_generator.py hub/tests/test_social.py
ruff check hub/image_generator.py hub/tests/test_social.py
```

## What to Check
Verify that the following are valid
* `grep -rn "generate_event_flyer" --include=*.py .` returns nothing — it matched only the definition before this change.
* The `hub/` suite passes on SQLite: 85 passed, 2 subtests passed in ~52s.
* `black --check` and `ruff check` are clean on both touched files.
* KPI and profile card rendering is unchanged — `test_pillow_renderer_creates_public_png_without_browser_runtime` still exercises `generate_kpi_card` end to end and asserts a real PNG lands in `crush_media` storage.

## Other Information
`hub/tests/test_social.py` loses `test_remote_background_stops_streaming_at_size_limit`. That test covered the streaming size cap inside `_background_image`; with the helper gone there is nothing left for it to assert, so it is removed rather than left pointing at dead code. The `ImageGeneratorTests` class and its remaining renderer test stay.

`requests` remains in `requirements.txt` — `hub/claude_service.py` and other modules still use it. Only the now-unused import in `hub/image_generator.py` was dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_019GSxmodmKDvD5DTWksGVbD)_