### PR TITLE
Make two tables rotate, and stop a failed rebuild reading as a rotation

### DIFF
--- a/crush_lu/api_quiz.py
+++ b/crush_lu/api_quiz.py
@@ -26,6 +26,7 @@ from crush_lu.models.quiz import (
     QuizTableMembership,
     TableRoundScore,
 )
+from crush_lu.views_quiz import get_table_occupants
 
 
 def _is_quiz_host(quiz, user):
@@ -243,60 +244,37 @@ def my_assignment(request, quiz_id):
                 }
             )
 
-        # Read the room off the same membership rows the seat itself came
-        # from, the way ``quiz_live_view`` does when it renders this table
-        # into the page. An empty list here is not "no tablemates", it is
-        # the client's instruction to clear the ones the server just drew:
-        # ``fetchAssignment`` assigns every field it is handed (#723), and
-        # it runs on init, on reconnect and on every rotate. So a player on
-        # this fallback — anyone seated before a schedule existed, and
-        # everyone in the room when the rebuild for the current round has
-        # failed — watched their tablemates appear with the page and then
-        # vanish a moment later, which is the whole of what "it loads and
-        # then goes blank" looks like from the floor.
-        mates = []
-        for m in membership.table.memberships.exclude(user=user).select_related(
-            "user__crushprofile"
-        ):
-            profile = getattr(m.user, "crushprofile", None)
-            mates.append(
-                {
-                    "display_name": (
-                        (profile.display_name if profile else None) or "Anonymous"
-                    ),
-                    "role": "",
-                }
-            )
+        # Name this table's other occupants. An empty list here is not "no
+        # tablemates", it is the client's instruction to clear the ones the
+        # server just drew: ``fetchAssignment`` assigns every field it is
+        # handed (#723), and it runs on init, on reconnect and on every
+        # rotate. So a player on this fallback watched their tablemates
+        # appear with the page and then vanish a moment later, which is the
+        # whole of what "it loads and then goes blank" looks like.
+        #
+        # Landing on this branch does not mean the room is unscheduled —
+        # only that *this* player is not in the round — so the helper, not
+        # the memberships, decides which rows answer. It is the one the
+        # page itself renders from, and the two must agree or the refetch
+        # flickers onto a different set of names.
         return Response(
             {
                 "seated": True,
                 "table_number": membership.table.table_number,
                 "role": "unknown",
                 "rotation_group": "",
-                "tablemates": mates,
+                "tablemates": get_table_occupants(
+                    quiz, membership.table, round_number, exclude_user=user
+                ),
                 "personal_score": _get_personal_score(quiz, user),
                 "next_table": None,
             }
         )
 
     # Get tablemates for current round
-    tablemates = []
-    for r in (
-        QuizRotationSchedule.objects.filter(
-            quiz=quiz,
-            round_number=round_number,
-            table=rotation.table,
-        )
-        .exclude(user=user)
-        .select_related("user__crushprofile")
-    ):
-        profile = getattr(r.user, "crushprofile", None)
-        tablemates.append(
-            {
-                "display_name": (profile.display_name if profile else "Anonymous"),
-                "role": r.role,
-            }
-        )
+    tablemates = get_table_occupants(
+        quiz, rotation.table, round_number, exclude_user=user
+    )
 
     # Peek at next round table
     next_table_number = None

--- a/crush_lu/api_quiz.py
+++ b/crush_lu/api_quiz.py
@@ -243,13 +243,37 @@ def my_assignment(request, quiz_id):
                 }
             )
 
