### PR TITLE
Add preview_event_cancellation: dry-run an event cancellation

### DIFF
--- a/crush_lu/management/commands/preview_event_cancellation.py
+++ b/crush_lu/management/commands/preview_event_cancellation.py
@@ -1,0 +1,487 @@
+"""preview_event_cancellation — what cancelling an event would actually do.
+
+The admin "cancel events" action (``MeetupEventAdmin.cancel_events``) does a
+lot silently and, crucially, tells **nobody**: there is no organiser-cancellation
+email or push anywhere in this codebase. ``event_cancellation.html`` is the
+template for a *member dropping their own seat*, not for the event being called
+off. So the people who need contacting have to be pulled out by hand, and the
+money likewise — there is no refund path either (``PaymentTransaction.REFUNDED``
+is a status nothing ever sets; see ``views_payments.py``).
+
+This command answers the three questions you need before pressing that button:
+
+  1. What changes mechanically (listings, echo.lu, wallet passes)?
+  2. Who must be contacted, and how do I reach them?
+  3. Who is owed money, and who is explicitly NOT?
+
+On (3), the binding rule is **Terms of Service §7.3**, and it is not a single
+rule but four:
+
+    member cancels >48h before  -> full refund
+    member cancels 24-48h before -> 50%
+    member cancels <24h before   -> nothing
+    CRUSH.LU cancels the event   -> full, regardless of timing
+
+So the two groups are computed differently and reported apart. Everyone still
+holding a seat when you call the event off is owed the full amount, no timing
+test. A member who had already dropped their own seat is owed whatever §7.3 says
+for *when they dropped it* — which is often still a full refund, not nothing.
+
+⚠️ That timing cannot be read exactly. ``EventRegistration`` has no
+``cancelled_at``; the closest thing is ``updated_at`` (auto_now), which is the
+last time anything touched the row. It is a good proxy and it is not proof, so
+every §7.3 tier below is printed as an ESTIMATE with the hours it was derived
+from. Check any row near a boundary by hand.
+
+Either way the money is invisible to the query you would reach for first: a
+self-cancelled registration's PaymentTransaction still reads ``paid``, because
+``REFUNDED`` is never set by anything.
+
+This command is READ-ONLY. It writes nothing, sends nothing, and charges
+nothing. The apply path is the admin action; run this first, act on the report,
+then press it.
+
+Usage::
+
+    # Which upcoming events could I cancel?
+    python manage.py preview_event_cancellation
+
+    # Full report for one event
+    python manage.py preview_event_cancellation --event-id 42
+
+    # Just the address list, ready to paste into a BCC field
+    python manage.py preview_event_cancellation --event-id 42 --emails
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from crush_lu.models import CrushProfile, EventRegistration, MeetupEvent
+from crush_lu.models.payments import PaymentTransaction
+
+# Registration states that still represent a person expecting to turn up (or
+# waiting for a seat). These are the people who must be told, and the only ones
+# with a refund claim. "cancelled" is excluded deliberately — see module
+# docstring.
+LIVE_STATUSES = ("confirmed", "pending", "waitlist")
+
+# Terms of Service §7.3. Hours before event start -> share of the fee owed when
+# the MEMBER is the one who cancelled. When Crush.lu cancels, none of this
+# applies: the refund is full regardless of timing.
+TOS_FULL_REFUND_HOURS = 48
+TOS_HALF_REFUND_HOURS = 24
+
+RULE = "=" * 72
+THIN = "-" * 72
+
+
+def tos_tier(event, registration):
+    """(share owed, label, hours before start) under ToS §7.3 for a self-cancel.
+
+    ``updated_at`` stands in for the cancellation time — there is no
+    ``cancelled_at`` on the model. Anything else that wrote to the row after the
+    member cancelled moves it later, which biases the estimate toward a SMALLER
+    refund, so a row this calls "none" is the one worth checking by hand.
+    """
+    hours = (event.date_time - registration.updated_at).total_seconds() / 3600
+    if hours >= TOS_FULL_REFUND_HOURS:
+        return Decimal("1.00"), "FULL", hours
+    if hours >= TOS_HALF_REFUND_HOURS:
+        return Decimal("0.50"), "50%", hours
+    return Decimal("0.00"), "none", hours
+
+
+class Command(BaseCommand):
+    help = (
+        "Dry-run an event cancellation: what changes, who must be contacted, "
+        "and who is owed a refund. Read-only."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--event-id",
+            type=int,
+            help="MeetupEvent id to preview. Omit to list candidate events.",
+        )
+        parser.add_argument(
+            "--emails",
+            action="store_true",
+            help="Print only a comma-separated address list for the people who "
+            "must be told (for pasting into BCC).",
+        )
+
+    # -- entry ----------------------------------------------------------
+    def handle(self, *args, **options):
+        event_id = options.get("event_id")
+        if not event_id:
+            self._list_candidates()
+            return
+
+        try:
+            event = MeetupEvent.objects.get(pk=event_id)
+        except MeetupEvent.DoesNotExist:
+            raise CommandError(f"No MeetupEvent with id={event_id}")
+
+        regs = list(
+            EventRegistration.objects.filter(event=event)
+            .select_related("user")
+            .order_by("status", "user__email")
+        )
+        live = [r for r in regs if r.status in LIVE_STATUSES]
+        self_cancelled = [r for r in regs if r.status == "cancelled"]
+
+        if options["emails"]:
+            self._write_email_list(live)
+            return
+
+        self._report_header(event, regs)
+        self._report_mechanics(event, regs)
+        self._report_contacts(live)
+        self._report_refunds(event, live, self_cancelled)
+        self._report_edge_cases(event, regs)
+
+    # -- sections -------------------------------------------------------
+    def _list_candidates(self):
+        # Deliberately looks BACKWARD as well. The event you most urgently need
+        # this report for is the one you just called off hours before it was due
+        # to start, and a strictly-future filter drops it off its own index
+        # exactly when you go looking. A week covers the refund window.
+        now = timezone.now()
+        events = MeetupEvent.objects.filter(
+            is_cancelled=False, date_time__gte=now - timedelta(days=7)
+        ).order_by("date_time")[:20]
+        if not events:
+            self.stdout.write("No upcoming, non-cancelled events.")
+            return
+        self.stdout.write(self.style.MIGRATE_HEADING("Upcoming events"))
+        self.stdout.write(THIN)
+        for ev in events:
+            seats = ev.get_confirmed_count()
+            self.stdout.write(
+                f"  id={ev.pk:<5} {ev.date_time:%Y-%m-%d %H:%M}  "
+                f"{ev.title[:44]:<44} {seats}/{ev.max_participants} seats"
+            )
+        self.stdout.write("")
+        self.stdout.write("Re-run with --event-id <id> for the full report.")
+
+    def _report_header(self, event, regs):
+        self.stdout.write(RULE)
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(f"CANCELLATION PREVIEW — {event.title}")
+        )
+        self.stdout.write(RULE)
+        self.stdout.write(f"  Event id        : {event.pk}")
+        self.stdout.write(f"  Starts          : {event.date_time:%a %d %b %Y %H:%M}")
+        self.stdout.write(f"  Fee             : EUR {event.registration_fee}")
+        self.stdout.write(
+            f"  Capacity        : {event.get_confirmed_count()}/"
+            f"{event.max_participants} confirmed"
+        )
+        self.stdout.write(f"  Published       : {event.is_published}")
+        self.stdout.write(f"  Already cancelled: {event.is_cancelled}")
+        self.stdout.write(f"  Registrations   : {len(regs)} rows total")
+        if event.is_cancelled:
+            self.stdout.write(
+                self.style.WARNING(
+                    "\n  NOTE: this event is ALREADY cancelled. The action would "
+                    "be a no-op; the rosters below are still accurate."
+                )
+            )
+        self.stdout.write("")
+
+    def _report_mechanics(self, event, regs):
+        """What the admin action changes. Traced from cancel_events()."""
+        self.stdout.write(self.style.MIGRATE_HEADING("1. WHAT THE ACTION CHANGES"))
+        self.stdout.write(THIN)
+        for line in (
+            "sets is_cancelled=True -> registration closes immediately",
+            "event drops off the homepage, events list and My Events",
+            "withdraws the listing from echo.lu (national portal)",
+            "schema.org JSON-LD flips to EventCancelled (for Google)",
+            "reminder emails are suppressed for this event",
+            'the "happening now" banner can never appear',
+        ):
+            self.stdout.write(f"  [x] {line}")
+
+        apple_tickets = (
+            EventRegistration.objects.filter(event=event)
+            .exclude(apple_wallet_ticket_serial="")
+            .count()
+        )
+        apple_members = (
+            CrushProfile.objects.filter(user__eventregistration__event=event)
+            .exclude(apple_pass_serial="")
+            .distinct()
+            .count()
+        )
+        self.stdout.write(
+            f"  [x] voids {apple_tickets} Apple Wallet ticket(s) and refreshes "
+            f"{apple_members} member pass(es)"
+        )
+
+        # Reuse the action's OWN selector so this count cannot drift from what
+        # the real run would push. It must be evaluated pre-cancellation, which
+        # is exactly the situation we are in.
+        try:
+            from crush_lu.admin.events import MeetupEventAdmin
+
+            google = MeetupEventAdmin._google_holders_for_cancellation([event])
+            self.stdout.write(
+                f"  [x] refreshes {len(google)} Google Wallet member object(s)"
+            )
+        except Exception as exc:  # pragma: no cover - diagnostic only
+            self.stdout.write(
+                self.style.WARNING(f"  [?] Google Wallet holders unknown ({exc})")
+            )
+
+        self.stdout.write("")
+        self.stdout.write(self.style.ERROR("  [ ] emails or notifies attendees: NO."))
+        self.stdout.write(
+            "      Nothing in the codebase tells a registrant their event was\n"
+            "      called off. Everyone in section 2 must be contacted by hand."
+        )
+        self.stdout.write("")
+
+    def _report_contacts(self, live):
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                f"2. WHO MUST BE TOLD ({len(live)} people) — the app will not"
+            )
+        )
+        self.stdout.write(THIN)
+        if not live:
+            self.stdout.write("  Nobody holds a live registration. Nothing to send.")
+            self.stdout.write("")
+            return
+
+        phones = {
+            p.user_id: p.phone_number
+            for p in CrushProfile.objects.filter(
+                user_id__in=[r.user_id for r in live]
+            ).exclude(phone_number="")
+        }
+        self.stdout.write(f"  {'status':<10} {'email':<34} {'phone':<16} name")
+        for reg in live:
+            user = reg.user
+            name = (user.get_full_name() or user.username or "")[:20]
+            self.stdout.write(
+                f"  {reg.status:<10} {user.email[:34]:<34} "
+                f"{phones.get(user.id, '-')[:16]:<16} {name}"
+            )
+        self.stdout.write("")
+        self.stdout.write("  Re-run with --emails for a paste-ready BCC list.")
+        self.stdout.write("")
+
+    def _report_refunds(self, event, live, self_cancelled):
+        self.stdout.write(self.style.MIGRATE_HEADING("3. MONEY"))
+        self.stdout.write(THIN)
+        self.stdout.write(
+            "  There is no refund path in this codebase. Everything below has\n"
+            "  to be done by hand in the SumUp dashboard, and the app will keep\n"
+            "  showing these transactions as 'paid' afterwards.\n"
+        )
+
+        live_ids = [r.pk for r in live]
+        cancelled_ids = [r.pk for r in self_cancelled]
+
+        owed = list(
+            PaymentTransaction.objects.filter(
+                event_registration_id__in=live_ids,
+                status=PaymentTransaction.Status.PAID,
+            ).select_related("event_registration__user")
+        )
+        not_owed = list(
+            PaymentTransaction.objects.filter(
+                event_registration_id__in=cancelled_ids,
+                status=PaymentTransaction.Status.PAID,
+            ).select_related("event_registration__user")
+        )
+
+        # --- owed ---
+        self.stdout.write(self.style.WARNING(f"  REFUND OWED — {len(owed)} payment(s)"))
+        self.stdout.write("  You cancelled, so these people get their money back.\n")
+        total = Decimal("0.00")
+        if owed:
+            self.stdout.write(
+                f"    {'email':<32} {'amount':>9}  {'sumup_checkout_id':<38} ref"
+            )
+            for tx in owed:
+                total += tx.amount
+                email = (
+                    tx.event_registration.user.email if tx.event_registration else "?"
+                )
+                self.stdout.write(
+                    f"    {email[:32]:<32} {tx.amount:>6} {tx.currency}  "
+                    f"{(tx.sumup_checkout_id or '-'):<38} {tx.transaction_reference}"
+                )
+            self.stdout.write(f"\n    TOTAL TO REFUND: {total} EUR")
+        else:
+            self.stdout.write("    (none)")
+        self.stdout.write("")
+
+        # --- self-cancelled: graded by ToS §7.3, not a flat no ---
+        self.stdout.write(
+            self.style.WARNING(
+                f"  SELF-CANCELLED, STILL HOLDING MONEY — {len(not_owed)} payment(s)"
+            )
+        )
+        self.stdout.write(
+            "  These members dropped their own seat before you called the event\n"
+            "  off, so ToS §7.3 grades them by WHEN they dropped it — >48h full,\n"
+            "  24-48h half, <24h nothing. Tiers below are ESTIMATED from\n"
+            "  updated_at (there is no cancelled_at); check rows near a boundary.\n"
+        )
+        if not_owed:
+            due = Decimal("0.00")
+            kept = Decimal("0.00")
+            self.stdout.write(
+                f"    {'email':<30} {'paid':>8}  {'h before':>9}  "
+                f"{'§7.3':<5} {'owed':>8}"
+            )
+            for tx in not_owed:
+                reg = tx.event_registration
+                email = reg.user.email if reg else "?"
+                share, label, hours = tos_tier(event, reg)
+                owed_amount = (tx.amount * share).quantize(Decimal("0.01"))
+                due += owed_amount
+                kept += tx.amount - owed_amount
+                style = self.style.WARNING if share else self.style.SUCCESS
+                self.stdout.write(
+                    style(
+                        f"    {email[:30]:<30} {tx.amount:>8}  {hours:>9.1f}  "
+                        f"{label:<5} {owed_amount:>8}"
+                    )
+                )
+            self.stdout.write(f"\n    OWED UNDER §7.3 : {due} EUR")
+            self.stdout.write(f"    RETAINED        : {kept} EUR")
+            if due:
+                self.stdout.write(
+                    self.style.ERROR(
+                        "\n    NOTE: each of these seats was offered to the "
+                        "waitlist on\n    cancellation "
+                        "(promote_waitlist_on_cancellation). Promotion is\n"
+                        "    gender-pool gated, so it may have promoted nobody — "
+                        "but where\n    the seat WAS resold, retaining money owed "
+                        "here means being paid\n    twice for one chair. Check the "
+                        "pool before deciding."
+                    )
+                )
+        else:
+            self.stdout.write("    (none)")
+        self.stdout.write("")
+
+        # The half of a refund that lives in our DB, and is easy to forget.
+        if owed or not_owed:
+            self.stdout.write(self.style.MIGRATE_HEADING("  AFTER YOU REFUND"))
+            self.stdout.write(
+                "  Refunding in SumUp is only step one. _admitted_status() reads\n"
+                "  payment_confirmed, so a refunded member who re-registers for\n"
+                "  THIS event is admitted confirmed and free. Once the money has\n"
+                "  actually left SumUp:\n\n"
+                "      r = EventRegistration.objects.get(pk=<id>)\n"
+                "      r.payment_confirmed = False\n"
+                "      r.payment_date = None\n"
+                "      r.save(update_fields=['payment_confirmed', 'payment_date'])\n\n"
+                "  Order matters: clear the flag only once the refund is real.\n"
+            )
+
+    def _report_edge_cases(self, event, regs):
+        """Things that will bite quietly if nobody looks for them."""
+        self.stdout.write(self.style.MIGRATE_HEADING("4. WATCH OUT"))
+        self.stdout.write(THIN)
+        found = False
+
+        reg_ids = [r.pk for r in regs]
+
+        # An open checkout can still capture AFTER the event is cancelled —
+        # cancelling the event does not close SumUp's side.
+        pending = PaymentTransaction.objects.filter(
+            event_registration_id__in=reg_ids,
+            status=PaymentTransaction.Status.PENDING,
+        ).select_related("event_registration__user")
+        if pending:
+            found = True
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  * {len(pending)} checkout(s) still PENDING. Cancelling the "
+                    "event does not\n    close them at SumUp — one could capture "
+                    "after you press the button.\n    Verify with: python manage.py "
+                    "sumup_checkout_status --registration-id <id>"
+                )
+            )
+            for tx in pending:
+                email = (
+                    tx.event_registration.user.email if tx.event_registration else "?"
+                )
+                self.stdout.write(
+                    f"      reg={tx.event_registration_id} {email[:36]} "
+                    f"{tx.amount} {tx.currency}"
+                )
+
+        # Double charges: more than one PAID row against a single registration.
+        paid_per_reg = {}
+        for tx in PaymentTransaction.objects.filter(
+            event_registration_id__in=reg_ids,
+            status=PaymentTransaction.Status.PAID,
+        ):
+            paid_per_reg.setdefault(tx.event_registration_id, []).append(tx)
+        doubles = {k: v for k, v in paid_per_reg.items() if len(v) > 1}
+        if doubles:
+            found = True
+            self.stdout.write(
+                self.style.ERROR(
+                    f"  * {len(doubles)} registration(s) carry MORE THAN ONE paid "
+                    "transaction.\n    Refund each row, not each person."
+                )
+            )
+            for reg_id, txs in doubles.items():
+                self.stdout.write(
+                    f"      reg={reg_id}: {len(txs)} payments totalling "
+                    f"{sum(t.amount for t in txs)} EUR"
+                )
+
+        # Paid money for this event we cannot attribute to a registration.
+        orphans = PaymentTransaction.objects.filter(
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            status=PaymentTransaction.Status.PAID,
+            event_registration__isnull=True,
+        ).count()
+        if orphans:
+            found = True
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  * {orphans} paid event payment(s) platform-wide have no "
+                    "registration attached\n    (FK is SET_NULL). Some may belong "
+                    "to this event — check by hand before refunding."
+                )
+            )
+
+        # Anyone already through the door on an event being called off.
+        odd = [r for r in regs if r.status in ("attended", "no_show")]
+        if odd:
+            found = True
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  * {len(odd)} registration(s) are already marked "
+                    "attended/no_show on an event\n    you are cancelling. Worth a "
+                    "look before you press it."
+                )
+            )
+
+        if not found:
+            self.stdout.write("  Nothing unusual.")
+        self.stdout.write("")
+        self.stdout.write(RULE)
+        self.stdout.write("Read-only preview. Nothing above has been changed.")
+        self.stdout.write(RULE)
+
+    # -- helpers --------------------------------------------------------
+    def _write_email_list(self, live):
+        addresses = [r.user.email for r in live if r.user.email]
+        if not addresses:
+            self.stdout.write("(nobody to contact)")
+            return
+        self.stdout.write(", ".join(sorted(set(addresses))))

--- a/crush_lu/tests/test_preview_event_cancellation.py
+++ b/crush_lu/tests/test_preview_event_cancellation.py
@@ -1,0 +1,235 @@
+"""The cancellation preview, and the two rules it exists to keep apart.
+
+Every paid transaction on a cancelled event reads ``paid``, whether the member
+was still coming or had dropped out weeks earlier — ``REFUNDED`` is never set by
+anything. So the obvious query, the one written under time pressure, cannot tell
+the two apart, and both directions of getting it wrong cost real money:
+
+  * refunding a self-cancelled member who is owed nothing, or
+  * retaining money from one who is owed a full refund under ToS §7.3.
+
+The second is the easier mistake, because "they cancelled, so they get nothing"
+sounds like a policy and is only the <24h row of a four-row table. A member who
+dropped out three days ahead is owed the whole fee.
+
+Asserted here: live seats get the full amount with no timing test (Crush.lu
+cancelled, §7.3 last row), self-cancelled seats get graded by timing, and the
+grading lands on the right side of both boundaries.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from crush_lu.models import EventRegistration, MeetupEvent
+from crush_lu.models.payments import PaymentTransaction
+from crush_lu.tests.test_profile_edit_connect_card import _make_member
+
+
+def _make_event(title="Quiz Night", *, days_from_now=1, fee="15.50"):
+    when = timezone.now() + timedelta(days=days_from_now)
+    return MeetupEvent.objects.create(
+        title=title,
+        description="x",
+        event_type="mixer",
+        date_time=when,
+        location="Luxembourg",
+        address="1 Test St",
+        max_participants=20,
+        duration_minutes=160,
+        registration_fee=Decimal(fee),
+        registration_deadline=when - timedelta(hours=2),
+        is_published=True,
+    )
+
+
+class PreviewEventCancellationTests(TestCase):
+    def setUp(self):
+        self.event = _make_event()
+
+    def _register(self, email, status):
+        return EventRegistration.objects.create(
+            user=_make_member(email), event=self.event, status=status
+        )
+
+    def _pay(self, registration, amount="15.50", status=None):
+        return PaymentTransaction.objects.create(
+            user=registration.user,
+            event_registration=registration,
+            amount=Decimal(amount),
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            status=status or PaymentTransaction.Status.PAID,
+            sumup_checkout_id=f"chk-{registration.pk}",
+        )
+
+    def _run(self, *args):
+        out = StringIO()
+        call_command(
+            "preview_event_cancellation",
+            "--event-id",
+            str(self.event.pk),
+            *args,
+            stdout=out,
+        )
+        return out.getvalue()
+
+    @staticmethod
+    def _section(report, heading, until):
+        """The slice of the report between two headings."""
+        start = report.index(heading)
+        return report[start : report.index(until, start)]
+
+    # -- the split --------------------------------------------------------
+
+    def _cancelled_at(self, registration, *, hours_before_event):
+        """Backdate the cancellation. updated_at is auto_now, so .update()."""
+        EventRegistration.objects.filter(pk=registration.pk).update(
+            updated_at=self.event.date_time - timedelta(hours=hours_before_event)
+        )
+        return registration
+
+    def test_the_two_groups_are_reported_apart(self):
+        staying = self._register("staying@example.com", "confirmed")
+        self._pay(staying)
+        dropped = self._register("dropped@example.com", "cancelled")
+        self._pay(dropped)
+
+        report = self._run()
+        owed = self._section(report, "REFUND OWED", "SELF-CANCELLED")
+        graded = self._section(report, "SELF-CANCELLED", "AFTER YOU REFUND")
+
+        self.assertIn("staying@example.com", owed)
+        self.assertNotIn("dropped@example.com", owed)
+
+        self.assertIn("dropped@example.com", graded)
+        self.assertNotIn("staying@example.com", graded)
+
+    def test_live_seats_get_the_full_fee_with_no_timing_test(self):
+        """Crush.lu cancelled, so §7.3's last row applies: full, regardless."""
+        for email in ("a@example.com", "b@example.com"):
+            reg = self._pay(self._register(email, "confirmed")).event_registration
+            # Even a seat touched minutes before the event is owed in full.
+            self._cancelled_at(reg, hours_before_event=1)
+
+        self.assertIn("TOTAL TO REFUND: 31.00 EUR", self._run())
+
+    # -- ToS §7.3 grading -------------------------------------------------
+
+    def test_self_cancel_more_than_48h_out_is_owed_the_full_fee(self):
+        """The expensive misreading: "they cancelled" does not mean "no refund"."""
+        self._pay(
+            self._cancelled_at(
+                self._register("early@example.com", "cancelled"),
+                hours_before_event=60,
+            )
+        )
+
+        report = self._run()
+        self.assertIn("OWED UNDER §7.3 : 15.50 EUR", report)
+        self.assertIn("RETAINED        : 0.00 EUR", report)
+
+    def test_self_cancel_inside_48h_is_owed_half(self):
+        self._pay(
+            self._cancelled_at(
+                self._register("late@example.com", "cancelled"),
+                hours_before_event=30,
+            )
+        )
+
+        report = self._run()
+        self.assertIn("OWED UNDER §7.3 : 7.75 EUR", report)
+        self.assertIn("RETAINED        : 7.75 EUR", report)
+
+    def test_self_cancel_inside_24h_is_owed_nothing(self):
+        self._pay(
+            self._cancelled_at(
+                self._register("verylate@example.com", "cancelled"),
+                hours_before_event=6,
+            )
+        )
+
+        report = self._run()
+        self.assertIn("OWED UNDER §7.3 : 0.00 EUR", report)
+        self.assertIn("RETAINED        : 15.50 EUR", report)
+
+    def test_resale_warning_appears_only_when_money_is_owed(self):
+        """Retaining an owed refund means being paid twice for one chair."""
+        owed = self._cancelled_at(
+            self._register("owed@example.com", "cancelled"), hours_before_event=60
+        )
+        self._pay(owed)
+        self.assertIn("twice for one chair", self._run())
+
+        PaymentTransaction.objects.all().delete()
+        EventRegistration.objects.all().delete()
+        self._pay(
+            self._cancelled_at(
+                self._register("nothing@example.com", "cancelled"),
+                hours_before_event=2,
+            )
+        )
+        self.assertNotIn("twice for one chair", self._run())
+
+    def test_two_step_refund_reminder_is_shown(self):
+        """Refunding in SumUp alone leaves the member admitted free."""
+        self._pay(self._register("payer@example.com", "confirmed"))
+        self.assertIn("payment_confirmed = False", self._run())
+
+    def test_waitlist_and_pending_seats_count_as_live(self):
+        """Neither has been told the event is off, so both need contacting."""
+        self._register("waiting@example.com", "waitlist")
+        self._register("unpaid@example.com", "pending")
+
+        report = self._run()
+        contacts = self._section(report, "2. WHO MUST BE TOLD", "3. MONEY")
+        self.assertIn("waiting@example.com", contacts)
+        self.assertIn("unpaid@example.com", contacts)
+        self.assertIn("WHO MUST BE TOLD (2 people)", report)
+
+    # -- what it tells you ------------------------------------------------
+
+    def test_report_states_that_nobody_is_emailed(self):
+        """The single most load-bearing line: the app notifies no one."""
+        self._register("someone@example.com", "confirmed")
+        self.assertIn("emails or notifies attendees: NO.", self._run())
+
+    def test_emails_flag_lists_live_seats_only(self):
+        self._register("live@example.com", "confirmed")
+        self._register("dropped@example.com", "cancelled")
+
+        addresses = self._run("--emails").strip()
+        self.assertEqual(addresses, "live@example.com")
+
+    def test_open_checkout_is_flagged_as_able_to_capture_late(self):
+        reg = self._register("inflight@example.com", "pending")
+        self._pay(reg, status=PaymentTransaction.Status.PENDING)
+
+        report = self._run()
+        self.assertIn("still PENDING", report)
+        self.assertIn("inflight@example.com", report)
+
+    def test_double_charge_is_flagged(self):
+        reg = self._register("twice@example.com", "confirmed")
+        self._pay(reg)
+        self._pay(reg)
+
+        report = self._run()
+        self.assertIn("MORE THAN ONE paid", report)
+        self.assertIn("31.00 EUR", report)
+
+    def test_preview_changes_nothing(self):
+        reg = self._register("safe@example.com", "confirmed")
+        tx = self._pay(reg)
+
+        self._run()
+
+        self.event.refresh_from_db()
+        reg.refresh_from_db()
+        tx.refresh_from_db()
+        self.assertFalse(self.event.is_cancelled)
+        self.assertEqual(reg.status, "confirmed")
+        self.assertEqual(tx.status, PaymentTransaction.Status.PAID)


