### PR TITLE
chore(deps): take the weekly minor/patch bumps, hold Django at 6.0.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,24 @@
 # Core Django
+# HELD at 6.0.x: Django 6.1 dropped django.utils.cache.cc_delim_re, which
+# djangorestframework<=3.17.2 still imports at module scope, so azureproject/urls.py
+# fails to import under 6.1. DRF replaced it with split_header_value upstream
+# (encode/django-rest-framework#9978) — unpin once that ships in a DRF release.
 Django==6.0.7  # Security patch (PYSEC-2026-2090..2092: cache_page cookie leak, DomainNameValidator header injection, GDALRaster over-read); requires Python 3.12+
-djangorestframework==3.17.1
+djangorestframework==3.17.2
 djangorestframework-simplejwt==5.5.1
 django-crispy-forms==2.7
 crispy-tailwind==1.0.3
 django-cors-headers==4.9.0
-django-htmx==1.28.0  # HTMX server-side integration
+django-htmx==1.29.0  # HTMX server-side integration
 
 # Database
 psycopg2-binary==2.9.12  # Updated from 2.9.10 (security & bug fixes)
 
 # Authentication
-django-allauth==65.18.0  # Updated from 65.1.0 (latest stable)
+django-allauth==65.19.0  # Updated from 65.1.0 (latest stable)
 PyJWT==2.13.0  # Updated from 2.11.0 (CVE-2026-32597: crit header bypass)
 cryptography>=50.0.0  # Required for JWT token verification with RSA keys (CVE-2026-26007, OpenSSL fixes)
-google-auth==2.56.2  # Required for Google Wallet API authentication
+google-auth==2.56.3  # Required for Google Wallet API authentication
 
 # Analytics reporting (GA4 Data API + Search Console) — used by scripts/ga4_report.py,
 # gsc_report.py, seo_funnel_report.py for SEO/traffic reporting.
@@ -45,7 +49,7 @@ gunicorn==26.0.0
 channels==4.3.2
 channels-redis==4.3.0
 django-redis==7.0.0  # Redis cache backend for Django 6.0
-uvicorn[standard]==0.52.0
+uvicorn[standard]==0.52.1
 
 # Utilities
 python-dotenv==1.2.2  # Updated from 1.0.1
@@ -58,7 +62,7 @@ reportlab==5.0.0  # Printable QR sheets (Advent + Crush Cache)
 
 # Push Notifications
 py-vapid==1.9.4
-pywebpush==2.3.0
+pywebpush==2.4.0
 
 # Azure Application Insights - SDK-based for exception filtering
 # IMPORTANT: Set ApplicationInsightsAgent_EXTENSION_VERSION=disabled in Azure App Service
@@ -73,7 +77,7 @@ polib==1.2.0  # .po file parsing for check_translations command and scripts/i18n
 
 # Testing
 pytest==9.1.1
-pytest-django==4.12.0
+pytest-django==4.13.0
 pytest-playwright==0.8.0
 pytest-mock==3.15.1  # Provides 'mocker' fixture for mocking
-playwright==1.61.0
+playwright==1.62.0


### PR DESCRIPTION
## Purpose

* Unblock Dependabot's weekly minor/patch group, which has been red since 2026-08-14.
* #811 bundled `Django 6.0.7 -> 6.1` together with eight unrelated bumps. Django 6.1 dropped `django.utils.cache.cc_delim_re`, and `djangorestframework==3.17.2` still imports it at module scope:

  ```
  File "azureproject/urls.py", line 10, in <module>
      from rest_framework_simplejwt.views import (
  File ".../rest_framework/views.py", line 10, in <module>
      from django.utils.cache import cc_delim_re, patch_vary_headers
  ImportError: cannot import name 'cc_delim_re' from 'django.utils.cache'
  ```

  Anything that loads the root URLconf therefore died, taking `validate`, `test`, `Run Tests (Python 3.12)` and `Django Deploy Check` down with it — so all nine bumps were parked behind one incompatibility.
* DRF has already replaced that import with `split_header_value` upstream (encode/django-rest-framework#9978), but it is not in a released version yet. This PR holds Django on 6.0.x and lands the other eight bumps now. The comment above the pin records the reason and the unpin condition.
* Django 6.0.7 already carries the PYSEC-2026-2090..2092 patches, so holding costs no known security coverage.

Bumps taken: `djangorestframework 3.17.1→3.17.2`, `django-htmx 1.28.0→1.29.0`, `django-allauth 65.18.0→65.19.0`, `google-auth 2.56.2→2.56.3`, `uvicorn[standard] 0.52.0→0.52.1`, `pywebpush 2.3.0→2.4.0`, `pytest-django 4.12.0→4.13.0`, `playwright 1.61.0→1.62.0`.

Held: `Django 6.0.7`.

Supersedes #811, which can be closed once this is green.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout claude/branch-review-task-selection-6agrm5
```

* Test the code

```
pip install -r requirements.txt
python manage.py check
python -m pytest
```

## What to Check

* CI is green on this branch — in particular `validate`, `test`, `Run Tests (Python 3.12)` and `Django Deploy Check`, the four jobs that failed on #811.
* `requirements.txt` is the only changed file, and its diff is #811's diff minus the Django line.
* The `python -c "import azureproject.urls"` path resolves, i.e. DRF 3.17.2 loads cleanly against Django 6.0.7.

## Other Information

* **Not verified locally.** PyPI (`pypi.org` and `files.pythonhosted.org`) is blocked by this environment's egress policy — 403 on every request, direct and via the proxy — so no dependency could be installed and no part of the suite could be run here. The diagnosis comes from the installed-package list and traceback in the #811 job log, which show `Django-6.1` and `djangorestframework-3.17.2` together with the `ImportError` above. CI on this branch is the first real verification.
* Dependabot will keep re-proposing Django 6.1 every week until DRF ships the fix. A targeted `ignore` entry for Django `6.1.x` in `.github/dependabot.yml` would stop the recurring red PR, but it would also mask any 6.1 security release, so it is deliberately left out of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_015DA4UWRYLtquGjwVEtqyy5)_