### PR TITLE
Bound the venue search to what echo.lu will actually serve

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,6 +153,10 @@ SECRET_KEY=your-development-secret-key-change-in-production
 # ECHO_LU_SIGNAL_TIMEOUT_SECONDS=5
 # Wall-clock ceiling on one hourly sweep; the next run takes the remainder.
 # ECHO_LU_SWEEP_BUDGET_SECONDS=90
+# Pages of echo.lu's venue registry to search before registering a new venue.
+# Each page is 3-4s and a call makes up to two passes, so 3 is ~20s worst
+# case. Raise it for a shell run; keep it low for the admin action.
+# ECHO_LU_VENUE_SEARCH_PAGES=3
 # ECHO_LU_CONTACT_NAME=Crush.lu
 # ECHO_LU_CONTACT_COMPANY=Crush.lu
 # ECHO_LU_CONTACT_EMAIL=hello@crush.lu

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -908,12 +908,20 @@ ECHO_LU_DEFAULT_LANGUAGES = os.environ.get("ECHO_LU_DEFAULT_LANGUAGES", "en,fr")
 ECHO_LU_DEFAULT_TAGS = os.environ.get("ECHO_LU_DEFAULT_TAGS", "crush.lu")
 # How many 100-row pages of echo.lu's venue registry to read before giving up
 # and registering a new venue. The registry is 5,000+ rows with no text search
-# and each page costs 3-4 seconds, so an uncapped scan is minutes — far past
-# what the admin action (5s per call) or the save-signal can hold. Five pages
-# is ~500 venues per pass and a couple of seconds; a match beyond it is missed
-# and a duplicate registered, which is untidy rather than broken. Raise it when
-# running the sync from a shell, where the budget is generous.
-ECHO_LU_VENUE_SEARCH_PAGES = int(os.environ.get("ECHO_LU_VENUE_SEARCH_PAGES", "5"))
+# and **each page measures 3-4 seconds**, so do the arithmetic before raising
+# this: a call can make TWO passes (commune-narrowed, then the full registry),
+# so N pages is up to 2N requests — at the default 3 that is ~20s worst case,
+# and at 5 it would be 30-40s, i.e. the whole ECHO_LU_ADMIN_BUDGET_SECONDS on a
+# single event. The admin action only checks its deadline *between* events, so
+# one slow venue search cannot be interrupted once started.
+#
+# Hence a deliberately low default. A miss inside the cap registers a new venue
+# — untidy, not broken — while a scan that outlives the request is broken. Each
+# venue is searched once and then cached in EchoVenue, so this cost is paid per
+# venue, not per event. Raise it (ECHO_LU_VENUE_SEARCH_PAGES=20) when running
+# `sync_events_to_echo` from a shell, where the budget is generous and a
+# thorough search is worth the wait.
+ECHO_LU_VENUE_SEARCH_PAGES = int(os.environ.get("ECHO_LU_VENUE_SEARCH_PAGES", "3"))
 # Optional override for the picture sent when an event has no image of its own.
 # Left EMPTY on purpose: the fallback is resolved at call time in
 # services.echo_lu, from SOCIAL_PREVIEW_IMAGE_URL. Binding it to that value