+        # Read the room off the same membership rows the seat itself came
+        # from, the way ``quiz_live_view`` does when it renders this table
+        # into the page. An empty list here is not "no tablemates", it is
+        # the client's instruction to clear the ones the server just drew:
+        # ``fetchAssignment`` assigns every field it is handed (#723), and
+        # it runs on init, on reconnect and on every rotate. So a player on
+        # this fallback — anyone seated before a schedule existed, and
+        # everyone in the room when the rebuild for the current round has
+        # failed — watched their tablemates appear with the page and then
+        # vanish a moment later, which is the whole of what "it loads and
+        # then goes blank" looks like from the floor.
+        mates = []
+        for m in membership.table.memberships.exclude(user=user).select_related(
+            "user__crushprofile"
+        ):
+            profile = getattr(m.user, "crushprofile", None)
+            mates.append(
+                {
+                    "display_name": (
+                        (profile.display_name if profile else None) or "Anonymous"
+                    ),
+                    "role": "",
+                }
+            )
         return Response(
             {
                 "seated": True,
                 "table_number": membership.table.table_number,
                 "role": "unknown",
                 "rotation_group": "",
-                "tablemates": [],
+                "tablemates": mates,
                 "personal_score": _get_personal_score(quiz, user),
                 "next_table": None,
             }

--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -591,6 +591,18 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             return
 
         rotation_data = await self.advance_round_and_rotate()
+        # A rebuild that could not produce seating for the new round comes
+        # back as an error, and it has to reach the host the way the guard
+        # above does. Falling through to the broadcast below sent the error
+        # dict itself as `quiz.rotate`: every screen in the room switched to
+        # the rotate splash and refetched an assignment that had not moved,
+        # while the one person who could act on it — the host — was told
+        # nothing. A room that visibly rotates but seats nobody anywhere new
+        # is exactly how a broken schedule reads as "the rotators stay put".
+        if rotation_data.get("error"):
+            await self.send_error(rotation_data["error"])
+            return
+
         if rotation_data.get("finished"):
             # No more rounds — broadcast finished status with leaderboard
             leaderboard = await self.get_leaderboard()

--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -1664,6 +1664,67 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
                 quiz.save(update_fields=["status"])
                 return {"finished": True, "status": "finished"}
 
+            # Get the round_number for rotation lookup. Derived from
+            # next_round explicitly, so it does not depend on
+            # current_round having been written yet.
+            round_number = quiz.get_round_number(next_round)
+
+            # Self-heal: a quiz_night quiz that reached this point with no
+            # rotation rows for the new round (e.g. started before the
+            # generation-error fix landed, or the schedule was wiped) would
+            # otherwise broadcast empty assignments and leave the coach
+            # staring at a wiped Table Overview. Try to (re)generate the
+            # missing rounds — passing ``preserve_current_round=False``
+            # because we want to fill in ``round_number``, which is the
+            # round we are about to advance ``current_round`` to. (The
+            # default preserve flag would bump from_round past it.) If
+            # regen also fails, surface the error instead of pretending
+            # success.
+            #
+            # Seat the room *before* the round moves, not after. Advancing
+            # first and rebuilding second commits a round that nothing is
+            # scheduled for: current_question_index is back at -1, so a
+            # second Rotate is refused by check_can_rotate ("questions
+            # remain in this round") and the host is left with a round they
+            # cannot re-enter and a room that never moved. Ordering it this
+            # way makes a failed rebuild a no-op — generate_rotation_rounds
+            # does all its work inside its own atomic block, so its
+            # savepoint unwinds and this transaction commits nothing.
+            if (
+                quiz.event.event_type == "quiz_night"
+                and quiz.num_tables
+                and not QuizRotationSchedule.objects.filter(
+                    quiz=quiz, round_number=round_number
+                ).exists()
+            ):
+                from django.core.exceptions import ValidationError
+
+                from crush_lu.services.quiz_rotation import (
+                    generate_rotation_rounds,
+                )
+
+                try:
+                    generate_rotation_rounds(
+                        quiz,
+                        from_round=round_number,
+                        preserve_current_round=False,
+                    )
+                except ValidationError as exc:
+                    msg = exc.messages[0] if exc.messages else str(exc)
+                    return {"error": f"Cannot rotate: {msg}"}
+                except Exception:
+                    logger.exception(
+                        "Rotation regeneration failed for quiz %s round %d",
+                        quiz.id,
+                        round_number,
+                    )
+                    return {
+                        "error": (
+                            "Cannot rotate: rotation schedule could not be "
+                            "regenerated. Check the server logs for details."
+                        )
+                    }
+
             quiz.current_round = next_round
             # Set to -1 so first next_question lands on Q0 (Issue #2)
             quiz.current_question_index = -1
@@ -1671,52 +1732,6 @@ class QuizConsumer(AsyncJsonWebsocketConsumer):
             quiz.save(
                 update_fields=["current_round", "current_question_index", "status"]
             )
-
-        # Get the round_number for rotation lookup
-        round_number = quiz.get_round_number(next_round)
-
-        # Self-heal: a quiz_night quiz that reached this point with no
-        # rotation rows for the new round (e.g. started before the
-        # generation-error fix landed, or the schedule was wiped) would
-        # otherwise broadcast empty assignments and leave the coach
-        # staring at a wiped Table Overview. Try to (re)generate the
-        # missing rounds — passing ``preserve_current_round=False``
-        # because we want to fill in ``round_number``, which is the
-        # round we just advanced ``current_round`` to. (The default
-        # preserve flag would bump from_round past it.) If regen also
-        # fails, surface the error instead of pretending success.
-        if (
-            quiz.event.event_type == "quiz_night"
-            and quiz.num_tables
-            and not QuizRotationSchedule.objects.filter(
-                quiz=quiz, round_number=round_number
-            ).exists()
-        ):
-            from django.core.exceptions import ValidationError
-
-            from crush_lu.services.quiz_rotation import generate_rotation_rounds
-
-            try:
-                generate_rotation_rounds(
-                    quiz,
-                    from_round=round_number,
-                    preserve_current_round=False,
-                )
-            except ValidationError as exc:
-                msg = exc.messages[0] if exc.messages else str(exc)
-                return {"error": f"Cannot rotate: {msg}"}
-            except Exception:
-                logger.exception(
-                    "Rotation regeneration failed for quiz %s round %d",
-                    quiz.id,
-                    round_number,
-                )
-                return {
-                    "error": (
-                        "Cannot rotate: rotation schedule could not be "
-                        "regenerated. Check the server logs for details."
-                    )
-                }
 
         # Build per-user assignment map from rotation schedule
         assignments = {}

--- a/crush_lu/services/quiz_rotation.py
+++ b/crush_lu/services/quiz_rotation.py
@@ -3,14 +3,18 @@ Quiz Night table rotation algorithm.
 
 Generates a rotation schedule where:
 - Men are anchored at fixed tables (distributed evenly)
-- Women rotate between tables (split into groups A and B at different speeds)
+- Women rotate between tables (group A forwards, group B backwards)
 - Every woman is seated at exactly one table in every round
 - After N rounds (N = number of tables), every woman has visited every table
-- No two women are paired at the same table more than once
+- Group A and group B re-pair as they pass each other
 
-The last property needs at least 3 tables. Modulo 2 the only non-zero step
-is +1, so a 2-table room can either move both groups every round or freeze
-one of them — it cannot also vary who meets whom. Rotation wins.
+How often an A rotator meets the same B rotator is set by how far the two
+groups drift apart each round, and that cannot always be made maximal: at
+an even table count no step gives both full table coverage *and* a fresh
+pairing every round, because a step coprime with an even N is odd, which
+leaves the drift even. Coverage wins — meeting every anchor is the point of
+the evening. So the pairing cycles every N rounds at odd N and every N/2 at
+even N, and at 2 tables, where the only move is a swap, every round.
 """
 
 from django.core.exceptions import ValidationError
@@ -116,14 +120,18 @@ def generate_rotation_schedule(men, women, num_rounds=3, num_tables=None):
             f"spillover distributed round-robin)."
         )
 
-    # Group A advances one table per round, group B two, so the two groups
-    # meet a different half of the room each round. A step is only a
-    # rotation when it is non-zero *modulo the table count*: with 2 tables
-    # +2 is the identity, which would leave every group-B rotator sitting
-    # at her check-in table for the whole quiz. Two tables leaves +1 as the
-    # only real move, so both groups take it — at that size the room cannot
-    # also vary who meets whom, since the only alternative speed is zero.
-    step_b = 2 if num_tables > 2 else 1
+    # Group A advances one table per round; group B counter-rotates by one,
+    # so the two groups pass each other and re-pair as they go.
+    #
+    # What makes a step a rotation is not that it is non-zero but that it is
+    # *coprime* with the table count — only then does repeating it reach
+    # every table. The old +2 was neither at 2 tables (where it is the
+    # identity, so group B never moved at all) nor at any other even count
+    # (where it walks the same-parity tables and skips half the room:
+    # at 4 tables, 1 → 3 → 1 → 3, meeting the same anchors all night).
+    # n-1 is coprime with n for every n, consecutive integers always being
+    # coprime, so this holds at every table count the quiz allows.
+    step_b = num_tables - 1
 
     for round_num in range(num_rounds):
         for table_idx in range(num_tables):

--- a/crush_lu/services/quiz_rotation.py
+++ b/crush_lu/services/quiz_rotation.py
@@ -4,8 +4,13 @@ Quiz Night table rotation algorithm.
 Generates a rotation schedule where:
 - Men are anchored at fixed tables (distributed evenly)
 - Women rotate between tables (split into groups A and B at different speeds)
+- Every woman is seated at exactly one table in every round
 - After N rounds (N = number of tables), every woman has visited every table
 - No two women are paired at the same table more than once
+
+The last property needs at least 3 tables. Modulo 2 the only non-zero step
+is +1, so a 2-table room can either move both groups every round or freeze
+one of them — it cannot also vary who meets whom. Rotation wins.
 """
 
 from django.core.exceptions import ValidationError
@@ -93,15 +98,16 @@ def generate_rotation_schedule(men, women, num_rounds=3, num_tables=None):
 
     schedule = []
 
-    # Split women into rotation groups (all women are seated)
-    if num_tables == 2:
-        group_a = women[:4] if len(women) >= 4 else women
-        group_b = []
-        group_c = women[4:]
-    else:
-        group_a = women[:num_tables]
-        group_b = women[num_tables : num_tables * 2]
-        group_c = women[num_tables * 2 :]  # spillover — everyone gets seated
+    # Split women into rotation groups (all women are seated): one group-A
+    # and one group-B rotator per table, everyone past that into spillover.
+    # This is the same split ``assign_table_on_checkin`` and
+    # ``manual_assign_table`` apply when they stamp ``rotation_group`` at
+    # check-in (A while fewer than num_tables rotators exist, then B, then
+    # C), so the labels this function reads back out of round 0 via
+    # ``generate_rotation_rounds`` mean the same thing here.
+    group_a = women[:num_tables]
+    group_b = women[num_tables : num_tables * 2]
+    group_c = women[num_tables * 2 :]  # spillover — everyone gets seated
 
     if group_c:
         warnings.append(
@@ -109,6 +115,15 @@ def generate_rotation_schedule(men, women, num_rounds=3, num_tables=None):
             f"(groups A/B hold {len(group_a) + len(group_b)}, "
             f"spillover distributed round-robin)."
         )
+
+    # Group A advances one table per round, group B two, so the two groups
+    # meet a different half of the room each round. A step is only a
+    # rotation when it is non-zero *modulo the table count*: with 2 tables
+    # +2 is the identity, which would leave every group-B rotator sitting
+    # at her check-in table for the whole quiz. Two tables leaves +1 as the
+    # only real move, so both groups take it — at that size the room cannot
+    # also vary who meets whom, since the only alternative speed is zero.
+    step_b = 2 if num_tables > 2 else 1
 
     for round_num in range(num_rounds):
         for table_idx in range(num_tables):
@@ -126,49 +141,29 @@ def generate_rotation_schedule(men, women, num_rounds=3, num_tables=None):
                     }
                 )
 
