### PR TITLE
Link echo.lu venues by hand instead of registering them

### DIFF
--- a/crush_lu/management/commands/echo_venue.py
+++ b/crush_lu/management/commands/echo_venue.py
@@ -1,0 +1,172 @@
+"""Link a Crush.lu venue name to an echo.lu venue id.
+
+echo.lu's ``venues`` field takes ids from its own registry — a shared national
+table of 5,000+ rows that every organiser reads and writes. Two things follow,
+and together they are why this command exists instead of the sync doing it:
+
+* **We never register a venue.** ``CreateVenue`` wants a description, a
+  category, a website and a contact, and for premises we merely book the only
+  values we hold are Crush.lu's own. Registering under them would publish
+  somebody else's venue with our contact on it.
+* **We cannot usefully search for one at request time.** There is no text
+  search, and paging 5,000 rows at 3-4 seconds a page takes minutes. That is
+  fine here, in a shell, once per venue — and impossible inside an admin
+  action that allows five seconds.
+
+So the mapping is made once, by a person, and cached in ``EchoVenue``. After
+that the sync path is a single indexed lookup with no network at all.
+
+Usage:
+    # Find the id (slow, exhaustive, read-only)
+    python manage.py echo_venue --search "MAIN Experience"
+
+    # Record it, keyed the same way the sync looks it up
+    python manage.py echo_venue --link "MAIN Experience" --postcode 1450 \\
+        --venue-id main-experience-abc123
+
+    # What is linked today
+    python manage.py echo_venue --list
+
+If the venue is not in the registry at all, create it in the echo.lu organiser
+back office first — where it can be given a real description, the right
+category and the venue's own contact details — then link the id it is given.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from crush_lu.services import echo_lu
+
+
+class Command(BaseCommand):
+    help = "Link a Crush.lu venue name to an echo.lu venue id."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--search",
+            metavar="NAME",
+            help=(
+                "Search echo.lu's venue registry for NAME (case- and "
+                "spacing-insensitive substring). Read-only and slow — it pages "
+                "the whole registry."
+            ),
+        )
+        parser.add_argument(
+            "--link",
+            metavar="LOCATION",
+            help=(
+                "The MeetupEvent.location string to map, exactly as events " "spell it"
+            ),
+        )
+        parser.add_argument(
+            "--postcode",
+            default="",
+            help=(
+                "Postcode that goes with --link. The lookup key is name plus "
+                "postcode, so this must match what parse_address extracts from "
+                "the event's address, or the sync will not find the mapping. "
+                "Check it with `sync_events_to_echo --event-id N --dry-run "
+                "--show-payload`."
+            ),
+        )
+        parser.add_argument("--venue-id", help="The echo.lu venue id to record")
+        parser.add_argument(
+            "--list", action="store_true", dest="show", help="Show every mapping"
+        )
+        parser.add_argument(
+            "--pages",
+            type=int,
+            default=60,
+            help="How many 100-row pages to read when searching (default 60)",
+        )
+
+    def handle(self, *args, **options):
+        if options["show"]:
+            return self._list()
+        if options["search"]:
+            return self._search(options["search"], options["pages"])
+        if options["link"]:
+            return self._link(options["link"], options["postcode"], options["venue_id"])
+        raise CommandError("Pass one of --search, --link or --list.")
+
+    def _list(self):
+        from crush_lu.models.echo_lu import EchoVenue
+
+        rows = list(EchoVenue.objects.all())
+        if not rows:
+            self.stdout.write("No venues linked yet.")
+            return
+        self.stdout.write(f"{len(rows)} linked venue(s):")
+        for row in rows:
+            self.stdout.write(f"  {row.key}\n      -> {row.venue_id}  {row.title}")
+
+    def _search(self, name, pages):
+        import re
+
+        needle = re.sub(r"\s+", " ", name.strip().lower())
+        client = echo_lu.EchoLuClient()
+        self.stdout.write(
+            f"Searching echo.lu's venue registry for {name!r} "
+            f"(up to {pages} pages — this takes a few minutes)…"
+        )
+
+        found = 0
+        scanned = 0
+        for record in echo_lu.iter_venue_records(client, None, max_pages=pages):
+            scanned += 1
+            title = record.get("title") or ""
+            if isinstance(title, dict):
+                title = title.get("en") or next(iter(title.values()), "")
+            address = (record.get("location") or {}).get("address") or {}
+            haystack = re.sub(r"\s+", " ", str(title).strip().lower())
+            if needle in haystack:
+                found += 1
+                where = " ".join(
+                    str(address.get(k, ""))
+                    for k in ("street", "number", "postcode", "town")
+                ).strip()
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  {echo_lu.extract_experience_id(record)}\n"
+                        f"      {title}\n"
+                        f"      {where}"
+                    )
+                )
+
+        self.stdout.write(f"\nScanned {scanned} venue(s).")
+        if not found:
+            self.stdout.write(
+                self.style.WARNING(
+                    "No match. If the venue really is not on echo.lu, create it "
+                    "in the organiser back office — with its own description, "
+                    "category and contact details, not ours — then link the id "
+                    "it is given."
+                )
+            )
+
+    def _link(self, location, postcode, venue_id):
+        from crush_lu.models.echo_lu import EchoVenue
+
+        if not venue_id:
+            raise CommandError("--link needs --venue-id")
+
+        key = echo_lu.venue_key(location, postcode)
+        clash = EchoVenue.objects.filter(key=key).first()
+        row, created = EchoVenue.objects.update_or_create(
+            key=key,
+            defaults={"venue_id": venue_id.strip(), "title": location},
+        )
+        verb = "Linked" if created else "Re-linked"
+        self.stdout.write(
+            self.style.SUCCESS(f"{verb} {location!r} (key {key}) -> {row.venue_id}")
+        )
+        if clash and clash.venue_id != row.venue_id:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  was {clash.venue_id}. Events already published against "
+                    f"the old venue keep it until they are re-synced."
+                )
+            )
+        self.stdout.write(
+            "Check the key matches what the event produces:\n"
+            "  manage.py sync_events_to_echo --event-id N --dry-run --show-payload"
+        )

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -357,18 +357,6 @@ class EchoLuClient:
     def list_venues(self, **params):
         return self._request("GET", "/venues", params=params or None)
 
-    def create_venue(self, payload):
-        """Register a venue and get its id back.
-
-        Not retried on anything but 429, for the same reason creating an
-        experience is not: venues are a shared national registry with
-        server-assigned ids, so a replay after a lost response leaves a
-        duplicate venue nobody can tell from the original.
-        """
-        return self._request(
-            "POST", "/venues", json_body=payload, retry_statuses=CREATE_RETRY_STATUSES
-        )
-
     # --- vocabularies ----------------------------------------------------
 
     #: The facets echo.lu validates against its own vocabularies. An unknown
@@ -634,11 +622,11 @@ def venue_key(name, postcode=""):
 
 
 def cached_venue_ids(event):
-    """Venue ids already known locally — no API calls, no writes.
+    """Venue ids already known locally, or ``[]`` if none is linked.
 
-    The read-only half of :func:`resolve_venue_ids`, for the paths that must
-    not touch echo.lu: the dry run, and the pre-lock fingerprint that decides
-    whether an unchanged event needs a write at all.
+    The non-raising twin of :func:`resolve_venue_ids`, for the paths that need
+    an answer rather than an error: the dry run, and the pre-lock fingerprint
+    that decides whether an unchanged event needs a write at all.
     """
     from ..models.echo_lu import EchoVenue
 
