### PR TITLE
Gate the audit on published events only

### DIFF
--- a/crush_lu/management/commands/backfill_event_addresses.py
+++ b/crush_lu/management/commands/backfill_event_addresses.py
@@ -450,13 +450,29 @@ class Command(BaseCommand):
             )
         ]
         valid_cantons = {value for value, _label in MeetupEvent.CANTON_CHOICES}
-        # A blank canton counts as stray on a PUBLISHED event: `clean()` has
-        # required one there since long before this work, so leaving it out
-        # would let the audit report all-clear on a row the very validation it
-        # gates would reject. Unpublished events may legitimately have none.
+        # Only PUBLISHED events block.
+        #
+        # This gates a change that makes canton and the address components
+        # required on save, and that rule only applies to published events --
+        # so the gate has to ask about the same set. Blocking on every row with
+        # an odd canton means one archived event that nobody can publish, with
+        # 'test' typed into it years ago, holds up the whole rollout.
+        #
+        # A blank canton still counts as stray when published: `clean()` has
+        # required one there all along, so ignoring it would let the audit
+        # report all-clear on a row the validation would reject.
         stray_cantons = list(
-            MeetupEvent.objects.exclude(canton__in=valid_cantons)
-            .exclude(canton="", is_published=False)
+            MeetupEvent.objects.filter(is_published=True)
+            .exclude(canton__in=valid_cantons)
+            .values_list("pk", "canton")
+            .order_by("pk")
+        )
+        # Unpublished ones are worth seeing -- they become a problem the moment
+        # somebody republishes -- but they are not a reason to stop.
+        dormant_cantons = list(
+            MeetupEvent.objects.filter(is_published=False)
+            .exclude(canton__in=valid_cantons)
+            .exclude(canton="")
             .values_list("pk", "canton")
             .order_by("pk")
         )
@@ -468,6 +484,11 @@ class Command(BaseCommand):
         for pk, canton in stray_cantons:
             self.stdout.write(
                 self.style.WARNING(f"[{pk}] canton not in the list — {canton!r}")
+            )
+        for pk, canton in dormant_cantons:
+            self.stdout.write(
+                f"[{pk}] canton not in the list — {canton!r} "
+                f"(unpublished, not blocking)"
             )
 
         if not incomplete and not stray_cantons:
@@ -481,5 +502,5 @@ class Command(BaseCommand):
 
         raise CommandError(
             f"{len(incomplete)} published event(s) with an incomplete address, "
-            f"{len(stray_cantons)} unrecognised canton(s)."
+            f"{len(stray_cantons)} published event(s) with an unrecognised canton."
         )

--- a/crush_lu/tests/test_backfill_event_addresses.py
+++ b/crush_lu/tests/test_backfill_event_addresses.py
@@ -353,8 +353,42 @@ class TestCommand:
         call_command("backfill_event_addresses", "--audit", stdout=out)
         assert "complete structured address" in out.getvalue()
 
-    def test_audit_flags_a_canton_outside_the_list(self, legacy_event):
-        MeetupEvent.objects.filter(pk=legacy_event.pk).update(canton="Beaufort")
+    def test_an_unpublished_stray_canton_is_reported_but_does_not_block(
+        self, legacy_event
+    ):
+        """The gate asks about the same rows the rule applies to.
+
+        `clean()` only requires a canton on published events, so blocking on
+        every row with an odd one meant a single archived event with 'test'
+        typed into it held up the whole rollout.
+        """
+        call_command("backfill_event_addresses", stdout=StringIO())
+        MeetupEvent.objects.filter(pk=legacy_event.pk).update(
+            canton="test", is_published=False
+        )
+
+        out = StringIO()
+        call_command("backfill_event_addresses", "--audit", stdout=out)
+
+        report = out.getvalue()
+        assert "not blocking" in report
+        assert "'test'" in report
+
+    def test_a_published_stray_canton_still_blocks(self, legacy_event):
+        call_command("backfill_event_addresses", stdout=StringIO())
+        MeetupEvent.objects.filter(pk=legacy_event.pk).update(
+            canton="test", is_published=True
+        )
+
+        with pytest.raises(CommandError):
+            call_command("backfill_event_addresses", "--audit", stdout=StringIO())
+
+    def test_audit_flags_a_commune_where_a_canton_belongs(self, legacy_event):
+        """Beaufort is a commune in canton Echternach, not a canton."""
+        call_command("backfill_event_addresses", stdout=StringIO())
+        MeetupEvent.objects.filter(pk=legacy_event.pk).update(
+            canton="Beaufort", is_published=True
+        )
 
         with pytest.raises(CommandError):
             call_command("backfill_event_addresses", "--audit", stdout=StringIO())


### PR DESCRIPTION
Found by running `--audit` on staging. One archived event with `test` typed into its canton blocked the entire rollout.

## The mismatch

`--audit` gates the change that makes canton and the address components required on save. That rule applies **only to published events** — `clean()` has always been written that way. But the audit's stray-canton check looked at every row regardless of publication status.

So on staging:

```
[20] canton not in the list — 'test'
CommandError: 0 published event(s) with an incomplete address, 1 unrecognised canton(s).
```

Zero incomplete addresses. Everything that could possibly be published was fine. The gate failed anyway, on an unpublished event that nobody can publish without fixing it first — at which point `clean()` would catch it.

On production this is worse: a year of archived events, any one of which with an odd canton holds up the rollout for no benefit.

## The fix

Blocking is now scoped to `is_published=True`, matching the rule it gates. Unpublished strays are still **printed** — they become a problem the moment somebody republishes — but marked `(unpublished, not blocking)` and excluded from the exit code.

A blank canton still counts as stray when published, unchanged: `clean()` requires one there, so ignoring it would let the audit report all-clear on a row the validation would reject.

## Why it is a separate PR

Same reason as #818. The enforcement PR is gated on this audit passing, so a fix to the audit cannot ship inside it.

Merge order: **this** → deploy → `--audit` should now pass on staging → slot swap → production backfill → enforcement PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)