### PR TITLE
Make --publish survive the re-run it is advertised for

### DIFF
--- a/crush_lu/management/commands/create_quiz_night_event.py
+++ b/crush_lu/management/commands/create_quiz_night_event.py
@@ -9,7 +9,8 @@ The event is created **unpublished** unless ``--publish`` is passed — it is a
 draft a coach reviews (date, venue, capacity) and publishes when ready. Re-runs
 match an existing Quiz Night on the exact title, so the command is idempotent
 and safe to repeat; it refuses to seed over an existing set of rounds unless
-``--clear`` is given.
+``--clear`` is given. Re-running with ``--publish`` alone publishes the event
+and leaves the rounds where they are.
 
 Usage:
     python manage.py create_quiz_night_event
@@ -129,8 +130,6 @@ class Command(BaseCommand):
 
         with transaction.atomic():
             event, event_created = self._get_or_create_event(options, starts_at)
-            if not event_created:
-                self._publish_on_reuse(event, options)
             quiz, quiz_created = QuizEvent.objects.get_or_create(
                 event=event,
                 defaults={
@@ -143,15 +142,29 @@ class Command(BaseCommand):
                 quiz.ensure_tables()
 
             existing_rounds = quiz.rounds.count()
-            if existing_rounds and not options["clear"]:
+            seed = options["clear"] or not existing_rounds
+
+            # Rounds already there and no --clear: the run is only meaningful
+            # if it publishes. Refusing outright would be the error the drafted
+            # event's own advice ("re-run with --publish") walks the operator
+            # straight into.
+            if not seed and not options["publish"]:
                 raise CommandError(
                     f"'{event.title}' already has {existing_rounds} rounds. "
-                    f"Re-run with --clear to replace them."
+                    f"Re-run with --clear to replace them, or with --publish "
+                    f"to publish the event and leave them alone."
                 )
 
-            result = populate_quiz(quiz, clear=options["clear"], pack=pack)
+            # After the guard above, never before it: this writes, and a raise
+            # inside the same atomic block would roll the publish back.
+            if not event_created:
+                self._publish_on_reuse(event, options)
 
-        self._report(event, quiz, result, pack, event_created)
+            result = (
+                populate_quiz(quiz, clear=options["clear"], pack=pack) if seed else None
+            )
+
+        self._report(event, quiz, result, pack, event_created, existing_rounds)
 
     # --- helpers ---------------------------------------------------------
 
@@ -205,6 +218,9 @@ class Command(BaseCommand):
         of those would seed questions nobody can ever play — quiz rotation and
         the scoring consumer both return nothing for events whose `event_type`
         is not `quiz_night` — so refuse instead of touching the other event.
+        Two Quiz Nights sharing the title are ambiguous in the same way, and
+        `get_or_create` would raise `MultipleObjectsReturned` at the operator
+        rather than say what is wrong.
         """
         title = options["title"]
         clash = (
@@ -219,19 +235,34 @@ class Command(BaseCommand):
                 f"Pass a different --title."
             )
 
-        return MeetupEvent.objects.get_or_create(
-            title=title,
-            event_type="quiz_night",
-            defaults={
-                "description": DEFAULT_DESCRIPTION_EN,
-                "location": options["location"],
-                "address": options["address"],
-                "canton": options["canton"],
-                "date_time": starts_at,
-                "registration_deadline": starts_at - REGISTRATION_CUTOFF,
-                "max_participants": options["max_participants"],
-                "is_published": options["publish"],
-            },
+        matches = list(
+            MeetupEvent.objects.filter(title=title, event_type="quiz_night").order_by(
+                "pk"
+            )[:2]
+        )
+        if len(matches) > 1:
+            raise CommandError(
+                f"More than one Quiz Night is already titled '{title}' "
+                f"(ids {matches[0].pk}, {matches[1].pk}, …). Pass a different "
+                f"--title, or remove the duplicates first."
+            )
+        if matches:
+            return matches[0], False
+
+        return (
+            MeetupEvent.objects.create(
+                title=title,
+                event_type="quiz_night",
+                description=DEFAULT_DESCRIPTION_EN,
+                location=options["location"],
+                address=options["address"],
+                canton=options["canton"],
+                date_time=starts_at,
+                registration_deadline=starts_at - REGISTRATION_CUTOFF,
+                max_participants=options["max_participants"],
+                is_published=options["publish"],
+            ),
+            True,
         )
 
     def _publish_on_reuse(self, event, options):
@@ -270,7 +301,7 @@ class Command(BaseCommand):
             f"  published: {'yes' if options['publish'] else 'no (draft)'}"
         )
 
-    def _report(self, event, quiz, result, pack, event_created):
+    def _report(self, event, quiz, result, pack, event_created, existing_rounds):
         verb = "Created" if event_created else "Reused"
         self.stdout.write(
             self.style.SUCCESS(
@@ -278,10 +309,16 @@ class Command(BaseCommand):
                 f"quiz id={quiz.pk}) starting {event.date_time:%Y-%m-%d %H:%M}."
             )
         )
-        self.stdout.write(
-            f"Seeded {result.rounds_created} rounds and "
-            f"{result.questions_created} questions from pack '{pack}'."
-        )
+        if result is None:
+            self.stdout.write(
+                f"Left the existing {existing_rounds} rounds untouched "
+                f"(no --clear given)."
+            )
+        else:
+            self.stdout.write(
+                f"Seeded {result.rounds_created} rounds and "
+                f"{result.questions_created} questions from pack '{pack}'."
+            )
 
         if not event.is_published:
             self.stdout.write(
@@ -301,7 +338,7 @@ class Command(BaseCommand):
             "on the night — seeding cannot satisfy them.)"
         )
 
-        if result.pending_uploads:
+        if result is not None and result.pending_uploads:
             self.stdout.write("")
             self.stdout.write(
                 self.style.WARNING(

--- a/crush_lu/tests/test_quiz_packs.py
+++ b/crush_lu/tests/test_quiz_packs.py
@@ -558,6 +558,48 @@ class TestCreateQuizNightEventCommand:
         self._run(clear=True, publish=True)
         assert MeetupEvent.objects.get(title=self.TITLE).is_published is True
 
+    def test_rerun_with_publish_alone_publishes_and_keeps_the_rounds(self, db):
+        """The workflow the drafted event's own advice sends operators to.
+
+        The publish write and the "already has rounds" refusal live in one
+        atomic block, so raising after publishing rolls the publish back.
+        """
+        from crush_lu.models import MeetupEvent
+
+        self._run()
+        assert MeetupEvent.objects.get(title=self.TITLE).is_published is False
+
+        self._run(publish=True)
+
+        assert MeetupEvent.objects.get(title=self.TITLE).is_published is True
+        assert QuizQuestion.objects.count() == 36  # rounds survived, once
+
+    def test_publish_alone_reports_that_the_rounds_were_kept(self, db, capsys):
+        self._run()
+        capsys.readouterr()
+
+        self._run(publish=True)
+        assert "Left the existing 6 rounds untouched" in capsys.readouterr().out
+
+    def test_duplicate_quiz_night_titles_are_a_clear_error(self, db):
+        """Two matches would crash `get_or_create` with MultipleObjectsReturned."""
+        from crush_lu.models import MeetupEvent
+
+        for _ in range(2):
+            MeetupEvent.objects.create(
+                title=self.TITLE,
+                description="Hand-made duplicate",
+                event_type="quiz_night",
+                date_time=timezone.now() + timedelta(days=1),
+                location="Luxembourg City",
+                address="1 Place d'Armes",
+                max_participants=30,
+                registration_deadline=timezone.now() + timedelta(hours=12),
+            )
+
+        with pytest.raises(CommandError, match="More than one Quiz Night"):
+            self._run()
+
     def test_reuse_publish_backfills_a_missing_canton(self, db):
         """A published event without a canton is one `clean()` would reject."""
         from crush_lu.models import MeetupEvent


### PR DESCRIPTION
Follow-up to #821. The post-merge `claude-review` run flagged two defects in that PR's fix commit; both reproduce, and both are on `main` now.

## The rollback

#821 added `_publish_on_reuse()` so a re-run would apply `--publish` to an event that already existed. It writes inside `transaction.atomic()` — and the "already has N rounds" `CommandError` is raised a few lines further down, in the same block. Django rolls the transaction back on the exception, and the publish goes with it.

So the workflow the drafted event's own output advises:

```
The event is a DRAFT. … publish it from the admin or re-run with --publish.
```

still failed. Verified against merged `main` before writing the fix:

```
assert published is True
E   AssertionError: publish was rolled back with the CommandError
E   assert False is True
```

#821's test only ran `--clear --publish` together, which takes the seeding path and never reaches the raise — the gap was in the test, not just the code.

**Fix:** re-running with `--publish` and no `--clear` is now a supported operation rather than an error — it publishes and leaves the rounds alone, reporting `Left the existing 6 rounds untouched (no --clear given).` A bare re-run with neither flag still refuses exactly as before. The publish write moved below the guard, where nothing left in the block can roll it back.

## The crash

`get_or_create(title=..., event_type="quiz_night")` assumes at most one match, but `MeetupEvent.title` has no uniqueness constraint. Two Quiz Nights sharing a title — one made by hand in the admin, say — raised `MultipleObjectsReturned` at the operator instead of saying what was wrong. It now names the ids and asks for a different `--title`.

## Testing

`crush_lu/tests/test_quiz_packs.py` — 72 passing (68 before, +4): publish-alone publishes and keeps the 36 questions, the report line, and the duplicate-title error. 290 pass across the quiz suites; ruff and black clean.

## Still open from #821's review

Deliberately not in scope here, all pre-existing:

- `--tables` is ignored on a reused quiz, and `ensure_tables()` only runs for a newly created one
- `--dry-run` returns before owner resolution and the reuse checks, so it can green-light a run that then errors
- the command writes only the legacy free-text `address`; `main` has since grown structured address fields (#817–#819) that echo.lu reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)