@@ -670,109 +658,54 @@ def fallback_picture_url():
     )
 
 
-def _venue_payload(event, address):
-    """A CreateVenue body for this event's location."""
-    return {
-        "title": event.location,
-        "location": {"address": address},
-    }
-
-
-def resolve_venue_ids(event, client, address=None):
-    """The echo.lu venue ids for this event, registering one if needed.
+def resolve_venue_ids(event):
+    """The echo.lu venue ids for this event, from the local mapping only.
 
     Returns a list because the field is a list; in practice it is one venue.
 
-    Three steps, cheapest first: the local cache, then echo.lu's registry, then
-    registering a new venue. The middle step matters because that registry is
-    shared with every other organiser in the country — a venue we create beside
-    an identical one that already exists is litter in a public dataset, not
-    just a wasted call.
+    **This never creates a venue, and never calls the API.** Both were tried
+    and both were wrong:
 
-    Matching is deliberately strict: normalised equality on the venue name, not
-    a fuzzy or substring match. Attaching our event to somebody else's venue
-    because the names looked similar is a worse failure than registering a
-    duplicate, and it is the kind that is invisible from our side.
+    * *Creating* one means claiming it. ``CreateVenue`` requires a description,
+      a category, a website and a contact — for premises we merely book. The
+      only values we hold are Crush.lu's own, so an automatic registration
+      would publish somebody else's venue into a shared national registry with
+      our contact details on it, which other organisers then attach their
+      events to. That is not a call a program should make by itself.
+    * *Searching* for one does not work at this size. The registry is 5,000+
+      rows with no text search and 3-4 seconds a page, so a scan bounded
+      tightly enough for a web request sees a few hundred rows and reliably
+      misses — while an unbounded one takes minutes. A search that almost
+      always falls through to a create is just a slow way to reach the wrong
+      answer.
+
+    So the mapping is explicit and made once per venue by a person:
+    ``manage.py echo_venue --search`` to find the id, ``--link`` to record it.
+    After that this is a single indexed lookup and the sync path touches no
+    network at all.
     """
     from ..models.echo_lu import EchoVenue
 
     if not event.location:
         return []
 
-    address = (
-        address if address is not None else parse_address(event.address, event.canton)
-    )
+    address = parse_address(event.address, event.canton)
     key = venue_key(event.location, address.get("postcode", ""))
+    row = EchoVenue.objects.filter(key=key).first()
+    if row is not None:
+        return [row.venue_id]
 
-    cached = EchoVenue.objects.filter(key=key).first()
-    if cached is not None:
-        return [cached.venue_id]
-
-    target = venue_key(event.location)
-    match_id, match_title = "", ""
-    try:
-        for record in _iter_venue_records(client, address):
-            title = record.get("title") or ""
-            if isinstance(title, dict):
-                title = title.get("en") or next(iter(title.values()), "")
-            if venue_key(str(title)) == target:
-                match_id = extract_experience_id(record)
-                match_title = str(title)
-                if match_id:
-                    break
-    except EchoLuError as exc:
-        # A registry we could not read is not a reason to register a duplicate
-        # into it. Fail the sync instead; the sweep retries in an hour.
-        #
-        # EchoLuNotSent, emphatically, and not a bare EchoLuError. Everything
-        # here happens *before* the experience create is attempted, so nothing
-        # can possibly have been created — but a locally raised error carries no
-        # status code, and `_proves_nothing_was_created` reads a missing status
-        # as "the answer was lost, assume a listing exists". A bare raise here
-        # therefore parked the event in ORPHANED: blocked from syncing forever
-        # and pointing its operator at an `--audit` that cannot find anything,
-        # because there is nothing to find. That is exactly what happened on the
-        # first production sync.
-        raise EchoLuNotSent(
-            f"could not search echo.lu venues for {event.location!r}: {exc}"
-        ) from exc
-
-    created_by_us = False
-    if not match_id:
-        response = client.create_venue(_venue_payload(event, address))
-        match_id = extract_experience_id(response)
-        match_title = event.location
-        created_by_us = True
-        if not match_id:
-            # Same shape of problem as an experience create with no id back,
-            # and the same answer: do not try again automatically. Without the
-            # id we cannot reference the venue, and a second attempt registers
-            # a second one into a shared national table.
-            raise EchoLuOrphanedCreate(
-                f"echo.lu accepted a venue for {event.location!r} but returned "
-                f"no id; it is now registered and untracked. Find it in the "
-                f"organiser back office and record its id on an EchoVenue row "
-                f"before syncing this event again."
-            )
-
-    EchoVenue.objects.update_or_create(
-        key=key,
-        defaults={
-            "venue_id": match_id,
-            "title": match_title,
-            "created_by_us": created_by_us,
-        },
+    raise EchoLuNotSent(
+        f"no echo.lu venue is linked to {event.location!r}. echo.lu requires a "
+        f"venue id from its own registry, and we deliberately do not register "
+        f"venues we only book. Find it with `manage.py echo_venue --search "
+        f"{event.location!r}`, or create it in the organiser back office, then "
+        f"link it with `manage.py echo_venue --link {event.location!r} "
+        f"--postcode {address.get('postcode', '')} --venue-id <id>`."
     )
-    logger.info(
-        "echo.lu venue %s for %r (%s)",
-        match_id,
-        event.location,
-        "registered" if created_by_us else "matched",
-    )
-    return [match_id]
 
 
-def _iter_venue_records(client, address):
+def iter_venue_records(client, address=None, max_pages=None):
     """Every venue worth checking, cheapest first.
 
     The registry is thousands of rows and ListVenues offers no text search, so