-            if num_tables == 2:
-                # 2 tables: all women in one group, rotating +1
-                for offset in range(2):
-                    w_idx = (
-                        (table_idx * 2 + offset + round_num) % len(group_a)
-                        if group_a
-                        else -1
-                    )
-                    if 0 <= w_idx < len(group_a):
-                        schedule.append(
-                            {
-                                "round_number": round_num,
-                                "table_number": table_number,
-                                "user": group_a[w_idx],
-                                "role": "rotator",
-                                "rotation_group": "A",
-                            }
-                        )
-            else:
-                # 3+ tables: Group A at step +1, Group B at step +2
-                a_idx = (table_idx + round_num) % num_tables
-                if a_idx < len(group_a):
-                    schedule.append(
-                        {
-                            "round_number": round_num,
-                            "table_number": table_number,
-                            "user": group_a[a_idx],
-                            "role": "rotator",
-                            "rotation_group": "A",
-                        }
-                    )
+            a_idx = (table_idx + round_num) % num_tables
+            if a_idx < len(group_a):
+                schedule.append(
+                    {
+                        "round_number": round_num,
+                        "table_number": table_number,
+                        "user": group_a[a_idx],
+                        "role": "rotator",
+                        "rotation_group": "A",
+                    }
+                )
 
-                b_idx = (table_idx + round_num * 2) % num_tables
-                if b_idx < len(group_b):
-                    schedule.append(
-                        {
-                            "round_number": round_num,
-                            "table_number": table_number,
-                            "user": group_b[b_idx],
-                            "role": "rotator",
-                            "rotation_group": "B",
-                        }
-                    )
+            b_idx = (table_idx + round_num * step_b) % num_tables
+            if b_idx < len(group_b):
+                schedule.append(
+                    {
+                        "round_number": round_num,
+                        "table_number": table_number,
+                        "user": group_b[b_idx],
+                        "role": "rotator",
+                        "rotation_group": "B",
+                    }
+                )
 
         # Group C (spillover): distribute round-robin across tables each round
         for c_idx, extra_woman in enumerate(group_c):

--- a/crush_lu/tests/test_quiz.py
+++ b/crush_lu/tests/test_quiz.py
@@ -2005,6 +2005,68 @@ class TestQuizAPI:
             f"expected the current round's occupants of this table, got {names}"
         )
 
