### PR TITLE
Keep both Echternach hunts: fold all four Crush Cache presets into one registry

### DIFF
--- a/crush_lu/management/commands/seed_crush_cache.py
+++ b/crush_lu/management/commands/seed_crush_cache.py
@@ -1,12 +1,18 @@
 """
-Seed a ready-to-play **Crush Cache** scavenger hunt through Luxembourg City,
-for manual QA of the GPS + QR gameplay.
+Seed a ready-to-play **Crush Cache** scavenger hunt, for manual QA of the
+GPS + QR gameplay.
 
 Creates one `crush_cache` MeetupEvent + a CacheHunt with a walking loop of real
-Luxembourg City landmarks (GPS coords + a QR station), each with a challenge,
-plus a demo team. Every existing `debug_*` account (from
-`seed_debug_profiles`) is registered as a confirmed attendee so you can log in
-and play immediately; if none exist it creates a couple of players.
+Luxembourg landmarks (GPS coords + QR stations), each with a challenge, plus a
+demo team. Every existing `debug_*` account (from `seed_debug_profiles`) is
+registered as a confirmed attendee so you can log in and play immediately; if
+none exist it creates a couple of players.
+
+Presets live in the `PRESETS` registry below — adding a hunt is data, not code:
+
+    lux_city    Luxembourg City old town, English trivia about landmarks
+    minette     Fond-de-Gras mining valley, German icebreakers, QR at every stop
+    echternach  Echternach lake loop, German icebreakers, QR at every stop
 
 LOCAL-ONLY: refuses to run on Azure (WEBSITE_HOSTNAME set) or when DEBUG is
 False, unless --force. Also needs the feature flag: CRUSH_CACHE_ENABLED=true
@@ -14,9 +20,9 @@ False, unless --force. Also needs the feature flag: CRUSH_CACHE_ENABLED=true
 
 Usage:
     python manage.py seed_crush_cache --reset
-    python manage.py seed_crush_cache --reset --live   # start the hunt now
+    python manage.py seed_crush_cache --preset echternach --reset --live
 
-Testing GPS without being in Luxembourg: open the play page in Chrome, then
+Testing GPS without being on site: open the play page in Chrome, then
 DevTools → ⋮ → More tools → Sensors → Location → "Other…" and paste a
 station's lat/lng (printed below). The arrival check will pass.
 """
@@ -37,9 +43,6 @@ from crush_lu.models.crush_cache import (
     CacheTeam,
 )
 from crush_lu.models.profiles import CrushCoach