--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -906,6 +906,14 @@ ECHO_LU_DEFAULT_ENVIRONMENTS = os.environ.get("ECHO_LU_DEFAULT_ENVIRONMENTS", "i
 # Required too, and an event with no languages set cannot simply omit them.
 ECHO_LU_DEFAULT_LANGUAGES = os.environ.get("ECHO_LU_DEFAULT_LANGUAGES", "en,fr")
 ECHO_LU_DEFAULT_TAGS = os.environ.get("ECHO_LU_DEFAULT_TAGS", "crush.lu")
+# How many 100-row pages of echo.lu's venue registry to read before giving up
+# and registering a new venue. The registry is 5,000+ rows with no text search
+# and each page costs 3-4 seconds, so an uncapped scan is minutes — far past
+# what the admin action (5s per call) or the save-signal can hold. Five pages
+# is ~500 venues per pass and a couple of seconds; a match beyond it is missed
+# and a duplicate registered, which is untidy rather than broken. Raise it when
+# running the sync from a shell, where the budget is generous.
+ECHO_LU_VENUE_SEARCH_PAGES = int(os.environ.get("ECHO_LU_VENUE_SEARCH_PAGES", "5"))
 # Optional override for the picture sent when an event has no image of its own.
 # Left EMPTY on purpose: the fallback is resolved at call time in
 # services.echo_lu, from SOCIAL_PREVIEW_IMAGE_URL. Binding it to that value

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -720,7 +720,17 @@ def resolve_venue_ids(event, client, address=None):
     except EchoLuError as exc:
         # A registry we could not read is not a reason to register a duplicate
         # into it. Fail the sync instead; the sweep retries in an hour.
-        raise EchoLuError(
+        #
+        # EchoLuNotSent, emphatically, and not a bare EchoLuError. Everything
+        # here happens *before* the experience create is attempted, so nothing
+        # can possibly have been created — but a locally raised error carries no
+        # status code, and `_proves_nothing_was_created` reads a missing status
+        # as "the answer was lost, assume a listing exists". A bare raise here
+        # therefore parked the event in ORPHANED: blocked from syncing forever
+        # and pointing its operator at an `--audit` that cannot find anything,
+        # because there is nothing to find. That is exactly what happened on the
+        # first production sync.
+        raise EchoLuNotSent(
             f"could not search echo.lu venues for {event.location!r}: {exc}"
         ) from exc
 

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -57,8 +57,11 @@ RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
 # already, and replaying that is how you get two. See create_experience.
 CREATE_RETRY_STATUSES = frozenset({429})
 # echo.lu rejects a page larger than this outright — "It is not allowed to
-# retrieve more than 100 items per page" — rather than clamping it.
-VENUE_PAGE_SIZE = 100
+# retrieve more than 100 items per page" — rather than clamping it. It governs
+# every list endpoint, not just venues, which is why the name is generic: a
+# future reader raising it "for venues" would silently repage the experience
+# sweep too.
+LIST_PAGE_SIZE = 100
 MAX_RETRIES = 3
 DEFAULT_RETRY_AFTER = 2.0
 # Ceiling on total sleep across retries. The sync can run from a request-thread
@@ -307,7 +310,7 @@ class EchoLuClient:
                 return {"records": []}
             raise
 
-    def iter_experiences(self, per_page=VENUE_PAGE_SIZE):
+    def iter_experiences(self, per_page=LIST_PAGE_SIZE):
         """Every experience, page by page.
 
         echo.lu pages with ``pagination[page]`` / ``pagination[perPage]`` and
@@ -804,7 +807,7 @@ def _iter_venue_records(client, address):
       one — the opposite trade to the one above, and the right way round: a
       duplicate is untidy, while a hung admin request is broken.
     """
-    per_page = VENUE_PAGE_SIZE
+    per_page = LIST_PAGE_SIZE
     max_pages = max(1, int(getattr(settings, "ECHO_LU_VENUE_SEARCH_PAGES", 5)))
     commune = (address or {}).get("commune") or ""
     passes = [{"communes[]": commune}] if commune else []
@@ -842,13 +845,24 @@ def _iter_venue_records(client, address):
             if len(records) < per_page:
                 break
         else:
-            logger.info(
-                "[ECHO] venue search stopped at the %s-page cap (%s venues "
-                "read); a match beyond it will not be found and a new venue "
-                "may be registered instead",
-                max_pages,
-                max_pages * per_page,
-            )
+            # Only the LAST pass decides anything. The narrow pass capping out
+            # says nothing about the outcome — the wide pass runs straight
+            # after it and may well find the match — so announcing a probable
+            # duplicate there would be a false alarm in the common case.
+            if extra:
+                logger.debug(
+                    "[ECHO] commune-narrowed venue search hit the %s-page cap; "
+                    "continuing with the full registry",
+                    max_pages,
+                )
+            else:
+                logger.info(
+                    "[ECHO] venue search stopped at the %s-page cap (%s venues "
+                    "read); a match beyond it will not be found and a new venue "
+                    "may be registered instead",
+                    max_pages,
+                    max_pages * per_page,
+                )
 
 
 # Exactly what a create must carry, read off the API rather than the schema

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -56,6 +56,9 @@ RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
 # not process the request; a 5xx or a lost socket may mean the listing exists
 # already, and replaying that is how you get two. See create_experience.
 CREATE_RETRY_STATUSES = frozenset({429})
+# echo.lu rejects a page larger than this outright — "It is not allowed to
+# retrieve more than 100 items per page" — rather than clamping it.
+VENUE_PAGE_SIZE = 100
 MAX_RETRIES = 3
 DEFAULT_RETRY_AFTER = 2.0
 # Ceiling on total sleep across retries. The sync can run from a request-thread
@@ -304,7 +307,7 @@ class EchoLuClient:
                 return {"records": []}
             raise
 
-    def iter_experiences(self, per_page=100):
+    def iter_experiences(self, per_page=VENUE_PAGE_SIZE):
         """Every experience, page by page.
 
         echo.lu pages with ``pagination[page]`` / ``pagination[perPage]`` and
@@ -774,20 +777,49 @@ def _iter_venue_records(client, address):
     pass costs nothing in the case that matters.
 
     Ids already yielded by the narrow pass are not yielded twice.
+
+    Three things learned from the first live call, all of them the hard way:
+
+    * **100 items per page is a hard ceiling.** Asking for more is a 400, not a
+      clamp — ``It is not allowed to retrieve more than 100 items per page``.
+    * **A commune the API does not recognise is a 404**, and our value comes
+      from ``canton``, which is free text ("Luxembourg - City") while echo.lu
+      wants one of its own 113 ids ("luxembourg"). So an unusable filter must
+      demote to the wide pass rather than failing the sync — the filter is an
+      optimisation, and no optimisation is worth an outage.
+    * **Pages cost 3–4 seconds each.** Reading 5,000 venues is minutes, which
+      no caller here has: the admin action allows 5s per call. So the scan is
+      capped, and a miss inside the cap registers a new venue rather than
+      hunting forever. That trades a small chance of a duplicate for a bounded
+      one — the opposite trade to the one above, and the right way round: a
+      duplicate is untidy, while a hung admin request is broken.
     """
-    per_page = 200
+    per_page = VENUE_PAGE_SIZE
+    max_pages = max(1, int(getattr(settings, "ECHO_LU_VENUE_SEARCH_PAGES", 5)))
     commune = (address or {}).get("commune") or ""
     passes = [{"communes[]": commune}] if commune else []
     passes.append({})
 
     seen_ids = set()
     for extra in passes:
-        page = 0
-        while True:
+        for page in range(max_pages):
             params = dict(extra)
             params["pagination[page]"] = page
             params["pagination[perPage]"] = per_page
-            records = response_records(client.list_venues(**params))
+            try:
+                records = response_records(client.list_venues(**params))
+            except EchoLuError as exc:
+                if extra and exc.status_code in (400, 404):
+                    # The narrowed pass is unusable — almost always a commune
+                    # echo.lu has never heard of. Fall through to the wide one.
+                    logger.info(
+                        "[ECHO] venue commune filter %r rejected (%s); "
+                        "searching without it",
+                        commune,
+                        exc.status_code,
+                    )
+                    break
+                raise
             if not records:
                 break
             for record in records:
@@ -799,9 +831,14 @@ def _iter_venue_records(client, address):
                 yield record
             if len(records) < per_page:
                 break
-            page += 1
-            if page > 200:  # pragma: no cover - runaway guard
-                return
+        else:
+            logger.info(
+                "[ECHO] venue search stopped at the %s-page cap (%s venues "
+                "read); a match beyond it will not be found and a new venue "
+                "may be registered instead",
+                max_pages,
+                max_pages * per_page,
+            )
 
 
 # Exactly what a create must carry, read off the API rather than the schema

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -383,6 +383,28 @@ class PayloadTests(TestCase):
 class UnsendablePayloadTests(TestCase):
     """Refusing to send is not the same as a create whose answer was lost."""
 
+    def test_an_unreadable_venue_registry_leaves_the_row_retryable(self):
+        # This one bit on the very first production sync. The venue search
+        # happens BEFORE the experience create, so a registry we cannot read
+        # proves nothing was created — but a locally raised error carries no
+        # status code, and a missing status otherwise reads as "the answer was
+        # lost". The event was parked in ORPHANED: blocked from syncing, and
+        # sent to an --audit with nothing to find.
+        event = make_event()
+
+        class BrokenRegistryClient(FakeClient):
+            def list_venues(self, **params):
+                raise echo_lu.EchoLuError("nope", status_code=400)
+
+        client = BrokenRegistryClient(venues=[])
+        with self.assertRaises(echo_lu.EchoLuError):
+            echo_lu.sync_event(event, client=client)
+
+        self.assertEqual(client.calls, [])  # no venue and no experience created
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.FAILED)
+        self.assertNotEqual(event.echo_sync.status, EchoExperienceSync.Status.ORPHANED)
+
     @override_settings(
         ECHO_LU_DEFAULT_CATEGORIES="",
         ECHO_LU_DEFAULT_AUDIENCES="",

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -552,6 +552,61 @@ class VenueResolutionTests(TestCase):
         self.assertEqual(echo_lu.resolve_venue_ids(event, client), ["venue-real"])
         self.assertEqual(client.calls, [])  # nothing was registered
 
+    def test_pages_never_exceed_the_hundred_item_ceiling(self):
+        # echo.lu rejects a bigger page outright rather than clamping it:
+        # "It is not allowed to retrieve more than 100 items per page". The
+        # first live sync asked for 200 and failed on this.
+        seen = []
+
+        class RecordingClient(FakeClient):
+            def list_venues(self, **params):
+                seen.append(params.get("pagination[perPage]"))
+                return {"records": []}
+
+        echo_lu.resolve_venue_ids(make_event(), RecordingClient(venues=[]))
+        self.assertTrue(seen)
+        self.assertTrue(all(p is not None and p <= 100 for p in seen), seen)
+
+    def test_an_unknown_commune_falls_back_to_the_wide_search(self):
+        # Our commune comes from `canton`, which is free text
+        # ("Luxembourg - City"), while echo.lu wants one of its own ids
+        # ("luxembourg") and 404s on anything else. The filter is an
+        # optimisation, so an unusable one must demote to the unfiltered pass
+        # rather than failing the sync.
+        real = {"id": "venue-real", "title": "Café Konrad"}
+
+        class PickyClient(FakeClient):
+            def list_venues(self, **params):
+                if "communes[]" in params:
+                    raise echo_lu.EchoLuError("no such commune", status_code=404)
+                return {"records": [real]}
+
+        client = PickyClient(venues=[])
+        self.assertEqual(
+            echo_lu.resolve_venue_ids(make_event(), client), ["venue-real"]
+        )
+        self.assertEqual(client.calls, [])  # matched, nothing registered
+
+    @override_settings(ECHO_LU_VENUE_SEARCH_PAGES=2)
+    def test_the_search_is_capped_and_then_registers(self):
+        # Pages cost 3-4s each and the admin action allows 5s per call, so an
+        # uncapped scan of 5,000 venues is a hung request. Past the cap we
+        # register rather than hunt — a duplicate is untidy, a hung admin
+        # request is broken.
+        pages = []
+
+        class EndlessClient(FakeClient):
+            def list_venues(self, **params):
+                pages.append(params.get("pagination[page]"))
+                return {"records": [{"id": f"v{len(pages)}", "title": "Nope"}] * 100}
+
+        client = EndlessClient(venues=[])
+        result = echo_lu.resolve_venue_ids(make_event(), client)
+        self.assertTrue(result[0].startswith("venue-"))
+        self.assertEqual([c[0] for c in client.calls], ["create_venue"])
+        # 2 pages for the commune pass + 2 for the wide one, and no more.
+        self.assertLessEqual(len(pages), 4)
+
     def test_an_existing_venue_is_matched_not_registered(self):
         # The registry is shared with every other organiser, so registering a
         # second "Café Konrad" beside the one already there is litter in a


### PR DESCRIPTION
## Purpose

The **first real sync attempt** failed:

```
[14] 💘 Speed Dating: could not search echo.lu venues for 'MAIN Experience':
echo.lu GET /venues rejected (HTTP 400):
{'error': 'It is not allowed to retrieve more than 100 items per page'}
```

Three defects on that one path, none of which any test or doc could have caught — probed against the live API to confirm each:

| Probe | Result |
| --- | --- |
| `perPage=100` | 100 records, 3.9s |
| `perPage=200` | **400 — "not allowed to retrieve more than 100 items per page"** |
| `communes[]=luxembourg` (their id) | 100 records, 3s |
| `communes[]=Luxembourg - City` (ours, from `canton`) | **404** |

1. **Page ceiling is 100, and it rejects rather than clamps.** We asked for 200. `iter_experiences` now shares the same constant so they can't drift.
2. **An unrecognised commune 404s.** `canton` is free text; echo.lu wants one of its 113 ids. So even with the page size fixed, the narrowed pass would have failed the sync outright. It now demotes to the unfiltered pass and logs why — the filter is an optimisation, and no optimisation is worth an outage.
3. **No ceiling on the scan.** 5,000+ venues, no text search, 3–4s per page — minutes of paging against an admin action that allows **5 seconds per call**. Now capped at `ECHO_LU_VENUE_SEARCH_PAGES` (default 5, ~500 venues per pass), registering a new venue past that and saying so in the log.

Point 3 is the opposite trade to point 2, deliberately: **a duplicate venue is untidy; a hung admin request is broken.**

## What the failure got right

Worth noting, because it's the design working: the sync **refused** rather than registering a duplicate venue or creating a half-linked experience. The "never act on a registry we could not read" guard held, the error landed on the sync row and in the admin message bar, and nothing was written to echo.lu.

## Testing

Two of the three tests fail against `2fbf4532`. The third pins the cap but doesn't discriminate — the old code happened to stop after one page for an unrelated reason (`len(records) < per_page` was true when `per_page` was 200). Called out rather than dressed up as a regression test.

Full `crush_lu` suite green apart from the pre-existing `test_preview_can_load_roster_photos`.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Note for the operator

Even fixed, the **first** resolution of a venue is several seconds of paging. Run the first sync for a new venue from a shell (`manage.py sync_events_to_echo --event-id N`, 20s client timeout) rather than the admin action (5s). Once the id is cached in `EchoVenue`, every later event at that venue is instant either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)