+    def test_my_assignment_alone_at_a_scheduled_table(self, quiz_event, quiz_table):
+        """Being the only person the round seats here means no tablemates —
+        not a fall back to the check-in roster.
+
+        ``get_table_occupants`` reaches for memberships on an empty result
+        only once it has confirmed the round has no schedule *anywhere*.
+        Treating this table's emptiness as reason enough would answer a
+        player sitting alone with everyone who checked in beside them and
+        has since rotated away.
+        """
+        def _player(handle, first_name):
+            u = User.objects.create_user(
+                username=f"{handle}@test.com",
+                email=f"{handle}@test.com",
+                password="test",
+                first_name=first_name,
+            )
+            _grant_consent(u)
+            _create_profile(u)
+            return u
+
+        loner = _player("loner", "Loner")
+        moved_on = _player("emptied", "MovedOn")
+
+        table_two = QuizTable.objects.create(quiz=quiz_event, table_number=2)
+        QuizRound.objects.create(quiz=quiz_event, title="R1", sort_order=0)
+        next_round = QuizRound.objects.create(
+            quiz=quiz_event, title="R2", sort_order=1
+        )
+        quiz_event.current_round = next_round  # round_number 1
+        quiz_event.status = "active"
+        quiz_event.save()
+
+        # Both checked in at table 1, so its membership roster is not
+        # empty — but round 1 seats nobody there at all: the rotator has
+        # moved to table 2 and the latecomer has no row for this round.
+        QuizTableMembership.objects.create(table=quiz_table, user=loner)
+        QuizTableMembership.objects.create(table=quiz_table, user=moved_on)
+        QuizRotationSchedule.objects.create(
+            quiz=quiz_event,
+            round_number=1,
+            table=table_two,
+            user=moved_on,
+            role="rotator",
+            rotation_group="A",
+        )
+        assert quiz_event.get_round_number() == 1
+        assert not QuizRotationSchedule.objects.filter(
+            quiz=quiz_event, round_number=1, table=quiz_table
+        ).exists()
+
+        client = APIClient()
+        client.force_authenticate(user=loner)
+        response = client.get(f"/api/quiz/{quiz_event.id}/my-assignment/")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["seated"] is True
+        assert data["tablemates"] == [], (
+            f"expected nobody at an emptied table, got {data['tablemates']}"
+        )
+
     def test_my_assignment_not_assigned(self, quiz_event):
         """200 with `seated: false`, not 404.
 

--- a/crush_lu/tests/test_quiz.py
+++ b/crush_lu/tests/test_quiz.py
@@ -478,6 +478,79 @@ class TestQuizStartRotationFailure:
             > 0
         )
 
+    def test_advance_round_does_not_move_when_regeneration_fails(self, quiz_event):
+        """A rotate that cannot seat the next round must leave the quiz on
+        the round it was on.
+
+        Advancing first and rebuilding second commits a round nothing is
+        scheduled for. current_question_index goes back to -1 with it, so
+        check_can_rotate refuses the retry ('questions remain in this
+        round') and the host is left holding a round they cannot re-enter
+        while the room has not moved.
+        """
+        from asgiref.sync import async_to_sync
+
+        rounds = [
+            QuizRound.objects.create(quiz=quiz_event, title=f"R{i + 1}", sort_order=i)
+            for i in range(3)
+        ]
+        quiz_event.num_tables = 3
+        quiz_event.current_round = rounds[0]
+        quiz_event.current_question_index = 1
+        quiz_event.status = "active"
+        quiz_event.save()
+
+        # No attended registrations at all, so the rebuild for round 1
+        # raises rather than producing seating.
+        consumer = self._make_consumer(quiz_event)
+        result = async_to_sync(consumer.advance_round_and_rotate)()
+
+        assert "error" in result, f"expected an error, got {result}"
+
+        quiz_event.refresh_from_db()
+        assert quiz_event.current_round_id == rounds[0].pk, (
+            "a failed rebuild must not leave the quiz on the next round"
+        )
+        assert quiz_event.current_question_index == 1, (
+            "a failed rebuild must not reset the question index"
+        )
+        assert not QuizRotationSchedule.objects.filter(
+            quiz=quiz_event, round_number__gte=1
+        ).exists()
+
+    def test_handle_rotate_tells_the_host_a_rebuild_failed(self):
+        """The error goes to the host and nothing goes to the room.
+
+        Broadcasting it as ``quiz.rotate`` is what made a failed rebuild
+        read as a successful rotation: every screen switched to the rotate
+        splash and refetched seating that had not moved, and the one person
+        who could act on it was told nothing.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from asgiref.sync import async_to_sync
+
+        from crush_lu.consumers import QuizConsumer
+
+        consumer = QuizConsumer()
+        consumer.quiz_id = 1
+        consumer.quiz_group = "quiz_1"
+        consumer.check_can_rotate = AsyncMock(return_value={})
+        consumer.advance_round_and_rotate = AsyncMock(
+            return_value={"error": "Cannot rotate: not enough participants."}
+        )
+        consumer.send_json = AsyncMock()
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_send = AsyncMock()
+
+        async_to_sync(consumer.handle_rotate)()
+
+        consumer.channel_layer.group_send.assert_not_awaited()
+        consumer.send_json.assert_awaited_once()
+        payload = consumer.send_json.await_args.args[0]
+        assert payload["type"] == "quiz.error"
+        assert "Cannot rotate" in payload["data"]["message"]
+
 
 class TestLastRoundDetection:
     """Test that the quiz correctly detects when the last round's questions are done."""
@@ -1851,6 +1924,87 @@ class TestQuizAPI:
         assert data["personal_score"] == 0
         assert data["seated"] is True
 
+    def test_my_assignment_fallback_reads_the_current_round(
+        self, quiz_event, quiz_table
+    ):
+        """A player with a membership but no row in the current round is
+        told who the *current round* seats at that table.
+
+        This is the mid-quiz arrival: ``assign_table_on_checkin`` rebuilds
+        from the next round so the room does not move mid-question, which
+        leaves the new player a membership and a round-0 row and nothing
+        for the round in progress. Answering from memberships would hand
+        them the check-in roster — the rotators who have since moved on,
+        and none of the ones who have moved in.
+        """
+        def _player(handle, first_name):
+            u = User.objects.create_user(
+                username=f"{handle}@test.com",
+                email=f"{handle}@test.com",
+                password="test",
+                first_name=first_name,
+            )
+            _grant_consent(u)
+            _create_profile(u)
+            return u
+
+        latecomer = _player("late", "Latecomer")
+        moved_on = _player("movedon", "MovedOn")
+        moved_in = _player("movedin", "MovedIn")
+
+        table_two = QuizTable.objects.create(quiz=quiz_event, table_number=2)
+        # R1 exists only to put R2 at round_number 1 — the quiz has to be
+        # past round 0 for the check-in snapshot and the schedule to differ.
+        QuizRound.objects.create(quiz=quiz_event, title="R1", sort_order=0)
+        next_round = QuizRound.objects.create(
+            quiz=quiz_event, title="R2", sort_order=1
+        )
+        quiz_event.current_round = next_round  # round_number 1
+        quiz_event.status = "active"
+        quiz_event.save()
+
+        # Check-in roster of table 1: the latecomer plus someone who has
+        # since rotated to table 2 — and the ``quiz_table`` fixture's own
+        # member, who is on no round at all. Neither may be reported.
+        QuizTableMembership.objects.create(table=quiz_table, user=latecomer)
+        QuizTableMembership.objects.create(table=quiz_table, user=moved_on)
+        QuizTableMembership.objects.create(table=table_two, user=moved_in)
+
+        # Round 1 is scheduled — but not for the latecomer.
+        QuizRotationSchedule.objects.create(
+            quiz=quiz_event,
+            round_number=1,
+            table=table_two,
+            user=moved_on,
+            role="rotator",
+            rotation_group="A",
+        )
+        QuizRotationSchedule.objects.create(
+            quiz=quiz_event,
+            round_number=1,
+            table=quiz_table,
+            user=moved_in,
+            role="rotator",
+            rotation_group="A",
+        )
+        assert quiz_event.get_round_number() == 1
+        assert not QuizRotationSchedule.objects.filter(
+            quiz=quiz_event, round_number=1, user=latecomer
+        ).exists()
+
+        client = APIClient()
+        client.force_authenticate(user=latecomer)
+        response = client.get(f"/api/quiz/{quiz_event.id}/my-assignment/")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["seated"] is True
+        assert data["table_number"] == quiz_table.table_number
+        names = {m["display_name"] for m in data["tablemates"]}
+        assert names == {"MovedIn"}, (
+            f"expected the current round's occupants of this table, got {names}"
+        )
+
     def test_my_assignment_not_assigned(self, quiz_event):
         """200 with `seated: false`, not 404.
 
@@ -2923,14 +3077,31 @@ class TestRotationInvariants:
                     f"{key} has {len(users)} rotators: {users}"
                 )
 
-    def test_group_a_visits_every_table(self):
-        """Over N rounds (N = num_tables), every Group-A rotator visits
-        every table exactly once."""
+    def test_rotators_visit_every_table(self):
+        """Over N rounds (N = num_tables), every group-A *and* group-B
+        rotator visits every table exactly once.
+
+        Group B is the half this used to leave untested, and it was
+        broken wherever the table count is even: its old +2 step shares a
+        factor with an even N, so it walked the same-parity tables and
+        skipped the rest — at 4 tables, 1 → 3 → 1 → 3, meeting the same
+        anchors all night. Anchors never move, so a rotator who misses
+        half the tables misses half the people, which is the entire
+        purpose of the evening.
+        """
+        from collections import defaultdict
+
         from crush_lu.services.quiz_rotation import generate_rotation_schedule
 
-        # Use configs where num_rounds == num_tables so the property is
-        # well-formed (after N rounds, every table must have been visited).
-        visit_configs = [(6, 6, 3, 3), (8, 8, 4, 4), (12, 12, 6, 6)]
+        # num_rounds == num_tables so the property is well-formed (after N
+        # rounds, every table must have been visited), and enough women to
+        # fill both groups. Even and odd table counts both represented.
+        visit_configs = [
+            (6, 6, 3, 3),
+            (8, 8, 4, 4),
+            (10, 10, 5, 5),
+            (12, 12, 6, 6),
+        ]
         for cfg_idx, (men_n, women_n, tables_n, rounds_n) in enumerate(visit_configs):
             men = self._mk_users(f"v_m_c{cfg_idx}_", men_n)
             women = self._mk_users(f"v_w_c{cfg_idx}_", women_n)
@@ -2938,16 +3109,21 @@ class TestRotationInvariants:
                 men, women, num_rounds=rounds_n, num_tables=tables_n
             )
 
-            visits = {}
+            visits = defaultdict(lambda: defaultdict(set))
             for e in result["schedule"]:
-                if e["role"] == "rotator" and e["rotation_group"] == "A":
-                    visits.setdefault(e["user"].id, set()).add(e["table_number"])
+                if e["role"] == "rotator" and e["rotation_group"] in ("A", "B"):
+                    visits[e["rotation_group"]][e["user"].id].add(e["table_number"])
 
-            for user_id, tables in visits.items():
-                assert tables == set(range(1, tables_n + 1)), (
+            for group in ("A", "B"):
+                assert visits[group], (
                     f"config=({men_n},{women_n},{tables_n},{rounds_n}) "
-                    f"group-A user {user_id} visited {tables}"
+                    f"seated no group-{group} rotators at all"
                 )
+                for user_id, tables in visits[group].items():
+                    assert tables == set(range(1, tables_n + 1)), (
+                        f"config=({men_n},{women_n},{tables_n},{rounds_n}) "
+                        f"group-{group} user {user_id} visited {tables}"
+                    )
 
     def test_rotators_move_between_consecutive_rounds(self):
         """A rotator is at a different table after every rotation.

--- a/crush_lu/tests/test_quiz.py
+++ b/crush_lu/tests/test_quiz.py
@@ -1398,9 +1398,6 @@ class TestRotationRegistrationFiltering:
         from crush_lu.services.quiz_rotation import generate_rotation_rounds
         from crush_lu.models.events import EventRegistration
 
-        # num_tables=3 avoids the num_tables==2 special case in
-        # generate_rotation_schedule which creates duplicate (round, user)
-        # entries when len(group_a) is odd.
         quiz_event.num_tables = 3
         quiz_event.save()
         self._add_rounds(quiz_event, 3)
@@ -1718,6 +1715,68 @@ class TestRotationRegistrationFiltering:
         assert not QuizRotationSchedule.objects.filter(
             quiz=quiz_event, round_number__gte=1
         ).exists(), "no rounds 1+ should be generated while quiz is draft"
+
+    def test_two_tables_few_rotators_build_and_move(self, quiz_event):
+        """Reported from a live rehearsal: 2 tables, 7 men (4 + 3) and 2
+        women, and the women sat at their check-in table all night.
+
+        The schedule seated each woman at *both* tables in the same round,
+        which the (quiz, round_number, user) constraint rejects — so the
+        bulk insert of every round past check-in rolled back together and
+        rounds 1+ simply did not exist. With nothing to read for the
+        current round, every seat lookup in the app falls through to the
+        round-0 ``QuizTableMembership``: the view, the API and the socket
+        all answer with the table the player checked in at, and the room
+        rotates onto itself.
+        """
+        from crush_lu.services.quiz_rotation import (
+            assign_table_on_checkin,
+            generate_rotation_rounds,
+        )
+
+        quiz_event.num_tables = 2
+        quiz_event.save()
+        self._add_rounds(quiz_event, 3)
+
+        regs = self._make_attendees(quiz_event.event, men_count=7, women_count=2)
+        for reg in regs:
+            assign_table_on_checkin(quiz_event, reg.user)
+
+        generate_rotation_rounds(quiz_event)
+
+        women = [r.user for r in regs[7:]]
+        for rn in range(3):
+            seated = QuizRotationSchedule.objects.filter(
+                quiz=quiz_event, round_number=rn
+            )
+            assert seated.count() == 9, (
+                f"round {rn} seats {seated.count()}/9 participants"
+            )
+
+        for woman in women:
+            tables = [
+                QuizRotationSchedule.objects.get(
+                    quiz=quiz_event, round_number=rn, user=woman
+                ).table.table_number
+                for rn in range(3)
+            ]
+            assert tables[0] != tables[1] and tables[1] != tables[2], (
+                f"rotator {woman.username} never left table {tables[0]}: {tables}"
+            )
+            assert set(tables) == {1, 2}, (
+                f"rotator {woman.username} did not visit both tables: {tables}"
+            )
+
+        # The two women are never at the same table, so both tables keep a
+        # rotator in every round.
+        for rn in range(3):
+            occupied = {
+                QuizRotationSchedule.objects.get(
+                    quiz=quiz_event, round_number=rn, user=w
+                ).table.table_number
+                for w in women
+            }
+            assert occupied == {1, 2}, f"round {rn}: rotators bunched at {occupied}"
 
 
 # ============================================================================
@@ -2793,7 +2852,17 @@ class TestRotationInvariants:
         (7, 7, 3, 3),  # odd counts
         (6, 9, 3, 3),  # women > 2× tables → spillover group C
         (10, 4, 5, 3),  # more anchors than rotators
-        (4, 6, 2, 2),  # 2-table special case
+        (4, 6, 2, 2),  # 2 tables, exactly 2 rotators per table
+        # Two tables with a rotator count that is not a clean 2-per-table
+        # fit. The old 2-table branch packed the first four women into a
+        # single group indexed modulo their own count, so anything but
+        # exactly four seated the same woman at both tables in one round —
+        # which the DB rejects on (quiz, round_number, user) and which left
+        # a real 7-man/2-woman quiz with no rounds past check-in at all.
+        (7, 2, 2, 3),
+        (4, 3, 2, 3),
+        (5, 5, 2, 3),
+        (4, 7, 2, 3),  # 2 tables + spillover group C
     ]
 
     def test_anchor_invariance(self):
