### PR TITLE
Let any Crush Cache preset be field-tested on staging via --player-email

### DIFF
--- a/crush_lu/management/commands/seed_crush_cache.py
+++ b/crush_lu/management/commands/seed_crush_cache.py
@@ -14,7 +14,13 @@ The debug presets create a `crush_cache` MeetupEvent + CacheHunt with landmark
 stations, challenges and demo users. `echternach_lake` instead reuses one
 explicitly named account, creates no credentials, stays unpublished, and is
 permitted only locally or in the Azure staging slot — a preset sets
-`solo_prototype` to opt into that shape.
+`solo_prototype` to opt into that shape permanently.
+
+Passing --player-email puts ANY preset on that same solo path for one run, so
+a hunt written for local QA can be field-tested on staging without seeding the
+debug accounts and published event it would create locally. That matters
+because the debug path creates a STAFF account on a shared password: never
+run a preset on staging without --player-email.
 
 By default the command refuses to run on Azure (WEBSITE_HOSTNAME set) or when
 DEBUG is False. `--force` permits the Echternach prototype on staging, while
@@ -722,8 +728,26 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         preset = PRESETS[options["preset"]]
-        if preset["solo_prototype"]:
+        # Passing --player-email puts ANY preset on the solo path, so a hunt
+        # written for local QA can be field-tested on staging without seeding
+        # the debug accounts and published event it would create locally.
+        # solo_prototype presets have no other path — they always require it.
+        use_solo_path = preset["solo_prototype"] or bool(options.get("player_email"))
+        if use_solo_path:
             self._validate_prototype_environment(options)
+            preset = self._solo_safe(preset)
+
+        # The debug path creates debug_cache_coach@crush.lu as STAFF on a
+        # shared password and publishes the event into the public catalogue.
+        # That is fine on a laptop and never fine on an Azure slot, and
+        # --force must not buy its way past it: the solo path is right there.
+        if not use_solo_path and "WEBSITE_HOSTNAME" in os.environ:
+            raise CommandError(
+                f"'{options['preset']}' would create shared-password debug "
+                "accounts (including a staff account) and a published event. "
+                "Refusing to do that on Azure — pass --player-email <existing "
+                "account> to seed it as a private solo hunt instead."
+            )
 
         force = options["force"]
         if not force:
@@ -761,7 +785,7 @@ class Command(BaseCommand):
                 f"Deleted the previous debug Crush Cache event '{event_title}'."
             )
 
-        if preset["solo_prototype"]:
+        if use_solo_path:
             player = self._get_existing_player(options["player_email"])
             # One transaction, so a malformed preset cannot leave a half-built
             # event behind that the next run would refuse to overwrite.
@@ -794,6 +818,22 @@ class Command(BaseCommand):
                 hunt.save(update_fields=["status", "started_at"])
 
         self._report(hunt, team, players, preset)
+
+    def _solo_safe(self, preset):
+        """The shape the solo path guarantees, whatever the preset asked for.
+
+        This is the safety contract that makes a preset runnable on staging:
+        nothing published into the public catalogue, and one seat so a leaked
+        join code cannot pull anyone else in. Credential handling is the other
+        half and lives in the seeding path — the solo path never creates an
+        account, sets a password, or verifies an email.
+        """
+        return {
+            **preset,
+            "is_published": False,
+            "team_size_max": 1,
+            "allow_self_join": False,
+        }
 
     def _validate_prototype_environment(self, options):
         # Named from the chosen preset, not hardcoded: any preset can set
@@ -1028,12 +1068,22 @@ class Command(BaseCommand):
         out.write(f"   Solo team: {team.name}")
         out.write("\n   Staging play URL (sign in first):")
         out.write(f"     https://test.crush.lu/en/events/{hunt.event_id}/cache/play/")
-        out.write("\n   GPS-only stations on the official lake loop:")
-        for station in preset["stations"]:
-            out.write(
-                f"     {station['order']}. {station['name']}: "
-                f"{station['lat']}, {station['lng']}"
-            )
+        out.write("\n   Coach dashboard (you created the hunt, so you can watch it):")
+        out.write(f"     https://test.crush.lu/en/events/{hunt.event_id}/cache/coach/")
+        needs_qr = any(s.requires_qr for s in hunt.ordered_stations())
+        if needs_qr:
+            # This preset expects a Crush Statue at each stop. Without printed
+            # stickers the manual code is the only way past the scan, so it
+            # belongs in the report you carry to the lake.
+            out.write("\n   Stations (scan the statue, or type the manual code):")
+            self._write_station_lines(hunt, preset)
+        else:
+            out.write("\n   GPS-only stations on the official lake loop:")
+            for station in preset["stations"]:
+                out.write(
+                    f"     {station['order']}. {station['name']}: "
+                    f"{station['lat']}, {station['lng']}"
+                )
         if preset["coords_note"]:
             out.write(style.WARNING(f"\n   ⚠ {preset['coords_note']}"))
         if hunt.status == "draft":