@@ -808,7 +741,9 @@ def _iter_venue_records(client, address):
       duplicate is untidy, while a hung admin request is broken.
     """
     per_page = LIST_PAGE_SIZE
-    max_pages = max(1, int(getattr(settings, "ECHO_LU_VENUE_SEARCH_PAGES", 5)))
+    if max_pages is None:
+        max_pages = int(getattr(settings, "ECHO_LU_VENUE_SEARCH_PAGES", 3))
+    max_pages = max(1, int(max_pages))
     commune = (address or {}).get("commune") or ""
     passes = [{"communes[]": commune}] if commune else []
     passes.append({})
@@ -1307,12 +1242,11 @@ def sync_event(event, client=None, force=False, dry_run=False):
 
         try:
             # Recomputed from the event as it is now, for the same reason.
-            # Venue resolution lives in here too: it can register a venue on
-            # echo.lu, so it belongs inside the lock with every other write —
-            # and inside this try, so a registry we cannot read is recorded on
-            # the row like any other failure instead of escaping unrecorded.
-            address = parse_address(event.address, event.canton)
-            venue_ids = resolve_venue_ids(event, client, address=address)
+            # Venue resolution is a local lookup — it neither calls echo.lu nor
+            # registers anything — but it stays inside this try so an unlinked
+            # venue is recorded on the row and shown in the admin, rather than
+            # escaping as an unexplained failure.
+            venue_ids = resolve_venue_ids(event)
             payload = build_experience_payload(event, venue_ids=venue_ids)
             fingerprint = payload_fingerprint(payload)
 

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -55,8 +55,22 @@ def make_event(**overrides):
         "registration_deadline": start - timedelta(days=1),
         "is_published": True,
     }
+    link_venue = overrides.pop("link_venue", True)
     defaults.update(overrides)
-    return MeetupEvent.objects.create(**defaults)
+    event = MeetupEvent.objects.create(**defaults)
+    if link_venue and event.location:
+        # echo.lu takes venue IDS from its own registry, and the sync refuses
+        # to invent one, so an event with no linked venue cannot publish. Every
+        # test that is about something else gets the mapping for free; the
+        # tests that are about the mapping pass link_venue=False.
+        from crush_lu.models.echo_lu import EchoVenue
+
+        address = echo_lu.parse_address(event.address, event.canton)
+        EchoVenue.objects.get_or_create(
+            key=echo_lu.venue_key(event.location, address.get("postcode", "")),
+            defaults={"venue_id": "venue-1", "title": event.location},
+        )
+    return event
 
 
 def echo_response(record):
@@ -383,28 +397,6 @@ class PayloadTests(TestCase):
 class UnsendablePayloadTests(TestCase):
     """Refusing to send is not the same as a create whose answer was lost."""
 
-    def test_an_unreadable_venue_registry_leaves_the_row_retryable(self):
-        # This one bit on the very first production sync. The venue search
-        # happens BEFORE the experience create, so a registry we cannot read
-        # proves nothing was created — but a locally raised error carries no
-        # status code, and a missing status otherwise reads as "the answer was
-        # lost". The event was parked in ORPHANED: blocked from syncing, and
-        # sent to an --audit with nothing to find.
-        event = make_event()
-
-        class BrokenRegistryClient(FakeClient):
-            def list_venues(self, **params):
-                raise echo_lu.EchoLuError("nope", status_code=400)
-
-        client = BrokenRegistryClient(venues=[])
-        with self.assertRaises(echo_lu.EchoLuError):
-            echo_lu.sync_event(event, client=client)
-
-        self.assertEqual(client.calls, [])  # no venue and no experience created
-        event.refresh_from_db()
-        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.FAILED)
-        self.assertNotEqual(event.echo_sync.status, EchoExperienceSync.Status.ORPHANED)
-
     @override_settings(
         ECHO_LU_DEFAULT_CATEGORIES="",
         ECHO_LU_DEFAULT_AUDIENCES="",
@@ -550,34 +542,65 @@ class ResponseRecordsTests(TestCase):
 
 @override_settings(**ENABLED)
 class VenueResolutionTests(TestCase):
-    """`venues` takes echo.lu venue IDs from a shared national registry."""
+    """`venues` takes ids from echo.lu's registry, and we only ever link them."""
 