@@ -2825,17 +2894,15 @@ class TestRotationInvariants:
         """At most one user per (round, table, rotation_group) for groups
         A and B. Group C is spillover and may double up.
 
-        Skips ``num_tables == 2`` because the algorithm deliberately seats
-        two group-A rotators per table in the 2-table special case (there
-        is no group B; all women are in a single rotating group).
+        Every table count, including 2: the special case that used to seat
+        two group-A rotators per table there is gone, so a 2-table room now
+        fills A and B one deep each like any other size.
         """
         from collections import defaultdict
 
         from crush_lu.services.quiz_rotation import generate_rotation_schedule
 
         for cfg_idx, (men_n, women_n, tables_n, rounds_n) in enumerate(self.CONFIGS):
-            if tables_n == 2:
-                continue  # 2-table case intentionally groups 2 women per A-slot
             men = self._mk_users(f"cc_m_c{cfg_idx}_", men_n)
             women = self._mk_users(f"cc_w_c{cfg_idx}_", women_n)
             result = generate_rotation_schedule(
@@ -2881,6 +2948,41 @@ class TestRotationInvariants:
                     f"config=({men_n},{women_n},{tables_n},{rounds_n}) "
                     f"group-A user {user_id} visited {tables}"
                 )
+
+    def test_rotators_move_between_consecutive_rounds(self):
+        """A rotator is at a different table after every rotation.
+
+        The invariant the suite was missing: it checked that anchors hold
+        still, that groups do not collide and that everyone has a seat, so
+        a schedule could satisfy all three while leaving the rotators
+        exactly where they started — which is what a 2-table room did,
+        group B being advanced by +2 tables, a no-op modulo 2.
+        """
+        from collections import defaultdict
+
+        from crush_lu.services.quiz_rotation import generate_rotation_schedule
+
+        for cfg_idx, (men_n, women_n, tables_n, rounds_n) in enumerate(self.CONFIGS):
+            men = self._mk_users(f"mv_m_c{cfg_idx}_", men_n)
+            women = self._mk_users(f"mv_w_c{cfg_idx}_", women_n)
+            result = generate_rotation_schedule(
+                men, women, num_rounds=rounds_n, num_tables=tables_n
+            )
+
+            seats = defaultdict(dict)
+            for e in result["schedule"]:
+                if e["role"] == "rotator":
+                    seats[e["user"].id][e["round_number"]] = e["table_number"]
+
+            for user_id, per_round in seats.items():
+                for rn in range(rounds_n - 1):
+                    if rn not in per_round or rn + 1 not in per_round:
+                        continue
+                    assert per_round[rn] != per_round[rn + 1], (
+                        f"config=({men_n},{women_n},{tables_n},{rounds_n}) "
+                        f"rotator {user_id} sat at table {per_round[rn]} in "
+                        f"both round {rn} and round {rn + 1}"
+                    )
 
     def test_every_user_seated_every_round(self):
         """Every participant appears exactly once in every round."""

