### PR TITLE
Match canton aliases on letters only

### DIFF
--- a/crush_lu/migrations/0224_normalize_event_canton_again.py
+++ b/crush_lu/migrations/0224_normalize_event_canton_again.py
@@ -1,0 +1,103 @@
+"""Re-normalise MeetupEvent.canton, matching on letters only.
+
+0222 keyed its alias table on whitespace-collapsed, casefolded text. Real data
+turned out to be punctuated: staging holds `Luxembourg - City`, `Luxembourg-City`
+and `Lux`, none of which matched `luxembourg city`, so the migration ran, left
+them alone, and reported them as unmapped. Nobody reads a deploy log line.
+
+Matching now strips everything that is not a letter, so spacing and hyphens stop
+mattering, and the alias table gained the abbreviations that were actually in
+use. A separate migration rather than an edit to 0222 because 0222 has already
+run: migrations do not re-apply, and the rows it skipped would stay skipped.
+
+Re-running is safe. A value already equal to its canonical form is left
+untouched, so this is a no-op everywhere 0222 succeeded.
+"""
+
+import re
+
+from django.db import migrations
+
+# Everything that is not a letter goes, so "Luxembourg - City", "Luxembourg-City"
+# and "luxembourg  city" all reduce to the same key. Accents are kept: the
+# canonical names carry none, and stripping them would fold distinct communes
+# together for no gain.
+_KEY_RE = re.compile(r"[^a-zà-öø-ÿ]+")
+
+CANONICAL = [
+    "Capellen",
+    "Clervaux",
+    "Diekirch",
+    "Echternach",
+    "Esch-sur-Alzette",
+    "Grevenmacher",
+    "Luxembourg",
+    "Mersch",
+    "Redange",
+    "Remich",
+    "Vianden",
+    "Wiltz",
+]
+
+# Communes, quarters and abbreviations seen in the wild, mapped to their canton.
+# The city ones matter most: "Luxembourg - City" and friends are how the capital
+# has been typed, and they are a quarter-or-city name where a canton belongs.
+ALIASES = {
+    "luxembourgcity": "Luxembourg",
+    "luxembourgville": "Luxembourg",
+    "villehaute": "Luxembourg",
+    "lux": "Luxembourg",
+    "luxville": "Luxembourg",
+    "eschalzette": "Esch-sur-Alzette",
+    "eschsuralzette": "Esch-sur-Alzette",
+    "esch": "Esch-sur-Alzette",
+    "differdange": "Esch-sur-Alzette",
+    "dudelange": "Esch-sur-Alzette",
+    "belval": "Esch-sur-Alzette",
+    "ettelbruck": "Diekirch",
+    "mondorflesbains": "Remich",
+    "mondorf": "Remich",
+    "beaufort": "Echternach",
+}
+
+
+def _key(value):
+    return _KEY_RE.sub("", (value or "").casefold())
+
+
+def normalize(apps, schema_editor):
+    MeetupEvent = apps.get_model("crush_lu", "MeetupEvent")
+    by_key = {_key(name): name for name in CANONICAL}
+
+    changed = []
+    unmapped = set()
+    for event in MeetupEvent.objects.exclude(canton="").only("id", "canton"):
+        target = by_key.get(_key(event.canton)) or ALIASES.get(_key(event.canton))
+        if target is None:
+            unmapped.add(event.canton)
+            continue
+        if target != event.canton:
+            event.canton = target
+            changed.append(event)
+
+    if changed:
+        MeetupEvent.objects.bulk_update(changed, ["canton"], batch_size=500)
+        print(f"  normalised canton on {len(changed)} event(s)")
+    if unmapped:
+        # Still not silent, but `backfill_event_addresses --audit` is what
+        # actually blocks on these now, so they cannot slip by unnoticed.
+        print(
+            "  left unchanged, not a recognised canton or known alias: "
+            + ", ".join(sorted(repr(value) for value in unmapped))
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("crush_lu", "0223_event_canton_choices"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize, migrations.RunPython.noop),
+    ]

--- a/crush_lu/tests/test_canton_aliases.py
+++ b/crush_lu/tests/test_canton_aliases.py
@@ -1,0 +1,36 @@
+"""Tests for the canton alias normalisation in migration 0224.
+
+0222 keyed its alias table on whitespace-collapsed text, so the punctuated
+spellings real data actually holds -- "Luxembourg - City", "Luxembourg-City",
+"Lux" -- never matched and were silently left alone.
+"""
+
+import importlib
+
+import pytest
+
+
+class TestCantonAliases:
+    @pytest.mark.parametrize(
+        "typed,expected",
+        [
+            # The shapes staging actually held. 0222 keyed on whitespace-
+            # collapsed text, so the punctuated spellings never matched and it
+            # silently left them alone.
+            ("Luxembourg - City", "Luxembourg"),
+            ("Luxembourg-City", "Luxembourg"),
+            ("Lux", "Luxembourg"),
+            ("luxembourg", "Luxembourg"),
+            ("Esch/Alzette", "Esch-sur-Alzette"),
+            ("Beaufort", "Echternach"),
+        ],
+    )
+    def test_canton_aliases_survive_punctuation(self, typed, expected):
+        import importlib
+
+        migration = importlib.import_module(
+            "crush_lu.migrations.0224_normalize_event_canton_again"
+        )
+        by_key = {migration._key(name): name for name in migration.CANONICAL}
+        key = migration._key(typed)
+        assert (by_key.get(key) or migration.ALIASES.get(key)) == expected


### PR DESCRIPTION
Small, standalone, and **blocking the rest of the address work** — see the last section.

## What went wrong

`0222` (merged in #816) normalises `MeetupEvent.canton` onto the 12 canonical names. It keyed its alias table on whitespace-collapsed, casefolded text.

Real data is punctuated. Staging holds:

```
'Luxembourg - City'   -> 'luxembourg - city'   != 'luxembourg city'   ✗
'Luxembourg-City'     -> 'luxembourg-city'     != 'luxembourg city'   ✗
'Lux'                 -> not in the table at all                       ✗
```

So the migration ran, changed nothing, printed them as unmapped into a deploy log, and left seven staging events failing `backfill_event_addresses --audit`.

**No test could have caught this.** The alias table was written from `create_sample_events.py` and test fixtures — these values exist only in the database. It surfaced the first time `--audit` ran against a real one.

## The fix

`0224` re-runs the normalisation with a key that strips everything except letters, so spacing and hyphens stop mattering:

```
'Luxembourg - City'  -> Luxembourg
'Luxembourg-City'    -> Luxembourg
'Lux'                -> Luxembourg
'Esch/Alzette'       -> Esch-sur-Alzette
'Beaufort'           -> Echternach
'test'               -> (unmapped, correctly)
```

plus the abbreviations actually in use — `Lux`, `Ville-Haute`, `Belval`, `Esch`, `Mondorf`.

A **new** migration rather than an edit to `0222`, because `0222` has already applied on staging and migrations do not re-run — the rows it skipped would stay skipped. Re-running is a no-op wherever `0222` already succeeded, so this is safe on a database that never had the problem.

## Why it is split out

#817 makes canton and the address components required on every save. It is gated on `--audit` reporting clean — and `--audit` fails on exactly these unrecognised cantons. Shipping the fix inside the PR it gates is a deadlock, so it goes first, on its own.

Merge order: **this** → deploy → `--audit` → fix whatever it still names → #817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)