-
-EVENT_TITLE_LUX = "🧭 [DEBUG] Luxembourg City Crush Cache"
-EVENT_TITLE_MINETTE = "🧭 [DEBUG] Fond-de-Gras Crush Cache \"Minette\""
 
 STATIONS_LUX_CITY = [
     {
@@ -221,25 +224,220 @@ STATIONS_MINETTE = [
         "challenge_type": "riddle",
         "question": "Glückwunsch! Welches historische Industriezeitalter hat dieses Tal geprägt?",
         "answer": "Industrielle Revolution",
-        "alternatives": ["Industrial Revolution", "Bergbau", "Stahlindustrie", "Stahlzeitalter"],
+        "alternatives": [
+            "Industrial Revolution",
+            "Bergbau",
+            "Stahlindustrie",
+            "Stahlzeitalter",
+        ],
         "hint_1": "Das Zeitalter von Eisen, Stahl und Dampf im 19. und 20. Jahrhundert.",
         "points": 150,
     },
 ]
 
+# Echternach lake Crush Cache "Um See" — a ~1.8 km clockwise loop of the
+# lakeside path, 6 stations, Crush Statue QR at every stop (same shape as the
+# Minette hunt). The loop starts at the Roman villa on the west shore, runs
+# east along the south bank to the playground/BBQ area, and comes back along
+# the north bank past the bike park to the boat rental.
+#
+# Station 1 is the only surveyed point: the villa's published visitor-parking
+# GPS (N49°48'18.1" E6°24'30.8"). Stations 2-6 are laid out from it along the
+# lake and are ACCURATE TO ROUGHLY 50-100 m — see `coords_note` on the preset.
+# Walk the loop with a phone and correct them here (or in the Django admin,
+# Cache Stations) before running this hunt for real.
+STATIONS_ECHTERNACH = [
+    {
+        "order": 1,
+        "name": "Réimervilla (Villa Romaine)",
+        "lat": "49.805028",
+        "lng": "6.408556",
+        "unlock_mode": "gps_qr",
+        "intro": "Start am Westufer bei der Réimervilla! Beim Ausbaggern des Sees stießen die Arbeiter hier 1975 auf etwas sehr Altes. Findet die Crush-Statue beim Museumseingang und scannt den QR-Code.",
+        "challenge_type": "multiple_choice",
+        "question": "Wenn du eine Zeitreise machen könntest — wohin?",
+        "options": {
+            "1": "Ins römische Echternach, genau hier",
+            "2": "Hundert Jahre in die Zukunft",
+            "3": "Zurück in meine eigene Kindheit",
+        },
+        "answer": "",  # Accepts any choice (icebreaker prompt)
+        "alternatives": [],
+        "hint_1": "Es gibt kein Richtig oder Falsch — nimm das, was dich zuerst anlacht.",
+        "points": 100,
+    },
+    {
+        "order": 2,
+        "name": "Uferwee Südufer",
+        "lat": "49.805900",
+        "lng": "6.411800",
+        "unlock_mode": "gps_qr",
+        "intro": "Folgt dem Uferweg nach Osten, mit dem Wasser zu eurer Linken. Zwischen See und Wald wartet die nächste Crush-Statue am Wegrand.",
+        "challenge_type": "multiple_choice",
+        "question": "Ein perfekter Nachmittag am See ist für dich...",
+        "options": {
+            "1": "Schwimmen, Sonne, Sprung ins Wasser",
+            "2": "Spazieren und gute Gespräche",
+            "3": "Decke, Buch und Ruhe",
+        },
+        "answer": "",  # Accepts any choice
+        "alternatives": [],
+        "hint_1": "Stell dir den nächsten freien Samstag vor.",
+        "points": 100,
+    },
+    {
+        "order": 3,
+        "name": "Aventure-Insel & Jugendherberge",
+        "lat": "49.807000",
+        "lng": "6.415200",
+        "unlock_mode": "gps_qr",
+        "intro": "Ihr erreicht die Aventure-Insel bei der Jugendherberge — hier wird von Mai bis September geschwommen. Die Crush-Statue steht beim Badebereich.",
+        "challenge_type": "multiple_choice",
+        "question": "Der See hat 14 Grad. Du...",
+        "options": {
+            "1": "springst sofort rein",
+            "2": "gehst langsam bis zu den Knien",
+            "3": "bleibst am Ufer und lachst die anderen aus",
+        },
+        "answer": "",  # Accepts any choice
+        "alternatives": [],
+        "hint_1": "Ehrlich sein zählt hier mehr als mutig sein.",
+        "points": 100,
+    },
+    {
+        "order": 4,
+        "name": "Ostufer: Spillplaz & Grillplazen",
+        "lat": "49.809200",
+        "lng": "6.418200",
+        "unlock_mode": "gps_qr",
+        "intro": "Am Ostufer liegen Spielplatz und Grillplätze, mit Blick zurück über den ganzen See. Sucht die Crush-Statue bei den Grillhütten.",
+        "challenge_type": "multiple_choice",
+        "question": "Beim Grillen mit Freunden bist du...",
+        "options": {
+            "1": "am Grill — ich habe das im Griff",
+            "2": "für Musik und Stimmung zuständig",
+            "3": "der, der isst, redet und zuhört",
+        },
+        "answer": "",  # Accepts any choice
+        "alternatives": [],
+        "hint_1": "Denk an das letzte Grillfest, bei dem du dabei warst.",
+        "points": 100,
+    },
+    {
+        "order": 5,
+        "name": "Nordufer: Bike Park & Trampolinen",
+        "lat": "49.809600",
+        "lng": "6.414300",
+        "unlock_mode": "gps_qr",
+        "intro": "Jetzt zurück am Nordufer, vorbei am Bike Park und den Trampolinen. Die nächste Crush-Statue steht am Wegrand.",
+        "challenge_type": "multiple_choice",
+        "question": "Etwas Neues ausprobieren:",
+        "options": {
+            "1": "sofort, ohne lange nachzudenken",
+            "2": "erst zuschauen, dann mitmachen",
+            "3": "lieber bei dem bleiben, was ich kann",
+        },
+        "answer": "",  # Accepts any choice
+        "alternatives": [],
+        "hint_1": "Wie war es das letzte Mal, als dich jemand zu etwas überredet hat?",
+        "points": 100,
+    },
+    {
+        "order": 6,
+        "name": "Bootsverleih Nordwestufer (Schluss)",
+        "lat": "49.807600",
+        "lng": "6.410600",
+        "unlock_mode": "gps_qr",
+        "intro": "Letzte Station am Nordwestufer beim Bootsverleih — der Kreis schließt sich. Scannt die letzte Crush-Statue und denkt an Station 1 zurück.",
+        "challenge_type": "riddle",
+        "question": "Zum Schluss: Beim Ausbaggern dieses künstlichen Sees fanden die Arbeiter 1975 Mauerreste. Was wurde hier ausgegraben?",
+        "answer": "Römische Villa",
+        "alternatives": [
+            "Roemische Villa",
+            "eine römische Villa",
+            "Gallo-römische Villa",
+            "Römervilla",
+            "Reimervilla",
+            "Réimervilla",
+            "Villa Romaine",
+            "Roman villa",
+            "Villa",
+        ],
+        "hint_1": "Station 1 steht direkt darauf — 40 Räume, Fußbodenheizung, Mosaike.",
+        "points": 150,
+    },
+]
+
+# Everything that differs between hunts lives here, so a new preset is data,
+# not another branch in the command.
+PRESETS = {
+    "lux_city": {
+        "event_title": "🧭 [DEBUG] Luxembourg City Crush Cache",
+        "event_description": "Debug scavenger hunt through Luxembourg City for QA.",
+        "location": "Luxembourg City",
+        "address": "Place de la Constitution, Luxembourg",
+        "hunt_title": "Old Town GPS Hunt",
+        "hunt_description": "Follow the pins around the Ville Haute. First team home wins!",
+        "team_name": "Explorers",
+        "radius_meters": 40,
+        "completion_message": "Nice — on to the next station!",
+        "success_message": "Correct!",
+        "stations": STATIONS_LUX_CITY,
+    },
+    "minette": {
+        "event_title": '🧭 [DEBUG] Fond-de-Gras Crush Cache "Minette"',
+        "event_description": "Debug scavenger hunt through Fond-de-Gras Minette mining area for QA.",
+        "location": "Fond-de-Gras",
+        "address": "Fond-de-Gras, L-4570 Differdange",
+        "hunt_title": 'Crush Cache "Minette"',
+        "hunt_description": "Explore the historic red-rock mining valley of Fond-de-Gras. First team to the Schluss station wins!",
+        "team_name": "Minette Miners",
+        "radius_meters": 40,
+        "completion_message": "Nice — on to the next station!",
+        "success_message": "Correct!",
+        "stations": STATIONS_MINETTE,
+    },
+    "echternach": {
+        "event_title": '🧭 [DEBUG] Echternach Lake Crush Cache "Um See"',
+        "event_description": "Debug scavenger hunt around Echternach lake for QA.",
+        "location": "Echternach",
+        "address": "Rue des Romains, L-6478 Echternach",
+        "hunt_title": 'Crush Cache "Um See"',
+        "hunt_description": "Ein Rundweg um den Echternacher See: sechs Stationen, sechs Fragen, rund 1,8 km. Wer zuerst zurück beim Bootsverleih ist, gewinnt!",
+        "team_name": "Seewanderer",
+        # Slightly more forgiving than the other presets: the lakeside path is
+        # open ground and these coordinates are still estimates.
+        "radius_meters": 50,
+        "completion_message": "Stark — weiter zur nächsten Station!",
+        "success_message": "Gespeichert — weiter geht's!",
+        "stations": STATIONS_ECHTERNACH,
+        "coords_note": (
+            "Only station 1 (Réimervilla) is a surveyed coordinate. Stations 2-6 "
+            "are laid out along the lake and are accurate to roughly 50-100 m. "
+            "Walk the loop and correct them in the admin (Cache Stations) "
+            "before running this hunt for real."
+        ),
+    },
+}
+
+DEFAULT_PRESET = "lux_city"
+
 
 class Command(BaseCommand):
     help = (
-        "Seed a playable Crush Cache hunt (Luxembourg City or Fond-de-Gras Minette) "
-        "for manual QA. Local-only."
+        "Seed a playable Crush Cache hunt (Luxembourg City, Fond-de-Gras Minette "
+        "or Echternach lake) for manual QA. Local-only."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--preset",
-            choices=["lux_city", "minette"],
-            default="lux_city",
-            help="Which hunt preset to seed: 'lux_city' (default) or 'minette' (Fond-de-Gras).",
+            choices=sorted(PRESETS),
+            default=DEFAULT_PRESET,
+            help=(
+                "Which hunt preset to seed: 'lux_city' (default), 'minette' "
+                "(Fond-de-Gras) or 'echternach' (lake loop)."
+            ),
         )
         parser.add_argument(
             "--reset",
@@ -278,9 +476,8 @@ class Command(BaseCommand):
                 )
             )
 