--- a/crush_lu/views_quiz.py
+++ b/crush_lu/views_quiz.py
@@ -111,6 +111,53 @@ def _get_table_members_json(quiz, round_number=0):
     return result
 
 
+def get_table_occupants(quiz, table, round_number, exclude_user=None):
+    """Who is sitting at ``table`` in ``round_number``, as a JSON-safe list
+    of ``{display_name, role}``.
+
+    Answers the seat question the same way ``_get_table_members_json``
+    answers it for the whole room, and for the same reason: whether the
+    round is scheduled is a fact about the *quiz*, not about any one
+    player. A player can be missing from a round that everyone else is in
+    — someone who checks in mid-quiz gets a membership and a round-0 row
+    while ``assign_table_on_checkin`` rebuilds from the *next* round, so as
+    not to move the room mid-question — and their neighbours are still
+    whoever the current round seats here. Falling back to memberships for
+    them would name the check-in roster: the rotators who have since moved
+    on, and none of the ones who have moved in.
+
+    ``QuizTableMembership`` answers only when the round has no schedule at
+    all, which is a legacy non-rotating quiz or a rebuild that failed.
+    """
+    from crush_lu.models.quiz import QuizRotationSchedule
+
+    round_is_scheduled = QuizRotationSchedule.objects.filter(
+        quiz=quiz, round_number=round_number
+    ).exists()
+
+    if round_is_scheduled:
+        rows = QuizRotationSchedule.objects.filter(
+            quiz=quiz, round_number=round_number, table=table
+        ).select_related("user__crushprofile")
+    else:
+        rows = table.memberships.select_related("user__crushprofile")
+    if exclude_user is not None:
+        rows = rows.exclude(user=exclude_user)
+
+    occupants = []
+    for row in rows:
+        profile = getattr(row.user, "crushprofile", None)
+        occupants.append(
+            {
+                "display_name": (
+                    (profile.display_name if profile else None) or "Anonymous"
+                ),
+                "role": getattr(row, "role", ""),
+            }
+        )
+    return occupants
+
+
 @login_required
 def quiz_live_view(request, event_id):
     """Attendee view for the live quiz."""