### PR DESCRIPTION
## Why

The first real event cancellation (Quiz Night, 2026-08-13) exposed that the admin **cancel events** action is silent in the two places that matter most. It sets `is_cancelled`, withdraws the listing from echo.lu and voids wallet passes — but it **notifies nobody**, and it **touches no money**. Both had to be reconstructed by hand under time pressure, by phone, with no roster to work from.

This adds a read-only command that builds that roster *before* the button is pressed. It writes nothing, sends nothing and charges nothing; the apply path is still the admin action.

## The part that earns its keep

Every paid transaction on a cancelled event reads `paid` — `REFUNDED` is never set by anything — so the obvious query cannot tell a member who was still coming from one who dropped out weeks ago. Both directions of getting it wrong cost real money.

ToS §7.3 (`terms_of_service.html:191-198`) grades them:

| Situation | Refund |
| --- | --- |
| Member cancels >48h before | Full |
| Member cancels 24–48h before | 50% |
| Member cancels <24h before | None |
| **Crush.lu cancels the event** | **Full, regardless of timing** |

So live seats are reported apart from self-cancelled ones, and only the latter get a timing test. *"They cancelled, so they get nothing"* is the bottom row of four, not the policy — and since the seat is usually resold on cancellation, applying it wrongly means being paid twice for one chair.