-        preset = options["preset"]
-        event_title = EVENT_TITLE_MINETTE if preset == "minette" else EVENT_TITLE_LUX
-        stations_data = STATIONS_MINETTE if preset == "minette" else STATIONS_LUX_CITY
+        preset = PRESETS[options["preset"]]
+        event_title = preset["event_title"]
 
         existing = MeetupEvent.objects.filter(
             title=event_title, event_type="crush_cache"
@@ -293,12 +490,14 @@ class Command(BaseCommand):
                 )
             # Cascades to hunt, stations, challenges, teams, registrations.
             existing.delete()
-            self.stdout.write(f"Deleted the previous debug Crush Cache event '{event_title}'.")
+            self.stdout.write(
+                f"Deleted the previous debug Crush Cache event '{event_title}'."
+            )
 
         coach = self._ensure_coach()
-        event = self._create_event(preset, event_title)
+        event = self._create_event(preset)
         hunt = self._create_hunt(event, coach, preset)
-        self._create_stations(hunt, stations_data)
+        self._create_stations(hunt, preset)
         team = self._create_demo_team(hunt, preset)
         players = self._register_players(event)
 
@@ -307,7 +506,7 @@ class Command(BaseCommand):
             hunt.started_at = timezone.now()
             hunt.save(update_fields=["status", "started_at"])
 