@@ -159,41 +206,16 @@ def quiz_live_view(request, event_id):
             user_table_number = membership.table.table_number
             user_table = membership.table
 
-    # Build initial tablemates list (so it shows immediately without API call)
+    # Build initial tablemates list (so it shows immediately without API
+    # call). Same helper as ``my_assignment``, which matters here twice
+    # over: that endpoint overwrites this list a moment after the page
+    # paints, and the two disagreeing is a visible flicker onto a
+    # different set of names.
     tablemates = []
     if user_table:
-        if rotation:
-            mates = (
-                QuizRotationSchedule.objects.filter(
-                    quiz=quiz, round_number=round_number, table=user_table
-                )
-                .exclude(user=request.user)
-                .select_related("user__crushprofile")
-            )
-            for r in mates:
-                profile = getattr(r.user, "crushprofile", None)
-                tablemates.append(
-                    {
-                        "display_name": (
-                            (profile.display_name if profile else None) or "Anonymous"
-                        ),
-                        "role": r.role,
-                    }
-                )
-        else:
-            mates = user_table.memberships.exclude(user=request.user).select_related(
-                "user__crushprofile"
-            )
-            for m in mates:
-                profile = getattr(m.user, "crushprofile", None)
-                tablemates.append(
-                    {
-                        "display_name": (
-                            (profile.display_name if profile else None) or "Anonymous"
-                        ),
-                        "role": "",
-                    }
-                )
+        tablemates = get_table_occupants(
+            quiz, user_table, round_number, exclude_user=request.user
+        )
 
     # For coaches/staff who aren't assigned to a table, provide the full
     # table overview so they can see the setup from the participant view

--- a/crush_lu/views_quiz.py
+++ b/crush_lu/views_quiz.py
@@ -54,6 +54,20 @@ def _member_color(name):
     return _AVATAR_COLORS[h % len(_AVATAR_COLORS)]
 
 
+def _round_has_schedule(quiz, round_number):
+    """Whether the rotation schedule seats ``round_number`` at all.
+
+    The single fact the rotation-vs-membership fallback turns on, kept in
+    one place because every reader of a seat has to decide it the same
+    way. It is a question about the *quiz*, never about one player: a
+    player can be missing from a round the rest of the room is in, and
+    that is not licence to answer them from the check-in snapshot.
+    """
+    return QuizRotationSchedule.objects.filter(
+        quiz=quiz, round_number=round_number
+    ).exists()
+
+
 def _get_table_members_json(quiz, round_number=0):
     """Build JSON-safe list of tables with their current members.
 
@@ -62,12 +76,12 @@ def _get_table_members_json(quiz, round_number=0):
     shows as empty rather than the stale round-0 check-in snapshot).
     Only fall back to ``QuizTableMembership`` when the quiz has no
     rotation schedule for this round at all (legacy non-rotating
-    events).
+    events). Asked once here rather than per table, which is why this
+    renders the whole room in one decision and ``get_table_occupants``
+    answers for one table.
     """
     tables = QuizTable.objects.filter(quiz=quiz).order_by("table_number")
-    rotation_exists = QuizRotationSchedule.objects.filter(
-        quiz=quiz, round_number=round_number
-    ).exists()
+    rotation_exists = _round_has_schedule(quiz, round_number)
     result = []
     for table in tables:
         members = []
@@ -128,24 +142,28 @@ def get_table_occupants(quiz, table, round_number, exclude_user=None):
 
     ``QuizTableMembership`` answers only when the round has no schedule at
     all, which is a legacy non-rotating quiz or a rebuild that failed.
