### PR TITLE
Give the social post length limit one home

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -1,0 +1,3 @@
+"""Shared hub constants that must stay identical across serializers and views."""
+
+SOCIAL_CONTENT_MAX_LENGTH = 1500

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from .constants import SOCIAL_CONTENT_MAX_LENGTH
 from .models import (
     HubRequest,
     HubResource,
@@ -167,9 +168,10 @@ class SocialPostSerializer(serializers.ModelSerializer):
         return value
 
     def validate_content(self, value):
-        if len(value) > 1500:
+        if len(value) > SOCIAL_CONTENT_MAX_LENGTH:
             raise serializers.ValidationError(
-                "Social post content cannot exceed 1500 characters."
+                f"Social post content cannot exceed {SOCIAL_CONTENT_MAX_LENGTH} "
+                "characters."
             )
         return value
 

--- a/hub/views_social.py
+++ b/hub/views_social.py
@@ -24,6 +24,7 @@ from .buffer_service import (
     list_buffer_profiles,
 )
 from .claude_service import ClaudeServiceError, expand_social_post, generate_social_copy
+from .constants import SOCIAL_CONTENT_MAX_LENGTH
 from .image_generator import (
     generate_kpi_card,
     generate_profile_card,
@@ -37,7 +38,6 @@ ALLOWED_CATEGORIES = {"events", "kpis", "profiles", "tips", "recaps"}
 ALLOWED_PLATFORMS = {"instagram", "facebook", "linkedin"}
 ALLOWED_LANGUAGES = {choice for choice, _label in SocialPost.Language.choices}
 ALLOWED_PILLARS = {choice for choice, _label in SocialPost.Pillar.choices}
-SOCIAL_CONTENT_MAX_LENGTH = 1500
 
 BUFFER_SCHEDULE_ERROR = "Buffer could not schedule this post. Try again later."
 COPY_GENERATION_ERROR = "Social copy generation is temporarily unavailable."


### PR DESCRIPTION
## Purpose
* The 1500-character social post limit lived in two places: `hub/views_social.py` defined `SOCIAL_CONTENT_MAX_LENGTH = 1500` for event-copy validation, while `SocialPostSerializer.validate_content` in `hub/serializers.py` hardcoded the same `1500` as a literal. Changing one without the other silently desynced event-copy validation from the generic serializer validation.
* The direct fix doesn't work: `views_social.py` already does `from .serializers import SocialPostSerializer`, so importing the constant back from `views_social` into `serializers.py` is a circular import.
* This moves the constant into a new dependency-free `hub/constants.py` that both modules import, and interpolates it into both error messages so they track the value automatically.

Follow-up to a bot review comment on #799 that was deferred there as out of scope.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
Both user-facing error strings render identically to before at the current value of 1500.

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform
cd Multi-Domain-Django-Platform
git checkout claude/sharp-volta-9mjmke
```

* Test the code
```
DBHOST= SECRET_KEY=test-secret-key-for-local-pytest .venv/Scripts/python.exe -m pytest hub/ -n 0
black --check hub/constants.py hub/serializers.py hub/views_social.py
ruff check hub/constants.py hub/serializers.py hub/views_social.py
```

All 86 `hub/` tests pass; `black --check` and `ruff check` are clean on the three touched files.

## What to Check
Verify that the following are valid
* `hub/constants.py` imports nothing, so neither `serializers.py` nor `views_social.py` gains a new import edge that could cycle.
* `SocialPostSerializer.validate_content` still rejects content over the limit with the same message text.
* `_event_copy_validation_error` still names the limit in its message (`"The stored event copy exceeds 1500 characters for: ..."`), now interpolated from the shared constant.

## Other Information
* `hub/tests/test_social.py:610` still asserts on the literal `"exceeds 1500"` (and builds its fixture with `"x" * 1500`). I left the test as-is to keep this diff to the scope that was flagged. Note that unlike the production duplication, this one fails loudly rather than silently if the limit changes — the assertion breaks — so it is a guard rather than a desync risk. Say the word if you'd rather it derived from `SOCIAL_CONTENT_MAX_LENGTH` too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvvEs4EgVZ4VYfc4EsTpvd)_