-    def test_a_match_outside_the_commune_filter_is_still_found(self):
-        # The commune pass is an optimisation, not the search. Our `canton` is
-        # free text while echo.lu's commune filter is a controlled value, so
-        # the narrowed pass can return unrelated venues while the real match
-        # sits in another bucket. Skipping the wide pass because the narrow one
-        # returned *something* registered a duplicate into a shared national
-        # registry — the exact cost this lookup exists to avoid.
+    def test_a_linked_venue_is_used(self):
         event = make_event()
-        real = {"id": "venue-real", "title": "Café Konrad"}
-        unrelated = {"id": "venue-other", "title": "Somewhere Else"}
+        client = FakeClient()
+        self.assertEqual(echo_lu.resolve_venue_ids(event), ["venue-1"])
+        self.assertEqual(client.calls, [])
 
-        class CommuneFilteringClient(FakeClient):
-            def list_venues(self, **params):
-                if "communes[]" in params:
-                    # Narrowed pass: rows, but not the one we want.
-                    return {"records": [unrelated]}
-                return {"records": [unrelated, real]}
+    def test_resolution_never_calls_the_api(self):
+        # The whole point of linking: the sync path does no network work for
+        # venues at all, so it cannot be slow and cannot register anything.
+        event = make_event()
 
-        client = CommuneFilteringClient(venues=[])
-        self.assertEqual(echo_lu.resolve_venue_ids(event, client), ["venue-real"])
-        self.assertEqual(client.calls, [])  # nothing was registered
+        class ExplodingClient(FakeClient):
+            def list_venues(self, **params):  # pragma: no cover - must not run
+                raise AssertionError("resolution must not call echo.lu")
+
+        echo_lu.sync_event(event, client=ExplodingClient())
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.SYNCED)
+
+    def test_an_unlinked_venue_fails_with_instructions(self):
+        # And fails as EchoLuNotSent, so the row stays retryable rather than
+        # being parked as an orphan for a listing that was never created.
+        event = make_event(link_venue=False)
+        client = FakeClient()
+        with self.assertRaises(echo_lu.EchoLuNotSent) as caught:
+            echo_lu.sync_event(event, client=client)
+
+        self.assertEqual(client.calls, [])
+        self.assertIn("echo_venue --search", str(caught.exception))
+        self.assertIn("Café Konrad", str(caught.exception))
+        event.refresh_from_db()
+        self.assertEqual(event.echo_sync.status, EchoExperienceSync.Status.FAILED)
+
+    def test_an_event_with_no_venue_at_all_sends_none(self):
+        event = make_event(location="", link_venue=False)
+        self.assertEqual(echo_lu.resolve_venue_ids(event), [])
+
+    def test_the_key_ignores_casing_and_spacing(self):
+        # A hand-typed location that drifts in case or spacing must still find
+        # the mapping, or the same venue gets linked twice.
+        self.assertEqual(
+            echo_lu.venue_key("  café   KONRAD ", "1450"),
+            echo_lu.venue_key("Café Konrad", "1450"),
+        )
+        self.assertNotEqual(
+            echo_lu.venue_key("Café Konrad", "1450"),
+            echo_lu.venue_key("Café Konrad", "2229"),
+        )
+
+
+@override_settings(**ENABLED)
+class VenueSearchHelperTests(TestCase):
+    """The registry pager, which now only serves `manage.py echo_venue`."""
 
     def test_pages_never_exceed_the_hundred_item_ceiling(self):
         # echo.lu rejects a bigger page outright rather than clamping it:
-        # "It is not allowed to retrieve more than 100 items per page". The
-        # first live sync asked for 200 and failed on this.
+        # "It is not allowed to retrieve more than 100 items per page".
         seen = []
 
         class RecordingClient(FakeClient):
@@ -585,16 +608,14 @@ class VenueResolutionTests(TestCase):
                 seen.append(params.get("pagination[perPage]"))
                 return {"records": []}
 
-        echo_lu.resolve_venue_ids(make_event(), RecordingClient(venues=[]))
+        list(echo_lu.iter_venue_records(RecordingClient(), None))
         self.assertTrue(seen)
         self.assertTrue(all(p is not None and p <= 100 for p in seen), seen)
 
     def test_an_unknown_commune_falls_back_to_the_wide_search(self):
-        # Our commune comes from `canton`, which is free text
-        # ("Luxembourg - City"), while echo.lu wants one of its own ids
-        # ("luxembourg") and 404s on anything else. The filter is an
-        # optimisation, so an unusable one must demote to the unfiltered pass
-        # rather than failing the sync.
+        # Our commune comes from `canton` (free text) while echo.lu wants one
+        # of its own ids and 404s otherwise. The filter is an optimisation, so
+        # an unusable one demotes rather than failing.
         real = {"id": "venue-real", "title": "Café Konrad"}
 
         class PickyClient(FakeClient):