### Known limitation, surfaced in the output

`EventRegistration` has no `cancelled_at`, so `updated_at` stands in. Anything writing to the row afterwards moves it later, which biases the estimate toward a **smaller** refund. Tiers therefore print as estimates next to the hours they were derived from, and a `none` row near the boundary is flagged as the one to check by hand.

## Also reported

- Who must be contacted, with phone numbers, since nothing emails them
- Open checkouts that can still capture *after* the event is cancelled
- Duplicate captures against one registration
- The second half of a refund — clearing `payment_confirmed`, without which a refunded member re-registering for the same event is admitted confirmed and free

The Google Wallet count calls the admin action's own `_google_holders_for_cancellation` rather than reimplementing it, so the preview cannot drift from what a real run pushes.

## Usage

```
python manage.py preview_event_cancellation                 # candidate events
python manage.py preview_event_cancellation --event-id 42   # full report
python manage.py preview_event_cancellation --event-id 42 --emails
```

List mode looks back 7 days as well as forward: the event you most urgently need this for is the one just called off hours before it was due to start.

## Testing

13 tests in `crush_lu/tests/test_preview_event_cancellation.py`, all passing. They pin both §7.3 boundaries (48h and 24h), that live seats get the full fee with no timing test, that the preview mutates nothing, and the edge-case warnings.

```
pytest crush_lu/tests/test_preview_event_cancellation.py
```

`black` and `ruff` clean. No migrations, no model changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)