-        self._report(hunt, team, players, stations_data)
+        self._report(hunt, team, players, preset)
 
     # ------------------------------------------------------------------ #
 
@@ -338,41 +537,25 @@ class Command(BaseCommand):
         )
         return coach_user
 
-    def _create_event(self, preset, title):
+    def _create_event(self, preset):
         now = timezone.now()
-        if preset == "minette":
-            desc = "Debug scavenger hunt through Fond-de-Gras Minette mining area for QA."
-            loc = "Fond-de-Gras"
-            addr = "Fond-de-Gras, L-4570 Differdange"
-        else:
-            desc = "Debug scavenger hunt through Luxembourg City for QA."
-            loc = "Luxembourg City"
-            addr = "Place de la Constitution, Luxembourg"
-
         return MeetupEvent.objects.create(
-            title=title,
-            description=desc,
+            title=preset["event_title"],
+            description=preset["event_description"],
             event_type="crush_cache",
             date_time=now + timedelta(hours=2),
             registration_deadline=now + timedelta(hours=1),
-            location=loc,
-            address=addr,
+            location=preset["location"],
+            address=preset["address"],
             max_participants=30,
             is_published=True,
         )
 
     def _create_hunt(self, event, coach, preset):
-        if preset == "minette":
-            title = "Crush Cache \"Minette\""
-            desc = "Explore the historic red-rock mining valley of Fond-de-Gras. First team to the Schluss station wins!"
-        else:
-            title = "Old Town GPS Hunt"
-            desc = "Follow the pins around the Ville Haute. First team home wins!"
-
         return CacheHunt.objects.create(
             event=event,
-            title=title,
-            description=desc,
+            title=preset["hunt_title"],
+            description=preset["hunt_description"],
             status="draft",
             navigation_mode="map",  # target pin shown — easiest to test GPS with
             team_size_max=4,
@@ -380,8 +563,8 @@ class Command(BaseCommand):
             created_by=coach,
         )
 
-    def _create_stations(self, hunt, stations_data):
-        for s in stations_data:
+    def _create_stations(self, hunt, preset):
+        for s in preset["stations"]:
             station = CacheStation.objects.create(
                 hunt=hunt,
                 order=s["order"],
@@ -389,9 +572,9 @@ class Command(BaseCommand):
                 intro_text=s["intro"],
                 latitude=s["lat"],
                 longitude=s["lng"],
-                radius_meters=40,
+                radius_meters=preset["radius_meters"],
                 unlock_mode=s["unlock_mode"],
-                completion_message="Nice — on to the next station!",
+                completion_message=preset["completion_message"],
             )
             CacheChallenge.objects.create(
                 station=station,
@@ -403,13 +586,12 @@ class Command(BaseCommand):
                 alternative_answers=s["alternatives"],
                 hint_1=s["hint_1"],
                 points_awarded=s["points"],
-                success_message="Correct!",
+                success_message=preset["success_message"],
             )
 
     def _create_demo_team(self, hunt, preset):
-        team_name = "Minette Miners" if preset == "minette" else "Explorers"
         return CacheTeam.objects.create(
-            hunt=hunt, name=team_name, color="#3b82f6"
+            hunt=hunt, name=preset["team_name"], color="#3b82f6"
         )
 
     def _register_players(self, event):
@@ -451,7 +633,7 @@ class Command(BaseCommand):
             registered.append(user)
         return registered
 
-    def _report(self, hunt, team, players, stations_data):
+    def _report(self, hunt, team, players, preset):
         out = self.stdout
         style = self.style
         out.write(style.SUCCESS(f"\n✅ Seeded '{hunt.title}' ({hunt.status})."))