@@ -603,72 +624,19 @@ class VenueResolutionTests(TestCase):
                     raise echo_lu.EchoLuError("no such commune", status_code=404)
                 return {"records": [real]}
 
-        client = PickyClient(venues=[])
-        self.assertEqual(
-            echo_lu.resolve_venue_ids(make_event(), client), ["venue-real"]
-        )
-        self.assertEqual(client.calls, [])  # matched, nothing registered
+        found = list(echo_lu.iter_venue_records(PickyClient(), {"commune": "Nowhere"}))
+        self.assertIn("venue-real", [echo_lu.extract_experience_id(r) for r in found])
 
-    @override_settings(ECHO_LU_VENUE_SEARCH_PAGES=2)
-    def test_the_search_is_capped_and_then_registers(self):
-        # Pages cost 3-4s each and the admin action allows 5s per call, so an
-        # uncapped scan of 5,000 venues is a hung request. Past the cap we
-        # register rather than hunt — a duplicate is untidy, a hung admin
-        # request is broken.
+    def test_the_caller_can_widen_the_page_budget(self):
         pages = []
 
         class EndlessClient(FakeClient):
             def list_venues(self, **params):
                 pages.append(params.get("pagination[page]"))
-                return {"records": [{"id": f"v{len(pages)}", "title": "Nope"}] * 100}
+                return {"records": [{"id": f"v{len(pages)}", "title": "x"}] * 100}
 
-        client = EndlessClient(venues=[])
-        result = echo_lu.resolve_venue_ids(make_event(), client)
-        self.assertTrue(result[0].startswith("venue-"))
-        self.assertEqual([c[0] for c in client.calls], ["create_venue"])
-        # 2 pages for the commune pass + 2 for the wide one, and no more.
-        self.assertLessEqual(len(pages), 4)
-
-    def test_an_existing_venue_is_matched_not_registered(self):
-        # The registry is shared with every other organiser, so registering a
-        # second "Café Konrad" beside the one already there is litter in a
-        # public dataset.
-        event = make_event()
-        client = FakeClient(venues=[{"id": "venue-77", "title": "café  KONRAD"}])
-        self.assertEqual(echo_lu.resolve_venue_ids(event, client), ["venue-77"])
-        self.assertEqual(client.calls, [])
-
-    def test_an_unknown_venue_is_registered(self):
-        event = make_event()
-        client = FakeClient(venues=[])
-        self.assertEqual(echo_lu.resolve_venue_ids(event, client), ["venue-1"])
-        self.assertEqual([c[0] for c in client.calls], ["create_venue"])
-        self.assertEqual(client.calls[0][1]["title"], "Café Konrad")
-
-    def test_a_similar_name_is_not_matched(self):
-        # Attaching our event to somebody else's venue is worse than a
-        # duplicate, and invisible from our side — so matching is normalised
-        # equality, never a substring.
-        event = make_event()
-        client = FakeClient(venues=[{"id": "venue-9", "title": "Café Konrad Bar"}])
-        # A fresh registration, not venue-9.
-        self.assertEqual(echo_lu.resolve_venue_ids(event, client), ["venue-2"])
-        self.assertEqual([c[0] for c in client.calls], ["create_venue"])
-
-    def test_the_id_is_cached_so_the_next_event_costs_nothing(self):
-        first = make_event()
-        client = FakeClient(venues=[])
-        echo_lu.resolve_venue_ids(first, client)
-        second = make_event(title="Another night")
-        after = FakeClient(venues=[])
-        self.assertEqual(echo_lu.resolve_venue_ids(second, after), ["venue-1"])
-        self.assertEqual(after.calls, [])
-
-    def test_cached_ids_never_call_the_api(self):
-        event = make_event()
-        self.assertEqual(echo_lu.cached_venue_ids(event), [])
-        echo_lu.resolve_venue_ids(event, FakeClient(venues=[]))
-        self.assertEqual(echo_lu.cached_venue_ids(event), ["venue-1"])
+        list(echo_lu.iter_venue_records(EndlessClient(), None, max_pages=2))
+        self.assertEqual(len(pages), 2)
 
 
 @override_settings(**ENABLED)

--- a/docs/integrations/echo-lu-sync.md
+++ b/docs/integrations/echo-lu-sync.md
@@ -149,6 +149,144 @@ on its first tick.
    dormant sweep cannot look green — which the `EchoLuSync` timer records as a
    Failed invocation every hour until step 5 is done.
 