+    Never because *this* table came back empty — an empty table in a
+    scheduled round means nobody is sitting there, and saying so is the
+    point of deciding at the quiz level.
     """
-    from crush_lu.models.quiz import QuizRotationSchedule
-
-    round_is_scheduled = QuizRotationSchedule.objects.filter(
-        quiz=quiz, round_number=round_number
-    ).exists()
-
-    if round_is_scheduled:
-        rows = QuizRotationSchedule.objects.filter(
+    rows = list(
+        QuizRotationSchedule.objects.filter(
             quiz=quiz, round_number=round_number, table=table
         ).select_related("user__crushprofile")
-    else:
-        rows = table.memberships.select_related("user__crushprofile")
-    if exclude_user is not None:
-        rows = rows.exclude(user=exclude_user)
+    )
+    # Ask the quiz-level question only when it is the one still open.
+    # Rows here prove the round is scheduled, and a table with people at
+    # it is the ordinary case, so the common path costs one query instead
+    # of two — including the one ``my_assignment`` used to make after
+    # already having found the caller's own row for this very round.
+    if not rows and not _round_has_schedule(quiz, round_number):
+        rows = list(table.memberships.select_related("user__crushprofile"))
 
+    exclude_pk = exclude_user.pk if exclude_user is not None else None
     occupants = []
     for row in rows:
+        if row.user_id == exclude_pk:
+            continue
         profile = getattr(row.user, "crushprofile", None)
         occupants.append(
             {


### PR DESCRIPTION
## Purpose

* Fix the reported rehearsal bug: a Quiz Night with **2 tables, 7 men (4 + 3) and 2 women** left both women at their check-in table for the whole quiz.

The `num_tables == 2` branch of `generate_rotation_schedule` packed the first four women into a single group and indexed it modulo *their own count* while walking tables as `table_idx * 2 + offset`. That only lands on distinct indices when there are exactly four rotators. With two, each woman was scheduled at table 1 **and** table 2 in the same round.

`QuizRotationSchedule` is unique on `(quiz, round_number, user)`, so the `bulk_create` of every round past check-in rolled back as one unit and **rounds 1+ never existed**. Every seat lookup in the app — `quiz_live_view`, `my_assignment`, the socket connect path, `_get_table_members_json` — falls back to the round-0 `QuizTableMembership` when the current round has no rotation rows, so the entire room kept answering with the table each player had checked in at. The rotation looked like it happened; nobody moved.

* Drop the special case so 2 tables use the same A/B/C split as every other size. That split is the one `assign_table_on_checkin` and `manual_assign_table` already stamp at the door (`A` while fewer than `num_tables` rotators exist, then `B`, then `C`) — the old branch relabelled them all `A`, contradicting the rows it was reading back.
* **Fix group B's step at every table count, not just 2.** What makes a step a rotation is not that it is non-zero but that it is *coprime* with the table count, and the old `+2` is coprime with no even count: at 4 tables group B walked `1 → 3 → 1 → 3`, meeting the same anchors all night; at 2 tables it was a standstill. `step_b = num_tables - 1` — consecutive integers are always coprime — holds everywhere and subsumes the 2-table case rather than adding a second rule beside it.
* `handle_rotate` broadcast `advance_round_and_rotate`'s error dict as `quiz.rotate`, so every screen switched to the rotate splash and refetched seating that had not moved, while the host — the one person who could act — was told nothing. Route it to `send_error` like the pre-rotate guard already does.
* **Make the round advance atomic with the rebuild.** The advance committed before the rebuild ran, so a failed rebuild left the quiz on a round nothing was scheduled for, with `current_question_index` back at `-1` — which `check_can_rotate` reads as "questions remain in this round", refusing the retry. Seating the room first makes a failed rebuild a clean no-op.
* `my_assignment` answered the membership fallback with `tablemates: []`. `fetchAssignment` assigns every field it is handed (#723) and runs on init, on reconnect and on every rotate, so that **cleared the tablemates the server had just rendered into the page**. Now filled — and read from the current round's schedule, not the check-in roster, since a player missing from a round the rest of the room is in (any mid-quiz arrival) would otherwise be shown the rotators who had since moved away.
* That rule now lives once, in `get_table_occupants` / `_round_has_schedule`, instead of the four near-copies that had already drifted apart.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

No API, schema, or migration changes. Seating output is unchanged at 3 tables and changes at 4+, which is the even-table-count fix above — the old arrangement there was the defect.

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
git checkout claude/rotation-mixed-groups-review-395dvy
python -m pytest crush_lu/tests
```

Targeted:

```
python -m pytest crush_lu/tests/test_quiz.py -k "two_tables_few_rotators or rotators_move_between or rotators_visit_every_table or no_group_ab_collisions or regeneration_fails or handle_rotate_tells_the_host or fallback_reads_the_current_round or alone_at_a_scheduled_table"
```

Every one of these was confirmed to fail on the baseline it targets, not merely to pass here:

| Test | Fails on baseline with |
|---|---|
| `test_two_tables_few_rotators_build_and_move` | `IntegrityError: UNIQUE constraint failed: quiz_id, round_number, user_id` |
| `test_no_group_ab_collisions` | `(0, 1, 'A') has 2 rotators` |
| `test_rotators_move_between_consecutive_rounds` | `rotator 6 sat at table 1 in both round 0 and round 1` |
| `test_rotators_visit_every_table` | `group-B user 25 visited {1, 3}` at `(8, 8, 4, 4)` |
| `test_advance_round_does_not_move_when_regeneration_fails` | `a failed rebuild must not leave the quiz on the next round` |
| `test_handle_rotate_tells_the_host_a_rebuild_failed` | `Expected group_send to not have been awaited. Awaited 1 times.` |
| `test_my_assignment_fallback_reads_the_current_round` | `got {'Anonymous', 'MovedOn'}` — a rotator who had left that table |
| `test_my_assignment_alone_at_a_scheduled_table` | returns the check-in roster of an emptied table |

## What to Check

* `test_rotators_move_between_consecutive_rounds` — the invariant the suite was missing. It pinned anchors, group collisions and per-round seat counts, **all of which a completely frozen rotator satisfies**, which is why a 2-table room could ship this way.
* `test_rotators_visit_every_table` replaces `test_group_a_visits_every_table`, covering group B and both table-count parities.
* Four new 2-table configs in `CONFIGS` covering rotator counts that are not a clean 2-per-table fit: `(7,2,2,3)`, `(4,3,2,3)`, `(5,5,2,3)`, `(4,7,2,3)`.
* Full suite: 3898 passed, 31 skipped. `ruff` findings identical to baseline (65, all pre-existing); `black` touches no added line.

## Other Information

Two tables cannot both rotate everyone *and* vary who meets whom — modulo 2 the only non-zero step is +1, so the alternative to moving both groups is freezing one. The same tension appears at every even table count: a step coprime with an even `N` is odd, which leaves the A/B drift even. Coverage wins in both cases — the anchors never move, so a rotator who misses half the tables misses half the people — and the module docstring now states that trade instead of claiming the pairing property unconditionally.

Separately worth knowing, and left alone here: the split behind "some people show up instantly, others load late" is that `quiz_live_view` bakes the seat into `data-table-number` only when the server can resolve one. Resolvable → painted on first render. Not resolvable → the page paints empty and waits on `/api/quiz/<id>/my-assignment/`, then retries twice at 2s before showing "Could not load table assignment." The broken schedule widened that gap for everyone, since the primary rotation lookup missed for the whole room.