@@ -465,12 +647,18 @@ class Command(BaseCommand):
             out.write(f"     - {u.username}")
         out.write("\n   Play URL (log in as a registered player first):")
         out.write(f"     http://localhost:8000/en/events/{hunt.event_id}/cache/")
-        out.write("\n   Station coordinates (for the DevTools → Sensors override):")
-        for s in stations_data:
+        out.write(
+            "\n   Station coordinates (for the DevTools → Sensors override, "
+            "and to check each pin on a map):"
+        )
+        for s in preset["stations"]:
             out.write(
                 f"     {s['order']}. {s['name']}: {s['lat']}, {s['lng']} "
                 f"({s['unlock_mode']})"
             )
+            out.write(f"        https://www.google.com/maps?q={s['lat']},{s['lng']}")
+        if preset.get("coords_note"):
+            out.write(style.WARNING(f"\n   ⚠ {preset['coords_note']}"))
         if hunt.status == "draft":
             out.write(
                 style.WARNING(
@@ -480,4 +668,3 @@ class Command(BaseCommand):
                 )
             )
         out.write("")
-

--- a/crush_lu/management/commands/seed_crush_cache.py
+++ b/crush_lu/management/commands/seed_crush_cache.py
@@ -428,10 +428,14 @@ STATIONS_ECHTERNACH_UM_SEE = [
         "lat": "49.801690",
         "lng": "6.415928",
         "unlock_mode": "gps_qr",
+        # The station label is the navigation cue in the field, so the intro
+        # repeats it verbatim and glosses it — "Kloterhal" is Luxembourgish,
+        # and a tester should not have to bridge it to "Kletterhalle" while
+        # standing at the lake.
         "intro": (
-            "Folgt dem Uferweg im Uhrzeigersinn bis zur Kletterhalle und dem "
-            "Trampolinpark. Hier wird im Sommer auch gebadet — die "
-            "Crush-Statue steht am Weg."
+            "Folgt dem Uferweg im Uhrzeigersinn bis zur Kloterhal "
+            "(Kletterhalle) und dem Trampolinpark bei der Jugendherberge. "
+            "Hier wird im Sommer auch gebadet — die Crush-Statue steht am Weg."
         ),
         "challenge_type": "multiple_choice",
         "question": "Der See hat 14 Grad. Du...",
@@ -792,10 +796,12 @@ class Command(BaseCommand):
         self._report(hunt, team, players, preset)
 
     def _validate_prototype_environment(self, options):
+        # Named from the chosen preset, not hardcoded: any preset can set
+        # solo_prototype, and a guard that blames the wrong one sends whoever
+        # hits it looking in the wrong place.
+        name = options["preset"]
         if not options.get("player_email"):
-            raise CommandError(
-                "--player-email is required for the echternach_lake prototype."
-            )
+            raise CommandError(f"--player-email is required for the {name} prototype.")
 
         # This prototype may run locally or in the staging slot, but never in
         # the production slot. --force only bypasses the command's general
@@ -804,7 +810,7 @@ class Command(BaseCommand):
         slot_name = os.getenv("WEBSITE_SLOT_NAME", "").casefold()
         if hostname and "staging" not in hostname and slot_name != "staging":
             raise CommandError(
-                "The echternach_lake prototype is restricted to local or Azure "
+                f"The {name} prototype is restricted to local or Azure "
                 "staging environments; refusing to modify production."
             )
 

--- a/crush_lu/management/commands/seed_crush_cache.py
+++ b/crush_lu/management/commands/seed_crush_cache.py
@@ -393,10 +393,10 @@ STATIONS_ECHTERNACH_LAKE = [
 # played as a team hunt: a Crush Statue QR at every stop and German icebreaker
 # prompts, the Minette shape rather than the prototype's GPS-only feedback run.
 #
-# Stations sit on the SAME official GPX track as STATIONS_ECHTERNACH_LAKE,
-# spaced round the loop so that one walk can field-test both presets. Five are
-# points the prototype already uses; station 6 is the midpoint of the long
-# western leg back to the villa. Do not re-derive these from a map — the
+# Every station is a point the prototype already uses on the official GPX
+# track, so one walk of the ~3.25 km lake loop can field-test both presets.
+# The loop runs villa → climbing hall → east shore → south bend → west shore
+# and finishes back at the villa. Do not re-derive these from a map — the
 # prototype's track is the surveyed source.
 STATIONS_ECHTERNACH_UM_SEE = [
     {
@@ -513,14 +513,19 @@ STATIONS_ECHTERNACH_UM_SEE = [
     },
     {
         "order": 6,
-        "name": "Nordwestufer (Schluss)",
-        "lat": "49.800881",
-        "lng": "6.410979",
+        # Same coordinates as station 1 on purpose: the hunt is won back at
+        # the villa where it started, so the finish line matches what the
+        # event copy promises. (The prototype closes its loop the same way.)
+        # One statue position therefore carries two codes — or players type
+        # the manual codes, which the seed report prints.
+        "name": "Réimervilla (Schluss)",
+        "lat": "49.804108",
+        "lng": "6.411389",
         "unlock_mode": "gps_qr",
         "intro": (
-            "Letzte Station auf dem Rückweg zur Villa — der Kreis schließt "
-            "sich. Scannt die letzte Crush-Statue und denkt an Station 1 "
-            "zurück."
+            "Zurück am Startpunkt unterhalb der Réimervilla — der Kreis "
+            "schließt sich. Scannt die letzte Crush-Statue und denkt an "
+            "Station 1 zurück."
         ),
         "challenge_type": "riddle",
         "question": (
@@ -614,7 +619,7 @@ PRESETS = {
         "hunt_title": 'Crush Cache "Um See"',
         "hunt_description": (
             "Ein Rundweg um den Echternacher See: sechs Stationen, sechs "
-            "Fragen, rund 2,5 km. Wer zuerst zurück an der Villa ist, gewinnt!"
+            "Fragen, rund 3,25 km. Wer zuerst zurück an der Villa ist, gewinnt!"
         ),
         "team_name": "Seewanderer",
         # Wider than the other presets: these are GPX track points rather than

--- a/crush_lu/tests/test_crush_cache.py
+++ b/crush_lu/tests/test_crush_cache.py
@@ -1769,10 +1769,12 @@ class TestSeedCrushCacheCommand:
         assert all(s.manual_code for s in stations)
         assert len({s.manual_code for s in stations}) == 6
 
-        # The loop closes back near the villa with a real answer that
-        # station 1 gives away — the only non-icebreaker challenge.
+        # The hunt is won back at the villa where it started, so the finish
+        # line matches what the event copy promises.
         schluss = stations[5]
-        assert schluss.name == "Nordwestufer (Schluss)"
+        assert schluss.name == "Réimervilla (Schluss)"
+        assert schluss.latitude == stations[0].latitude
+        assert schluss.longitude == stations[0].longitude
         final = schluss.challenges.get()
         assert final.challenge_type == "riddle"
         assert final.points_awarded == 150
@@ -1791,19 +1793,14 @@ class TestSeedCrushCacheCommand:
         )
 
         track = {(s["lat"], s["lng"]) for s in STATIONS_ECHTERNACH_LAKE}
-        on_track = [
-            s for s in STATIONS_ECHTERNACH_UM_SEE if (s["lat"], s["lng"]) in track
-        ]
-        # Five of six are prototype points; only the long western leg's
-        # midpoint is interpolated.
-        assert len(on_track) == 5
-
-        # And that interpolated point really is between two track points.
-        extra = next(
+        off_track = [
             s for s in STATIONS_ECHTERNACH_UM_SEE if (s["lat"], s["lng"]) not in track
-        )
-        assert 49.7976 < float(extra["lat"]) < 49.8042
-        assert 6.4105 < float(extra["lng"]) < 6.4114
+        ]
+        # No invented coordinates: every station is a surveyed track point.
+        assert off_track == []
+
+        # Both loops cover the whole lake rather than doubling up on one shore.
+        assert len({(s["lat"], s["lng"]) for s in STATIONS_ECHTERNACH_UM_SEE}) == 5
 
     def test_seed_echternach_um_see_stations_are_icebreakers_with_choices(self):
         from django.core.management import call_command

--- a/crush_lu/tests/test_crush_cache.py
+++ b/crush_lu/tests/test_crush_cache.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from crush_lu.geo import bearing_deg, haversine_m
+from crush_lu.management.commands.seed_crush_cache import PRESETS as SEED_PRESETS
 from crush_lu.models import CrushCoach, EventRegistration, MeetupEvent
 from crush_lu.models.crush_cache import (
     CacheChallenge,
@@ -1620,3 +1621,71 @@ class TestSeedCrushCacheCommand:
         hunt = CacheHunt.objects.get(event__title__contains="Luxembourg City")
         assert hunt.stations.count() == 5
 
+    def test_seed_echternach_preset(self):
+        from django.core.management import call_command
+        from crush_lu.models.crush_cache import CacheHunt
+
+        call_command(
+            "seed_crush_cache", preset="echternach", reset=True, live=True, force=True
+        )
+
+        hunt = CacheHunt.objects.get(event__title__contains="Echternach")
+        assert hunt.status == "live"
+        assert hunt.event.location == "Echternach"
+
+        stations = list(hunt.ordered_stations())
+        assert len(stations) == 6
+
+        # Station 1 is the only surveyed coordinate (the villa's published
+        # visitor-parking GPS) — the rest are laid out from it, so pin this one.
+        assert stations[0].name == "Réimervilla (Villa Romaine)"
+        assert str(stations[0].latitude) == "49.805028"
+        assert str(stations[0].longitude) == "6.408556"
+
+        # Crush Statue at every stop, same shape as the Minette hunt, and the
+        # wider radius the open lakeside path needs.
+        assert all(s.unlock_mode == "gps_qr" for s in stations)
+        assert all(s.radius_meters == 50 for s in stations)
+
+        # The loop closes back at the boat rental with a real answer that
+        # station 1 gives away — the only non-icebreaker challenge.
+        schluss = stations[5]
+        assert schluss.name == "Bootsverleih Nordwestufer (Schluss)"
+        final = schluss.challenges.get()
+        assert final.challenge_type == "riddle"
+        assert final.points_awarded == 150
+        # Phone-typed spellings all land: accents fold, alternates cover the
+        # ö→oe transliteration that folding alone does not.
+        for typed in ("Römische Villa", "romische villa", "Roemische Villa", "villa"):
+            assert final.check_answer(typed), typed
+        assert not final.check_answer("Bergbau")
+
+    def test_seed_echternach_stations_are_icebreakers_with_choices(self):
+        from django.core.management import call_command
+        from crush_lu.models.crush_cache import CacheHunt
+
+        call_command("seed_crush_cache", preset="echternach", reset=True, force=True)
+
+        hunt = CacheHunt.objects.get(event__title__contains="Echternach")
+        for station in list(hunt.ordered_stations())[:5]:
+            challenge = station.challenges.get()
+            assert challenge.challenge_type == "multiple_choice"
+            assert len(challenge.options) == 3
+            # Blank correct_answer = every choice accepted (opinion prompt).
+            assert challenge.accepts_any_answer
+
+    @pytest.mark.parametrize("preset_name", sorted(SEED_PRESETS))
+    def test_every_preset_seeds_a_playable_hunt(self, preset_name):
+        """The readiness check must pass for each preset in the registry —
+        this is what the coach dashboard gates Start on."""
+        from django.core.management import call_command
+        from crush_lu.models.crush_cache import CacheHunt
+
+        call_command("seed_crush_cache", preset=preset_name, reset=True, force=True)
+
+        hunt = CacheHunt.objects.get(
+            event__title=SEED_PRESETS[preset_name]["event_title"]
+        )
+        blocking = [c for c in hunt.readiness_check() if c["blocking"]]
+        assert blocking, "expected blocking readiness checks"
+        assert all(c["ok"] for c in blocking), [c for c in blocking if not c["ok"]]


### PR DESCRIPTION
## Purpose

* `main` landed a second Echternach hunt (#828) touching the same two files, so this branch conflicted. **The two are not duplicates** — they test different things, and both are worth keeping:

| Preset | Shape | Unlock | Player | Event |
|---|---|---|---|---|
| `echternach_lake` (from #828) | solo field-test prototype, questions collect feedback *about the format* | GPS only | one named existing account, no credentials created | unpublished, staging-allowed, never production |
| `echternach_um_see` (this PR) | team hunt, German icebreakers, riddle finale | GPS + Crush Statue QR | debug accounts + demo team join code | published, local QA |

* Resolve by folding **all four** presets into the `PRESETS` registry rather than leaving two competing structures in one file. The prototype's per-preset behaviour becomes registry data — `solo_prototype` selects its seeding path and report; `is_published` / `team_size_max` / `allow_self_join` stop being inline conditionals. Its staging-only guard, its refusal to touch production even under `--force`, and all six of its tests are unchanged.
* **Both presets now walk the same loop, so one trip round the lake field-tests the pair.**

```
python manage.py seed_crush_cache --preset echternach_lake --reset --live --player-email you@example.com --force
python manage.py seed_crush_cache --preset echternach_um_see --reset --live
```

### The coordinate fix

This branch originally laid its stations out from the Roman villa's published parking GPS — and put the lake about **a kilometre off**. #828's coordinates are points on the official Visit Luxembourg GPX track, which makes them the surveyed source. The team hunt is re-anchored onto that track: five of its six stations are prototype points, the sixth is the midpoint of the long western leg back to the villa.

| Preset | Stations | Loop | Radius |
|---|---|---|---|
| `lux_city` | 5 | 1.53 km | 40 m |
| `minette` | 6 | 2.72 km | 40 m |
| `echternach_lake` | 6 | 2.48 km | 40 m |
| `echternach_um_see` | 6 | 2.48 km | 75 m |

Its event title is deliberately `…Echternach Crush Cache "Um See"`, **not** "Echternach Lake" — the prototype owns that phrase and both sets of tests look events up by title substring.

### From the review on this PR

* **#1 (radius vs. disclosed coordinate error)** — root cause gone now that stations sit on the surveyed track. Radius still goes to 75 m, since these are track points rather than marker positions and the lakeside path is open ground.
* **#4 (duplicated defaults)** — `PRESET_DEFAULTS` holds what every preset shares, so each entry shows only its real deltas.
* **#5 (`coords_note` the only optional key)** — schema is uniform; every preset is fully populated and the command never needs `.get()`.
* **#2 (no schema validation, non-transactional)** — `_build_presets()` rejects a missing or misspelled key at import with the preset named, and seeding runs in one transaction so a bad preset cannot leave a half-built event behind. I did not go as far as dataclasses.
* **#3 (icebreaker boilerplate)** and **#6 (parametrized test reseeds)** — not taken. Both are fair; neither is worth churning the file for today.

### Playable without printed QR stickers

`echternach_um_see` stations are `gps_qr`, and there are no Crush Statues on the trail yet. The seed report now prints each station's **typeable manual code** next to its coordinates and a maps link, so the scanner page's manual-code entry covers the walk.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

`lux_city`, `minette` and `echternach_lake` seed exactly what `main` seeds — verified field by field (titles, descriptions, address, radius, publish flag, team size, self-join, navigation mode, completion/success messages and all station data).

## Pull Request Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout claude/echternach-lake-crush-cache-r3ldhv
```

* Test the code

```
pytest crush_lu/tests/test_crush_cache.py::TestSeedCrushCacheCommand
```

* Field-test both on one walk. Needs `CRUSH_CACHE_ENABLED=true`, or the gameplay URLs 404.

```
python manage.py seed_crush_cache --preset echternach_lake --reset --live \
    --player-email you@example.com --force
python manage.py seed_crush_cache --preset echternach_um_see --reset --live
```

Both print their stations; the second also prints a manual code per station. To rehearse indoors, fake position with DevTools → ⋮ → More tools → Sensors → Location → "Other…".

## What to Check

Verify that the following are valid

* Both Echternach events exist side by side and neither `--reset` deletes the other (distinct titles).
* `echternach_lake` is unchanged from `main`: solo team, `is_published False`, `created_by` = the named player, password untouched, and it still refuses to run against production even with `--force`.
* `echternach_um_see` seeds 6 `gps_qr` stations at 75 m with 6 distinct manual codes, a demo team join code, and no blocking readiness failures on the coach dashboard.
* Station 6's riddle accepts `Römische Villa`, `romische villa`, `Roemische Villa`, `Villa Romaine`, `Réimervilla`, `villa` and rejects `Bergbau`.
* Reseeding `lux_city` and `minette` still produces what they produced before.

## Other Information

**Still could not run pytest** — this container has no Django and PyPI is blocked by the egress proxy, so CI is the first real execution of these tests. What I verified locally: `ruff --select=E9,F63,F7,F82` and `black --check` are clean on both files; a script that rebuilds the registry from source confirmed the three pre-existing presets match `main` field by field, that all four have contiguous station orders, coordinates within `DecimalField(max_digits=9, decimal_places=6)`, GPS stations with coordinates, multiple-choice stations with options, distinct event titles, and no two distinct stations inside twice the arrival radius.

One thing that check caught and I deliberately did **not** change: `echternach_lake`'s stations 1 and 6 share coordinates. That is its loop closing at the climbing hall, its own test asserts it, and sequential progression makes it harmless.

Tests: all six prototype tests from #828 are kept as-is, plus `test_seed_echternach_um_see_preset`, `test_seed_echternach_um_see_walks_the_prototype_track` (asserts the two presets stay on one loop), `test_seed_echternach_um_see_stations_are_icebreakers_with_choices`, `test_preset_registry_fills_defaults_and_keeps_deltas`, `test_preset_registry_rejects_a_malformed_preset`, and a parametrized `test_every_preset_seeds_a_playable_hunt` that now covers all four and handles the solo-prototype path.

Two follow-ups I left alone: `minette` still has German content with English `"Correct!"` messages (now a one-line change in the registry), and these strings land in the base field only — a real multilingual event would want the modeltranslation `_en`/`_de`/`_fr` variants filled in.