+### Venues are linked by hand, never created
+
+`venues` on an experience is a list of **ids** from echo.lu's own venue
+registry — a shared national table of 5,000+ rows that every organiser reads
+and writes. Two facts about it shape everything else:
+
+* **There is no text search.** ListVenues filters only by category and commune,
+  and a page of 100 costs 3-4 seconds. Finding one venue means paging the whole
+  registry: minutes. That is fine once, in a shell; it is impossible inside an
+  admin action that allows five seconds.
+* **Registering a venue means claiming it.** CreateVenue requires a
+  description, a category, a website and a contact. For premises we merely
+  book, the only values we hold are Crush.lu's own — so an automatic
+  registration would publish somebody else's venue into a public national
+  registry with our contact details on it, for other organisers to attach their
+  events to.
+
+So the sync **never registers a venue and never searches at request time.** It
+reads a mapping made once, by a person:
+
+```bash
+# find the id (slow, exhaustive, read-only)
+python manage.py echo_venue --search "MAIN Experience"
+
+# record it — the key is name + postcode, exactly as the event produces them
+python manage.py echo_venue --link "MAIN Experience" --postcode 1450     --venue-id <id>
+
+python manage.py echo_venue --list
+```
+
+If the venue is not in the registry, create it in the echo.lu organiser back
+office first — with its own description, category and contact, not ours — then
+link the id it is given.
+
+Until a venue is linked, syncing an event there fails with a message naming it
+and the command to run. That failure is retryable (`FAILED`, not `ORPHANED`):
+nothing was sent, so the next sweep succeeds by itself once the link exists.
+
+## Turning it on
+
+> **There is no sandbox.** An earlier version of this page sent you to
+> `test-api.echo.lu` with a separate key. That environment is not real: the
+> published docs name exactly one base URL, never mention a test environment,
+> and that hostname serves a byte-identical documentation page from the same
+> address as `api.echo.lu`. **Every write lands on the live national portal.**
+>
+> That inverts the obvious rollout. Staging is the *dangerous* place to try
+> this — its database is `pythonapp_staging`, full of test events, and
+> publishing those to echo.lu is exactly the failure this integration is meant
+> to avoid. The safe first run is **one real production event, by id**. Its
+> blast radius is that one listing, and `DeleteExperience` is the undo.
+
+**Order matters and it is not the obvious order.** The switch goes on late, and
+the hourly timer later still — the sweep reconciles the whole upcoming calendar
+on its first tick.
+
+1. **Issue an API key** in the echo.lu organiser back office. The key is tied to
+   your organisation — there is no separate organisation id to configure.
+2. **Set the credentials on the production slot, switch still off:**
+
+   ```
+   ECHO_LU_API_KEY=<key>
+   ECHO_LU_CONTACT_EMAIL=<a mailbox somebody actually reads>
+   ECHO_LU_CONTACT_PHONE=+352...
+   ```
+
+   `ECHO_LU_API_BASE_URL` needs no setting; it defaults to
+   `https://api.echo.lu/v1`, the only base URL there is.
+
+   `ECHO_LU_SYNC_ENABLED` defaults to **false**, and the key alone is inert —
+   that is what lets the next steps run against the real API while nothing can
+   be published. Note that `ECHO_LU_API_KEY` and `ECHO_LU_SYNC_ENABLED` are
+   **slot-sticky** (they are in `slotConfigNames`), so each slot keeps its own
+   and a swap does not carry them.
+
+   **Contact is all-or-nothing.** `name`, `email` and `phone` are all required
+   *within* the contact block while the block itself is optional, so a partial
+   one is worse than none — it turns an optional field into a guaranteed
+   rejection. Without a phone number the contact block is omitted entirely and
+   the listing carries no organiser contact.
+
+3. **Check the taxonomy ids.** All four facets are **required** — an experience
+   without them is rejected with `Missing categories` and so on, so "leave it
+   blank" is not an option:
+
+   ```bash
+   python manage.py echo_taxonomy            # 190 categories, 10 audiences,
+   python manage.py echo_taxonomy --check    # 16 formats, 3 environments
+   ```
+
+   The shipped defaults are real ids read off the live API
+   (`nightlife` / `adults` / `networking` / `indoors`, languages `en,fr`),
+   chosen for a dating meetup rather than editorially decided. Override per
+   environment once somebody has read how the listings look:
+
+   ```
+   ECHO_LU_DEFAULT_CATEGORIES=nightlife
+   ECHO_LU_CATEGORY_MAP={"speed_dating": ["nightlife"], "mixer": ["nightlife-afterwork"]}
+   ```
+
+4. **Dry-run and read the payload**, which writes nothing:
+
+   ```bash
+   python manage.py sync_events_to_echo --event-id 42 --dry-run --show-payload
+   ```
+
+   Read it rather than skim it. `location.address` is parsed out of a free-text
+   field, and echo.lu renders whatever it accepts verbatim.
+
+5. **Turn it on:** `ECHO_LU_SYNC_ENABLED=true` on the production slot.
+
+6. **Sync exactly one event and go and look at it:**
+
+   ```bash
+   python manage.py sync_events_to_echo --event-id 42
+   ```
+
+   This is the real test, because there is nowhere else to run one. The
+   experience is created with `status=pending`, which submits it for
+   validation — **echo.lu moderates listings**, so it will not appear publicly
+   the moment the command returns. Check the organiser back office. Set
+   `ECHO_LU_CREATE_STATUS=draft` first if you would rather it park there
+   without being submitted at all.
+
+7. **Only then wire up the hourly sweep**, by setting `DJANGO_ECHO_SYNC_URL` on
+   the `crush-hybrid-maintenance` Function App — re-running `provision.sh` /
+   `provision.ps1` does it, or set it directly:
+
+   ```bash
+   az functionapp config appsettings set -g django-app-rg      -n crush-hybrid-maintenance      --settings DJANGO_ECHO_SYNC_URL=https://crush.lu/api/admin/echo-sync/
+   ```
+
+   Last, for two reasons. The sweep's first tick reconciles the *entire*
+   upcoming calendar, so everything above needs to have been checked by then.
+   And the endpoint answers 500 while the switch is off — deliberately, so a
+   dormant sweep cannot look green — which the `EchoLuSync` timer records as a
+   Failed invocation every hour until step 5 is done.
+
 ### Venues
 
 `venues` on an experience is a list of **ids** from echo.lu's own venue


