### PR TITLE
Send commune again — echo.lu requires it

### DIFF
--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -653,25 +653,39 @@ def address_payload(event):
             "number": event.address_number,
             "postcode": event.address_postcode or legacy.get("postcode", ""),
             # The town is the town. This used to fall back to `canton`, which
-            # published a canton name where echo.lu shows a locality — and
-            # `commune` got the canton outright. echo.lu's commune filter is a
-            # controlled vocabulary and an unrecognised value 404s, so a wrong
-            # one is worse than none: `commune` is omitted until we hold a real
-            # one.
+            # published a canton name where echo.lu shows a locality.
             "town": event.address_town or legacy.get("town", ""),
+            # `commune` is REQUIRED, and gets the town.
+            #
+            # It previously carried `canton`, which is the wrong administrative
+            # level. Omitting it looked like the safe correction -- a wrong
+            # value on a controlled vocabulary 404s their venue filter, so none
+            # seemed better than wrong. It is not: echo.lu rejects the whole
+            # experience with "Missing or malformed address" and the listing
+            # never publishes at all. Verified against the live API on
+            # 2026-08-10, when six events failed at once.
+            #
+            # The town is the right value, not a stand-in: a Luxembourg commune
+            # takes its name from its principal town, so Differdange the town
+            # is Differdange the commune. Where they differ, the town is still
+            # the closer answer of the two we hold.
+            "commune": event.address_town or legacy.get("town", ""),
             "country": "Luxembourg",
         }
         return {key: value for key, value in payload.items() if value}
 
-    # Parsed with NO canton, deliberately. Given one, `parse_address` puts it in
-    # `commune` and substitutes it for a town it could not read -- and published
-    # events always have a canton, so every fallback payload would otherwise
-    # keep shipping the canton-in-a-commune-field value this whole change
-    # exists to remove, on exactly the rows most likely to hit it. Passing ""
-    # switches both substitutions off at the source rather than trying to
-    # recognise and undo them afterwards, which cannot tell a canton that was
-    # substituted from a town that genuinely shares its name.
+    # Parsed with NO canton, deliberately. Given one, `parse_address` puts the
+    # canton in `commune` and substitutes it for a town it could not read --
+    # the wrong administrative level in both places. Passing "" switches both
+    # substitutions off at the source rather than trying to recognise and undo
+    # them afterwards, which cannot tell a canton that was substituted from a
+    # town that genuinely shares its name.
     legacy = parse_address(event.address, "")
+    # `commune` is required, so the parsed town fills it here too. A legacy row
+    # with no readable town sends neither, and echo.lu will reject it -- which
+    # is the correct outcome: it has no address worth publishing, and `--audit`
+    # names it.
+    legacy["commune"] = legacy.get("town", "")
     return {key: value for key, value in legacy.items() if value}
 
 

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -254,11 +254,11 @@ class PayloadTests(TestCase):
         self.assertEqual(address["postcode"], "4620")
         self.assertEqual(address["country"], "Luxembourg")
 
