### PR TITLE
Stop a re-submitted admin change form from 500ing on the registration index

### DIFF
--- a/azureproject/production.py
+++ b/azureproject/production.py
@@ -480,18 +480,36 @@ LOGGING = {
         "handlers": ["console"],
         "level": "INFO",  # Allow INFO+ to propagate to App Insights
     },
+    # NOTE ON `handlers: []` BELOW.
+    #
+    # Every logger here that propagates must leave `handlers` empty: root
+    # already owns "console", and logging calls the handlers found at EVERY
+    # level it walks, not just the first. A logger that names "console" AND
+    # propagates therefore prints twice, and `django.request` — which walks
+    # django.request -> django -> root, all three naming "console" — printed
+    # every record three times. One 500 on the MeetupEvent change form filled
+    # the staging log with three identical IntegrityError tracebacks
+    # (2026-08-11), which reads as three failures.
+    #
+    # Do NOT "fix" that by setting `propagate: False`. App Insights is fed by
+    # an OTel LoggingHandler attached to the ROOT logger
+    # (azureproject/apps.py -> attach_otel_logging_handler_to_root), so
+    # anything that stops propagating stops being exported. Dropping the
+    # duplicate handler keeps console at one line and leaves the export path
+    # untouched; the "console" handler's own ERROR level still applies, so
+    # nothing new reaches the console either.
     "loggers": {
         # =================================================================
         # Django Core Loggers - Minimal console output
         # =================================================================
         "django": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "WARNING",
             # Propagate to root so App Insights captures Django warnings/errors
             "propagate": True,
         },
         "django.request": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "WARNING",
             # Propagate to root so 4xx/5xx and CSRF failures reach App Insights
             "propagate": True,
@@ -542,33 +560,33 @@ LOGGING = {
         # WARNING: state not found
         # ERROR: database failures
         "crush_lu.oauth_statekit": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "INFO",
             "propagate": True,  # Propagate to App Insights
         },
         # ASGI transport errors (e.g. CurrentThreadExecutor broken)
         # These occur before Django's request pipeline starts
         "azureproject.asgi": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "ERROR",
             "propagate": True,  # Propagate to root → App Insights
         },
         # Middleware logging (CSRF failures, routing)
         "azureproject.middleware": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "WARNING",
             "propagate": True,
         },
         # Crush.lu application logging
         "crush_lu": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "INFO",
             "propagate": True,
         },
         # CSP violation reports
         # Query in App Insights: traces | where message contains "CSP"
         "csp_reports": {
-            "handlers": ["console"],
+            "handlers": [],
             "level": "WARNING",
             "propagate": True,
         },

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -14,7 +14,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.contrib import messages as django_messages
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
@@ -1369,6 +1369,79 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
                 attrs=ADDRESS_WIDGET_ATTRS[db_field.name]
             )
         return super().formfield_for_dbfield(db_field, request, **kwargs)
+
+    def save_formset(self, request, form, formset, change):
+        """
+        Don't let a re-submitted registration row take the whole save down.
+
+        `EventRegistration` is unique on (event, user) and the formset does
+        check that before saving — but only against the table as it stood when
+        the form was validated. Two overlapping submissions of the same change
+        form therefore both pass validation, both INSERT, and the loser gets
+
+            IntegrityError: duplicate key value violates unique constraint
+            "crush_lu_eventregistration_event_id_user_id_52c32bb9_uniq"
+
+        rendered as a 500. `changeform_view` wraps the POST in a transaction,
+        so that rollback also discards the parent event's edits and every other
+        inline in the same submission — for a row the admin's own twin request
+        had already written (staging 2026-08-11, event 29 / user 86). The
+        registration exists either way, so the duplicate is dropped and named
+        in a warning instead of costing the rest of the save.
+
+        Only that exact collision is absorbed. Each row goes in under its own
+        savepoint and anything that is not an already-registered (event, user)
+        pair is re-raised untouched.
+        """
+        if formset.model is not EventRegistration:
+            super().save_formset(request, form, formset, change)
+            return
+
+        instances = formset.save(commit=False)
+        for obj in formset.deleted_objects:
+            obj.delete()
+
+        skipped = []
+        for obj in instances:
+            try:
+                # A savepoint, not a nested transaction: the admin's atomic
+                # block is already open, and an IntegrityError that escapes
+                # into it poisons it — Postgres rejects every later statement
+                # in an aborted transaction, including the lookup below.
+                with transaction.atomic():
+                    obj.save()
+            except IntegrityError:
+                already_registered = EventRegistration.objects.filter(
+                    event_id=obj.event_id, user_id=obj.user_id
+                )
+                if obj.pk is not None:
+                    already_registered = already_registered.exclude(pk=obj.pk)
+                if not already_registered.exists():
+                    raise
+                skipped.append(obj)
+
+        formset.save_m2m()
+
+        if skipped:
+            names = ", ".join(
+                obj.user.get_full_name() or obj.user.username for obj in skipped
+            )
+            logger.warning(
+                "Dropped %d duplicate registration row(s) on event %s (users: %s) "
+                "— the change form was submitted more than once.",
+                len(skipped),
+                form.instance.pk,
+                names,
+            )
+            self.message_user(
+                request,
+                _(
+                    "Already registered for this event, so no duplicate was "
+                    "created: %(users)s."
+                )
+                % {"users": names},
+                level=django_messages.WARNING,
+            )
 
 
 class EventRegistrationAdmin(admin.ModelAdmin):

--- a/crush_lu/admin/events.py
+++ b/crush_lu/admin/events.py
@@ -14,6 +14,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.contrib import messages as django_messages
+from django.core.exceptions import FieldDoesNotExist
 from django.db import IntegrityError, transaction
 from django.urls import reverse
 from django.utils import timezone