### PR DESCRIPTION
## What the first real sync taught us

Two things, and the second is a design error of mine rather than a bug.

**1. Registering a venue means claiming it.** The sync got far enough to try, and echo.lu rejected it:

```
POST /venues 400: location.address / description / categories / website / contact
```

`CreateVenue` requires a description, a category, a website and a **contact**. For premises we merely book, the only values we hold are Crush.lu's own — so registering automatically would publish somebody else's venue into a **shared national registry with our contact details on it**, which other organisers then attach their events to. Tom's call: never do that.

**2. Searching for one does not work at this size.** The registry is **5,488 rows**, with no text search, at 3–4 seconds a page. A scan bounded tightly enough for a web request sees a few hundred rows and reliably misses; an unbounded one takes minutes. I built a search that almost always falls through to a create — a slow way to reach the wrong answer.

I paged the entire registry to check: **"MAIN Experience" is not in it**, and the only venue on Côte d'Eich at L-1450 is a different business at number 75.

## The change

Venue resolution is now a **local lookup and nothing else** — no API call, nothing registered, cannot be slow. An event whose venue isn't linked fails with a message naming it and the command to fix it, as `EchoLuNotSent`, so the row stays **retryable** and the next sweep succeeds on its own once the link exists.

The searching moves to `manage.py echo_venue`, where a shell has the minutes an exhaustive scan needs and it runs once per venue rather than once per sync:

```bash
python manage.py echo_venue --search "MAIN Experience"
python manage.py echo_venue --link "MAIN Experience" --postcode 1450 --venue-id <id>
python manage.py echo_venue --list
```

When the venue genuinely isn't on echo.lu, the operator creates it in the organiser back office — with its own description, category and contact — and links the id.

## What to check

- **`make_event` links its venue by default.** Tests that are about something else keep working; the ones about the mapping pass `link_venue=False`. Worth a look that this doesn't mask anything.
- **The old create/search tests are replaced, not adapted** — the behaviour they pinned is gone deliberately. The registry pager keeps its own tests now that it only serves the search command.
- `EchoLuClient.create_venue` is **removed**, not left unused, so it can't be reached for later.
- The lookup key is name + postcode, and the link command warns you to check it against `--dry-run --show-payload`. A mismatch there is the one way to link a venue and still not have it found.

## Testing

Echo suite and full `crush_lu` green (bar the pre-existing `test_preview_can_load_roster_photos`).

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

Nothing published yet, so there's no existing mapping to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)