### PR TITLE
Translate "lu" to "lb", and stand in for an oversized banner

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -906,6 +906,12 @@ ECHO_LU_DEFAULT_ENVIRONMENTS = os.environ.get("ECHO_LU_DEFAULT_ENVIRONMENTS", "i
 # Required too, and an event with no languages set cannot simply omit them.
 ECHO_LU_DEFAULT_LANGUAGES = os.environ.get("ECHO_LU_DEFAULT_LANGUAGES", "en,fr")
 ECHO_LU_DEFAULT_TAGS = os.environ.get("ECHO_LU_DEFAULT_TAGS", "crush.lu")
+# echo.lu rejects the whole experience over an oversized banner, not just the
+# banner — "The max image size (2048Kb) is exceeded: 2317Kb" — so an event
+# whose own image is over this sends the fallback instead of failing.
+ECHO_LU_MAX_PICTURE_BYTES = int(
+    os.environ.get("ECHO_LU_MAX_PICTURE_BYTES", str(2048 * 1024))
+)
 # How many 100-row pages of echo.lu's venue registry to read before giving up
 # and registering a new venue. The registry is 5,000+ rows with no text search
 # and **each page measures 3-4 seconds**, so do the arithmetic before raising

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -62,6 +62,18 @@ CREATE_RETRY_STATUSES = frozenset({429})
 # future reader raising it "for venues" would silently repage the experience
 # sweep too.
 LIST_PAGE_SIZE = 100
+# Crush.lu spells Luxembourgish "lu"; echo.lu wants "lb", and rejects the whole
+# experience on anything it does not know ("Nonexisting value was found: lu").
+# "lb" is the ISO 639-1 language code — "lu" is the ISO 3166 code for the
+# *country*, which is a very easy thing to have picked years ago and never
+# noticed, because nothing outside the platform ever read it.
+#
+# Only aliases go here. Codes echo.lu already accepts pass through untouched:
+# there is no vocabulary endpoint for languages, so we cannot validate them,
+# and silently dropping an unrecognised one would publish an event as
+# English-only rather than telling anybody.
+ECHO_LANGUAGE_CODES = {"lu": "lb"}
+
 MAX_RETRIES = 3
 DEFAULT_RETRY_AFTER = 2.0
 # Ceiling on total sleep across retries. The sync can run from a request-thread
@@ -650,6 +662,35 @@ def cached_venue_ids(event):
     return [row.venue_id] if row else []
 
 
+def _picture_too_big(event):
+    """True when the event's own banner exceeds echo.lu's image limit.
+
+    echo.lu rejects the **whole experience** over an oversized picture — "The
+    max image size (2048Kb) is exceeded: 2317Kb" — so a heavy banner does not
+    cost a banner, it costs the listing. Checked here so an event with a big
+    image still publishes, with the fallback standing in.
+
+    Reads `.size`, which is a storage metadata call rather than a download.
+    Any failure answers False: sending it and letting echo.lu decide is better
+    than dropping a good banner because a HEAD request was unlucky.
+    """
+    limit = int(getattr(settings, "ECHO_LU_MAX_PICTURE_BYTES", 2048 * 1024))
+    try:
+        size = event.image.size
+    except Exception:  # noqa: BLE001 - storage errors must not fail the sync
+        return False
+    if size and size > limit:
+        logger.info(
+            "[ECHO] event %s banner is %sKB, over echo.lu's %sKB limit; "
+            "sending the fallback image instead",
+            event.pk,
+            size // 1024,
+            limit // 1024,
+        )
+        return True
+    return False
+
+
 def fallback_picture_url():
     """The picture to send for an event that has no image of its own.
 
@@ -977,7 +1018,7 @@ def build_experience_payload(event, venue_ids=None):
     # go out incomplete, and `missing_required_fields` names it before it costs
     # a round trip.
     picture_url = ""
-    if event.image:
+    if event.image and not _picture_too_big(event):
         try:
             picture_url = _absolute_media_url(event.image.url)
         except ValueError:
@@ -989,9 +1030,15 @@ def build_experience_payload(event, venue_ids=None):
         payload["pictures"] = [{"url": picture_url, "copy": "Crush.lu", "alt": title}]
 
     # `languages` is required too, so an event with none configured falls back
-    # rather than omitting the key.
-    languages = [code for code in (event.languages or []) if code]
-    payload["languages"] = languages or _setting_list("ECHO_LU_DEFAULT_LANGUAGES", "en")
+    # rather than omitting the key. Codes are translated on the way out — see
+    # ECHO_LANGUAGE_CODES.
+    languages = [
+        ECHO_LANGUAGE_CODES.get(code, code) for code in (event.languages or []) if code
+    ]
+    payload["languages"] = languages or [
+        ECHO_LANGUAGE_CODES.get(code, code)
+        for code in _setting_list("ECHO_LU_DEFAULT_LANGUAGES", "en")
+    ]
 
     for facet, setting_name in (
         ("categories", "ECHO_LU_DEFAULT_CATEGORIES"),

--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -650,6 +650,25 @@ def cached_venue_ids(event):
     return [row.venue_id] if row else []
 
 
+def _echo_languages(codes):
+    """Our language codes in echo.lu's spelling.
+
+    One helper rather than the mapping written out at each call site: the two
+    would drift the moment the aliasing grows, and it already has to be more
+    than a dict lookup — matching is case-insensitive, because a stray "LU"
+    from an import or a fixture would otherwise sail past `{"lu": "lb"}` and be
+    rejected by echo.lu with the same opaque message as before.
+    """
+    result = []
+    for code in codes or []:
+        if not code:
+            continue
+        cleaned = str(code).strip().lower()
+        if cleaned:
+            result.append(ECHO_LANGUAGE_CODES.get(cleaned, cleaned))
+    return result
+
+
 def _picture_too_big(event):
     """True when the event's own banner exceeds echo.lu's image limit.
 
@@ -658,15 +677,34 @@ def _picture_too_big(event):
     cost a banner, it costs the listing. Checked here so an event with a big
     image still publishes, with the fallback standing in.
 
-    Reads `.size`, which is a storage metadata call rather than a download.
+    **Cached, because `.size` is a network call.** On Azure Blob it is a
+    blob-properties request, and `FieldFile.size` caches nothing — so a naive
+    read here would cost a round trip for every event with a banner on every
+    sweep, including the events that turn out to be no-ops. That would quietly
+    undo the "an unchanged event costs no API call" property this module is
+    built around, and the sweep's time budget reserves nothing for it. Worse,
+    it is invisible in dev and CI, where storage is the local filesystem.
+
+    Keyed on the stored file name, which for uploaded banners is a content
+    hash — so a re-upload is a new key and the cache never goes stale.
+
     Any failure answers False: sending it and letting echo.lu decide is better
-    than dropping a good banner because a HEAD request was unlucky.
+    than dropping a good banner because one metadata call was unlucky.
     """
+    from django.core.cache import cache
+
     limit = int(getattr(settings, "ECHO_LU_MAX_PICTURE_BYTES", 2048 * 1024))
-    try:
-        size = event.image.size
-    except Exception:  # noqa: BLE001 - storage errors must not fail the sync
-        return False
+    name = getattr(event.image, "name", "") or ""
+    cache_key = f"echo_lu:picture_size:{name}" if name else ""
+
+    size = cache.get(cache_key) if cache_key else None
+    if size is None:
+        try:
+            size = event.image.size
+        except Exception:  # noqa: BLE001 - storage errors must not fail the sync
+            return False
+        if cache_key and size:
+            cache.set(cache_key, size, 7 * 24 * 3600)
     if size and size > limit:
         logger.info(
             "[ECHO] event %s banner is %sKB, over echo.lu's %sKB limit; "
@@ -967,13 +1005,9 @@ def build_experience_payload(event, venue_ids=None):
     # `languages` is required too, so an event with none configured falls back
     # rather than omitting the key. Codes are translated on the way out — see
     # ECHO_LANGUAGE_CODES.
-    languages = [
-        ECHO_LANGUAGE_CODES.get(code, code) for code in (event.languages or []) if code
-    ]
-    payload["languages"] = languages or [
-        ECHO_LANGUAGE_CODES.get(code, code)
-        for code in _setting_list("ECHO_LU_DEFAULT_LANGUAGES", "en")
-    ]
+    payload["languages"] = _echo_languages(event.languages) or _echo_languages(
+        _setting_list("ECHO_LU_DEFAULT_LANGUAGES", "en")
+    )
 
     for facet, setting_name in (
         ("categories", "ECHO_LU_DEFAULT_CATEGORIES"),

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -373,6 +373,52 @@ class PayloadTests(TestCase):
         payload = echo_lu.build_experience_payload(make_event(languages=["de"]))
         self.assertEqual(payload["languages"], ["de"])
 
+    def test_luxembourgish_is_translated_to_echo_lu_s_code(self):
+        # We spell it "lu" (which is really the ISO country code); echo.lu
+        # wants the ISO 639-1 language code "lb", and rejects the whole
+        # experience on anything else: "Nonexisting value was found: lu".
+        payload = echo_lu.build_experience_payload(make_event(languages=["en", "lu"]))
+        self.assertEqual(payload["languages"], ["en", "lb"])
+
+    def test_unknown_language_codes_are_passed_through(self):
+        # There is no vocabulary endpoint for languages, so we cannot validate
+        # them. Dropping one silently would publish an event as English-only
+        # and tell nobody; echo.lu rejecting it says exactly what is wrong.
+        payload = echo_lu.build_experience_payload(make_event(languages=["xx"]))
+        self.assertEqual(payload["languages"], ["xx"])
+
+    @override_settings(ECHO_LU_MAX_PICTURE_BYTES=1000)
+    def test_an_oversized_banner_falls_back_instead_of_failing(self):
+        # echo.lu rejects the whole experience over a heavy image, so a big
+        # banner costs the listing rather than the banner.
+        event = make_event()
+
+        class BigImage:
+            size = 5000
+            url = "https://cdn.crush.lu/huge.png"
+
+            def __bool__(self):
+                return True
+
+        event.image = BigImage()
+        payload = echo_lu.build_experience_payload(event)
+        self.assertEqual(payload["pictures"][0]["url"], echo_lu.fallback_picture_url())
+
+    @override_settings(ECHO_LU_MAX_PICTURE_BYTES=10000)
+    def test_a_banner_within_the_limit_is_used(self):
+        event = make_event()
+
+        class SmallImage:
+            size = 5000
+            url = "https://cdn.crush.lu/fine.png"
+
+            def __bool__(self):
+                return True
+
+        event.image = SmallImage()
+        payload = echo_lu.build_experience_payload(event)
+        self.assertEqual(payload["pictures"][0]["url"], "https://cdn.crush.lu/fine.png")
+
     def test_status_is_not_part_of_the_payload(self):
         # It is a create-time instruction, not content. In the payload it would
         # join the fingerprint and ride every PUT.

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -394,6 +394,20 @@ class PayloadTests(TestCase):
         payload = echo_lu.build_experience_payload(make_event(languages=["en", "lu"]))
         self.assertEqual(payload["languages"], ["en", "lb"])
 
+    def test_language_matching_is_case_insensitive(self):
+        # A stray "LU" from an import or a fixture would otherwise sail past a
+        # bare dict lookup and be rejected by echo.lu with the same opaque
+        # message the mapping exists to prevent.
+        payload = echo_lu.build_experience_payload(make_event(languages=["LU", "EN"]))
+        self.assertEqual(payload["languages"], ["lb", "en"])
+
+    def test_the_default_languages_are_translated_too(self):
+        # The fallback goes through the same helper, so a deployment that set
+        # ECHO_LU_DEFAULT_LANGUAGES=lu is not a rejection waiting to happen.
+        with override_settings(ECHO_LU_DEFAULT_LANGUAGES="lu"):
+            payload = echo_lu.build_experience_payload(make_event(languages=[]))
+        self.assertEqual(payload["languages"], ["lb"])
+
     def test_unknown_language_codes_are_passed_through(self):
         # There is no vocabulary endpoint for languages, so we cannot validate
         # them. Dropping one silently would publish an event as English-only
@@ -417,6 +431,35 @@ class PayloadTests(TestCase):
         event.image = BigImage()
         payload = echo_lu.build_experience_payload(event)
         self.assertEqual(payload["pictures"][0]["url"], echo_lu.fallback_picture_url())
+
+    @override_settings(ECHO_LU_MAX_PICTURE_BYTES=1000)
+    def test_the_banner_size_is_read_once_and_cached(self):
+        # `.size` is a network call on Azure Blob and FieldFile caches nothing,
+        # so reading it per payload build would put a storage round trip on
+        # every event of every sweep — including the no-ops the whole
+        # fingerprint design exists to keep free.
+        from django.core.cache import cache
+
+        cache.clear()
+        reads = []
+
+        class CountingImage:
+            name = "banners/counted.png"
+            url = "https://cdn.crush.lu/counted.png"
+
+            def __bool__(self):
+                return True
+
+            @property
+            def size(self):
+                reads.append(1)
+                return 5000
+
+        event = make_event()
+        event.image = CountingImage()
+        for _ in range(3):
+            echo_lu.build_experience_payload(event)
+        self.assertEqual(len(reads), 1, "banner size should be read once, then cached")
 
     @override_settings(ECHO_LU_MAX_PICTURE_BYTES=10000)
     def test_a_banner_within_the_limit_is_used(self):


### PR DESCRIPTION
## Purpose

The first full sweep published 2 of 6 events and gave two clear reasons for the rest:

```
[15] languages: Nonexisting value was found: lu
[17] pictures:  The max image size (2048Kb) is exceeded: 2317Kb
[18] languages: Nonexisting value was found: lu
[19] pictures:  The max image size (2048Kb) is exceeded: 2317Kb
```

**`lu` → `lb`.** Crush.lu spells Luxembourgish `lu` (`EVENT_LANGUAGE_CHOICES`, `LANGUAGE_DISPLAY`); echo.lu wants `lb`. `lb` is the ISO 639-1 **language** code — `lu` is the ISO 3166 code for the **country**. An easy thing to have picked years ago and never noticed, because nothing outside the platform read it until now.

Only aliases are mapped. Unknown codes pass through untouched: there's no vocabulary endpoint for languages so we can't validate, and silently dropping one would publish an event as English-only and tell nobody — whereas echo.lu rejecting it says exactly what's wrong.

**Oversized banner → fallback.** echo.lu rejects the **whole experience** over a heavy image, so one big banner costs the listing, not the banner. Size is now checked before sending (`.size`, a storage metadata read rather than a download) and an over-limit image falls back to the social-preview file, measured at **798 KB** against the 2048 KB ceiling. Any failure reading the size answers "fine" — sending it and letting echo.lu decide beats dropping a good banner because a metadata call was unlucky.

## Testing

Both new tests fail against `663fdfa7`. Full `crush_lu` green bar the pre-existing `test_preview_can_load_roster_photos`.

## Not in this PR

echo.lu stored the two successful listings with **empty `commune` and `town`**. We send the canton (`"Luxembourg - City"`) where it wants one of its 113 commune ids (`luxembourg`). It accepts the experience and silently drops the field, so this costs *discovery* rather than publication — your listing may not surface under Luxembourg City in their filters. Worth its own change; not blocking.

Also open: `venues` came back empty on the created experience despite being sent, which needs a look at how they expect it attached.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)