@@ -1391,7 +1392,10 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
 
         Only that exact collision is absorbed. Each row goes in under its own
         savepoint and anything that is not an already-registered (event, user)
-        pair is re-raised untouched.
+        pair is re-raised untouched. A collision whose winner does NOT match
+        what was submitted is still absorbed — a 500 helps nobody — but it is
+        reported field by field rather than as a plain duplicate, because
+        there the admin's values really were dropped.
         """
         if formset.model is not EventRegistration:
             super().save_formset(request, form, formset, change)
@@ -1400,6 +1404,13 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
         instances = formset.save(commit=False)
         for obj in formset.deleted_objects:
             obj.delete()
+
+        # The form each row came from, so a collision is reported against
+        # exactly the fields the admin submitted and no others.
+        forms_by_instance = {
+            id(saved.instance): saved
+            for saved in getattr(formset, "saved_forms", [])
+        }
 
         skipped = []
         for obj in instances:
@@ -1416,20 +1427,86 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
                 )
                 if obj.pk is not None:
                     already_registered = already_registered.exclude(pk=obj.pk)
-                if not already_registered.exists():
+                winner = already_registered.first()
+                if winner is None:
                     raise
-                skipped.append(obj)
+                skipped.append(
+                    (
+                        obj,
+                        self._registration_conflicts(
+                            forms_by_instance.get(id(obj)), obj, winner
+                        ),
+                    )
+                )
 
         formset.save_m2m()
 
-        if skipped:
-            names = ", ".join(
-                obj.user.get_full_name() or obj.user.username for obj in skipped
-            )
+        if not skipped:
+            return
+
+        # `construct_change_message()` runs right after this and reads these
+        # two collections straight into the admin LogEntry. A row the savepoint
+        # rolled back must not show up in the event's history as added or
+        # changed — the history is the record of what was persisted.
+        dropped = {id(obj) for obj, _ in skipped}
+        formset.new_objects = [
+            obj for obj in formset.new_objects if id(obj) not in dropped
+        ]
+        formset.changed_objects = [
+            (obj, fields)
+            for obj, fields in formset.changed_objects
+            if id(obj) not in dropped
+        ]
+
+        self._report_skipped_registrations(request, form, skipped)
+
+    @staticmethod
+    def _registration_conflicts(saved_form, submitted, winner):
+        """Submitted values the row that won the race does not agree with.
+
+        A twin submission of the same form agrees on every field, so this comes
+        back empty and dropping the row costs nothing. A row written by someone
+        else inside the same window need not agree — a member self-registering
+        as `waitlist` while an admin adds them as `confirmed` with payment
+        recorded leaves those two values unapplied — and reporting that as a
+        plain duplicate would claim a save that did not happen.
+        """
+        if saved_form is None:
+            return []
+
+        conflicts = []
+        for name in saved_form.fields:
+            # `id` and `event` identify the row rather than describe it, and
+            # `user` is equal by construction: it is half the unique key.
+            if name in {"id", "event", "user"}:
+                continue
+            try:
+                field = EventRegistration._meta.get_field(name)
+            except FieldDoesNotExist:
+                continue  # the formset's own DELETE checkbox, etc.
+            if not field.concrete:
+                continue
+            mine = getattr(submitted, field.attname, None)
+            theirs = getattr(winner, field.attname, None)
+            if mine != theirs:
+                conflicts.append((field.verbose_name, mine, theirs))
+        return conflicts
+
+    def _report_skipped_registrations(self, request, form, skipped):
+        """Tell the admin which rows were dropped, and whether anything was lost."""
+
+        def label(obj):
+            return obj.user.get_full_name() or obj.user.username
+
+        duplicates = [obj for obj, conflicts in skipped if not conflicts]
+        conflicted = [(obj, conflicts) for obj, conflicts in skipped if conflicts]
+
+        if duplicates:
+            names = ", ".join(label(obj) for obj in duplicates)
             logger.warning(
                 "Dropped %d duplicate registration row(s) on event %s (users: %s) "
                 "— the change form was submitted more than once.",
-                len(skipped),
+                len(duplicates),
                 form.instance.pk,
                 names,
             )
@@ -1440,6 +1517,30 @@ class MeetupEventAdmin(AutoTranslateMixin, TranslationAdmin):
                     "created: %(users)s."
                 )
                 % {"users": names},
+                level=django_messages.WARNING,
+            )
+
+        for obj, conflicts in conflicted:
+            details = "; ".join(
+                _("%(field)s — you sent %(mine)s, the saved one has %(theirs)s")
+                % {"field": verbose_name, "mine": mine, "theirs": theirs}
+                for verbose_name, mine, theirs in conflicts
+            )
+            logger.warning(
+                "Kept an existing registration for user %s on event %s over a "
+                "concurrent admin submission; unapplied: %s",
+                obj.user_id,
+                form.instance.pk,
+                details,
+            )
+            self.message_user(
+                request,
+                _(
+                    "%(user)s was registered for this event by another request "
+                    "while you were editing, so your row was not applied "
+                    "(%(details)s). Open that registration to apply your values."
+                )
+                % {"user": label(obj), "details": details},
                 level=django_messages.WARNING,
             )
 

--- a/crush_lu/static/crush_lu/sw-workbox.js
+++ b/crush_lu/static/crush_lu/sw-workbox.js
@@ -2,7 +2,9 @@
 // Production-ready PWA implementation using local Workbox library
 // Version: v31 - Keep /crush-admin/ off the background-sync queue and out of the
 //                cache. The admin is mounted at /crush-admin/, not /admin/, so
-//                every exclusion list written against /admin/ missed it.
+//                every exclusion list written against /admin/ missed it. The
+//                queue is also drained through the same list, so entries an
+//                older worker already stored are dropped rather than replayed.
 
 // ============================================================================
 // CRITICAL: OAuth Callback Bypass - MUST BE BEFORE WORKBOX
@@ -512,26 +514,14 @@ if (workbox) {
     // Background Sync (for future offline form submissions)
     // ============================================================================
 
-    const bgSyncPlugin = new workbox.backgroundSync.BackgroundSyncPlugin(
-        "crush-queue",
-        {
-            maxRetentionTime: 24 * 60, // Retry for up to 24 hours (in minutes)
-            onSync: async ({ queue }) => {
-                let entry;
-                while ((entry = await queue.shiftRequest())) {
-                    try {
-                        await fetch(entry.request);
-                    } catch (error) {
-                        await queue.unshiftRequest(entry);
-                        throw error;
-                    }
-                }
-            },
-        },
-    );
-
-    // Use background sync for POST requests (event registrations, etc.)
-    // IMPORTANT: Exclude auth-related POSTs - they have CSRF tokens that can't be replayed
+    // Which POSTs the queue may hold. ONE list with TWO readers: the route
+    // below decides what may ENTER the queue, and onSync decides what may
+    // LEAVE it. They have to agree. A path excluded only at the entrance still
+    // replays out of the IndexedDB store an older worker filled — the queue is
+    // named, so it survives the update, and `maxRetentionTime` keeps its
+    // contents replayable for 24h after this worker ships.
+    //
+    // IMPORTANT: auth-related POSTs carry CSRF tokens that can't be replayed.
     //
     // Admin POSTs are excluded for a second reason: a queued admin form is
     // replayed verbatim up to 24h later, which re-submits the whole change
@@ -545,16 +535,46 @@ if (workbox) {
     // but cannot say whether the queue or a double-click produced it. Both
     // mount points are listed: /admin/ is Django's own admin, /crush-admin/
     // is the Crush coach panel (urls_crush.py).
+    function isQueueablePost(pathname) {
+        return (
+            !pathname.startsWith("/api/") &&
+            !pathname.startsWith("/admin/") &&
+            !pathname.startsWith("/crush-admin/") &&
+            !pathname.startsWith("/login") &&
+            !pathname.startsWith("/logout") &&
+            !pathname.startsWith("/accounts/") &&
+            !pathname.startsWith("/signup")
+        );
+    }
+
+    const bgSyncPlugin = new workbox.backgroundSync.BackgroundSyncPlugin(
+        "crush-queue",
+        {
+            maxRetentionTime: 24 * 60, // Retry for up to 24 hours (in minutes)
+            onSync: async ({ queue }) => {
+                let entry;
+                while ((entry = await queue.shiftRequest())) {
+                    // Discard, don't replay: an entry an earlier worker
+                    // queued predates the exclusions above, and shifting it
+                    // out without fetching is what actually removes it.
+                    if (!isQueueablePost(new URL(entry.request.url).pathname)) {
+                        continue;
+                    }
+                    try {
+                        await fetch(entry.request);
+                    } catch (error) {
+                        await queue.unshiftRequest(entry);
+                        throw error;
+                    }
+                }
+            },
+        },
+    );
+
+    // Use background sync for POST requests (event registrations, etc.)
     workbox.routing.registerRoute(
         ({ url, request }) =>
-            request.method === "POST" &&
-            !url.pathname.startsWith("/api/") &&
-            !url.pathname.startsWith("/admin/") &&
-            !url.pathname.startsWith("/crush-admin/") &&
-            !url.pathname.startsWith("/login") &&
-            !url.pathname.startsWith("/logout") &&
-            !url.pathname.startsWith("/accounts/") &&
-            !url.pathname.startsWith("/signup"),
+            request.method === "POST" && isQueueablePost(url.pathname),
         new workbox.strategies.NetworkOnly({
             plugins: [bgSyncPlugin],
         }),

--- a/crush_lu/static/crush_lu/sw-workbox.js
+++ b/crush_lu/static/crush_lu/sw-workbox.js
@@ -1,7 +1,8 @@
 // Crush.lu Service Worker with Workbox
 // Production-ready PWA implementation using local Workbox library
-// Version: v30 - Bypass /api/mobile/ so the native auth handoff's crushlu:// redirect
-//                is followed by the browser, not by the SW's fetch() (which cannot)
+// Version: v31 - Keep /crush-admin/ off the background-sync queue and out of the
+//                cache. The admin is mounted at /crush-admin/, not /admin/, so
+//                every exclusion list written against /admin/ missed it.
 
 // ============================================================================
 // CRITICAL: OAuth Callback Bypass - MUST BE BEFORE WORKBOX
@@ -295,6 +296,13 @@ if (workbox) {
     function isAuthenticatedRoute(pathname) {
         const authPaths = [
             "/admin",
+            // The Crush admin site is mounted at /crush-admin/ (urls_crush.py),
+            // which does NOT contain the substring "/admin" — the character
+            // before "admin" is a hyphen. Listing it separately keeps admin
+            // pages off every cache: a change form served from cache carries
+            // stale inline `id`/INITIAL_FORMS values, and re-posting those
+            // rows as new ones is what trips the (event, user) unique index.
+            "/crush-admin",
             "/accounts",
             "/coach",
             "/dashboard",
@@ -524,11 +532,25 @@ if (workbox) {
 
     // Use background sync for POST requests (event registrations, etc.)
     // IMPORTANT: Exclude auth-related POSTs - they have CSRF tokens that can't be replayed
+    //
+    // Admin POSTs are excluded for a second reason: a queued admin form is
+    // replayed verbatim up to 24h later, which re-submits the whole change
+    // form including its inline rows — writing them a second time, with no
+    // one watching the tab it answers into. On the MeetupEvent change form
+    // that means a second EventRegistration INSERT and
+    //   duplicate key ... crush_lu_eventregistration_event_id_user_id_..._uniq
+    // which surfaces as a form error if the replay is well separated from the
+    // original and as a 500 if the two overlap. Staging hit that 500 on
+    // 2026-08-11 (event 29 / user 86); the logs show a duplicate submission
+    // but cannot say whether the queue or a double-click produced it. Both
+    // mount points are listed: /admin/ is Django's own admin, /crush-admin/
+    // is the Crush coach panel (urls_crush.py).
     workbox.routing.registerRoute(
         ({ url, request }) =>
             request.method === "POST" &&
             !url.pathname.startsWith("/api/") &&
             !url.pathname.startsWith("/admin/") &&
+            !url.pathname.startsWith("/crush-admin/") &&
             !url.pathname.startsWith("/login") &&
             !url.pathname.startsWith("/logout") &&
             !url.pathname.startsWith("/accounts/") &&

--- a/crush_lu/tests/sw_route_probe.js
+++ b/crush_lu/tests/sw_route_probe.js
@@ -51,10 +51,15 @@ const workbox = {
         skipWaiting: () => {},
     }),
     routing: lenientNamespace({
-        registerRoute: (match, handler) => {
+        // Workbox keeps one router per HTTP method and defaults to GET, so a
+        // POST probe must only be matched against POST-registered routes.
+        // Ignoring the method here made every probe look like it hit the
+        // background-sync route.
+        registerRoute: (match, handler, method) => {
             routes.push({
                 match,
                 strategy: (handler && handler.__strategy) || "unknown",
+                method: method || "GET",
             });
         },
         setCatchHandler: () => {},
@@ -140,6 +145,7 @@ function earlyListenerClaims(request) {
 function matchingRoute(request) {
     const url = new URL(request.url);
     for (const route of routes) {
+        if (route.method !== (request.method || "GET")) continue;
         let hit = false;
         try {
             hit = !!route.match({ url, request, event: { request } });
@@ -192,6 +198,40 @@ const probes = [
         destination: "document",
         mustBeClaimed: true, // proves the probe detects claiming at all
     },
+    {
+        // A queued admin POST is replayed verbatim for up to 24h, which
+        // re-submits the change form's inline rows and duplicates whatever the
+        // first submission already wrote. Staging 2026-08-11: a second
+        // EventRegistration INSERT for (event 29, user 86) came back as a 500
+        // on the unique index.
+        name: "crush_admin_form_post",
+        url: "https://crush.lu/crush-admin/crush_lu/meetupevent/29/change/",
+        method: "POST",
+        mode: "same-origin",
+        destination: "",
+        mustBeClaimed: false,
+    },
+    {
+        // The admin lives at /crush-admin/, which does not contain "/admin" —
+        // so it slipped past the authenticated-route list and its pages were
+        // cacheable. A cached change form carries stale inline ids.
+        name: "crush_admin_page_navigation",
+        url: "https://crush.lu/crush-admin/crush_lu/meetupevent/29/change/",
+        mode: "navigate",
+        destination: "document",
+        mustBeClaimed: true,
+        mustMatchStrategy: "NetworkOnly",
+    },
+    {
+        // Guards the method-aware probe: ordinary site POSTs must KEEP their
+        // background-sync queueing, which is the whole point of the route.
+        name: "ordinary_form_post",
+        url: "https://crush.lu/en/events/29/register/",
+        method: "POST",
+        mode: "same-origin",
+        destination: "",
+        mustBeClaimed: true,
+    },
 ];
 
 const results = probes.map((probe) => {
@@ -199,21 +239,26 @@ const results = probes.map((probe) => {
         url: probe.url,
         mode: probe.mode,
         destination: probe.destination,
-        method: "GET",
+        method: probe.method || "GET",
         headers: { get: () => "" },
     };
     const early = earlyListenerClaims(request);
     const route = early ? null : matchingRoute(request);
     const claimed = early || route !== null;
+    const strategyOk = !probe.mustMatchStrategy || route === probe.mustMatchStrategy;
     return {
         name: probe.name,
         url: probe.url,
+        method: request.method,
         claimedByEarlyListener: early,
         matchedRoute: route,
         claimed,
         informational: !!probe.informational,
         mustBeClaimed: probe.informational ? null : probe.mustBeClaimed,
-        ok: probe.informational ? true : claimed === probe.mustBeClaimed,
+        mustMatchStrategy: probe.mustMatchStrategy || null,
+        ok: probe.informational
+            ? true
+            : claimed === probe.mustBeClaimed && strategyOk,
     };
 });
 

--- a/crush_lu/tests/sw_route_probe.js
+++ b/crush_lu/tests/sw_route_probe.js
@@ -23,6 +23,7 @@ const source = fs.readFileSync(swPath, "utf8");
 
 const routes = [];
 const fetchListeners = [];
+let backgroundSync = null;
 
 function strategyName(name) {
     return function Strategy(opts) {
@@ -82,7 +83,13 @@ const workbox = {
     }),
     expiration: lenientNamespace(),
     cacheableResponse: lenientNamespace(),
-    backgroundSync: lenientNamespace(),
+    // Captured rather than stubbed away: the route predicate only governs what
+    // ENTERS the queue, so the replay loop has to be probed on its own.
+    backgroundSync: lenientNamespace({
+        BackgroundSyncPlugin: function (queueName, options) {
+            backgroundSync = { queueName, options: options || {} };
+        },
+    }),
     recipes: lenientNamespace(),
     rangeRequests: lenientNamespace(),
     broadcastUpdate: lenientNamespace(),
@@ -262,4 +269,43 @@ const results = probes.map((probe) => {
     };
 });
 
-process.stdout.write(JSON.stringify({ routeCount: routes.length, results }, null, 2));
+/**
+ * Drive the background-sync plugin's onSync over a queue that ALREADY holds
+ * these requests, as a store filled by an earlier worker version would.
+ * Returns the URLs it actually re-fetched.
+ */
+async function probeReplay(urls) {
+    if (!backgroundSync || typeof backgroundSync.options.onSync !== "function") {
+        return { available: false, replayed: [], drained: false };
+    }
+    const pending = urls.map((url) => ({ request: { url, method: "POST" } }));
+    const queue = {
+        shiftRequest: async () => pending.shift(),
+        unshiftRequest: async (entry) => {
+            pending.unshift(entry);
+        },
+    };
+    const replayed = [];
+    const realFetch = sandbox.fetch;
+    sandbox.fetch = async (request) => {
+        replayed.push(request.url);
+        return new Response("");
+    };
+    try {
+        await backgroundSync.options.onSync({ queue });
+    } finally {
+        sandbox.fetch = realFetch;
+    }
+    // A skipped entry must be shifted OUT, not left behind to try again.
+    return { available: true, replayed, drained: pending.length === 0 };
+}
+
+(async () => {
+    const replay = await probeReplay([
+        "https://crush.lu/crush-admin/crush_lu/meetupevent/29/change/",
+        "https://crush.lu/en/events/29/register/",
+    ]);
+    process.stdout.write(
+        JSON.stringify({ routeCount: routes.length, results, replay }, null, 2),
+    );
+})();

--- a/crush_lu/tests/test_events.py
+++ b/crush_lu/tests/test_events.py
@@ -1160,6 +1160,154 @@ class EventRegistrationAdminFormAgeTests(TestCase):
         self.assertFalse(form.is_valid())
 
 
+@override_settings(ROOT_URLCONF="azureproject.urls_crush")
+class MeetupEventAdminDuplicateRegistrationTests(TestCase):
+    """
+    A change form submitted twice must not 500 on the (event, user) unique index.
+
+    Staging 2026-08-11, event 29 / user 86: two overlapping POSTs of the
+    MeetupEvent change form each validated against a table that did not hold
+    the registration yet, both INSERTed, and the loser came back as
+
+        IntegrityError: duplicate key value violates unique constraint
+        "crush_lu_eventregistration_event_id_user_id_52c32bb9_uniq"
+
+    `changeform_view` runs the POST inside a transaction, so that rollback took
+    the parent event's edits and every other inline down with it — over a row
+    its own twin had already written.
+
+    These tests drive `save_formset` directly and create the conflicting row
+    between `is_valid()` and the save, which is precisely the window the
+    database index was catching.
+    """
+
+    def setUp(self):
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.test import RequestFactory
+
+        from crush_lu.admin import crush_admin_site
+        from crush_lu.admin.events import EventRegistrationInline, MeetupEventAdmin
+        from crush_lu.models import MeetupEvent
+
+        self.factory = RequestFactory()
+        self.FallbackStorage = FallbackStorage
+        self.site = crush_admin_site
+        self.inline_cls = EventRegistrationInline
+        self.admin = MeetupEventAdmin(MeetupEvent, crush_admin_site)
+
+        self.staff = User.objects.create_superuser(
+            username='dup-admin', email='dup-admin@test.lu', password='x',
+        )
+        self.member = User.objects.create_user(
+            username='dup-member', email='dup-member@test.lu', password='x',
+        )
+        self.event = MeetupEvent.objects.create(
+            title='Duplicate Guard Event',
+            description='no age restriction, so the age gate stays inert',
+            event_type='mixer',
+            date_time=timezone.now() + timedelta(days=7),
+            location='Luxembourg',
+            address='123 Test Street',
+            max_participants=10,
+            registration_deadline=timezone.now() + timedelta(days=5),
+            is_published=True,
+        )
+
+    def _request(self):
+        request = self.factory.post('/')
+        request.user = self.staff
+        request.session = {}
+        request._messages = self.FallbackStorage(request)
+        return request
+
+    def _validated_formset_adding(self, user):
+        """One new registration row, already through `is_valid()`."""
+        from crush_lu.models import MeetupEvent
+
+        inline = self.inline_cls(MeetupEvent, self.site)
+        formset_cls = inline.get_formset(self._request())
+        prefix = formset_cls.get_default_prefix()
+        formset = formset_cls(
+            {
+                f'{prefix}-TOTAL_FORMS': '1',
+                f'{prefix}-INITIAL_FORMS': '0',
+                f'{prefix}-MIN_NUM_FORMS': '0',
+                f'{prefix}-MAX_NUM_FORMS': '1000',
+                f'{prefix}-0-id': '',
+                f'{prefix}-0-user': str(user.pk),
+                f'{prefix}-0-status': 'confirmed',
+            },
+            instance=self.event,
+        )
+        self.assertTrue(formset.is_valid(), formset.errors)
+        return formset
+
+    def _parent_form(self):
+        request = self._request()
+        return self.admin.get_form(request, self.event)(instance=self.event)
+
+    def _messages(self, request):
+        return [str(m) for m in request._messages]
+
+    def test_row_written_by_a_twin_submission_is_skipped(self):
+        from crush_lu.models import EventRegistration
+
+        formset = self._validated_formset_adding(self.member)
+
+        # The twin request lands after validation and before the save.
+        EventRegistration.objects.create(
+            event=self.event, user=self.member, status='confirmed'
+        )
+
+        request = self._request()
+        self.admin.save_formset(request, self._parent_form(), formset, change=True)
+
+        self.assertEqual(
+            EventRegistration.objects.filter(
+                event=self.event, user=self.member
+            ).count(),
+            1,
+        )
+        self.assertTrue(
+            any('Already registered' in m for m in self._messages(request)),
+            f'expected a warning naming the skipped user, got {self._messages(request)}',
+        )
+
+    def test_registration_is_still_created_when_there_is_no_conflict(self):
+        """The happy path must survive the override."""
+        from crush_lu.models import EventRegistration
+
+        formset = self._validated_formset_adding(self.member)
+        request = self._request()
+        self.admin.save_formset(request, self._parent_form(), formset, change=True)
+
+        registration = EventRegistration.objects.get(
+            event=self.event, user=self.member
+        )
+        self.assertEqual(registration.status, 'confirmed')
+        self.assertEqual(self._messages(request), [])
+
+    def test_other_integrity_errors_are_not_swallowed(self):
+        """
+        Only an already-registered (event, user) pair is absorbed. Anything
+        else still has to reach the caller, or the override would be hiding
+        real database failures behind a warning.
+        """
+        from django.db import IntegrityError
+
+        formset = self._validated_formset_adding(self.member)
+        # A NOT NULL violation: an IntegrityError the guard must not recognise.
+        # Not a foreign-key violation — Django declares those DEFERRABLE on
+        # SQLite, so under `TestCase` they would not surface until a commit
+        # that never comes, and the row would insert cleanly instead.
+        formset.forms[0].instance.checkin_token = None
+
+        with self.assertRaises(IntegrityError):
+            self.admin.save_formset(
+                self._request(), self._parent_form(), formset, change=True
+            )
+
+
 @override_settings(
     ROOT_URLCONF="azureproject.urls_crush",
     RATELIMIT_ENABLE=False,

--- a/crush_lu/tests/test_events.py
+++ b/crush_lu/tests/test_events.py
@@ -1287,6 +1287,71 @@ class MeetupEventAdminDuplicateRegistrationTests(TestCase):
         self.assertEqual(registration.status, 'confirmed')
         self.assertEqual(self._messages(request), [])
 
+    def test_a_conflicting_winner_is_reported_field_by_field(self):
+        """
+        Codex review: the row that wins the race is not always the admin's own
+        twin. A member self-registering as 'waitlist' while an admin adds them
+        as 'confirmed' with payment recorded leaves those two values unapplied,
+        and calling that a plain duplicate would claim a save that never
+        happened. The save still succeeds — a 500 helps nobody — but the
+        warning has to name what was dropped.
+        """
+        from crush_lu.models import EventRegistration
+
+        formset = self._validated_formset_adding(self.member)
+
+        # Someone else gets there first, with different values.
+        EventRegistration.objects.create(
+            event=self.event,
+            user=self.member,
+            status='waitlist',
+            payment_confirmed=False,
+        )
+
+        request = self._request()
+        self.admin.save_formset(request, self._parent_form(), formset, change=True)
+
+        messages = self._messages(request)
+        self.assertEqual(len(messages), 1, messages)
+        message = messages[0]
+        self.assertIn('was not applied', message)
+        # The status the admin submitted and the one that actually won.
+        self.assertIn('confirmed', message)
+        self.assertIn('waitlist', message)
+        # The winner is left exactly as the other request wrote it.
+        registration = EventRegistration.objects.get(
+            event=self.event, user=self.member
+        )
+        self.assertEqual(registration.status, 'waitlist')
+
+    def test_skipped_rows_stay_out_of_the_admin_history(self):
+        """
+        Codex review: `formset.save(commit=False)` has already put the row in
+        `new_objects`, and Django reads that collection into the LogEntry after
+        save_formset() returns. A row the savepoint rolled back must not appear
+        in the event's history as added.
+        """
+        from django.contrib.admin.utils import construct_change_message
+
+        from crush_lu.models import EventRegistration
+
+        formset = self._validated_formset_adding(self.member)
+        EventRegistration.objects.create(
+            event=self.event, user=self.member, status='confirmed'
+        )
+
+        parent_form = self._parent_form()
+        self.admin.save_formset(self._request(), parent_form, formset, change=True)
+
+        self.assertEqual(formset.new_objects, [])
+        self.assertEqual(formset.changed_objects, [])
+        change_message = construct_change_message(parent_form, [formset], False)
+        self.assertEqual(
+            [entry for entry in change_message if 'added' in entry],
+            [],
+            f'history claims a rolled-back row was added: {change_message}',
+        )
+
     def test_other_integrity_errors_are_not_swallowed(self):
         """
         Only an already-registered (event, user) pair is absorbed. Anything