-    def test_town_is_the_town_and_commune_is_not_the_canton(self):
-        # `town` used to fall back to `canton`, and `commune` was set to it
-        # outright -- publishing a canton name where echo.lu shows a locality.
-        # echo.lu's commune filter is a controlled vocabulary and an
-        # unrecognised value 404s, so none is better than a wrong one.
+    def test_town_and_commune_are_the_town_not_the_canton(self):
+        # Both used to carry `canton` -- the wrong administrative level. They
+        # carry the town now. `commune` is REQUIRED: omitting it made echo.lu
+        # reject the whole experience with "Missing or malformed address", so
+        # six events stopped publishing entirely (verified live 2026-08-10).
         event = make_event(
             address_street="rue Emile Mark",
             address_postcode="4620",
@@ -268,7 +268,7 @@ class PayloadTests(TestCase):
         address = echo_lu.build_experience_payload(event)["location"]["address"]
 
         self.assertEqual(address["town"], "Differdange")
-        self.assertNotIn("commune", address)
+        self.assertEqual(address["commune"], "Differdange")
 
     def test_empty_components_are_absent_rather_than_blank(self):
         # echo.lu treats "" as a supplied value and renders a blank line for it.
@@ -387,9 +387,7 @@ class PayloadTests(TestCase):
 
     def test_the_legacy_fallback_does_not_smuggle_the_canton_back_in(self):
         # `parse_address` puts the canton in `commune` and substitutes it for a
-        # town it could not read. Published events always have a canton, so
-        # without sanitising the fallback, the rows most likely to use it would
-        # be the ones still shipping the value this change removes.
+        # town it could not read -- the wrong level in both places.
         event = make_event(
             address="Behind the old brewery",
             canton="Esch-sur-Alzette",
@@ -399,8 +397,20 @@ class PayloadTests(TestCase):
         )
         address = echo_lu.build_experience_payload(event)["location"]["address"]
 
-        self.assertNotIn("commune", address)
+        self.assertNotEqual(address.get("commune"), "Esch-sur-Alzette")
         self.assertNotEqual(address.get("town"), "Esch-sur-Alzette")
+
+    def test_the_legacy_fallback_still_sends_a_commune(self):
+        # Required field: a legacy row that parses a town must fill it.
+        event = make_event(
+            address="7, rue du Nord\nL-2229 Luxembourg",
+            address_street="",
+            address_postcode="",
+            address_town="",
+        )
+        address = echo_lu.build_experience_payload(event)["location"]["address"]
+
+        self.assertEqual(address["commune"], "Luxembourg")
 
     def test_dates_are_rfc3339_utc_and_span_the_duration(self):
         event = make_event(duration_minutes=90)

--- a/docs/integrations/echo-lu-sync.md
+++ b/docs/integrations/echo-lu-sync.md
@@ -527,7 +527,7 @@ row says so; the recovery is:
 | `dates[0].from` / `.to` | `date_time` / `end_time`, RFC 3339 in UTC |
 | `dates[0].purchaseLink` | the event detail page |
 | `venues` | `location` (venue name) |
-| `location.address` | `address_street` / `address_number` / `address_postcode` / `address_town`; `commune` is not sent |
+| `location.address` | `address_street` / `address_number` / `address_postcode` / `address_town`; `commune` gets the town too |
 | `location.address.latitude/longitude` | `latitude` / `longitude`, as strings, omitted when unset |
 | `pictures[0]` | `image`, made absolute |
 | `tickets` | `registration_fee` in EUR; free events get an explicit €0 ticket |
@@ -535,14 +535,26 @@ row says so; the recovery is:
 | `languages` | `languages` |
 | `categories` / `audiences` / `formats` / `environments` / `tags` | the `ECHO_LU_DEFAULT_*` settings |
 
-Two deliberate omissions:
+**`commune` is required, and gets the town.** It once carried the event's
+`canton`, which is a region rather than a commune. Omitting it looked like the
+safe correction — echo.lu's commune filter is a controlled vocabulary where an
+unrecognised value 404s the venue search — but the field is mandatory: on
+2026-08-10 every event was rejected with `location.address: Missing or malformed
+address`, including three that were already live, and the whole integration
+stopped publishing until the town was sent.
 
-- **`commune`** — this used to be sent as the event's `canton`, which is a
-  region, not a commune. echo.lu's commune filter is a controlled vocabulary and
-  an unrecognised value is a 404, so nothing is sent until we hold a real one.
-- **Blank contact and address fields** — echo.lu treats an empty string as a
-  supplied value and renders a blank line for it, so empty components are
-  dropped rather than sent.
+⚠️ **Known limitation.** A Luxembourg commune takes its name from its principal
+town, so this is right wherever the two coincide (Luxembourg, Differdange,
+Esch-sur-Alzette). It is wrong where they do not: **Rodange is in the commune of
+Pétange**, Belval is in Sanem, and a quarter like Ville-Haute is not a commune at
+all. Booking a venue in one of those will send a town where echo.lu expects a
+commune, and may be rejected or filed under the wrong municipality. Fixing it
+properly needs a postcode→commune table, or a `commune` field of its own on the
+event. Until then, check the listing after publishing an event outside the
+towns above.
+
+**Blank contact and address fields** are dropped rather than sent — echo.lu
+treats an empty string as a supplied value and renders a blank line for it.
 
 `dates[].duration` **is** sent, as `duration_minutes`. It was held back while
 its unit was undocumented — a wrong unit would have contradicted `from`/`to` on


### PR DESCRIPTION
**Live breakage.** After #817 reached production, all six upcoming events were rejected:

```
✗ [14] PUT  rejected (HTTP 400): location.address: Missing or malformed address
✗ [15] POST rejected (HTTP 400): location.address: Missing or malformed address
✗ [16] PUT  rejected (HTTP 400): location.address: Missing or malformed address
✗ [17] PUT  rejected (HTTP 400): location.address: Missing or malformed address
✗ [18] POST rejected (HTTP 400): location.address: Missing or malformed address
✗ [19] POST rejected (HTTP 400): location.address: Missing or malformed address
```

Three of those (14, 16, 17) had been live since 2026-08-08 and were only being *updated* — they had synced fine with the previous payload. The only address difference was the missing `commune`.

## What I got wrong

`commune` used to carry `canton`, which is the wrong administrative level — a canton is not a commune. Removing it looked like the safe half of that correction: echo.lu's commune filter is a controlled vocabulary and an unrecognised value 404s the venue search, so I reasoned that none beats wrong.

That reasoning only holds if the field is optional. It isn't. A missing required field is not "no opinion" — it is a rejected experience and a listing that never appears at all. The published API docs describe every address field as optional; the live API disagrees.

## The fix

`commune` gets the **town**, which is the right value rather than a stand-in: a Luxembourg commune takes its name from its principal town, so Differdange the town is Differdange the commune. Where the two genuinely differ, the town is still far closer than a canton.

```json
"address": {
  "street": "Cote d'Eich", "number": "7", "postcode": "1450",
  "town": "Luxembourg", "commune": "Luxembourg", "country": "Luxembourg"
}
```

The legacy fallback fills it the same way from the parsed town. A row whose town cannot be read sends neither field and is rejected — correct, since it has no address worth publishing, and `--audit` names it.

## After merging

Needs a slot swap to reach production, then:

```bash
/antenv/bin/python manage.py sync_events_to_echo
```

Expect six successes. Until then the three live listings keep their old (pre-#817) content — a failed PUT does not remove them — and the three that never published stay unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)