--- a/crush_lu/tests/test_crush_cache.py
+++ b/crush_lu/tests/test_crush_cache.py
@@ -1881,3 +1881,107 @@ class TestSeedCrushCacheCommand:
         blocking = [c for c in hunt.readiness_check() if c["blocking"]]
         assert blocking, "expected blocking readiness checks"
         assert all(c["ok"] for c in blocking), [c for c in blocking if not c["ok"]]
+
+    def test_player_email_puts_any_preset_on_the_solo_path(self, django_user_model):
+        """--player-email makes a local-QA preset safe to seed on staging: no
+        accounts created, nothing published, one seat."""
+        from django.core.management import call_command
+        from crush_lu.models import EventRegistration
+        from crush_lu.models.crush_cache import CacheHunt, CacheTeamMember
+
+        player = django_user_model.objects.create_user(
+            username="um-see-staging@example.com",
+            email="um-see-staging@example.com",
+            password="keep-this-password",
+        )
+        before = set(django_user_model.objects.values_list("username", flat=True))
+
+        call_command(
+            "seed_crush_cache",
+            preset="echternach_um_see",
+            player_email=player.email,
+            reset=True,
+            live=True,
+            force=True,
+        )
+
+        # The debug path would have created a STAFF account on a shared
+        # password — the whole reason this path exists.
+        assert (
+            set(django_user_model.objects.values_list("username", flat=True)) == before
+        )
+        player.refresh_from_db()
+        assert player.check_password("keep-this-password")
+        assert not django_user_model.objects.filter(is_staff=True).exists()
+
+        hunt = CacheHunt.objects.get(event__title__contains="Um See")
+        assert hunt.event.is_published is False
+        assert hunt.team_size_max == 1
+        assert hunt.allow_self_join is False
+        assert hunt.created_by == player
+        assert hunt.status == "live"
+
+        # Still the team hunt's own content: QR stations, not the prototype's
+        # GPS-only run.
+        stations = list(hunt.ordered_stations())
+        assert all(s.unlock_mode == "gps_qr" for s in stations)
+        assert all(s.manual_code for s in stations)
+
+        registration = EventRegistration.objects.get(event=hunt.event, user=player)
+        assert registration.status == "attended"
+        assert CacheTeamMember.objects.filter(
+            hunt=hunt, registration=registration
+        ).exists()
+
+    def test_player_email_carries_the_production_guard_to_any_preset(
+        self, django_user_model, monkeypatch
+    ):
+        """The staging escape hatch must not become a production one."""
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        player = django_user_model.objects.create_user(
+            username="um-see-prod-guard@example.com",
+            email="um-see-prod-guard@example.com",
+        )
+        monkeypatch.setenv("WEBSITE_HOSTNAME", "django-app.azurewebsites.net")
+        monkeypatch.delenv("WEBSITE_SLOT_NAME", raising=False)
+
+        with pytest.raises(CommandError, match="refusing to modify production"):
+            call_command(
+                "seed_crush_cache",
+                preset="echternach_um_see",
+                player_email=player.email,
+                reset=True,
+                live=True,
+                force=True,
+            )
+
+    def test_without_player_email_the_team_preset_still_seeds_debug_accounts(self):
+        """The local path is unchanged — teams, join code and debug logins."""
+        from django.core.management import call_command
+        from crush_lu.models.crush_cache import CacheHunt
+
+        call_command(
+            "seed_crush_cache", preset="echternach_um_see", reset=True, force=True
+        )
+
+        hunt = CacheHunt.objects.get(event__title__contains="Um See")
+        assert hunt.event.is_published is True
+        assert hunt.team_size_max == 4
+        assert hunt.allow_self_join is True
+        assert hunt.teams.get().join_code
+
+    def test_debug_path_is_refused_on_azure_even_with_force(self, monkeypatch):
+        """--force must not buy shared-password staff accounts onto a slot."""
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        monkeypatch.setenv("WEBSITE_HOSTNAME", "django-app-staging.azurewebsites.net")
+        monkeypatch.setenv("WEBSITE_SLOT_NAME", "staging")
+
+        for preset_name in ("lux_city", "minette", "echternach_um_see"):
+            with pytest.raises(CommandError, match="Refusing to do that on Azure"):
+                call_command(
+                    "seed_crush_cache", preset=preset_name, reset=True, force=True
+                )


### PR DESCRIPTION
## Purpose

* Running **both** Echternach hunts side by side on staging was blocked by shape, not content. `echternach_lake` was built credential-free and unpublished; `echternach_um_see` could only seed the local debug shape — `debug_cache_coach@crush.lu` as **staff on a shared password**, two more accounts on the same one, and a **published** event in the public catalogue. The only way to run it on a slot was `--force`, which is equally how that lands on production.
* Make the safe shape a property of **the run** rather than of the preset. `--player-email` now puts any preset on the solo path:

| | debug path (default, local) | solo path (`--player-email`) |
|---|---|---|
| Accounts | creates 3, sets passwords, verifies emails | **creates none**, touches no password |
| Staff account | yes (`debug_cache_coach`) | no |
| Event | published | **unpublished**, direct URL only |
| Hunt | 4 seats, self-join on | **1 seat**, self-join off |
| Azure | **refused** (see below) | allowed on staging, refused on production |

* `solo_prototype` presets are unchanged — they have no other path and still require the flag.
* **The matching hole is closed from the other side:** the debug path now refuses to run whenever `WEBSITE_HOSTNAME` is set, whatever `--force` says, and points at `--player-email`. Nothing changes on a laptop, where that variable is unset.

Resulting decision table:

| `solo_prototype` | `--player-email` | on Azure | outcome |
|---|---|---|---|
| ✓ | — | — | error: `--player-email is required` |
| ✓ | ✓ | — | solo path |
| ✓ | ✓ | ✓ | solo path + production-slot guard |
| — | — | — | debug path (accounts + published event) |
| — | ✓ | — | solo path |
| — | ✓ | ✓ | solo path + production-slot guard |
| — | — | ✓ | **error: refusing to do that on Azure** |

So the two hunts can now run together on staging:

```
python manage.py seed_crush_cache --preset echternach_lake     --reset --live --player-email you@example.com --force
python manage.py seed_crush_cache --preset echternach_um_see   --reset --live --player-email you@example.com --force
```

They have distinct event titles, so neither `--reset` disturbs the other.

* The solo report also gained the coach dashboard URL (the solo path sets `created_by` to the player, so they can watch their own hunt), and now prints **manual codes** when the preset's stations expect a QR — `echternach_um_see` is `gps_qr`, and a QR hunt walked without printed statues is unplayable without them.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

Local behaviour is untouched: without `--player-email` and without `WEBSITE_HOSTNAME`, every preset seeds exactly what it seeded before. The one deliberate behaviour change is protective — the debug path is now refused on Azure slots where `--force` previously allowed it. No existing test exercised that combination.

## Pull Request Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: hardening — stops shared-password staff credentials reaching a deployed slot
```

## How to Test

* Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout claude/echternach-lake-crush-cache-r3ldhv
```

* Test the code

```
pytest crush_lu/tests/test_crush_cache.py::TestSeedCrushCacheCommand
```

* Locally, confirm nothing changed:

```
python manage.py seed_crush_cache --preset echternach_um_see --reset --live
# still prints a demo team join code and debug_cache_player logins
```

* Then the staging shape, on the same machine:

```
python manage.py seed_crush_cache --preset echternach_um_see --reset --live --player-email <an existing local account>
# no new accounts, unpublished event, one seat, manual codes printed
```

## What to Check

Verify that the following are valid

* With `--player-email`, no `User` rows are created, no password is changed, and no staff account exists afterwards.
* The event is unpublished and the hunt has `team_size_max=1`, `allow_self_join=False`, `created_by` = the named player.
* The stations are still the preset's own — `echternach_um_see` stays `gps_qr` with manual codes, it does not become the GPS-only prototype.
* On a simulated production slot (`WEBSITE_HOSTNAME` set, no staging marker), `--player-email` + `--force` is still refused.
* Without `--player-email`, `lux_city`, `minette` and `echternach_um_see` are all refused once `WEBSITE_HOSTNAME` is set, even with `--force`.
* All six `echternach_lake` prototype tests still pass unchanged.

## Other Information

Same constraint as the previous PRs: **no pytest locally** — this container has no Django and PyPI is blocked by the egress proxy, so CI is the first real run. Verified here: `ruff --select=E9,F63,F7,F82` and `black --check` clean, and a static trace of `handle()` confirming the decision table above, including that the guard is evaluated before any DB write.

Four tests added to `TestSeedCrushCacheCommand`:

* `test_player_email_puts_any_preset_on_the_solo_path` — snapshots the user table before and after and asserts it is unchanged, the password survives, no staff account exists, the event is unpublished with one seat, and the stations are still `gps_qr` with manual codes.
* `test_player_email_carries_the_production_guard_to_any_preset` — the staging escape hatch must not become a production one.
* `test_without_player_email_the_team_preset_still_seeds_debug_accounts` — the local path is unchanged.
* `test_debug_path_is_refused_on_azure_even_with_force` — across all three debug presets.

Context: this came out of actually seeding `echternach_lake` on the staging slot over SSH. Two things surfaced there and are worth recording. `source /antenv/bin/activate` does not reliably fix `python` resolution in the Oryx wrapper — `startup.sh:60` already documents this and uses `/antenv/bin/python` by absolute path, which is what works. And `--reset` is a hard cascading delete of the matching event, including any answers a previous field-tester had already submitted; if that matters for a hunt collecting feedback, a `--suffix` option giving each walk its own event would be the fix, and I have not written it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158CyYe5U85eM4weARYZCSH)_