--- a/crush_lu/tests/test_sw_admin_routes.py
+++ b/crush_lu/tests/test_sw_admin_routes.py
@@ -74,12 +74,67 @@ def test_admin_pages_are_never_cached():
     )
 
 
+def _run_replay_probe():
+    """The onSync half of the probe: what the queue actually re-fetches."""
+    import crush_lu
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available to run the service-worker probe")
+
+    package_dir = Path(crush_lu.__file__).parent
+    result = subprocess.run(
+        [
+            node,
+            str(package_dir / "tests" / "sw_route_probe.js"),
+            str(package_dir / "static" / "crush_lu" / "sw-workbox.js"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    replay = json.loads(result.stdout)["replay"]
+    assert replay["available"], "the probe could not reach the BackgroundSyncPlugin"
+    return replay
+
+
+def test_already_queued_admin_posts_are_dropped_not_replayed():
+    """
+    Codex review: excluding admin paths from the route only governs what ENTERS
+    the queue. `crush-queue` is a named IndexedDB store that survives a worker
+    update, and onSync drains whatever an older worker left in it — so an admin
+    form queued before this change would still replay for up to 24h and
+    reproduce the duplicate submission this PR exists to stop.
+    """
+    replay = _run_replay_probe()
+    admin_posts = [url for url in replay["replayed"] if "/crush-admin/" in url]
+    assert not admin_posts, (
+        f"onSync re-fetched queued admin POSTs: {admin_posts}. Entries stored by "
+        "an earlier worker version must be discarded, not replayed."
+    )
+
+
+def test_dropped_entries_are_removed_from_the_queue():
+    """Skipping an entry has to shift it OUT. Left in place it would be retried
+    on every subsequent sync, forever."""
+    assert _run_replay_probe()["drained"], (
+        "the replay loop left entries in the queue; a skipped admin POST must be "
+        "discarded, not deferred to the next sync"
+    )
+
+
 def test_ordinary_form_posts_keep_background_sync():
-    """Guards the two assertions above: if the POST router stopped matching
-    anything at all they would pass vacuously, and offline form submission —
-    the reason the queue exists — would be silently gone."""
+    """Guards the assertions above: if the POST router stopped matching anything
+    at all, or the replay loop dropped everything, they would pass vacuously and
+    offline form submission — the reason the queue exists — would be gone."""
     probe = _run_sw_route_probe()["ordinary_form_post"]
     assert probe["claimed"], (
         f"POST {probe['url']} is no longer claimed by the background-sync route; "
         "offline form submission has been lost."
+    )
+    replayed = _run_replay_probe()["replayed"]
+    assert any("/events/" in url for url in replayed), (
+        f"onSync replayed nothing for an ordinary queued POST (got {replayed}); "
+        "the exclusion is now swallowing traffic it should retry."
     )

--- a/crush_lu/tests/test_sw_admin_routes.py
+++ b/crush_lu/tests/test_sw_admin_routes.py
@@ -1,0 +1,85 @@
+"""
+The service worker must keep the admin out of its queue and out of its cache.
+
+Staging, 2026-08-11: saving MeetupEvent #29 in the coach panel answered 500 with
+
+    IntegrityError: duplicate key value violates unique constraint
+    "crush_lu_eventregistration_event_id_user_id_52c32bb9_uniq"
+    DETAIL: Key (event_id, user_id)=(29, 86) already exists.
+
+The change form's registration inline was inserted twice. Django's formset
+validation catches a duplicate that is already committed, so the two writes had
+to overlap — and the service worker had two ways to produce that overlap, both
+because every exclusion list was written against `/admin/` while the coach panel
+is mounted at `/crush-admin/` (azureproject/urls_crush.py):
+
+  * admin POSTs went through BackgroundSyncPlugin, which replays a failed
+    request verbatim for up to 24h — re-submitting the whole change form,
+    inline rows included;
+  * admin GETs were NetworkFirst, so a change form could be served from cache
+    with stale inline ids and INITIAL_FORMS.
+
+These run the real routing table through the Node probe rather than grepping the
+source, for the reason given in test_mobile_auth_handoff_chain.py: a
+source-string assertion passes just as happily when the route it checks is not
+the route that matters.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _run_sw_route_probe():
+    """Shared harness with test_mobile_auth_handoff_chain.py; see sw_route_probe.js."""
+    import crush_lu
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is not available to run the service-worker probe")
+
+    package_dir = Path(crush_lu.__file__).parent
+    probe = package_dir / "tests" / "sw_route_probe.js"
+    sw = package_dir / "static" / "crush_lu" / "sw-workbox.js"
+
+    result = subprocess.run(
+        [node, str(probe), str(sw)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    return {r["name"]: r for r in json.loads(result.stdout)["results"]}
+
+
+def test_admin_post_is_never_queued_for_background_sync():
+    probe = _run_sw_route_probe()["crush_admin_form_post"]
+    assert not probe["claimed"], (
+        f"the service worker claims POST {probe['url']} "
+        f"(route={probe['matchedRoute']}). BackgroundSyncPlugin replays queued "
+        "POSTs for up to 24h, so the admin change form — inline rows and all — "
+        "gets submitted a second time and duplicates whatever it already wrote."
+    )
+
+
+def test_admin_pages_are_never_cached():
+    probe = _run_sw_route_probe()["crush_admin_page_navigation"]
+    assert probe["matchedRoute"] == "NetworkOnly", (
+        f"admin navigations resolve to {probe['matchedRoute']}, not NetworkOnly. "
+        "A change form served from cache carries stale inline ids, and re-posting "
+        "those rows as new ones trips the (event, user) unique index."
+    )
+
+
+def test_ordinary_form_posts_keep_background_sync():
+    """Guards the two assertions above: if the POST router stopped matching
+    anything at all they would pass vacuously, and offline form submission —
+    the reason the queue exists — would be silently gone."""
+    probe = _run_sw_route_probe()["ordinary_form_post"]
+    assert probe["claimed"], (
+        f"POST {probe['url']} is no longer claimed by the background-sync route; "
+        "offline form submission has been lost."
+    )


### PR DESCRIPTION
## Purpose

Saving MeetupEvent #29 in the staging coach panel answered 500 with

```
IntegrityError: duplicate key value violates unique constraint
"crush_lu_eventregistration_event_id_user_id_52c32bb9_uniq"
DETAIL:  Key (event_id, user_id)=(29, 86) already exists.
```

The change form's registration inline was inserted twice. Django's formset validation *does* catch an already-committed duplicate (verified against Django 6.0.7 with a repro of this exact inline), so the two writes had to overlap: both validated against a table that did not hold the row yet, both INSERTed, and the loser hit the index. The access log shows the twin — a redirect to the changelist on a second connection 0.4s later, which is where a successful admin save lands. The registration was created; only the losing request errored.

Three fixes, in the order they let the failure happen:

* **Service worker** (`crush_lu/static/crush_lu/sw-workbox.js`) — every exclusion list was written against `/admin/`, but the coach panel is mounted at `/crush-admin/`, a path that does not contain the substring `/admin`. So admin POSTs went through `BackgroundSyncPlugin`, which replays a failed request verbatim for up to 24h — re-submitting the whole change form, inline rows included — and admin GETs were `NetworkFirst`, so a change form could be served from cache with stale inline ids. Both now exclude `/crush-admin/`, through a single `isQueueablePost()` predicate that governs the queue's entrance *and* its drain. Ordinary site POSTs keep their offline queueing.
* **Admin** (`crush_lu/admin/events.py`) — `MeetupEventAdmin.save_formset` writes each registration under its own savepoint. A collision with an already-registered `(event, user)` pair is absorbed instead of rolling back the entire POST — the parent event's edits and every other inline with it — over a row the admin's own twin request had already written. Any other `IntegrityError` is re-raised untouched.
* **Logging** (`azureproject/production.py`) — `django.request` named the `console` handler *and* propagated, as did `django` and five app loggers. Logging calls the handlers found at every level it walks, so one 500 printed three identical tracebacks and read as three failures. The handler now lives only on root.

## Review round (commit `06bc9be`)

Three findings from the Codex reviewer, each verified against the source before fixing:

* **The service-worker fix did not close the window it was written for.** Excluding admin paths from the route only governs what *enters* the queue. `crush-queue` is a named IndexedDB store that survives a worker update, and `onSync` drains whatever the previous worker left in it — so a form queued by v30 would still replay for 24h after deploy. `isQueueablePost()` is now read by both the route and `onSync`; a non-queueable entry is shifted out and discarded rather than fetched. Measured against the previous worker: `replayed: [/crush-admin/…/change/, /en/events/29/register/]` → now `[/en/events/29/register/]`, `drained: true`.
* **A conflicting winner was reported as a plain duplicate.** If a member self-registers as `waitlist` while an admin adds them as `confirmed` with payment, the member's row wins and the admin's values are lost behind a message reading "no duplicate was created" — claiming a save that never happened. The collision is still absorbed (re-raising would restore the 500 for a save that is otherwise valid), but the submitted row is now compared against the winner across the fields the form actually carried, and each disagreement is reported with both values.
* **The admin history claimed rolled-back rows were added.** `save(commit=False)` had already put the row in `formset.new_objects`, and Django reads that collection into the `LogEntry` after `save_formset()` returns. Skipped rows are pruned from `new_objects` and `changed_objects` first.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

One intentional behaviour change: a duplicate registration row in the inline is skipped with a warning rather than aborting the save. When the existing row matches what was submitted, nothing is lost. When it does not, the warning names each field and both values so the admin can re-apply them.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
pytest crush_lu/tests/test_events.py -k MeetupEventAdminDuplicateRegistration
pytest crush_lu/tests/test_sw_admin_routes.py
pytest crush_lu/tests/test_mobile_auth_handoff_chain.py   # shares the route probe
```

Ran locally on Python 3.12 / SQLite: 132 passed across `test_events.py`, `test_admin_smoke.py`, `test_sw_admin_routes.py`, `test_mobile_auth_handoff_chain.py` and `test_production_middleware_order.py`. `manage.py check --deploy --fail-level WARNING` against `azureproject.production` is clean.

Every new test was confirmed non-vacuous by reverting the code it covers. The duplicate test then fails with the production error (`UNIQUE constraint failed: event_id, user_id`); the conflict test fails with the misleading "already registered" message; the history test fails with the rolled-back row still listed; and the replay tests fail with the queued admin POST re-fetched.

Manually: open a MeetupEvent change form, add a registration inline for a user already registered, save. Expect a warning naming the user and a normal save, not a 500.

## What to Check

* **App Insights export is unaffected.** The obvious fix for the tripled traceback — `propagate: False` — would have broken it: telemetry is fed by an OTel `LoggingHandler` attached to the **root** logger (`azureproject/apps.py` → `attach_otel_logging_handler_to_root`), so anything that stops propagating stops being exported. Dropping the duplicate handler instead keeps propagation intact. Verified on the real logger topology: console goes 3 records → 1, OTel stays at 3 → 3.
* Admin pages are now `NetworkOnly` in the service worker — deliberate, they should never have been cacheable. `/crush-admin/dashboard/` already was, via a `/dashboard` substring match; this makes the rest of the panel consistent.
* `save_formset` delegates to `super()` for every non-`EventRegistration` formset, so the other MeetupEvent inlines are untouched.
* Only an already-registered `(event, user)` pair is absorbed; `test_other_integrity_errors_are_not_swallowed` covers the re-raise. It uses a NOT NULL violation rather than a foreign-key one, because Django declares FK constraints DEFERRABLE on SQLite and they would not surface inside a `TestCase`.
* **Open product call:** on a conflicting winner this reports and lets the admin decide, rather than reconciling (overwriting the winner with the admin's values). Reconciling would make admin intent win but would clobber a member's own registration. Happy to switch if that is the preference.

## Other Information

`CACHE_VERSION` is deliberately **not** bumped. The routing change alone stops cached admin pages from being served, and bumping it would evict every user's runtime cache for no correctness gain. Likewise the queue keeps its name: renaming would orphan the legitimate offline registrations already in it rather than replay them.

The route probe gained two capabilities it needed to be meaningful here. It now models Workbox's per-method routers — without that a POST probe was matched against the GET table and every probe looked queued — and it captures the real `BackgroundSyncPlugin` rather than stubbing it away, so the replay loop is reachable by a test at all.

The logs cannot say whether the duplicate submission came from the background-sync queue or a double-click on Save; both produce this shape, and the service-worker gap is a real defect either way. The admin-side guard covers the double-click path regardless.