### PR TITLE
chore(deps): stop Dependabot re-proposing the Django bump that breaks CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,18 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+    # TEMPORARY — remove once a DRF release carries the fix (see below).
+    # Django 6.1 dropped django.utils.cache.cc_delim_re, which djangorestframework
+    # <=3.17.2 still imports at module scope, so azureproject/urls.py fails to import
+    # and every job that loads the root URLconf dies (#811, fixed by #834). DRF replaced
+    # it with split_header_value upstream (encode/django-rest-framework#9978) but has not
+    # released it, so without this entry Dependabot re-proposes 6.1 every Monday and the
+    # PR is red every time. The bound is >=6.1 rather than 6.1.x because the symbol stays
+    # removed in later majors/minors too. Django 6.0.x patch releases — the security
+    # channel that actually applies to the pinned version — are NOT affected by this.
+    ignore:
+      - dependency-name: "Django"
+        versions: [">=6.1"]
     # Group minor and patch updates together
     groups:
       django-ecosystem:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # djangorestframework<=3.17.2 still imports at module scope, so azureproject/urls.py
 # fails to import under 6.1. DRF replaced it with split_header_value upstream
 # (encode/django-rest-framework#9978) — unpin once that ships in a DRF release.
+# .github/dependabot.yml carries a matching `ignore` for Django >=6.1; drop both together.
 Django==6.0.7  # Security patch (PYSEC-2026-2090..2092: cache_page cookie leak, DomainNameValidator header injection, GDALRaster over-read); requires Python 3.12+
 djangorestframework==3.17.2
 djangorestframework-simplejwt==5.5.1


### PR DESCRIPTION
## Purpose

* Follow-up to #834. That PR held Django on 6.0.x because 6.1 dropped `django.utils.cache.cc_delim_re`, which `djangorestframework <= 3.17.2` still imports at module scope — every job loading the root URLconf died. But nothing told Dependabot, so it would re-propose `Django 6.1` on the next weekly run and the PR would be red again, every Monday, until DRF releases its fix.
* Adds a scoped `ignore` for Django to the pip ecosystem in `.github/dependabot.yml`, so the recurring red PR stops.

### Why `>=6.1` and not `6.1.x`

`cc_delim_re` stays removed in Django releases after 6.1, so a future 6.2 bump would fail identically. Bounding at `>=6.1` matches what the pin actually means — hold on 6.0.x — instead of deferring the same breakage by one minor.

### What this does not block

Django **6.0.x patch releases still come through**. That is the security channel that applies to the version actually pinned (6.0.7 already carries PYSEC-2026-2090..2092). The entry only suppresses 6.1+, which the app cannot run at all until DRF ships the fix — so nothing actionable is being hidden.

DRF itself is not ignored, so the release carrying `split_header_value` (encode/django-rest-framework#9978) will arrive as a normal Dependabot PR. That is the signal to undo all of this.

### Removing it later

The pin and this entry have to come out together — otherwise Django is unpinned but Dependabot silently keeps ignoring it. Each comment now names the other, so whichever one you touch first points at the second.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI/dependency-automation configuration
```

## How to Test

* Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout claude/branch-review-task-selection-6agrm5
```

* Test the code

```
python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"
```

No runtime code changes — `requirements.txt` gains a comment line only, no version changes.

## What to Check

* `.github/dependabot.yml` still parses, and the three groups (`django-ecosystem`, `azure-ecosystem`, `minor-and-patch`) plus the npm and github-actions ecosystems are intact — verified locally with `yaml.safe_load`.
* The `ignore` entry sits under the **pip** ecosystem only.
* The cross-reference comments in `requirements.txt` and `.github/dependabot.yml` point at each other.
* Real confirmation is behavioural and arrives on the next weekly Dependabot run: no Django 6.1 PR.

## Other Information

* Supersedes the "process note (not a blocker)" raised in the #834 review, and reverses the reasoning I gave there. I originally left this out on the grounds that it would mask a 6.1 security release — but since the app cannot run on 6.1 at all right now, a 6.1 advisory would not be actionable anyway, while 6.0.x patches keep flowing. The recurring red PR was the larger real cost.
* #811 is being closed as superseded, not conflict-resolved: `main` now carries eight of its nine bumps, so the only delta left is the Django bump this entry now suppresses.

---
_Generated by [Claude Code](https://claude.ai/code/session_015DA4UWRYLtquGjwVEtqyy5)_