### PR TITLE
Door check-in: summary endpoint + shared row-state applier (#710)

### DIFF
--- a/azureproject/urls_crush.py
+++ b/azureproject/urls_crush.py
@@ -5,6 +5,7 @@ URL configuration for Crush.lu dating platform.
 This is the URL config used when requests come from crush.lu domain.
 Supports internationalization with language-prefixed URLs (/en/, /de/, /fr/).
 """
+
 from django.contrib import admin
 from django.urls import path, include, reverse
 from django.conf import settings
@@ -22,11 +23,26 @@ from hub.views_whatsapp import WhatsAppWebhookView
 from crush_lu.admin import crush_admin_site
 from crush_lu.admin.user_segments import user_segments_dashboard, segment_detail
 from crush_lu.admin.profile_reminders import profile_reminders_panel
-from crush_lu import admin_views, views, views_phone_verification, views_profile, views_profile_draft, views_event_polls
+from crush_lu import (
+    admin_views,
+    views,
+    views_phone_verification,
+    views_profile,
+    views_profile_draft,
+    views_event_polls,
+)
 from crush_lu.views_language import LanguageScopedJavaScriptCatalog
-from crush_lu.admin.poll_analytics import poll_analytics_dashboard, poll_analytics_detail
+from crush_lu.admin.poll_analytics import (
+    poll_analytics_dashboard,
+    poll_analytics_detail,
+)
 from crush_lu.admin import campaign_dashboard as campaign_dashboard_views
-from crush_lu.admin_views import signup_trend_api, verification_trend_api, cumulative_growth_api, daily_active_users_api
+from crush_lu.admin_views import (
+    signup_trend_api,
+    verification_trend_api,
+    cumulative_growth_api,
+    daily_active_users_api,
+)
 from crush_lu.admin_views import (
     email_template_manager,
     email_template_user_search,
@@ -38,7 +54,32 @@ from crush_lu.admin_views import (
     email_template_load_invitations,
     email_template_load_gifts,
 )
-from crush_lu import api_views, api_push, api_coach_push, api_pwa, api_ios_app, api_android_app, views_oauth_popup, api_journey, views_wallet, api_referral, api_admin_sync, api_admin_hybrid, api_admin_metrics, api_admin_events, api_admin_campaigns, api_admin_changelog, views_crush_spark, views_checkin, api_crush_connect, views_coach, api_quiz, views_quiz, views_notifications, views_payments
+from crush_lu import (
+    api_views,
+    api_push,
+    api_coach_push,
+    api_pwa,
+    api_ios_app,
+    api_android_app,
+    views_oauth_popup,
+    api_journey,
+    views_wallet,
+    api_referral,
+    api_admin_sync,
+    api_admin_hybrid,
+    api_admin_metrics,
+    api_admin_events,
+    api_admin_campaigns,
+    api_admin_changelog,
+    views_crush_spark,
+    views_checkin,
+    api_crush_connect,
+    views_coach,
+    api_quiz,
+    views_quiz,
+    views_notifications,
+    views_payments,
+)
 from crush_lu.views_campaign_click import campaign_click_redirect
 from crush_lu.wallet import passkit_service, google_callback
 from crush_lu.sitemaps import crush_sitemaps
@@ -52,8 +93,8 @@ def redirect_profile_to_dashboard(request):
     LOGIN_REDIRECT_URL is set globally to /profile/ but Crush.lu uses /dashboard/.
     This redirect handles the non-prefixed URL and sends users to the localized dashboard.
     """
-    lang = get_language() or 'en'
-    return redirect(f'/{lang}/dashboard/')
+    lang = get_language() or "en"
+    return redirect(f"/{lang}/dashboard/")
 
 
 _QUIZ_REDIRECT_LANGS = frozenset(code for code, _ in settings.LANGUAGES)
@@ -71,432 +112,1017 @@ def quiz_display_language_redirect(request, event_id):
     built by Django's URL system (which enforces the ``<int:event_id>`` shape)
     rather than f-string concatenation — closes a CodeQL open-redirect alert.
     """
-    raw_lang = get_language() or 'en'
-    lang = raw_lang if raw_lang in _QUIZ_REDIRECT_LANGS else 'en'
+    raw_lang = get_language() or "en"
+    lang = raw_lang if raw_lang in _QUIZ_REDIRECT_LANGS else "en"
     with override(lang):
-        target = reverse('quiz_table_display', kwargs={'event_id': event_id})
+        target = reverse("quiz_table_display", kwargs={"event_id": event_id})
     return redirect(target)
 
 
 # Language-neutral patterns (no /en/, /de/, /fr/ prefix)
 # These include health checks, API endpoints, authentication, SEO files, and PWA files
-urlpatterns = [
-    # Redirect bare allauth account pages to the styled crush.lu settings page
-    path('accounts/', lambda req: redirect('/account/settings/')),
-    path('accounts/email/', lambda req: redirect('/account/settings/')),
-    # Redirect allauth's generic signup to the crush.lu signup view so GDPR
-    # consent (crushlu_consent / marketing_consent) is always captured
-    path('accounts/signup/', lambda req: redirect('/signup/')),
-] + base_patterns + api_patterns + [
-    # Dev: Ghost SVG showcase (no auth needed)
-    path('ghost-showcase/', TemplateView.as_view(template_name='crush_lu/ghost_showcase.html'), name='ghost_showcase'),
-
-    # SEO: robots.txt and sitemap.xml (must be at root, no language prefix)
-    path('robots.txt', robots_txt, name='robots_txt'),
-    path('sitemap.xml', sitemap, {'sitemaps': crush_sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
-
-    # JavaScript i18n catalog (must be language-neutral for JavaScript to access).
-    # Prefer the <lang> route from templates: on this unprefixed path
-    # LocaleMiddleware negotiates from the cookie/Accept-Language, which can
-    # disagree with the language prefix of the page doing the fetching.
-    path('jsi18n/<str:lang>/', LanguageScopedJavaScriptCatalog.as_view(packages=['crush_lu']), name='javascript-catalog-lang'),
-    path('jsi18n/', JavaScriptCatalog.as_view(packages=['crush_lu']), name='javascript-catalog'),
-
-    # PWA: Service Worker, Manifest, and Offline page (must be at root for scope)
-    # These CANNOT be inside i18n_patterns because browsers block redirected scripts
-    # Note: Use {% url 'pwa_manifest' %} instead of {% url 'crush_lu:manifest' %} in templates
-    path('sw-workbox.js', views.service_worker_view, name='pwa_service_worker'),
-    path('manifest.json', views.manifest_view, name='pwa_manifest'),
-    path('offline/', views.offline_view, name='pwa_offline'),
-    # Android App Links verification for PWA
-    path('.well-known/assetlinks.json', views.assetlinks_view, name='assetlinks'),
-    # Apple Universal Links / Associated Domains for the native iOS app
-    path('.well-known/apple-app-site-association', views.apple_app_site_association_view, name='apple_app_site_association'),
-    path('apple-app-site-association', views.apple_app_site_association_view, name='apple_app_site_association_root'),
-
-    # Phone verification API (language-neutral - called by JavaScript with hardcoded paths)
-    path('api/phone/mark-verified/', views_phone_verification.mark_phone_verified, name='api_phone_mark_verified'),
-    path('api/phone/check-available/', views_phone_verification.check_phone_available, name='api_phone_check_available'),
-    path('api/phone/status/', views_phone_verification.phone_verification_status, name='api_phone_status'),
-    path('api/phone/whatsapp/send/', views_phone_verification.send_whatsapp_otp, name='api_phone_whatsapp_send'),
-    path('api/phone/whatsapp/verify/', views_phone_verification.verify_whatsapp_otp, name='api_phone_whatsapp_verify'),
-
-    # ============================================================================
-    # LANGUAGE-NEUTRAL API ENDPOINTS
-    # These APIs are called from external JavaScript files with hardcoded paths.
-    # They must NOT be inside i18n_patterns to avoid 404 errors for non-English users.
-    # ============================================================================
-
-    # Push Notifications API (called from push-notifications.js, pwa-detector.js)
-    # In-app notifications (bell)
-    path('api/notifications/', views_notifications.api_notifications_list, name='api_notifications_list'),
-    path('api/notifications/<int:notification_id>/read/', views_notifications.api_notification_mark_read, name='api_notification_mark_read'),
-    path('api/notifications/mark-all-read/', views_notifications.api_notifications_mark_all_read, name='api_notifications_mark_all_read'),
-
-    path('api/push/vapid-public-key/', api_push.get_vapid_public_key, name='api_vapid_public_key'),
-    path('api/push/subscribe/', api_push.subscribe_push, name='api_subscribe_push'),
-    path('api/push/refresh-subscription/', api_push.refresh_subscription, name='api_refresh_push_subscription'),
-    path('api/push/validate-subscription/', api_push.validate_subscription, name='api_validate_push_subscription'),
-    path('api/push/unsubscribe/', api_push.unsubscribe_push, name='api_unsubscribe_push'),
-    path('api/push/delete-subscription/', api_push.delete_push_subscription, name='api_delete_push_subscription'),
-    path('api/push/subscriptions/', api_push.list_subscriptions, name='api_list_subscriptions'),
-    path('api/push/preferences/', api_push.update_subscription_preferences, name='api_update_push_preferences'),
-    path('api/push/test/', api_push.send_test_push, name='api_send_test_push'),
-    path('api/push/mark-pwa-user/', api_push.mark_pwa_user, name='api_mark_pwa_user'),
-    path('api/push/pwa-status/', api_push.get_pwa_status, name='api_pwa_status'),
-    path('api/push/health-check/', api_push.run_subscription_health_check, name='api_push_health_check'),
-
-    # Email Preferences API (called from alpine-components.js emailPreferences component)
-    path('api/email/preferences/', views.api_update_email_preference, name='api_update_email_preference'),
-
-    # PWA Device Registration API (called from pwa-detector.js)
-    path('api/pwa/register-installation/', api_pwa.register_pwa_installation, name='api_pwa_register_installation'),
-
-    # Native iOS app API (WKWebView shell + APNS)
-    path('api/mobile/ios/config/', api_ios_app.ios_app_config, name='api_ios_app_config'),
-    path('api/mobile/ios/auth/handoff/', api_ios_app.ios_auth_handoff, name='api_ios_auth_handoff'),
-    path('api/mobile/ios/auth/complete/<str:code>/', api_ios_app.ios_auth_complete, name='api_ios_auth_complete'),
-    path('api/mobile/ios/devices/', api_ios_app.list_ios_devices, name='api_ios_devices'),
-    path('api/mobile/ios/devices/register/', api_ios_app.register_ios_device, name='api_ios_device_register'),
-    path('api/mobile/ios/devices/unregister/', api_ios_app.unregister_ios_device, name='api_ios_device_unregister'),
-    path('api/mobile/ios/devices/preferences/', api_ios_app.update_ios_device_preferences, name='api_ios_device_preferences'),
-    path('api/mobile/android/config/', api_android_app.android_app_config, name='api_android_app_config'),
-    path('api/mobile/android/auth/handoff/', api_android_app.android_auth_handoff, name='api_android_auth_handoff'),
-    path('api/mobile/android/auth/complete/<str:code>/', api_android_app.android_auth_complete, name='api_android_auth_complete'),
-    path('api/mobile/android/devices/', api_android_app.list_android_devices, name='api_android_devices'),
-    path('api/mobile/android/devices/register/', api_android_app.register_android_device, name='api_android_device_register'),
-    path('api/mobile/android/devices/unregister/', api_android_app.unregister_android_device, name='api_android_device_unregister'),
-    path('api/mobile/android/devices/preferences/', api_android_app.update_android_device_preferences, name='api_android_device_preferences'),
-
-    # Coach Push Notifications API (called from alpine-components.js)
-    path('api/coach/push/vapid-public-key/', api_coach_push.get_vapid_public_key, name='api_coach_vapid_public_key'),
-    path('api/coach/push/subscribe/', api_coach_push.subscribe_push, name='api_coach_subscribe_push'),
-    path('api/coach/push/unsubscribe/', api_coach_push.unsubscribe_push, name='api_coach_unsubscribe_push'),
-    path('api/coach/push/delete-subscription/', api_coach_push.delete_push_subscription, name='api_coach_delete_push_subscription'),
-    path('api/coach/push/subscriptions/', api_coach_push.list_subscriptions, name='api_coach_list_subscriptions'),
-    path('api/coach/push/preferences/', api_coach_push.update_subscription_preferences, name='api_coach_update_push_preferences'),
-    path('api/coach/push/test/', api_coach_push.send_test_push, name='api_coach_send_test_push'),
-
-    # Coach Team Stats API (called from alpine-components.js coachTeamStats)
-    path('api/coach/team/claim/', views_coach.api_coach_claim_submission, name='api_coach_claim_submission'),
-
-    # Auth Status API (called from oauth-popup.js, auth.html templates)
-    path('api/auth/status/', views_oauth_popup.check_auth_status, name='check_auth_status'),
-
-    # Event Voting API (called from event-voting.js)
-    path('api/events/<int:event_id>/voting/status/', api_views.voting_status_api, name='voting_status_api'),
-    path('api/events/<int:event_id>/voting/submit/', api_views.submit_vote_api, name='submit_vote_api'),
-    path('api/events/<int:event_id>/voting/results/', api_views.voting_results_api, name='voting_results_api'),
-
-    # Event Presentations API (called from coach_presentation_control.html and event_presentations.html)
-    path('api/events/<int:event_id>/presentations/current/', views.get_current_presenter_api, name='get_current_presenter_api'),
-
-    # Speed Dating TV Display data endpoint (language-neutral, polled by the display page)
-    path('api/events/<int:event_id>/tv-display-data/', views.speed_dating_tv_display_data, name='speed_dating_tv_display_data'),
-
-    # Event Poll API (language-neutral for JS calls)
-    path('api/polls/<int:poll_id>/vote/', views_event_polls.poll_vote, name='api_poll_vote'),
-    path('api/polls/<int:poll_id>/results/', views_event_polls.poll_results_api, name='api_poll_results'),
-
-    # Crush Spark API (language-neutral for JS polling)
-    path('api/sparks/<int:spark_id>/status/', views_crush_spark.api_spark_status, name='api_spark_status'),
-
-    # Payments (SumUp)
-    path('payments/sumup/create-event-checkout/<int:registration_id>/', views_payments.create_sumup_event_checkout, name='sumup_create_event_checkout'),
-    path('payments/sumup/create-premium-checkout/<int:membership_id>/', views_payments.create_sumup_premium_checkout, name='sumup_create_premium_checkout'),
-    path('payments/sumup/create-donation-checkout/', views_payments.create_sumup_donation_checkout, name='sumup_create_donation_checkout'),
-    path('payments/sumup/widget/<str:checkout_id>/', views_payments.sumup_widget_view, name='sumup_widget'),
-    path('payments/sumup/widget/<str:checkout_id>/status/', views_payments.sumup_widget_status, name='sumup_widget_status'),
-    path('payments/sumup/widget/<str:checkout_id>/failed/', views_payments.report_sumup_widget_failure, name='sumup_widget_failure'),
-    path('payments/sumup/return/', views_payments.sumup_payment_return, name='sumup_payment_return'),
-    path('payments/sumup/webhook/', views_payments.sumup_webhook, name='sumup_webhook'),
-
-    # Crush Connect Waitlist API (language-neutral for JS calls)
-    path('api/crush-connect/join/', api_crush_connect.join_waitlist, name='crush_connect_join'),
-    path('api/crush-connect/status/', api_crush_connect.waitlist_status, name='crush_connect_status'),
-
-    # Journey Reward APIs (called from photo_reveal.html with hardcoded paths)
-    path('api/journey/unlock-puzzle-piece/', api_journey.unlock_puzzle_piece, name='api_unlock_puzzle_piece'),
-    path('api/journey/reward-progress/<int:reward_id>/', api_journey.get_reward_progress, name='api_get_reward_progress'),
-
-    # PassKit Web Service (Apple Wallet)
-    path(
-        'wallet/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>/<str:serial_number>',
-        passkit_service.device_registration,
-        name='passkit_device_registration',
-    ),
-    path(
-        'wallet/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>',
-        passkit_service.list_device_registrations,
-        name='passkit_list_registrations',
-    ),
-    path(
-        'wallet/v1/passes/<str:pass_type_identifier>/<str:serial_number>',
-        passkit_service.get_latest_pass,
-        name='passkit_get_pass',
-    ),
-    path(
-        'wallet/v1/log',
-        passkit_service.log_endpoint,
-        name='passkit_log',
-    ),
-
-    # --- Legacy doubled-version compatibility (Apple Wallet) ---------------
-    # Every pass installed before the webServiceURL fix carries the versioned
-    # root "https://crush.lu/wallet/v1". Apple appends its own protocol version
-    # to whatever a pass advertises, so those devices request
-    # /wallet/v1/v1/... — which matched nothing and 404'd.
-    #
-    # Correcting the embedded root only helps passes built AFTER the fix. An
-    # already-installed pass can only receive the corrected package by fetching
-    # it, and the only address it will ever use is this doubled one; an APNs
-    # push just sends the device back to the same 404. Without these aliases
-    # every existing holder would have to delete and re-add their pass by hand.
-    #
-    # Serving them from the same views is enough to self-heal: get_latest_pass
-    # rebuilds through resolve_web_service_url, and build_web_service_url uses
-    # an absolute base path, so the package handed back over this legacy route
-    # carries the CORRECT unversioned root. One fetch and the device moves to
-    # /wallet/v1/... on its own.
-    path(
-        'wallet/v1/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>/<str:serial_number>',
-        passkit_service.device_registration,
-        name='passkit_device_registration_legacy',
-    ),
-    path(
-        'wallet/v1/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>',
-        passkit_service.list_device_registrations,
-        name='passkit_list_registrations_legacy',
-    ),
-    path(
-        'wallet/v1/v1/passes/<str:pass_type_identifier>/<str:serial_number>',
-        passkit_service.get_latest_pass,
-        name='passkit_get_pass_legacy',
-    ),
-    path(
-        'wallet/v1/v1/log',
-        passkit_service.log_endpoint,
-        name='passkit_log_legacy',
-    ),
-
-    # CSRF Token Refresh (called from alpine-components.js before final form submit)
-    path('api/csrf-token/', views_profile.get_csrf_token, name='csrf_token_refresh'),
-
-    # Onboarding /welcome/ intent probe (called from welcome.html via hx-post)
-    path('api/welcome/intent/', views_profile.welcome_intent_api, name='api_welcome_intent'),
-
-    # Profile Step-by-Step Saving APIs (called from alpine-components.js with hardcoded paths)
-    path('api/profile/save-step1/', views_profile.save_profile_step1, name='api_save_profile_step1'),
-    path('api/profile/save-step2/', views_profile.save_profile_step2, name='api_save_profile_step2'),
-    path('api/profile/save-step3/', views_profile.save_profile_step3, name='api_save_profile_step3'),
-    path('api/profile/save-preferences/', views_profile.save_profile_preferences, name='api_save_profile_preferences'),
-    path('api/profile/progress/', views_profile.get_profile_progress, name='api_get_profile_progress'),
-
-    # Profile Draft APIs (auto-save and draft recovery)
-    path('api/profile/draft/save/', views_profile_draft.save_draft, name='api_save_draft'),
-    path('api/profile/draft/get/', views_profile_draft.get_draft, name='api_get_draft'),
-    path('api/profile/draft/clear/', views_profile_draft.clear_draft, name='api_clear_draft'),
-    path('api/profile/draft/upload-photo/', views_profile.upload_photo_draft, name='api_upload_photo_draft'),
-    path('api/profile/draft/delete-photo/', views_profile.delete_photo_draft, name='api_delete_photo_draft'),
-
-    # Social Photo Import APIs (called from alpine-components.js with hardcoded paths)
-    path('api/profile/social-photos/', views_profile.get_social_photos_api, name='api_get_social_photos'),
-    path('api/profile/import-social-photo/', views_profile.import_social_photo, name='api_import_social_photo'),
-
-    # Profile Photo Upload/Delete APIs (called from alpine-components.js with hardcoded paths)
-    path('api/profile/upload-photo/<int:slot>/', views_profile.upload_profile_photo, name='api_upload_profile_photo'),
-    path('api/profile/delete-photo/<int:slot>/', views_profile.delete_profile_photo, name='api_delete_profile_photo'),
-    path('api/profile/settings/', views.api_profile_settings_autosave, name='api_profile_settings_autosave'),
-
-    # Profile Completion API (called from alpine-components.js with hardcoded paths)
-    path('api/profile/complete/', views_profile.complete_profile_submission, name='api_complete_profile_submission'),
-
-    # Submission status polling and candidate note (called from profile_submitted.html)
-    path('api/submission/status/', views.api_submission_status, name='api_submission_status'),
-    path('api/submission/note/', views.api_submission_note, name='api_submission_note'),
-
-    # Event Check-In API (language-neutral - called from QR codes and scanner)
-    path('api/events/checkin/<int:registration_id>/<str:token>/', views_checkin.event_checkin_api, name='event_checkin_api'),
-
-    # Verify an attendee in person at an event (coach action from the scanner)
-    path('api/events/<int:event_id>/verify/<int:registration_id>/', views_checkin.coach_mark_verified, name='coach_mark_verified'),
-
-    # Undo a mis-scan, and check in a waitlisted walk-up (coach actions from the scanner)
-    path('api/events/<int:event_id>/undo-checkin/<int:registration_id>/', views_checkin.coach_undo_checkin, name='coach_undo_checkin'),
-    path('api/events/<int:event_id>/promote/<int:registration_id>/', views_checkin.coach_promote_from_waitlist, name='coach_promote_from_waitlist'),
-
-    # Wallet passes (language-neutral for platform-specific clients)
-    path('wallet/apple/pass/', views_wallet.apple_wallet_pass, name='wallet_apple_pass'),
-    path('wallet/google/jwt/', views_wallet.google_wallet_jwt, name='wallet_google_jwt'),
-    path('wallet/google/event-ticket/<int:registration_id>/jwt/', views_wallet.google_event_ticket_jwt, name='event_ticket_jwt'),
-    path('wallet/apple/event-ticket/<int:registration_id>/pass/', views_wallet.apple_event_ticket_pass, name='apple_event_ticket_pass'),
-
-    # Google Wallet callback (called by Google when users save/delete passes)
-    path('wallet/google/callback/', google_callback.google_wallet_callback, name='wallet_google_callback'),
-
-    # Referral API (called from dashboard with hardcoded paths)
-    path('api/referral/me/', api_referral.referral_me, name='api_referral_me'),
-    path('api/referral/redeem/', api_referral.redeem_points, name='api_referral_redeem'),
-
-    # Admin Sync API (called by Azure Functions for scheduled tasks)
-    path('api/admin/sync-contacts/', api_admin_sync.sync_contacts_endpoint, name='api_admin_sync_contacts'),
-    path('api/admin/sync-contacts/delete-all/', api_admin_sync.delete_all_contacts_endpoint, name='api_admin_delete_all_contacts'),
-    path('api/admin/sync-contacts/health/', api_admin_sync.sync_contacts_health, name='api_admin_sync_contacts_health'),
-
-    # Hybrid Coach Review System + pre-screening cron (Azure Functions call these)
-    # Must stay language-neutral: the Function App uses hardcoded /api/admin/... paths.
-    path('api/admin/hybrid-coach-sla-sweep/', api_admin_hybrid.sla_sweep, name='api_admin_sla_sweep'),
-    path('api/admin/pre-screening-invites/', api_admin_hybrid.pre_screening_invites, name='api_admin_pre_screening_invites'),
-    path('api/admin/crush-lead-reminders/', api_admin_hybrid.crush_lead_reminders, name='api_admin_crush_lead_reminders'),
-
-    # Weekly KPI digest (WeeklyKPIs Azure Function timer calls this on Mondays).
-    # Language-neutral path so the Function App can hardcode it.
-    path('api/admin/weekly-kpis/', api_admin_metrics.weekly_kpis_sweep, name='api_admin_weekly_kpis'),
-
-    # Weekly Crush Connect question rotation (RotateConnectQuestions Function
-    # timer calls this on Mondays). Language-neutral so the Function can hardcode it.
-    path('api/admin/rotate-connect-questions/', api_admin_metrics.rotate_connect_questions_sweep, name='api_admin_rotate_connect_questions'),
-
-    # Daily profile-completion reminders (ProfileReminders Function timer).
-    # Language-neutral so the Function App can hardcode it.
-    path('api/admin/profile-reminders/', api_admin_metrics.profile_reminders_sweep, name='api_admin_profile_reminders'),
-
-    # Weekly GDPR data-minimization retention sweep (GdprRetention Function
-    # timer). Language-neutral so the Function App can hardcode it.
-    path('api/admin/gdpr-retention/', api_admin_metrics.gdpr_retention_sweep, name='api_admin_gdpr_retention'),
-
-    # Event email lifecycle (EventReminders / EventRecaps / EventFeedback Function
-    # timers). Language-neutral so the Function App can hardcode them. Before these
-    # existed the three send_event_* commands had no scheduler of any kind.
-    path('api/admin/event-reminders/', api_admin_events.event_reminders_sweep, name='api_admin_event_reminders'),
-    path('api/admin/event-recaps/', api_admin_events.event_recaps_sweep, name='api_admin_event_recaps'),
-    path('api/admin/event-feedback/', api_admin_events.event_feedback_sweep, name='api_admin_event_feedback'),
-    path('api/admin/echo-sync/', api_admin_events.echo_lu_sync_sweep, name='api_admin_echo_sync'),
-
-    # Changelog ingest (called by the Claude Code changelog routine on PR merge).
-    # Language-neutral path; auto-publishes to /changelog/. See docs/changelog-routine.md.
-    path('api/admin/changelog/ingest/', api_admin_changelog.ingest_changelog, name='api_admin_changelog_ingest'),
-
-    # Campaign dispatch tick (CampaignDispatch Azure Function timer, every 5 min).
-    # Must stay language-neutral: the Function App uses hardcoded /api/admin/... paths.
-    path('api/admin/campaigns/dispatch/', api_admin_campaigns.dispatch_campaigns_endpoint, name='api_admin_campaign_dispatch'),
-
-
-    # Live Quiz API (called from quiz-live.js WebSocket fallback)
-    path('api/quiz/<int:quiz_id>/state/', api_quiz.quiz_state, name='api_quiz_state'),
-    path('api/quiz/<int:quiz_id>/tables/', api_quiz.quiz_tables, name='api_quiz_tables'),
-    path('api/quiz/<int:quiz_id>/my-assignment/', api_quiz.my_assignment, name='api_quiz_my_assignment'),
-    path('api/quiz/<int:quiz_id>/score-table/', api_quiz.score_table, name='api_quiz_score_table'),
-    path('api/quiz/<int:quiz_id>/mark-attended/', api_quiz.mark_attended, name='api_quiz_mark_attended'),
-    path('api/quiz/<int:quiz_id>/consolidate-tables/', api_quiz.consolidate_tables_view, name='api_quiz_consolidate_tables'),
-    path('api/quiz/<int:quiz_id>/assign-table/', api_quiz.assign_table_view, name='api_quiz_assign_table'),
-
-    # Quiz table display — redirect legacy /quiz/<id>/display/ to language-prefixed URL
-    # The actual view lives in i18n_patterns below so Django's LocaleMiddleware sets
-    # request.LANGUAGE_CODE before the view renders the template.
-    path('quiz/<int:event_id>/display/', quiz_display_language_redirect, name='quiz_table_display_redirect'),
-    path('api/quiz/<int:event_id>/display-data/', views_quiz.quiz_table_display_data, name='quiz_table_display_data'),
-    path('api/quiz/<int:event_id>/verify-pin/', views_quiz.quiz_display_verify_pin, name='quiz_display_verify_pin'),
-    path('api/quiz/photo/<int:user_id>/', views_quiz.quiz_display_photo, name='quiz_display_photo'),
-
-    # Referral redirect (language-neutral for wallet passes and sharing)
-    # This allows https://crush.lu/r/CODE/ to work without language prefix
-    # Users will be redirected to the home page in their browser's preferred language
-    path('r/<str:code>/', views.referral_redirect, name='referral_redirect_neutral'),
-
-    # Campaign click-tracking redirect (language-neutral: the URL is embedded
-    # in emails / WhatsApp / push payloads sent by the campaign dashboard)
-    path('c/<str:token>/', campaign_click_redirect, name='campaign_click_redirect'),
-
-    # ============================================================================
-    # LOGIN REDIRECT COMPATIBILITY
-    # LOGIN_REDIRECT_URL is set globally to /profile/ but Crush.lu uses /dashboard/.
-    # This redirect handles the non-prefixed URL from login and sends users to the
-    # localized dashboard. Without this, users would get a 404 after login.
-    # ============================================================================
-    path('profile/', redirect_profile_to_dashboard, name='profile_redirect'),
-
-    # ============================================================================
-    # ADMIN PANELS (language-neutral - always accessible without language prefix)
-    # These are moved outside i18n_patterns to avoid 404 errors when admins
-    # manually change the URL language prefix.
-    # ============================================================================
-
-    # Dedicated Crush.lu Admin Panel (Coach Panel)
-    # Note: Dashboard must come BEFORE admin site to avoid path matching issues
-    path('crush-admin/dashboard/', admin_views.crush_admin_dashboard, name='crush_admin_dashboard'),
-    path('crush-admin/pre-screening/export.csv', admin_views.export_pre_screening_csv, name='crush_admin_pre_screening_csv'),
-    path('crush-admin/api/signup-trend/', signup_trend_api, name='crush_admin_signup_trend'),
-    path('crush-admin/api/verification-trend/', verification_trend_api, name='crush_admin_verification_trend'),
-    path('crush-admin/api/cumulative-growth/', cumulative_growth_api, name='crush_admin_cumulative_growth'),
-    path('crush-admin/api/daily-active-users/', daily_active_users_api, name='crush_admin_daily_active_users'),
-    path('crush-admin/user-segments/', user_segments_dashboard, name='user_segments_dashboard'),
-    path('crush-admin/user-segments/<str:segment_key>/', segment_detail, name='segment_detail'),
-    path('crush-admin/profile-reminders/', profile_reminders_panel, name='profile_reminders_panel'),
-
-    # Email Template Manager
-    path('crush-admin/email-templates/', email_template_manager, name='email_template_manager'),
-    path('crush-admin/email-templates/search-users/', email_template_user_search, name='email_template_user_search'),
-    path('crush-admin/email-templates/preview/', email_template_preview, name='email_template_preview'),
-    path('crush-admin/email-templates/send/', email_template_send, name='email_template_send'),
-    path('crush-admin/email-templates/create-draft/', email_template_create_draft, name='email_template_create_draft'),
-    path('crush-admin/email-templates/load-events/', email_template_load_events, name='email_template_load_events'),
-    path('crush-admin/email-templates/load-connections/', email_template_load_connections, name='email_template_load_connections'),
-    path('crush-admin/email-templates/load-invitations/', email_template_load_invitations, name='email_template_load_invitations'),
-    path('crush-admin/email-templates/load-gifts/', email_template_load_gifts, name='email_template_load_gifts'),
-
-    # Account Merge Tool
-    path('crush-admin/merge-accounts/', admin_views.merge_accounts_confirm, name='merge_accounts_confirm'),
-
-    # Poll Analytics
-    path('crush-admin/poll-analytics/', poll_analytics_dashboard, name='poll_analytics_dashboard'),
-    path('crush-admin/poll-analytics/<int:poll_id>/', poll_analytics_detail, name='poll_analytics_detail'),
-
-    # Campaign & Remarketing Dashboard (unified multi-channel campaigns)
-    path('crush-admin/campaigns/', campaign_dashboard_views.campaign_dashboard, name='campaign_dashboard'),
-    path('crush-admin/campaigns/new/', campaign_dashboard_views.campaign_composer, name='campaign_new'),
-    path('crush-admin/campaigns/create/', campaign_dashboard_views.campaign_create, name='campaign_create'),
-    path('crush-admin/campaigns/estimate/', campaign_dashboard_views.campaign_estimate, name='campaign_estimate'),
-    path('crush-admin/campaigns/preview/', campaign_dashboard_views.campaign_preview, name='campaign_preview'),
-    path('crush-admin/campaigns/<int:campaign_id>/', campaign_dashboard_views.campaign_detail, name='campaign_detail'),
-    path('crush-admin/campaigns/<int:campaign_id>/cancel/', campaign_dashboard_views.campaign_cancel, name='campaign_cancel'),
-    path('crush-admin/campaigns/<int:campaign_id>/launch/', campaign_dashboard_views.campaign_launch, name='campaign_launch'),
-    path('crush-admin/campaigns/<int:campaign_id>/status/', campaign_dashboard_views.campaign_status_partial, name='campaign_status_partial'),
-    path('crush-admin/api/campaign-overview/', campaign_dashboard_views.campaign_overview_api, name='campaign_overview_api'),
-    path('crush-admin/api/campaign-clicks/<int:campaign_id>/', campaign_dashboard_views.campaign_clicks_api, name='campaign_clicks_api'),
-    path('crush-admin/api/reminders-funnel/', campaign_dashboard_views.reminders_funnel_api, name='reminders_funnel_api'),
-
-    path('crush-admin/', crush_admin_site.urls),
-
-    # Standard Django Admin (all platforms)
-    path('admin/', admin.site.urls),
-
-    # Hub API for the CRM SPA (Codex_Marketing_CRM) hosted at hub.crush.lu.
-    # Mounted on crush.lu / test.crush.lu since the SPA's preview env can't
-    # have its own subdomain — it uses test.crush.lu directly. Language-neutral.
-    path('hub/', include('hub.urls')),
-
-    # WhatsApp webhook — public, signature-verified. Mounted here because
-    # api.crush.lu is not a bound custom domain on the production App Service slot.
-    path('api/webhooks/whatsapp/', WhatsAppWebhookView.as_view(), name='whatsapp_webhook_crush'),
-
-    # Session→JWT bounce for the hub SPA. Lives on crush.lu because that's
-    # where the allauth session cookie is set; mints a single-use code that
-    # the SPA exchanges at api.crush.lu/api/token/exchange-code/.
-    path('api/auth/spa-callback/', spa_session_callback, name='spa_session_callback'),
-]
+urlpatterns = (
+    [
+        # Redirect bare allauth account pages to the styled crush.lu settings page
+        path("accounts/", lambda req: redirect("/account/settings/")),
+        path("accounts/email/", lambda req: redirect("/account/settings/")),
+        # Redirect allauth's generic signup to the crush.lu signup view so GDPR
+        # consent (crushlu_consent / marketing_consent) is always captured
+        path("accounts/signup/", lambda req: redirect("/signup/")),
+    ]
+    + base_patterns
+    + api_patterns
+    + [
+        # Dev: Ghost SVG showcase (no auth needed)
+        path(
+            "ghost-showcase/",
+            TemplateView.as_view(template_name="crush_lu/ghost_showcase.html"),
+            name="ghost_showcase",
+        ),
+        # SEO: robots.txt and sitemap.xml (must be at root, no language prefix)
+        path("robots.txt", robots_txt, name="robots_txt"),
+        path(
+            "sitemap.xml",
+            sitemap,
+            {"sitemaps": crush_sitemaps},
+            name="django.contrib.sitemaps.views.sitemap",
+        ),
+        # JavaScript i18n catalog (must be language-neutral for JavaScript to access).
+        # Prefer the <lang> route from templates: on this unprefixed path
+        # LocaleMiddleware negotiates from the cookie/Accept-Language, which can
+        # disagree with the language prefix of the page doing the fetching.
+        path(
+            "jsi18n/<str:lang>/",
+            LanguageScopedJavaScriptCatalog.as_view(packages=["crush_lu"]),
+            name="javascript-catalog-lang",
+        ),
+        path(
+            "jsi18n/",
+            JavaScriptCatalog.as_view(packages=["crush_lu"]),
+            name="javascript-catalog",
+        ),
+        # PWA: Service Worker, Manifest, and Offline page (must be at root for scope)
+        # These CANNOT be inside i18n_patterns because browsers block redirected scripts
+        # Note: Use {% url 'pwa_manifest' %} instead of {% url 'crush_lu:manifest' %} in templates
+        path("sw-workbox.js", views.service_worker_view, name="pwa_service_worker"),
+        path("manifest.json", views.manifest_view, name="pwa_manifest"),
+        path("offline/", views.offline_view, name="pwa_offline"),
+        # Android App Links verification for PWA
+        path(".well-known/assetlinks.json", views.assetlinks_view, name="assetlinks"),
+        # Apple Universal Links / Associated Domains for the native iOS app
+        path(
+            ".well-known/apple-app-site-association",
+            views.apple_app_site_association_view,
+            name="apple_app_site_association",
+        ),
+        path(
+            "apple-app-site-association",
+            views.apple_app_site_association_view,
+            name="apple_app_site_association_root",
+        ),
+        # Phone verification API (language-neutral - called by JavaScript with hardcoded paths)
+        path(
+            "api/phone/mark-verified/",
+            views_phone_verification.mark_phone_verified,
+            name="api_phone_mark_verified",
+        ),
+        path(
+            "api/phone/check-available/",
+            views_phone_verification.check_phone_available,
+            name="api_phone_check_available",
+        ),
+        path(
+            "api/phone/status/",
+            views_phone_verification.phone_verification_status,
+            name="api_phone_status",
+        ),
+        path(
+            "api/phone/whatsapp/send/",
+            views_phone_verification.send_whatsapp_otp,
+            name="api_phone_whatsapp_send",
+        ),
+        path(
+            "api/phone/whatsapp/verify/",
+            views_phone_verification.verify_whatsapp_otp,
+            name="api_phone_whatsapp_verify",
+        ),
+        # ============================================================================
+        # LANGUAGE-NEUTRAL API ENDPOINTS
+        # These APIs are called from external JavaScript files with hardcoded paths.
+        # They must NOT be inside i18n_patterns to avoid 404 errors for non-English users.
+        # ============================================================================
+        # Push Notifications API (called from push-notifications.js, pwa-detector.js)
+        # In-app notifications (bell)
+        path(
+            "api/notifications/",
+            views_notifications.api_notifications_list,
+            name="api_notifications_list",
+        ),
+        path(
+            "api/notifications/<int:notification_id>/read/",
+            views_notifications.api_notification_mark_read,
+            name="api_notification_mark_read",
+        ),
+        path(
+            "api/notifications/mark-all-read/",
+            views_notifications.api_notifications_mark_all_read,
+            name="api_notifications_mark_all_read",
+        ),
+        path(
+            "api/push/vapid-public-key/",
+            api_push.get_vapid_public_key,
+            name="api_vapid_public_key",
+        ),
+        path("api/push/subscribe/", api_push.subscribe_push, name="api_subscribe_push"),
+        path(
+            "api/push/refresh-subscription/",
+            api_push.refresh_subscription,
+            name="api_refresh_push_subscription",
+        ),
+        path(
+            "api/push/validate-subscription/",
+            api_push.validate_subscription,
+            name="api_validate_push_subscription",
+        ),
+        path(
+            "api/push/unsubscribe/",
+            api_push.unsubscribe_push,
+            name="api_unsubscribe_push",
+        ),
+        path(
+            "api/push/delete-subscription/",
+            api_push.delete_push_subscription,
+            name="api_delete_push_subscription",
+        ),
+        path(
+            "api/push/subscriptions/",
+            api_push.list_subscriptions,
+            name="api_list_subscriptions",
+        ),
+        path(
+            "api/push/preferences/",
+            api_push.update_subscription_preferences,
+            name="api_update_push_preferences",
+        ),
+        path("api/push/test/", api_push.send_test_push, name="api_send_test_push"),
+        path(
+            "api/push/mark-pwa-user/", api_push.mark_pwa_user, name="api_mark_pwa_user"
+        ),
+        path("api/push/pwa-status/", api_push.get_pwa_status, name="api_pwa_status"),
+        path(
+            "api/push/health-check/",
+            api_push.run_subscription_health_check,
+            name="api_push_health_check",
+        ),
+        # Email Preferences API (called from alpine-components.js emailPreferences component)
+        path(
+            "api/email/preferences/",
+            views.api_update_email_preference,
+            name="api_update_email_preference",
+        ),
+        # PWA Device Registration API (called from pwa-detector.js)
+        path(
+            "api/pwa/register-installation/",
+            api_pwa.register_pwa_installation,
+            name="api_pwa_register_installation",
+        ),
+        # Native iOS app API (WKWebView shell + APNS)
+        path(
+            "api/mobile/ios/config/",
+            api_ios_app.ios_app_config,
+            name="api_ios_app_config",
+        ),
+        path(
+            "api/mobile/ios/auth/handoff/",
+            api_ios_app.ios_auth_handoff,
+            name="api_ios_auth_handoff",
+        ),
+        path(
+            "api/mobile/ios/auth/complete/<str:code>/",
+            api_ios_app.ios_auth_complete,
+            name="api_ios_auth_complete",
+        ),
+        path(
+            "api/mobile/ios/devices/",
+            api_ios_app.list_ios_devices,
+            name="api_ios_devices",
+        ),
+        path(
+            "api/mobile/ios/devices/register/",
+            api_ios_app.register_ios_device,
+            name="api_ios_device_register",
+        ),
+        path(
+            "api/mobile/ios/devices/unregister/",
+            api_ios_app.unregister_ios_device,
+            name="api_ios_device_unregister",
+        ),
+        path(
+            "api/mobile/ios/devices/preferences/",
+            api_ios_app.update_ios_device_preferences,
+            name="api_ios_device_preferences",
+        ),
+        path(
+            "api/mobile/android/config/",
+            api_android_app.android_app_config,
+            name="api_android_app_config",
+        ),
+        path(
+            "api/mobile/android/auth/handoff/",
+            api_android_app.android_auth_handoff,
+            name="api_android_auth_handoff",
+        ),
+        path(
+            "api/mobile/android/auth/complete/<str:code>/",
+            api_android_app.android_auth_complete,
+            name="api_android_auth_complete",
+        ),
+        path(
+            "api/mobile/android/devices/",
+            api_android_app.list_android_devices,
+            name="api_android_devices",
+        ),
+        path(
+            "api/mobile/android/devices/register/",
+            api_android_app.register_android_device,
+            name="api_android_device_register",
+        ),
+        path(
+            "api/mobile/android/devices/unregister/",
+            api_android_app.unregister_android_device,
+            name="api_android_device_unregister",
+        ),
+        path(
+            "api/mobile/android/devices/preferences/",
+            api_android_app.update_android_device_preferences,
+            name="api_android_device_preferences",
+        ),
+        # Coach Push Notifications API (called from alpine-components.js)
+        path(
+            "api/coach/push/vapid-public-key/",
+            api_coach_push.get_vapid_public_key,
+            name="api_coach_vapid_public_key",
+        ),
+        path(
+            "api/coach/push/subscribe/",
+            api_coach_push.subscribe_push,
+            name="api_coach_subscribe_push",
+        ),
+        path(
+            "api/coach/push/unsubscribe/",
+            api_coach_push.unsubscribe_push,
+            name="api_coach_unsubscribe_push",
+        ),
+        path(
+            "api/coach/push/delete-subscription/",
+            api_coach_push.delete_push_subscription,
+            name="api_coach_delete_push_subscription",
+        ),
+        path(
+            "api/coach/push/subscriptions/",
+            api_coach_push.list_subscriptions,
+            name="api_coach_list_subscriptions",
+        ),
+        path(
+            "api/coach/push/preferences/",
+            api_coach_push.update_subscription_preferences,
+            name="api_coach_update_push_preferences",
+        ),
+        path(
+            "api/coach/push/test/",
+            api_coach_push.send_test_push,
+            name="api_coach_send_test_push",
+        ),
+        # Coach Team Stats API (called from alpine-components.js coachTeamStats)
+        path(
+            "api/coach/team/claim/",
+            views_coach.api_coach_claim_submission,
+            name="api_coach_claim_submission",
+        ),
+        # Auth Status API (called from oauth-popup.js, auth.html templates)
+        path(
+            "api/auth/status/",
+            views_oauth_popup.check_auth_status,
+            name="check_auth_status",
+        ),
+        # Event Voting API (called from event-voting.js)
+        path(
+            "api/events/<int:event_id>/voting/status/",
+            api_views.voting_status_api,
+            name="voting_status_api",
+        ),
+        path(
+            "api/events/<int:event_id>/voting/submit/",
+            api_views.submit_vote_api,
+            name="submit_vote_api",
+        ),
+        path(
+            "api/events/<int:event_id>/voting/results/",
+            api_views.voting_results_api,
+            name="voting_results_api",
+        ),
+        # Event Presentations API (called from coach_presentation_control.html and event_presentations.html)
+        path(
+            "api/events/<int:event_id>/presentations/current/",
+            views.get_current_presenter_api,
+            name="get_current_presenter_api",
+        ),
+        # Speed Dating TV Display data endpoint (language-neutral, polled by the display page)
+        path(
+            "api/events/<int:event_id>/tv-display-data/",
+            views.speed_dating_tv_display_data,
+            name="speed_dating_tv_display_data",
+        ),
+        # Event Poll API (language-neutral for JS calls)
+        path(
+            "api/polls/<int:poll_id>/vote/",
+            views_event_polls.poll_vote,
+            name="api_poll_vote",
+        ),
+        path(
+            "api/polls/<int:poll_id>/results/",
+            views_event_polls.poll_results_api,
+            name="api_poll_results",
+        ),
+        # Crush Spark API (language-neutral for JS polling)
+        path(
+            "api/sparks/<int:spark_id>/status/",
+            views_crush_spark.api_spark_status,
+            name="api_spark_status",
+        ),
+        # Payments (SumUp)
+        path(
+            "payments/sumup/create-event-checkout/<int:registration_id>/",
+            views_payments.create_sumup_event_checkout,
+            name="sumup_create_event_checkout",
+        ),
+        path(
+            "payments/sumup/create-premium-checkout/<int:membership_id>/",
+            views_payments.create_sumup_premium_checkout,
+            name="sumup_create_premium_checkout",
+        ),
+        path(
+            "payments/sumup/create-donation-checkout/",
+            views_payments.create_sumup_donation_checkout,
+            name="sumup_create_donation_checkout",
+        ),
+        path(
+            "payments/sumup/widget/<str:checkout_id>/",
+            views_payments.sumup_widget_view,
+            name="sumup_widget",
+        ),
+        path(
+            "payments/sumup/widget/<str:checkout_id>/status/",
+            views_payments.sumup_widget_status,
+            name="sumup_widget_status",
+        ),
+        path(
+            "payments/sumup/widget/<str:checkout_id>/failed/",
+            views_payments.report_sumup_widget_failure,
+            name="sumup_widget_failure",
+        ),
+        path(
+            "payments/sumup/return/",
+            views_payments.sumup_payment_return,
+            name="sumup_payment_return",
+        ),
+        path(
+            "payments/sumup/webhook/",
+            views_payments.sumup_webhook,
+            name="sumup_webhook",
+        ),
+        # Crush Connect Waitlist API (language-neutral for JS calls)
+        path(
+            "api/crush-connect/join/",
+            api_crush_connect.join_waitlist,
+            name="crush_connect_join",
+        ),
+        path(
+            "api/crush-connect/status/",
+            api_crush_connect.waitlist_status,
+            name="crush_connect_status",
+        ),
+        # Journey Reward APIs (called from photo_reveal.html with hardcoded paths)
+        path(
+            "api/journey/unlock-puzzle-piece/",
+            api_journey.unlock_puzzle_piece,
+            name="api_unlock_puzzle_piece",
+        ),
+        path(
+            "api/journey/reward-progress/<int:reward_id>/",
+            api_journey.get_reward_progress,
+            name="api_get_reward_progress",
+        ),
+        # PassKit Web Service (Apple Wallet)
+        path(
+            "wallet/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>/<str:serial_number>",
+            passkit_service.device_registration,
+            name="passkit_device_registration",
+        ),
+        path(
+            "wallet/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>",
+            passkit_service.list_device_registrations,
+            name="passkit_list_registrations",
+        ),
+        path(
+            "wallet/v1/passes/<str:pass_type_identifier>/<str:serial_number>",
+            passkit_service.get_latest_pass,
+            name="passkit_get_pass",
+        ),
+        path(
+            "wallet/v1/log",
+            passkit_service.log_endpoint,
+            name="passkit_log",
+        ),
+        # --- Legacy doubled-version compatibility (Apple Wallet) ---------------
+        # Every pass installed before the webServiceURL fix carries the versioned
+        # root "https://crush.lu/wallet/v1". Apple appends its own protocol version
+        # to whatever a pass advertises, so those devices request
+        # /wallet/v1/v1/... — which matched nothing and 404'd.
+        #
+        # Correcting the embedded root only helps passes built AFTER the fix. An
+        # already-installed pass can only receive the corrected package by fetching
+        # it, and the only address it will ever use is this doubled one; an APNs
+        # push just sends the device back to the same 404. Without these aliases
+        # every existing holder would have to delete and re-add their pass by hand.
+        #
+        # Serving them from the same views is enough to self-heal: get_latest_pass
+        # rebuilds through resolve_web_service_url, and build_web_service_url uses
+        # an absolute base path, so the package handed back over this legacy route
+        # carries the CORRECT unversioned root. One fetch and the device moves to
+        # /wallet/v1/... on its own.
+        path(
+            "wallet/v1/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>/<str:serial_number>",
+            passkit_service.device_registration,
+            name="passkit_device_registration_legacy",
+        ),
+        path(
+            "wallet/v1/v1/devices/<str:device_library_identifier>/registrations/<str:pass_type_identifier>",
+            passkit_service.list_device_registrations,
+            name="passkit_list_registrations_legacy",
+        ),
+        path(
+            "wallet/v1/v1/passes/<str:pass_type_identifier>/<str:serial_number>",
+            passkit_service.get_latest_pass,
+            name="passkit_get_pass_legacy",
+        ),
+        path(
+            "wallet/v1/v1/log",
+            passkit_service.log_endpoint,
+            name="passkit_log_legacy",
+        ),
+        # CSRF Token Refresh (called from alpine-components.js before final form submit)
+        path(
+            "api/csrf-token/", views_profile.get_csrf_token, name="csrf_token_refresh"
+        ),
+        # Onboarding /welcome/ intent probe (called from welcome.html via hx-post)
+        path(
+            "api/welcome/intent/",
+            views_profile.welcome_intent_api,
+            name="api_welcome_intent",
+        ),
+        # Profile Step-by-Step Saving APIs (called from alpine-components.js with hardcoded paths)
+        path(
+            "api/profile/save-step1/",
+            views_profile.save_profile_step1,
+            name="api_save_profile_step1",
+        ),
+        path(
+            "api/profile/save-step2/",
+            views_profile.save_profile_step2,
+            name="api_save_profile_step2",
+        ),
+        path(
+            "api/profile/save-step3/",
+            views_profile.save_profile_step3,
+            name="api_save_profile_step3",
+        ),
+        path(
+            "api/profile/save-preferences/",
+            views_profile.save_profile_preferences,
+            name="api_save_profile_preferences",
+        ),
+        path(
+            "api/profile/progress/",
+            views_profile.get_profile_progress,
+            name="api_get_profile_progress",
+        ),
+        # Profile Draft APIs (auto-save and draft recovery)
+        path(
+            "api/profile/draft/save/",
+            views_profile_draft.save_draft,
+            name="api_save_draft",
+        ),
+        path(
+            "api/profile/draft/get/",
+            views_profile_draft.get_draft,
+            name="api_get_draft",
+        ),
+        path(
+            "api/profile/draft/clear/",
+            views_profile_draft.clear_draft,
+            name="api_clear_draft",
+        ),
+        path(
+            "api/profile/draft/upload-photo/",
+            views_profile.upload_photo_draft,
+            name="api_upload_photo_draft",
+        ),
+        path(
+            "api/profile/draft/delete-photo/",
+            views_profile.delete_photo_draft,
+            name="api_delete_photo_draft",
+        ),
+        # Social Photo Import APIs (called from alpine-components.js with hardcoded paths)
+        path(
+            "api/profile/social-photos/",
+            views_profile.get_social_photos_api,
+            name="api_get_social_photos",
+        ),
+        path(
+            "api/profile/import-social-photo/",
+            views_profile.import_social_photo,
+            name="api_import_social_photo",
+        ),
+        # Profile Photo Upload/Delete APIs (called from alpine-components.js with hardcoded paths)
+        path(
+            "api/profile/upload-photo/<int:slot>/",
+            views_profile.upload_profile_photo,
+            name="api_upload_profile_photo",
+        ),
+        path(
+            "api/profile/delete-photo/<int:slot>/",
+            views_profile.delete_profile_photo,
+            name="api_delete_profile_photo",
+        ),
+        path(
+            "api/profile/settings/",
+            views.api_profile_settings_autosave,
+            name="api_profile_settings_autosave",
+        ),
+        # Profile Completion API (called from alpine-components.js with hardcoded paths)
+        path(
+            "api/profile/complete/",
+            views_profile.complete_profile_submission,
+            name="api_complete_profile_submission",
+        ),
+        # Submission status polling and candidate note (called from profile_submitted.html)
+        path(
+            "api/submission/status/",
+            views.api_submission_status,
+            name="api_submission_status",
+        ),
+        path(
+            "api/submission/note/",
+            views.api_submission_note,
+            name="api_submission_note",
+        ),
+        # Event Check-In API (language-neutral - called from QR codes and scanner)
+        path(
+            "api/events/checkin/<int:registration_id>/<str:token>/",
+            views_checkin.event_checkin_api,
+            name="event_checkin_api",
+        ),
+        # Verify an attendee in person at an event (coach action from the scanner)
+        path(
+            "api/events/<int:event_id>/verify/<int:registration_id>/",
+            views_checkin.coach_mark_verified,
+            name="coach_mark_verified",
+        ),
+        # Undo a mis-scan, and check in a waitlisted walk-up (coach actions from the scanner)
+        path(
+            "api/events/<int:event_id>/undo-checkin/<int:registration_id>/",
+            views_checkin.coach_undo_checkin,
+            name="coach_undo_checkin",
+        ),
+        path(
+            "api/events/<int:event_id>/promote/<int:registration_id>/",
+            views_checkin.coach_promote_from_waitlist,
+            name="coach_promote_from_waitlist",
+        ),
+        # Read-only door counters, refetched by the scanner after every door action (#710)
+        path(
+            "api/events/<int:event_id>/checkin-summary/",
+            views_checkin.event_checkin_summary,
+            name="event_checkin_summary",
+        ),
+        # Wallet passes (language-neutral for platform-specific clients)
+        path(
+            "wallet/apple/pass/",
+            views_wallet.apple_wallet_pass,
+            name="wallet_apple_pass",
+        ),
+        path(
+            "wallet/google/jwt/",
+            views_wallet.google_wallet_jwt,
+            name="wallet_google_jwt",
+        ),
+        path(
+            "wallet/google/event-ticket/<int:registration_id>/jwt/",
+            views_wallet.google_event_ticket_jwt,
+            name="event_ticket_jwt",
+        ),
+        path(
+            "wallet/apple/event-ticket/<int:registration_id>/pass/",
+            views_wallet.apple_event_ticket_pass,
+            name="apple_event_ticket_pass",
+        ),
+        # Google Wallet callback (called by Google when users save/delete passes)
+        path(
+            "wallet/google/callback/",
+            google_callback.google_wallet_callback,
+            name="wallet_google_callback",
+        ),
+        # Referral API (called from dashboard with hardcoded paths)
+        path("api/referral/me/", api_referral.referral_me, name="api_referral_me"),
+        path(
+            "api/referral/redeem/",
+            api_referral.redeem_points,
+            name="api_referral_redeem",
+        ),
+        # Admin Sync API (called by Azure Functions for scheduled tasks)
+        path(
+            "api/admin/sync-contacts/",
+            api_admin_sync.sync_contacts_endpoint,
+            name="api_admin_sync_contacts",
+        ),
+        path(
+            "api/admin/sync-contacts/delete-all/",
+            api_admin_sync.delete_all_contacts_endpoint,
+            name="api_admin_delete_all_contacts",
+        ),
+        path(
+            "api/admin/sync-contacts/health/",
+            api_admin_sync.sync_contacts_health,
+            name="api_admin_sync_contacts_health",
+        ),
+        # Hybrid Coach Review System + pre-screening cron (Azure Functions call these)
+        # Must stay language-neutral: the Function App uses hardcoded /api/admin/... paths.
+        path(
+            "api/admin/hybrid-coach-sla-sweep/",
+            api_admin_hybrid.sla_sweep,
+            name="api_admin_sla_sweep",
+        ),
+        path(
+            "api/admin/pre-screening-invites/",
+            api_admin_hybrid.pre_screening_invites,
+            name="api_admin_pre_screening_invites",
+        ),
+        path(
+            "api/admin/crush-lead-reminders/",
+            api_admin_hybrid.crush_lead_reminders,
+            name="api_admin_crush_lead_reminders",
+        ),
+        # Weekly KPI digest (WeeklyKPIs Azure Function timer calls this on Mondays).
+        # Language-neutral path so the Function App can hardcode it.
+        path(
+            "api/admin/weekly-kpis/",
+            api_admin_metrics.weekly_kpis_sweep,
+            name="api_admin_weekly_kpis",
+        ),
+        # Weekly Crush Connect question rotation (RotateConnectQuestions Function
+        # timer calls this on Mondays). Language-neutral so the Function can hardcode it.
+        path(
+            "api/admin/rotate-connect-questions/",
+            api_admin_metrics.rotate_connect_questions_sweep,
+            name="api_admin_rotate_connect_questions",
+        ),
+        # Daily profile-completion reminders (ProfileReminders Function timer).
+        # Language-neutral so the Function App can hardcode it.
+        path(
+            "api/admin/profile-reminders/",
+            api_admin_metrics.profile_reminders_sweep,
+            name="api_admin_profile_reminders",
+        ),
+        # Weekly GDPR data-minimization retention sweep (GdprRetention Function
+        # timer). Language-neutral so the Function App can hardcode it.
+        path(
+            "api/admin/gdpr-retention/",
+            api_admin_metrics.gdpr_retention_sweep,
+            name="api_admin_gdpr_retention",
+        ),
+        # Event email lifecycle (EventReminders / EventRecaps / EventFeedback Function
+        # timers). Language-neutral so the Function App can hardcode them. Before these
+        # existed the three send_event_* commands had no scheduler of any kind.
+        path(
+            "api/admin/event-reminders/",
+            api_admin_events.event_reminders_sweep,
+            name="api_admin_event_reminders",
+        ),
+        path(
+            "api/admin/event-recaps/",
+            api_admin_events.event_recaps_sweep,
+            name="api_admin_event_recaps",
+        ),
+        path(
+            "api/admin/event-feedback/",
+            api_admin_events.event_feedback_sweep,
+            name="api_admin_event_feedback",
+        ),
+        path(
+            "api/admin/echo-sync/",
+            api_admin_events.echo_lu_sync_sweep,
+            name="api_admin_echo_sync",
+        ),
+        # Changelog ingest (called by the Claude Code changelog routine on PR merge).
+        # Language-neutral path; auto-publishes to /changelog/. See docs/changelog-routine.md.
+        path(
+            "api/admin/changelog/ingest/",
+            api_admin_changelog.ingest_changelog,
+            name="api_admin_changelog_ingest",
+        ),
+        # Campaign dispatch tick (CampaignDispatch Azure Function timer, every 5 min).
+        # Must stay language-neutral: the Function App uses hardcoded /api/admin/... paths.
+        path(
+            "api/admin/campaigns/dispatch/",
+            api_admin_campaigns.dispatch_campaigns_endpoint,
+            name="api_admin_campaign_dispatch",
+        ),
+        # Live Quiz API (called from quiz-live.js WebSocket fallback)
+        path(
+            "api/quiz/<int:quiz_id>/state/", api_quiz.quiz_state, name="api_quiz_state"
+        ),
+        path(
+            "api/quiz/<int:quiz_id>/tables/",
+            api_quiz.quiz_tables,
+            name="api_quiz_tables",
+        ),
+        path(
+            "api/quiz/<int:quiz_id>/my-assignment/",
+            api_quiz.my_assignment,
+            name="api_quiz_my_assignment",
+        ),
+        path(
+            "api/quiz/<int:quiz_id>/score-table/",
+            api_quiz.score_table,
+            name="api_quiz_score_table",
+        ),
+        path(
+            "api/quiz/<int:quiz_id>/mark-attended/",
+            api_quiz.mark_attended,
+            name="api_quiz_mark_attended",
+        ),
+        path(
+            "api/quiz/<int:quiz_id>/consolidate-tables/",
+            api_quiz.consolidate_tables_view,
+            name="api_quiz_consolidate_tables",
+        ),
+        path(
+            "api/quiz/<int:quiz_id>/assign-table/",
+            api_quiz.assign_table_view,
+            name="api_quiz_assign_table",
+        ),
+        # Quiz table display — redirect legacy /quiz/<id>/display/ to language-prefixed URL
+        # The actual view lives in i18n_patterns below so Django's LocaleMiddleware sets
+        # request.LANGUAGE_CODE before the view renders the template.
+        path(
+            "quiz/<int:event_id>/display/",
+            quiz_display_language_redirect,
+            name="quiz_table_display_redirect",
+        ),
+        path(
+            "api/quiz/<int:event_id>/display-data/",
+            views_quiz.quiz_table_display_data,
+            name="quiz_table_display_data",
+        ),
+        path(
+            "api/quiz/<int:event_id>/verify-pin/",
+            views_quiz.quiz_display_verify_pin,
+            name="quiz_display_verify_pin",
+        ),
+        path(
+            "api/quiz/photo/<int:user_id>/",
+            views_quiz.quiz_display_photo,
+            name="quiz_display_photo",
+        ),
+        # Referral redirect (language-neutral for wallet passes and sharing)
+        # This allows https://crush.lu/r/CODE/ to work without language prefix
+        # Users will be redirected to the home page in their browser's preferred language
+        path(
+            "r/<str:code>/", views.referral_redirect, name="referral_redirect_neutral"
+        ),
+        # Campaign click-tracking redirect (language-neutral: the URL is embedded
+        # in emails / WhatsApp / push payloads sent by the campaign dashboard)
+        path("c/<str:token>/", campaign_click_redirect, name="campaign_click_redirect"),
+        # ============================================================================
+        # LOGIN REDIRECT COMPATIBILITY
+        # LOGIN_REDIRECT_URL is set globally to /profile/ but Crush.lu uses /dashboard/.
+        # This redirect handles the non-prefixed URL from login and sends users to the
+        # localized dashboard. Without this, users would get a 404 after login.
+        # ============================================================================
+        path("profile/", redirect_profile_to_dashboard, name="profile_redirect"),
+        # ============================================================================
+        # ADMIN PANELS (language-neutral - always accessible without language prefix)
+        # These are moved outside i18n_patterns to avoid 404 errors when admins
+        # manually change the URL language prefix.
+        # ============================================================================
+        # Dedicated Crush.lu Admin Panel (Coach Panel)
+        # Note: Dashboard must come BEFORE admin site to avoid path matching issues
+        path(
+            "crush-admin/dashboard/",
+            admin_views.crush_admin_dashboard,
+            name="crush_admin_dashboard",
+        ),
+        path(
+            "crush-admin/pre-screening/export.csv",
+            admin_views.export_pre_screening_csv,
+            name="crush_admin_pre_screening_csv",
+        ),
+        path(
+            "crush-admin/api/signup-trend/",
+            signup_trend_api,
+            name="crush_admin_signup_trend",
+        ),
+        path(
+            "crush-admin/api/verification-trend/",
+            verification_trend_api,
+            name="crush_admin_verification_trend",
+        ),
+        path(
+            "crush-admin/api/cumulative-growth/",
+            cumulative_growth_api,
+            name="crush_admin_cumulative_growth",
+        ),
+        path(
+            "crush-admin/api/daily-active-users/",
+            daily_active_users_api,
+            name="crush_admin_daily_active_users",
+        ),
+        path(
+            "crush-admin/user-segments/",
+            user_segments_dashboard,
+            name="user_segments_dashboard",
+        ),
+        path(
+            "crush-admin/user-segments/<str:segment_key>/",
+            segment_detail,
+            name="segment_detail",
+        ),
+        path(
+            "crush-admin/profile-reminders/",
+            profile_reminders_panel,
+            name="profile_reminders_panel",
+        ),
+        # Email Template Manager
+        path(
+            "crush-admin/email-templates/",
+            email_template_manager,
+            name="email_template_manager",
+        ),
+        path(
+            "crush-admin/email-templates/search-users/",
+            email_template_user_search,
+            name="email_template_user_search",
+        ),
+        path(
+            "crush-admin/email-templates/preview/",
+            email_template_preview,
+            name="email_template_preview",
+        ),
+        path(
+            "crush-admin/email-templates/send/",
+            email_template_send,
+            name="email_template_send",
+        ),
+        path(
+            "crush-admin/email-templates/create-draft/",
+            email_template_create_draft,
+            name="email_template_create_draft",
+        ),
+        path(
+            "crush-admin/email-templates/load-events/",
+            email_template_load_events,
+            name="email_template_load_events",
+        ),
+        path(
+            "crush-admin/email-templates/load-connections/",
+            email_template_load_connections,
+            name="email_template_load_connections",
+        ),
+        path(
+            "crush-admin/email-templates/load-invitations/",
+            email_template_load_invitations,
+            name="email_template_load_invitations",
+        ),
+        path(
+            "crush-admin/email-templates/load-gifts/",
+            email_template_load_gifts,
+            name="email_template_load_gifts",
+        ),
+        # Account Merge Tool
+        path(
+            "crush-admin/merge-accounts/",
+            admin_views.merge_accounts_confirm,
+            name="merge_accounts_confirm",
+        ),
+        # Poll Analytics
+        path(
+            "crush-admin/poll-analytics/",
+            poll_analytics_dashboard,
+            name="poll_analytics_dashboard",
+        ),
+        path(
+            "crush-admin/poll-analytics/<int:poll_id>/",
+            poll_analytics_detail,
+            name="poll_analytics_detail",
+        ),
+        # Campaign & Remarketing Dashboard (unified multi-channel campaigns)
+        path(
+            "crush-admin/campaigns/",
+            campaign_dashboard_views.campaign_dashboard,
+            name="campaign_dashboard",
+        ),
+        path(
+            "crush-admin/campaigns/new/",
+            campaign_dashboard_views.campaign_composer,
+            name="campaign_new",
+        ),
+        path(
+            "crush-admin/campaigns/create/",
+            campaign_dashboard_views.campaign_create,
+            name="campaign_create",
+        ),
+        path(
+            "crush-admin/campaigns/estimate/",
+            campaign_dashboard_views.campaign_estimate,
+            name="campaign_estimate",
+        ),
+        path(
+            "crush-admin/campaigns/preview/",
+            campaign_dashboard_views.campaign_preview,
+            name="campaign_preview",
+        ),
+        path(
+            "crush-admin/campaigns/<int:campaign_id>/",
+            campaign_dashboard_views.campaign_detail,
+            name="campaign_detail",
+        ),
+        path(
+            "crush-admin/campaigns/<int:campaign_id>/cancel/",
+            campaign_dashboard_views.campaign_cancel,
+            name="campaign_cancel",
+        ),
+        path(
+            "crush-admin/campaigns/<int:campaign_id>/launch/",
+            campaign_dashboard_views.campaign_launch,
+            name="campaign_launch",
+        ),
+        path(
+            "crush-admin/campaigns/<int:campaign_id>/status/",
+            campaign_dashboard_views.campaign_status_partial,
+            name="campaign_status_partial",
+        ),
+        path(
+            "crush-admin/api/campaign-overview/",
+            campaign_dashboard_views.campaign_overview_api,
+            name="campaign_overview_api",
+        ),
+        path(
+            "crush-admin/api/campaign-clicks/<int:campaign_id>/",
+            campaign_dashboard_views.campaign_clicks_api,
+            name="campaign_clicks_api",
+        ),
+        path(
+            "crush-admin/api/reminders-funnel/",
+            campaign_dashboard_views.reminders_funnel_api,
+            name="reminders_funnel_api",
+        ),
+        path("crush-admin/", crush_admin_site.urls),
+        # Standard Django Admin (all platforms)
+        path("admin/", admin.site.urls),
+        # Hub API for the CRM SPA (Codex_Marketing_CRM) hosted at hub.crush.lu.
+        # Mounted on crush.lu / test.crush.lu since the SPA's preview env can't
+        # have its own subdomain — it uses test.crush.lu directly. Language-neutral.
+        path("hub/", include("hub.urls")),
+        # WhatsApp webhook — public, signature-verified. Mounted here because
+        # api.crush.lu is not a bound custom domain on the production App Service slot.
+        path(
+            "api/webhooks/whatsapp/",
+            WhatsAppWebhookView.as_view(),
+            name="whatsapp_webhook_crush",
+        ),
+        # Session→JWT bounce for the hub SPA. Lives on crush.lu because that's
+        # where the allauth session cookie is set; mints a single-use code that
+        # the SPA exchanges at api.crush.lu/api/token/exchange-code/.
+        path(
+            "api/auth/spa-callback/", spa_session_callback, name="spa_session_callback"
+        ),
+    ]
+)
 
 # Language-prefixed patterns (all user-facing pages)
 # URLs will be: /en/events/, /de/events/, /fr/events/, etc.
 urlpatterns += i18n_patterns(
     # Crush.lu app URLs
-    path('', include('crush_lu.urls', namespace='crush_lu')),
-
+    path("", include("crush_lu.urls", namespace="crush_lu")),
     # Quiz projector display — language-prefixed so Django's LocaleMiddleware activates
     # the correct language before the template renders {% trans %} strings.
     # /en/quiz/<id>/display/ | /fr/quiz/<id>/display/ | /de/quiz/<id>/display/
-    path('quiz/<int:event_id>/display/', views_quiz.quiz_table_display, name='quiz_table_display'),
-
+    path(
+        "quiz/<int:event_id>/display/",
+        views_quiz.quiz_table_display,
+        name="quiz_table_display",
+    ),
     # Include /en/ prefix even for default language
     prefix_default_language=True,
 )

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -705,6 +705,10 @@ document.addEventListener("alpine:init", function () {
                     // A correction is not an arrival: take the row out of
                     // Recent Check-ins instead of celebrating it.
                     this._removeRecentCheckin(regId);
+                    // And clear the dedupe entry — mirroring the acting
+                    // coach's local undo path — so a legitimate re-check-in
+                    // after the undo isn't swallowed by the guard below.
+                    delete this.processedIds[regId];
                     return;
                 }
                 if (this.processedIds[regId]) return;
@@ -971,6 +975,14 @@ document.addEventListener("alpine:init", function () {
                 var wrap = document.createElement("div");
                 wrap.className = "flex-shrink-0 flex items-center gap-2";
                 wrap.setAttribute("data-row-actions", "");
+                // Verify sits outside the status split, exactly like the
+                // server-rendered twin: attended does not imply verified.
+                // _auto_verify_on_attendance deliberately declines coach-less
+                // self-scans, premium members and photo-less profiles, so the
+                // button has to survive the check-in for exactly those rows.
+                if (row.has_profile && !row.is_approved) {
+                    wrap.appendChild(this._buildVerifyButton(regId));
+                }
                 if (row.status === "attended") {
                     var checkedSpan = document.createElement("span");
                     checkedSpan.className =
@@ -1004,24 +1016,6 @@ document.addEventListener("alpine:init", function () {
                         if (undoBtn) wrap.appendChild(undoBtn);
                     }
                 } else {
-                    if (row.has_profile && !row.is_approved) {
-                        var verifyBtn = document.createElement("button");
-                        verifyBtn.type = "button";
-                        verifyBtn.className =
-                            "manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white";
-                        verifyBtn.setAttribute(
-                            "data-verify-url",
-                            this._apiUrl("verify", regId),
-                        );
-                        verifyBtn.setAttribute("data-reg-id", regId);
-                        verifyBtn.textContent = i18n.verifyAction || "Verify";
-                        // Bound directly rather than with x-on — Alpine only
-                        // wires directives present when it walked the tree.
-                        verifyBtn.addEventListener("click", function (clickEvent) {
-                            self.markVerified(clickEvent);
-                        });
-                        wrap.appendChild(verifyBtn);
-                    }
                     var checkinUrl = rowEl.getAttribute("data-checkin-url");
                     if (checkinUrl) {
                         var checkinBtn = document.createElement("button");
@@ -1333,6 +1327,29 @@ document.addEventListener("alpine:init", function () {
                     self.undoCheckin(clickEvent);
                 });
                 return undoBtn;
+            },
+
+            _buildVerifyButton: function (regId) {
+                var self = this;
+                var i18n = window._checkinI18n || {};
+                var verifyBtn = document.createElement("button");
+                verifyBtn.type = "button";
+                // Must stay identical to the server-rendered twin in
+                // coach_event_checkin.html — see _buildUndoButton.
+                verifyBtn.className =
+                    "manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white";
+                verifyBtn.setAttribute(
+                    "data-verify-url",
+                    this._apiUrl("verify", regId),
+                );
+                verifyBtn.setAttribute("data-reg-id", regId);
+                verifyBtn.textContent = i18n.verifyAction || "Verify";
+                // Bound directly rather than with x-on — Alpine only wires
+                // directives present when it walked the tree.
+                verifyBtn.addEventListener("click", function (clickEvent) {
+                    self.markVerified(clickEvent);
+                });
+                return verifyBtn;
             },
 
             // --- Scanner ---

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -451,6 +451,10 @@ document.addEventListener("alpine:init", function () {
             // Deduplication
             processedIds: {},
 
+            // Monotonic sequence for _refetchSummary: only the latest fetch
+            // may apply its response (out-of-order arrival guard).
+            _summarySeq: 0,
+
             init: function () {
                 this.eventId = parseInt(this.$el.getAttribute("data-event-id")) || 0;
                 if (this.eventId) {
@@ -980,12 +984,19 @@ document.addEventListener("alpine:init", function () {
                     }
                     // The check-in most worth undoing is the one just made,
                     // so the button appears with the row, not on the next
-                    // page load.
-                    var undoUrl =
-                        rowEl.getAttribute("data-undo-url") ||
-                        this._apiUrl("undo-checkin", regId);
-                    var undoBtn = this._buildUndoButton(undoUrl, regId);
-                    if (undoBtn) wrap.appendChild(undoBtn);
+                    // page load. Gated on checked_in_at like the
+                    // server-rendered twin: an attendance recorded without a
+                    // timestamp (admin-entered, or older than this flow) has
+                    // no undo window and the endpoint refuses it — rendering
+                    // the button would offer a correction that can only
+                    // answer 409.
+                    if (row.checked_in_at) {
+                        var undoUrl =
+                            rowEl.getAttribute("data-undo-url") ||
+                            this._apiUrl("undo-checkin", regId);
+                        var undoBtn = this._buildUndoButton(undoUrl, regId);
+                        if (undoBtn) wrap.appendChild(undoBtn);
+                    }
                 } else {
                     if (row.has_profile && !row.is_approved) {
                         var verifyBtn = document.createElement("button");
@@ -1049,9 +1060,10 @@ document.addEventListener("alpine:init", function () {
                 var avatarWrap = document.createElement("div");
                 avatarWrap.className = "relative flex-shrink-0";
                 avatarWrap.setAttribute("data-checkin-avatar", "");
-                if (row.photo_url) {
+                var photoUrl = this._safePhotoUrl(row.photo_url);
+                if (photoUrl) {
                     var img = document.createElement("img");
-                    img.src = row.photo_url;
+                    img.src = photoUrl;
                     img.alt = "";
                     img.className = "w-10 h-10 rounded-full object-cover";
                     avatarWrap.appendChild(img);
@@ -1108,9 +1120,10 @@ document.addEventListener("alpine:init", function () {
 
                 var left = document.createElement("div");
                 left.className = "flex items-center gap-3 min-w-0";
-                if (row.photo_url) {
+                var waitlistPhotoUrl = this._safePhotoUrl(row.photo_url);
+                if (waitlistPhotoUrl) {
                     var img = document.createElement("img");
-                    img.src = row.photo_url;
+                    img.src = waitlistPhotoUrl;
                     img.alt = "";
                     img.className = "w-10 h-10 rounded-full object-cover flex-shrink-0";
                     left.appendChild(img);
@@ -1174,6 +1187,16 @@ document.addEventListener("alpine:init", function () {
                 return null;
             },
 
+            // The photo URL arrives inside a JSON response body, which is
+            // untrusted input no matter that our own API built it — so only a
+            // site-relative path may reach img.src. Rejects absolute,
+            // protocol-relative and scheme-bearing values outright.
+            _safePhotoUrl: function (url) {
+                if (typeof url !== "string") return null;
+                if (url.charAt(0) !== "/" || url.charAt(1) === "/") return null;
+                return url;
+            },
+
             _apiUrl: function (action, regId) {
                 return (
                     "/api/events/" + this.eventId + "/" + action + "/" + regId + "/"
@@ -1190,6 +1213,12 @@ document.addEventListener("alpine:init", function () {
                 var self = this;
                 var url = this.$el.getAttribute("data-summary-url");
                 if (!url) return;
+                // Sequence guard: two door actions close together start two
+                // fetches, and the older read can land LAST — without this,
+                // it would apply a snapshot that predates the newer action
+                // and roll the counters back. Only the most recently started
+                // fetch may render.
+                var seq = ++this._summarySeq;
                 // A failed refetch keeps the current numbers: the door must
                 // not blank its counters because a phone lost signal.
                 fetch(url, { headers: { Accept: "application/json" } })
@@ -1197,6 +1226,7 @@ document.addEventListener("alpine:init", function () {
                         return r.json();
                     })
                     .then(function (summary) {
+                        if (seq !== self._summarySeq) return;
                         if (summary && summary.success) {
                             self._applySummary(summary);
                         }

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -778,23 +778,29 @@ document.addEventListener("alpine:init", function () {
                     // Undoing a promotion puts the walk-up back where they
                     // came from: out of the confirmed list, into the
                     // waitlist section — which is why that section renders
-                    // even while empty.
+                    // even while empty. The avatar photo is CARRIED OVER
+                    // from the row being removed: no URL is ever read back
+                    // from the payload, so nothing response-derived can
+                    // reach an img.src.
                     var mainRow = document.getElementById("manual-reg-" + regId);
+                    var mainPhoto = this._takeRowPhoto(mainRow);
                     if (mainRow) mainRow.remove();
                     if (
                         !document.getElementById("waitlist-reg-" + regId) &&
                         this._waitlistList()
                     ) {
                         this._waitlistList().appendChild(
-                            this._buildWaitlistRow(row),
+                            this._buildWaitlistRow(row, mainPhoto),
                         );
                     }
                 } else {
                     // A promotion leaves the waitlist on every path. The
                     // row used to survive it on every page but the acting
                     // coach's, leaving an enabled promote button over an
-                    // attended row that answers 409 (#710 finding 2).
+                    // attended row that answers 409 (#710 finding 2). The
+                    // photo rides across the same way as above.
                     var wlRow = document.getElementById("waitlist-reg-" + regId);
+                    var wlPhoto = this._takeRowPhoto(wlRow);
                     if (wlRow) wlRow.remove();
                     var rowEl = document.getElementById("manual-reg-" + regId);
                     if (!rowEl) {
@@ -804,7 +810,7 @@ document.addEventListener("alpine:init", function () {
                         // finding 3).
                         var list = this._attendeeList();
                         if (!list) return;
-                        rowEl = this._buildConfirmedRow(row);
+                        rowEl = this._buildConfirmedRow(row, wlPhoto);
                         list.appendChild(rowEl);
                         var empty = document.getElementById("attendee-empty");
                         if (empty) empty.remove();
@@ -1036,8 +1042,10 @@ document.addEventListener("alpine:init", function () {
 
             // Full row for an attendee the confirmed list never contained —
             // a waitlist walk-up being promoted. Class-identical to the
-            // server-rendered twin in coach_event_checkin.html.
-            _buildConfirmedRow: function (row) {
+            // server-rendered twin in coach_event_checkin.html. The photo,
+            // when there is one, is the <img> node carried over from the
+            // waitlist row this promotion empties.
+            _buildConfirmedRow: function (row, photoImg) {
                 var el = document.createElement("div");
                 el.className = "py-3 flex items-center justify-between gap-3";
                 el.id = "manual-reg-" + row.registration_id;
@@ -1060,19 +1068,9 @@ document.addEventListener("alpine:init", function () {
                 var avatarWrap = document.createElement("div");
                 avatarWrap.className = "relative flex-shrink-0";
                 avatarWrap.setAttribute("data-checkin-avatar", "");
-                var photoUrl = this._safePhotoUrl(row.photo_url);
-                if (photoUrl) {
-                    var img = document.createElement("img");
-                    // Photo URLs are minted server-side by reverse() on a
-                    // same-origin route and narrowed to a site-relative path
-                    // by _safePhotoUrl; the response-body taint CodeQL traces
-                    // here has no attacker-controlled shape.
-                    // lgtm[js/xss]
-                    // lgtm[js/client-side-unvalidated-url-redirection]
-                    img.src = photoUrl;
-                    img.alt = "";
-                    img.className = "w-10 h-10 rounded-full object-cover";
-                    avatarWrap.appendChild(img);
+                if (photoImg) {
+                    photoImg.className = "w-10 h-10 rounded-full object-cover";
+                    avatarWrap.appendChild(photoImg);
                 } else {
                     var initial = document.createElement("div");
                     initial.className =
@@ -1117,7 +1115,7 @@ document.addEventListener("alpine:init", function () {
 
             // Waitlist twin — what an undone promotion returns to. Same
             // classes as the server-rendered rows it sits between.
-            _buildWaitlistRow: function (row) {
+            _buildWaitlistRow: function (row, photoImg) {
                 var self = this;
                 var i18n = window._checkinI18n || {};
                 var el = document.createElement("div");
@@ -1126,16 +1124,10 @@ document.addEventListener("alpine:init", function () {
 
                 var left = document.createElement("div");
                 left.className = "flex items-center gap-3 min-w-0";
-                var waitlistPhotoUrl = this._safePhotoUrl(row.photo_url);
-                if (waitlistPhotoUrl) {
-                    var img = document.createElement("img");
-                    // Same reasoning as the confirmed-row builder above.
-                    // lgtm[js/xss]
-                    // lgtm[js/client-side-unvalidated-url-redirection]
-                    img.src = waitlistPhotoUrl;
-                    img.alt = "";
-                    img.className = "w-10 h-10 rounded-full object-cover flex-shrink-0";
-                    left.appendChild(img);
+                if (photoImg) {
+                    photoImg.className =
+                        "w-10 h-10 rounded-full object-cover flex-shrink-0";
+                    left.appendChild(photoImg);
                 } else {
                     var initial = document.createElement("div");
                     initial.className =
@@ -1196,14 +1188,16 @@ document.addEventListener("alpine:init", function () {
                 return null;
             },
 
-            // The photo URL arrives inside a JSON response body, which is
-            // untrusted input no matter that our own API built it — so only a
-            // site-relative path may reach img.src. Rejects absolute,
-            // protocol-relative and scheme-bearing values outright.
-            _safePhotoUrl: function (url) {
-                if (typeof url !== "string") return null;
-                if (url.charAt(0) !== "/" || url.charAt(1) === "/") return null;
-                return url;
+            // Detach the avatar <img> from a row that is about to be
+            // removed, so the photo survives the row transition without its
+            // URL ever being read back from an API payload — the src stays
+            // whatever the server rendered, which severs the response-body
+            // taint CodeQL traces into img.src.
+            _takeRowPhoto: function (rowEl) {
+                if (!rowEl) return null;
+                var img = rowEl.querySelector("[data-checkin-avatar] img");
+                if (img && img.parentNode) img.parentNode.removeChild(img);
+                return img || null;
             },
 
             _apiUrl: function (action, regId) {

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -1063,6 +1063,12 @@ document.addEventListener("alpine:init", function () {
                 var photoUrl = this._safePhotoUrl(row.photo_url);
                 if (photoUrl) {
                     var img = document.createElement("img");
+                    // Photo URLs are minted server-side by reverse() on a
+                    // same-origin route and narrowed to a site-relative path
+                    // by _safePhotoUrl; the response-body taint CodeQL traces
+                    // here has no attacker-controlled shape.
+                    // lgtm[js/xss]
+                    // lgtm[js/client-side-unvalidated-url-redirection]
                     img.src = photoUrl;
                     img.alt = "";
                     img.className = "w-10 h-10 rounded-full object-cover";
@@ -1123,6 +1129,9 @@ document.addEventListener("alpine:init", function () {
                 var waitlistPhotoUrl = this._safePhotoUrl(row.photo_url);
                 if (waitlistPhotoUrl) {
                     var img = document.createElement("img");
+                    // Same reasoning as the confirmed-row builder above.
+                    // lgtm[js/xss]
+                    // lgtm[js/client-side-unvalidated-url-redirection]
                     img.src = waitlistPhotoUrl;
                     img.alt = "";
                     img.className = "w-10 h-10 rounded-full object-cover flex-shrink-0";

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -689,21 +689,29 @@ document.addEventListener("alpine:init", function () {
 
             handleRemoteCheckin: function (data) {
                 var regId = data.registration_id;
-                // A verification is a genuinely new event about an ID this page
-                // has already seen: the attendee's first (unverified) scan
-                // marked the ID processed, so a later rescan that verifies them
-                // would be suppressed here and this page would keep showing the
-                // amber pill and Verify button until reload. Apply it before
-                // the duplicate check, which exists to stop repeat *check-in*
-                // toasts, not state changes.
-                if (data.auto_verified) {
-                    this._markRowVerified(regId);
+                // Row state and counters run on EVERY path, before the
+                // dedupe guard: the guard exists to stop repeat check-in
+                // toasts, not state changes. That ordering failure is what
+                // made an undo broadcast from another coach read as an
+                // arrival here, incrementing attendance for a correction
+                // (#710 finding 1).
+                this._applyRowState(data.row);
+                this._refetchSummary();
+                if (data.undone) {
+                    // A correction is not an arrival: take the row out of
+                    // Recent Check-ins instead of celebrating it.
+                    this._removeRecentCheckin(regId);
+                    return;
                 }
                 if (this.processedIds[regId]) return;
                 this.processedIds[regId] = true;
-
                 this.showProfileToast(data);
-                this._updateCheckinUI(data);
+                // Only a fresh arrival enters Recent Check-ins: a re-scan
+                // (already_checked_in) and a verification (no such flag at
+                // all) must not.
+                if (data.already_checked_in === false) {
+                    this._pushRecentCheckin(data);
+                }
             },
 
             // --- Toast management ---
@@ -750,22 +758,504 @@ document.addEventListener("alpine:init", function () {
                 if (el) el.remove();
             },
 
-            // --- Shared UI update logic ---
-            _updateCheckinUI: function (data) {
-                var regId = data.registration_id;
-                // Attending now verifies the profile, so the row must stop
-                // showing the amber "Unverified" pill and its Verify button —
-                // otherwise the toast and the DB say verified while the list
-                // still invites a redundant (and now pointless) verification.
-                // Before the already_checked_in early return: a re-scan is
-                // exactly when a previously self-scanned attendee gets verified.
-                if (data.auto_verified) {
-                    this._markRowVerified(regId);
-                }
-                if (data.already_checked_in) return;
+            // --- Shared row-state applier + summary refetch (#710) ---
+            //
+            // ONE applier for every path — local fetch callback and
+            // WebSocket broadcast alike — fed by the `row` object each
+            // action's own response carries. No handler patches its own
+            // subset of the DOM any more; that is what drifted across ~20
+            // hand-maintained update sites and left the 3-actions-x-2-paths
+            // matrix with two broken cells.
+            _applyRowState: function (row) {
+                if (!row || !row.registration_id) return;
+                var regId = row.registration_id;
 
-                // Add to recent checkins list
+                if (row.status === "waitlist") {
+                    // Undoing a promotion puts the walk-up back where they
+                    // came from: out of the confirmed list, into the
+                    // waitlist section — which is why that section renders
+                    // even while empty.
+                    var mainRow = document.getElementById("manual-reg-" + regId);
+                    if (mainRow) mainRow.remove();
+                    if (
+                        !document.getElementById("waitlist-reg-" + regId) &&
+                        this._waitlistList()
+                    ) {
+                        this._waitlistList().appendChild(
+                            this._buildWaitlistRow(row),
+                        );
+                    }
+                } else {
+                    // A promotion leaves the waitlist on every path. The
+                    // row used to survive it on every page but the acting
+                    // coach's, leaving an enabled promote button over an
+                    // attended row that answers 409 (#710 finding 2).
+                    var wlRow = document.getElementById("waitlist-reg-" + regId);
+                    if (wlRow) wlRow.remove();
+                    var rowEl = document.getElementById("manual-reg-" + regId);
+                    if (!rowEl) {
+                        // The confirmed list never contained this attendee:
+                        // build the whole row, undo button included, so a
+                        // mistaken promotion is correctable at once (#710
+                        // finding 3).
+                        var list = this._attendeeList();
+                        if (!list) return;
+                        rowEl = this._buildConfirmedRow(row);
+                        list.appendChild(rowEl);
+                        var empty = document.getElementById("attendee-empty");
+                        if (empty) empty.remove();
+                    }
+                    rowEl.setAttribute("data-attendee-status", row.status);
+                    this._applyRowInterior(rowEl, row);
+                }
+                // The "not arrived" filter re-reads the status attribute,
+                // so a row checked in under it leaves the list now rather
+                // than at the next keystroke (#710 finding 4).
+                if (window._applyAttendeeFilters) window._applyAttendeeFilters();
+            },
+
+            _attendeeList: function () {
+                return document.getElementById("attendee-list");
+            },
+
+            _waitlistList: function () {
+                return document.getElementById("waitlist-list");
+            },
+
+            // Rewrite everything an action can change on an existing
+            // confirmed-list row. Static identity (name, gender, age, avatar
+            // image) is only built by _buildConfirmedRow.
+            _applyRowInterior: function (rowEl, row) {
+                var attended = row.status === "attended";
+
+                // Green overlay tick: add or remove, never toggle, so both
+                // the server-rendered and the JS-injected badge come off on
+                // undo (#710 finding 7).
+                var avatarWrap = rowEl.querySelector("[data-checkin-avatar]");
+                if (avatarWrap) {
+                    var overlay = avatarWrap.querySelector(
+                        ".checkin-overlay-badge",
+                    );
+                    if (attended && !overlay) {
+                        avatarWrap.appendChild(this._buildOverlayBadge());
+                    } else if (!attended && overlay) {
+                        overlay.remove();
+                    }
+                }
+
+                // Verification pill — all three variants carry the tag.
+                var nameLine = rowEl.querySelector("[data-name-line]");
+                var pill = nameLine && nameLine.querySelector("[data-verify-pill]");
+                if (pill && pill.parentNode) {
+                    pill.parentNode.replaceChild(this._buildVerifyPill(row), pill);
+                }
+
+                // Coach line and arrival time are dropped and re-added in
+                // order, so every path lands on the same DOM whatever the
+                // server-rendered starting point (#710 findings 7 and 9): a
+                // walk-in granted a coach by this very scan gets their line
+                // now, and an undo takes the tick AND the time back off.
+                var oldCoach = rowEl.querySelector("[data-coach-line]");
+                if (oldCoach) oldCoach.remove();
+                var oldTime = rowEl.querySelector("[data-arrival-time]");
+                if (oldTime) oldTime.remove();
+                var meta = nameLine ? nameLine.parentNode : null;
+                if (meta) {
+                    if (row.coach_name || attended) {
+                        meta.appendChild(this._buildCoachLine(row, attended));
+                    }
+                    if (attended && row.checked_in_at) {
+                        meta.appendChild(
+                            this._buildArrivalTime(row.checked_in_at),
+                        );
+                    }
+                }
+
+                var actions = rowEl.querySelector("[data-row-actions]");
+                var newActions = this._buildActions(rowEl, row);
+                if (actions) {
+                    actions.replaceWith(newActions);
+                } else {
+                    rowEl.appendChild(newActions);
+                }
+            },
+
+            _buildOverlayBadge: function () {
+                var badge = document.createElement("span");
+                badge.className =
+                    "checkin-overlay-badge absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-green-500 rounded-full flex items-center justify-center";
+                badge.innerHTML =
+                    '<svg class="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>';
+                return badge;
+            },
+
+            _buildVerifyPill: function (row) {
+                var i18n = window._checkinI18n || {};
+                var span = document.createElement("span");
+                span.setAttribute("data-verify-pill", "");
+                var icon;
+                var label;
+                if (!row.has_profile) {
+                    span.className =
+                        "inline-flex items-center gap-0.5 rounded-full bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 text-xs font-medium text-red-700 dark:text-red-400";
+                    icon =
+                        '<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10A8 8 0 112 10a8 8 0 0116 0zm-8-4a1 1 0 00-1 1v3a1 1 0 002 0V7a1 1 0 00-1-1zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/></svg>';
+                    label = i18n.noProfile || "No profile";
+                } else if (row.is_approved) {
+                    span.className =
+                        "inline-flex items-center gap-0.5 rounded-full bg-green-100 dark:bg-green-900/30 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:text-green-400";
+                    icon =
+                        '<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>';
+                    label = i18n.verified || "Verified";
+                } else {
+                    span.className =
+                        "inline-flex items-center gap-0.5 rounded-full bg-amber-100 dark:bg-amber-900/30 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400";
+                    icon =
+                        '<svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>';
+                    label = i18n.unverifiedPill || "Unverified";
+                }
+                span.innerHTML = icon + this._esc(label);
+                return span;
+            },
+
+            _buildCoachLine: function (row, attended) {
+                var i18n = window._checkinI18n || {};
+                var p = document.createElement("p");
+                p.setAttribute("data-coach-line", "");
+                if (row.coach_name) {
+                    p.className =
+                        "text-xs text-crush-purple/70 dark:text-purple-400/70 mt-0.5";
+                    p.textContent =
+                        (i18n.coach || "Coach") + ": " + row.coach_name;
+                } else {
+                    p.className = "text-xs text-amber-600 dark:text-amber-400 mt-0.5";
+                    p.textContent = i18n.noCoachYet || "No coach yet";
+                }
+                return p;
+            },
+
+            _buildArrivalTime: function (iso) {
+                var p = document.createElement("p");
+                p.className = "text-xs text-gray-400 dark:text-gray-500 mt-0.5";
+                p.setAttribute("data-arrival-time", "");
+                p.textContent = this._formatArrivalTime(iso);
+                return p;
+            },
+
+            _formatArrivalTime: function (iso) {
+                var d = new Date(iso);
+                if (isNaN(d.getTime())) return "";
+                return d.toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                });
+            },
+
+            // The action buttons for a row's current state. Built fresh and
+            // swapped in whole, so no transition path can leave a stale
+            // button behind.
+            _buildActions: function (rowEl, row) {
+                var self = this;
+                var i18n = window._checkinI18n || {};
+                var regId = row.registration_id;
+                var wrap = document.createElement("div");
+                wrap.className = "flex-shrink-0 flex items-center gap-2";
+                wrap.setAttribute("data-row-actions", "");
+                if (row.status === "attended") {
+                    var checkedSpan = document.createElement("span");
+                    checkedSpan.className =
+                        "px-3 py-1.5 text-xs font-medium text-green-600 dark:text-green-400";
+                    checkedSpan.textContent = i18n.checkedIn || "Checked In";
+                    wrap.appendChild(checkedSpan);
+                    if (row.table_number) {
+                        var tableBadge = document.createElement("span");
+                        // `manual-table-badge` is what a later state change
+                        // clears along with the seat — without it an undone
+                        // check-in left its "T3" on screen.
+                        tableBadge.className =
+                            "manual-table-badge inline-flex items-center rounded-full bg-crush-purple/10 px-2 py-0.5 text-xs font-medium text-crush-purple dark:text-purple-300";
+                        tableBadge.setAttribute("data-user-id", row.user_id);
+                        tableBadge.textContent = "T" + row.table_number;
+                        wrap.appendChild(tableBadge);
+                    }
+                    // The check-in most worth undoing is the one just made,
+                    // so the button appears with the row, not on the next
+                    // page load.
+                    var undoUrl =
+                        rowEl.getAttribute("data-undo-url") ||
+                        this._apiUrl("undo-checkin", regId);
+                    var undoBtn = this._buildUndoButton(undoUrl, regId);
+                    if (undoBtn) wrap.appendChild(undoBtn);
+                } else {
+                    if (row.has_profile && !row.is_approved) {
+                        var verifyBtn = document.createElement("button");
+                        verifyBtn.type = "button";
+                        verifyBtn.className =
+                            "manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white";
+                        verifyBtn.setAttribute(
+                            "data-verify-url",
+                            this._apiUrl("verify", regId),
+                        );
+                        verifyBtn.setAttribute("data-reg-id", regId);
+                        verifyBtn.textContent = i18n.verifyAction || "Verify";
+                        // Bound directly rather than with x-on — Alpine only
+                        // wires directives present when it walked the tree.
+                        verifyBtn.addEventListener("click", function (clickEvent) {
+                            self.markVerified(clickEvent);
+                        });
+                        wrap.appendChild(verifyBtn);
+                    }
+                    var checkinUrl = rowEl.getAttribute("data-checkin-url");
+                    if (checkinUrl) {
+                        var checkinBtn = document.createElement("button");
+                        checkinBtn.type = "button";
+                        checkinBtn.className =
+                            "manual-checkin-btn btn-crush-solid btn-sm text-white";
+                        checkinBtn.setAttribute("data-checkin-url", checkinUrl);
+                        checkinBtn.setAttribute("data-reg-id", regId);
+                        checkinBtn.textContent = i18n.checkIn || "Check In";
+                        checkinBtn.addEventListener("click", function (clickEvent) {
+                            self.manualCheckin(clickEvent);
+                        });
+                        wrap.appendChild(checkinBtn);
+                    }
+                }
+                return wrap;
+            },
+
+            // Full row for an attendee the confirmed list never contained —
+            // a waitlist walk-up being promoted. Class-identical to the
+            // server-rendered twin in coach_event_checkin.html.
+            _buildConfirmedRow: function (row) {
+                var el = document.createElement("div");
+                el.className = "py-3 flex items-center justify-between gap-3";
+                el.id = "manual-reg-" + row.registration_id;
+                el.setAttribute("data-attendee-status", row.status);
+                // Undo and verify are addressed by id — no signed token
+                // involved — so a row that was waitlist-only until now can
+                // still carry them.
+                el.setAttribute(
+                    "data-undo-url",
+                    this._apiUrl("undo-checkin", row.registration_id),
+                );
+                el.setAttribute(
+                    "data-attendee-search",
+                    this._escAttr(row.search || row.display_name || ""),
+                );
+
+                var left = document.createElement("div");
+                left.className = "flex items-center gap-3 min-w-0";
+
+                var avatarWrap = document.createElement("div");
+                avatarWrap.className = "relative flex-shrink-0";
+                avatarWrap.setAttribute("data-checkin-avatar", "");
+                if (row.photo_url) {
+                    var img = document.createElement("img");
+                    img.src = row.photo_url;
+                    img.alt = "";
+                    img.className = "w-10 h-10 rounded-full object-cover";
+                    avatarWrap.appendChild(img);
+                } else {
+                    var initial = document.createElement("div");
+                    initial.className =
+                        "w-10 h-10 rounded-full bg-crush-purple/20 flex items-center justify-center text-crush-purple font-semibold text-sm";
+                    initial.textContent = (row.display_name || "?")
+                        .charAt(0)
+                        .toUpperCase();
+                    avatarWrap.appendChild(initial);
+                }
+                left.appendChild(avatarWrap);
+
+                var meta = document.createElement("div");
+                meta.className = "min-w-0";
+                var nameLine = document.createElement("div");
+                nameLine.className =
+                    "flex flex-wrap items-center gap-x-2 gap-y-0.5";
+                nameLine.setAttribute("data-name-line", "");
+                var name = document.createElement("span");
+                name.className = "font-medium text-sm dark:text-white truncate";
+                name.textContent = row.display_name || "";
+                nameLine.appendChild(name);
+                var genderIcon = this._genderIcon(row.gender);
+                if (genderIcon) {
+                    var g = document.createElement("span");
+                    g.className = genderIcon.cls + " text-xs";
+                    if (genderIcon.title) g.title = genderIcon.title;
+                    g.textContent = genderIcon.char;
+                    nameLine.appendChild(g);
+                }
+                if (row.age_display) {
+                    var age = document.createElement("span");
+                    age.className = "text-xs text-gray-500 dark:text-gray-400";
+                    age.textContent = row.age_display;
+                    nameLine.appendChild(age);
+                }
+                nameLine.appendChild(this._buildVerifyPill(row));
+                meta.appendChild(nameLine);
+                left.appendChild(meta);
+                el.appendChild(left);
+                return el;
+            },
+
+            // Waitlist twin — what an undone promotion returns to. Same
+            // classes as the server-rendered rows it sits between.
+            _buildWaitlistRow: function (row) {
+                var self = this;
+                var i18n = window._checkinI18n || {};
+                var el = document.createElement("div");
+                el.className = "py-3 flex items-center justify-between gap-3";
+                el.id = "waitlist-reg-" + row.registration_id;
+
+                var left = document.createElement("div");
+                left.className = "flex items-center gap-3 min-w-0";
+                if (row.photo_url) {
+                    var img = document.createElement("img");
+                    img.src = row.photo_url;
+                    img.alt = "";
+                    img.className = "w-10 h-10 rounded-full object-cover flex-shrink-0";
+                    left.appendChild(img);
+                } else {
+                    var initial = document.createElement("div");
+                    initial.className =
+                        "w-10 h-10 rounded-full bg-amber-500/20 flex items-center justify-center text-amber-700 dark:text-amber-400 font-semibold text-sm flex-shrink-0";
+                    initial.textContent = (row.display_name || "?")
+                        .charAt(0)
+                        .toUpperCase();
+                    left.appendChild(initial);
+                }
+                var meta = document.createElement("div");
+                meta.className = "min-w-0";
+                var name = document.createElement("span");
+                name.className = "font-medium text-sm dark:text-white truncate block";
+                name.textContent = row.display_name || "";
+                meta.appendChild(name);
+                var sub = [];
+                var genderIcon = this._genderIcon(row.gender);
+                if (genderIcon) sub.push(genderIcon.char);
+                if (row.age_display) sub.push(row.age_display);
+                if (sub.length) {
+                    var subSpan = document.createElement("span");
+                    subSpan.className = "text-xs text-gray-500 dark:text-gray-400";
+                    subSpan.textContent = " " + sub.join(" ");
+                    meta.appendChild(subSpan);
+                }
+                left.appendChild(meta);
+                el.appendChild(left);
+
+                var promoteBtn = document.createElement("button");
+                promoteBtn.type = "button";
+                promoteBtn.className =
+                    "waitlist-promote-btn flex-shrink-0 btn-crush-solid btn-sm bg-amber-600 hover:bg-amber-700 focus:ring-amber-500 text-white";
+                promoteBtn.setAttribute(
+                    "data-promote-url",
+                    this._apiUrl("promote", row.registration_id),
+                );
+                promoteBtn.setAttribute("data-reg-id", row.registration_id);
+                promoteBtn.textContent = i18n.promoteAction || "Check in";
+                promoteBtn.addEventListener("click", function (clickEvent) {
+                    self.promoteFromWaitlist(clickEvent);
+                });
+                el.appendChild(promoteBtn);
+                return el;
+            },
+
+            _genderIcon: function (gender) {
+                if (gender === "M")
+                    return { char: "\u2642", cls: "text-blue-500", title: "Male" };
+                if (gender === "F")
+                    return { char: "\u2640", cls: "text-pink-500", title: "Female" };
+                if (gender === "NB")
+                    return {
+                        char: "\u26A4",
+                        cls: "text-purple-500",
+                        title: "Non-binary",
+                    };
+                if (gender) return { char: "\u26A7", cls: "text-gray-400", title: "" };
+                return null;
+            },
+
+            _apiUrl: function (action, regId) {
+                return (
+                    "/api/events/" + this.eventId + "/" + action + "/" + regId + "/"
+                );
+            },
+
+            // --- Summary refetch (#710) ---
+            //
+            // The counters are never bumped by hand any more: every
+            // successful door action refetches this read-only summary, so a
+            // path that forgets a tile can only be late, never wrong — and
+            // both coaches' pages converge on the server's numbers.
+            _refetchSummary: function () {
+                var self = this;
+                var url = this.$el.getAttribute("data-summary-url");
+                if (!url) return;
+                // A failed refetch keeps the current numbers: the door must
+                // not blank its counters because a phone lost signal.
+                fetch(url, { headers: { Accept: "application/json" } })
+                    .then(function (r) {
+                        return r.json();
+                    })
+                    .then(function (summary) {
+                        if (summary && summary.success) {
+                            self._applySummary(summary);
+                        }
+                    })
+                    .catch(function () {});
+            },
+
+            _applySummary: function (s) {
+                this._setCount("attended-count", s.attended_count);
+                this._setCount("outstanding-count", s.outstanding_count);
+                this._setCount("expected-count", s.expected_count);
+                // Numerator AND denominator, all three buckets — the
+                // endpoint always sends them, so a promotion can no longer
+                // render a tile as "6 / 5" (#710 finding 5).
+                var buckets = [
+                    ["f", "F"],
+                    ["m", "M"],
+                    ["other", "other"],
+                ];
+                for (var i = 0; i < buckets.length; i++) {
+                    var elKey = buckets[i][0];
+                    var dataKey = buckets[i][1];
+                    this._setCount(
+                        "gender-" + elKey + "-count",
+                        (s.gender_checked_in || {})[dataKey],
+                    );
+                    this._setCount(
+                        "gender-" + elKey + "-expected",
+                        (s.gender_expected || {})[dataKey],
+                    );
+                }
+                // Waitlist badge and section visibility follow the count
+                // (#710 finding 6) — including the empty-rendered section an
+                // undone promotion has to be able to come back to.
+                this._setCount("waitlist-count-badge", s.waitlist_count);
+                var card = document.getElementById("waitlist-card");
+                if (card) {
+                    card.style.display = s.waitlist_count > 0 ? "" : "none";
+                }
+                var fill = s.table_fill || [];
+                for (var t = 0; t < fill.length; t++) {
+                    this._setCount(
+                        "table-fill-" + fill[t].number,
+                        fill[t].count,
+                    );
+                }
+            },
+
+            _setCount: function (id, value) {
+                var el = document.getElementById(id);
+                if (el && typeof value === "number") el.textContent = value;
+            },
+
+            // --- Recent check-ins ---
+            _pushRecentCheckin: function (data) {
                 this.checkins.unshift({
+                    // regId is what lets an undo take its entry back out
+                    // (#710 finding 8).
+                    regId: data.registration_id,
                     name: data.attendee_name,
                     table: data.table_number || 0,
                     hasTable: !!data.table_number,
@@ -776,120 +1266,22 @@ document.addEventListener("alpine:init", function () {
                     }),
                 });
                 this._renderCheckins();
-
-                // Update attended counter
-                var counter = document.getElementById("attended-count");
-                if (counter) {
-                    counter.textContent = parseInt(counter.textContent) + 1;
-                }
-                // A scan moves someone from "expected but not here" to "here",
-                // so outstanding drops. A PROMOTION does not: a waitlisted row
-                // was never in the expected set (views_coach counts only
-                // confirmed/attended), so on reload both expected and attended
-                // grow by one and outstanding is unchanged. Decrementing it
-                // here would understate exactly the number the coach is using
-                // to decide whether to keep promoting.
-                this._bumpCounter(
-                    data.promoted ? "expected-count" : "outstanding-count",
-                    data.promoted ? 1 : -1,
-                );
-                this._bumpGenderSplit(data.profile && data.profile.gender, 1);
-
-                // Update table fill display
-                if (data.table_number) {
-                    var fillEl = document.getElementById(
-                        "table-fill-" + data.table_number,
-                    );
-                    if (fillEl) {
-                        fillEl.textContent = parseInt(fillEl.textContent) + 1;
-                    }
-                }
-
-                // Update manual check-in row
-                var row = document.getElementById("manual-reg-" + regId);
-                if (row) {
-                    // Keeps the "not arrived" filter honest for rows checked
-                    // in after the page loaded.
-                    row.setAttribute("data-attendee-status", "attended");
-                    // Inject green overlay badge on the avatar (new layout)
-                    var avatarWrap = row.querySelector("[data-checkin-avatar]");
-                    if (
-                        avatarWrap &&
-                        !avatarWrap.querySelector(".checkin-overlay-badge")
-                    ) {
-                        var badge = document.createElement("span");
-                        badge.className =
-                            "checkin-overlay-badge absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-green-500 rounded-full flex items-center justify-center";
-                        badge.innerHTML =
-                            '<svg class="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>';
-                        avatarWrap.appendChild(badge);
-                    }
-                    // Legacy fallback: plain circle indicator (pre-avatar layout)
-                    var circle = row.querySelector(
-                        ".border-gray-300, .border-gray-600",
-                    );
-                    if (circle) {
-                        circle.outerHTML =
-                            '<svg class="w-5 h-5 text-green-500 shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>';
-                    }
-                    var btn = row.querySelector(".manual-checkin-btn");
-                    if (btn) {
-                        var i18n = window._checkinI18n || {};
-                        var wrap = document.createElement("div");
-                        wrap.className = "flex items-center gap-2";
-
-                        var checkedSpan = document.createElement("span");
-                        checkedSpan.className =
-                            "px-3 py-1.5 text-xs font-medium text-green-600 dark:text-green-400";
-                        checkedSpan.textContent = i18n.checkedIn || "Checked In";
-                        wrap.appendChild(checkedSpan);
-
-                        if (data.table_number) {
-                            var tableBadge = document.createElement("span");
-                            // `manual-table-badge` is what _updateUndoUI
-                            // removes. Without it, undoing a check-in made in
-                            // this same session cleared the seat server-side
-                            // but left its "T3" on screen — the server-rendered
-                            // twin in coach_event_checkin.html carries the
-                            // class, so only the freshest badge got stranded.
-                            tableBadge.className =
-                                "manual-table-badge inline-flex items-center rounded-full bg-crush-purple/10 px-2 py-0.5 text-xs font-medium text-crush-purple dark:text-purple-300";
-                            tableBadge.textContent = "T" + data.table_number;
-                            wrap.appendChild(tableBadge);
-                        }
-
-                        // The check-in most worth undoing is the one just
-                        // made, so the button has to appear now — not only on
-                        // the next page load, which is what a coach at the
-                        // door is least able to afford.
-                        var undoBtn = this._buildUndoButton(row, regId);
-                        if (undoBtn) wrap.appendChild(undoBtn);
-
-                        btn.replaceWith(wrap);
-                    }
-                }
             },
 
-            _bumpCounter: function (elementId, delta) {
-                var el = document.getElementById(elementId);
-                if (!el) return;
-                var current = parseInt(el.textContent, 10);
-                if (isNaN(current)) return;
-                el.textContent = Math.max(0, current + delta);
+            _removeRecentCheckin: function (regId) {
+                if (!regId) return;
+                for (var i = 0; i < this.checkins.length; i++) {
+                    if (this.checkins[i].regId === regId) {
+                        this.checkins.splice(i, 1);
+                        break;
+                    }
+                }
+                this._renderCheckins();
             },
 
-            _bumpGenderSplit: function (gender, delta) {
-                // The "In the room" tile is what the waitlist decision leans
-                // on, and a door shift runs for hours without a reload — a
-                // render-time-only count would be wrong from the first scan.
-                var key = gender === "F" || gender === "M" ? gender : "other";
-                this._bumpCounter("gender-" + key.toLowerCase() + "-count", delta);
-            },
-
-            _buildUndoButton: function (row, regId) {
+            _buildUndoButton: function (undoUrl, regId) {
                 var self = this;
                 var i18n = window._checkinI18n || {};
-                var undoUrl = row.getAttribute("data-undo-url");
                 if (!undoUrl) return null;
                 var undoBtn = document.createElement("button");
                 undoBtn.type = "button";
@@ -1143,7 +1535,13 @@ document.addEventListener("alpine:init", function () {
                                 self.processedIds[data.registration_id] = true;
                             }
                             self.showProfileToast(data);
-                            self._updateCheckinUI(data);
+                            self._applyRowState(data.row);
+                            self._refetchSummary();
+                            // Only a fresh arrival enters Recent Check-ins —
+                            // a re-scan of an already-attended badge must not.
+                            if (data.already_checked_in === false) {
+                                self._pushRecentCheckin(data);
+                            }
                         } else {
                             self.success = false;
                             self.errorState = true;
@@ -1194,7 +1592,11 @@ document.addEventListener("alpine:init", function () {
                                 self.processedIds[data.registration_id] = true;
                             }
                             self.showProfileToast(data);
-                            self._updateCheckinUI(data);
+                            self._applyRowState(data.row);
+                            self._refetchSummary();
+                            if (data.already_checked_in === false) {
+                                self._pushRecentCheckin(data);
+                            }
                         } else {
                             btn.disabled = false;
                             var i18n = window._checkinI18n || {};
@@ -1246,7 +1648,17 @@ document.addEventListener("alpine:init", function () {
                             // again — otherwise the dedupe set silently
                             // swallows the corrected check-in.
                             delete self.processedIds[regId];
-                            self._updateUndoUI(data, regId);
+                            // One applier, fed by the row the undo response
+                            // carries: it moves the row to whatever
+                            // `restored_status` says (confirmed list or back
+                            // onto the waitlist), clears the tick, the time
+                            // and the table badge, and rebuilds the Check In
+                            // path.
+                            self._applyRowState(data.row);
+                            self._removeRecentCheckin(
+                                data.registration_id || regId,
+                            );
+                            self._refetchSummary();
                         } else {
                             btn.disabled = false;
                             btn.textContent = i18n.undoAction || "Undo";
@@ -1258,115 +1670,6 @@ document.addEventListener("alpine:init", function () {
                         btn.textContent = i18n.undoAction || "Undo";
                         alert(i18n.networkError || "Network error");
                     });
-            },
-
-            _updateUndoUI: function (data, regId) {
-                var self = this;
-                var i18n = window._checkinI18n || {};
-                var id = data.registration_id || regId;
-                var row = document.getElementById("manual-reg-" + id);
-                // An undo returns the row to whatever it actually held before
-                // the check-in, which the server now records rather than
-                // assumes: undoing a mistaken promotion puts the walk-up back
-                // on the waitlist instead of leaving them a confirmed seat.
-                var toWaitlist = data.restored_status === "waitlist";
-
-                this._bumpCounter("attended-count", -1);
-                // Exact inverse of what the check-in bumped. A promotion grew
-                // the expected set (views_coach counts confirmed + attended,
-                // and a waitlisted row is in neither), so undoing it shrinks
-                // that set again — outstanding was never touched either way.
-                this._bumpCounter(
-                    toWaitlist ? "expected-count" : "outstanding-count",
-                    toWaitlist ? -1 : 1,
-                );
-                this._bumpGenderSplit(data.gender, -1);
-
-                // Give the chair back on the table-fill grid. The server sends
-                // this under its own key rather than `table_number`: an undo
-                // broadcast still reaches other coaches through
-                // _updateCheckinUI, which would read the arrival key and count
-                // the seat *up* (#710, finding 1). Which is also why this only
-                // corrects the acting coach's page — the remote one is put
-                // right by the redesign, not here.
-                // A list, because the seat model's uniqueness is only
-                // (table, user) — one person can hold chairs at two tables of
-                // the same quiz, and the grid counts both.
-                var releasedTables = data.released_table_numbers || [];
-                for (var ti = 0; ti < releasedTables.length; ti++) {
-                    var fillEl = document.getElementById(
-                        "table-fill-" + releasedTables[ti],
-                    );
-                    if (fillEl) {
-                        var fill = parseInt(fillEl.textContent, 10);
-                        if (!isNaN(fill)) {
-                            fillEl.textContent = Math.max(0, fill - 1);
-                        }
-                    }
-                }
-                if (!row) return;
-
-                if (toWaitlist) {
-                    // The confirmed list only ever renders confirmed and
-                    // attended rows, so a waitlisted one does not belong in
-                    // it — and rebuilding its Check In button would post to
-                    // event_checkin_api, which refuses anything but
-                    // `confirmed`. The waitlist section below is rebuilt on
-                    // the next page load (see #710).
-                    row.remove();
-                    return;
-                }
-
-                row.setAttribute("data-attendee-status", "confirmed");
-                var badge = row.querySelector(".checkin-overlay-badge");
-                if (badge) badge.remove();
-
-                // The coach line only ever showed a coach this attendance may
-                // have granted, so reflect the server's answer rather than
-                // guessing.
-                if (data.coach_cleared) {
-                    var coachLine = row.querySelector("[data-coach-line]");
-                    if (coachLine) coachLine.remove();
-                }
-
-                // Rebuild the Check In button the check-in flow replaced.
-                var actions = row.querySelector("[data-row-actions]");
-                if (actions) {
-                    var checkinUrl = row.getAttribute("data-checkin-url");
-                    Array.prototype.forEach.call(
-                        actions.querySelectorAll(
-                            ".manual-undo-btn, .manual-table-badge",
-                        ),
-                        function (el) {
-                            el.remove();
-                        },
-                    );
-                    Array.prototype.forEach.call(
-                        actions.querySelectorAll("span"),
-                        function (el) {
-                            if (el.textContent === (i18n.checkedIn || "Checked In")) {
-                                el.remove();
-                            }
-                        },
-                    );
-                    var newBtn = document.createElement("button");
-                    newBtn.type = "button";
-                    // Keep in sync with the server-rendered twin in
-                    // coach_event_checkin.html (see _buildUndoButton).
-                    newBtn.className =
-                        "manual-checkin-btn btn-crush-solid btn-sm text-white";
-                    newBtn.setAttribute("data-checkin-url", checkinUrl || "");
-                    newBtn.setAttribute("data-reg-id", id);
-                    newBtn.textContent = i18n.checkIn || "Check In";
-                    // Bound directly, not via x-on: Alpine only wires
-                    // directives it saw when it walked the tree, so a button
-                    // created here would render enabled and do nothing —
-                    // exactly the trap the undo exists to get out of.
-                    newBtn.addEventListener("click", function (clickEvent) {
-                        self.manualCheckin(clickEvent);
-                    });
-                    actions.appendChild(newBtn);
-                }
             },
 
             promoteFromWaitlist: function (evt) {
@@ -1397,13 +1700,14 @@ document.addEventListener("alpine:init", function () {
                                 self.processedIds[data.registration_id] = true;
                             }
                             self.showProfileToast(data);
-                            self._updateCheckinUI(data);
-                            // The row lives in the waitlist section, which the
-                            // confirmed-list update above does not know about.
-                            var wlRow = document.getElementById(
-                                "waitlist-reg-" + (data.registration_id || regId),
-                            );
-                            if (wlRow) wlRow.remove();
+                            // The applier takes the waitlist row away AND
+                            // builds the attended row in the confirmed list —
+                            // undo button included, so a mistaken promotion
+                            // is correctable at once instead of after a
+                            // reload (#710 finding 3).
+                            self._applyRowState(data.row);
+                            self._refetchSummary();
+                            self._pushRecentCheckin(data);
                         } else {
                             btn.disabled = false;
                             btn.textContent = i18n.checkIn || "Check In";
@@ -1437,7 +1741,10 @@ document.addEventListener("alpine:init", function () {
                     })
                     .then(function (data) {
                         if (data.success) {
-                            self._markRowVerified(regId);
+                            // Same applier as every other action: the row's
+                            // pill swaps to verified and the Verify button
+                            // leaves with the rebuilt actions.
+                            self._applyRowState(data.row);
                         } else {
                             btn.disabled = false;
                             btn.textContent = i18n.verifyAction || "Verify";
@@ -1453,22 +1760,6 @@ document.addEventListener("alpine:init", function () {
                         btn.textContent = i18n.verifyAction || "Verify";
                         alert(i18n.networkError || "Network error");
                     });
-            },
-
-            _markRowVerified: function (regId) {
-                var i18n = window._checkinI18n || {};
-                var row = document.getElementById("manual-reg-" + regId);
-                if (!row) return;
-                // Swap the amber "Unverified" pill for a green "Verified" pill.
-                var pill = row.querySelector("[data-verify-pill]");
-                if (pill) {
-                    pill.className =
-                        "inline-flex items-center gap-0.5 rounded-full bg-green-100 dark:bg-green-900/30 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:text-green-400";
-                    pill.textContent = i18n.verified || "Verified";
-                }
-                // Remove the verify button.
-                var btn = row.querySelector(".manual-verify-btn");
-                if (btn) btn.remove();
             },
         };
     });

--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -5,7 +5,12 @@
 {% block meta_robots %}noindex, nofollow{% endblock %}
 
 {% block content %}
-<div x-data="coachCheckin" data-event-id="{{ event.id }}">
+{% comment %}
+    data-summary-url is what every door action refetches after it succeeds,
+    local or broadcast (#710): the counters are re-rendered wholesale from the
+    response instead of being bumped by whichever handler knew about them.
+{% endcomment %}
+<div x-data="coachCheckin" data-event-id="{{ event.id }}" data-summary-url="/api/events/{{ event.id }}/checkin-summary/">
 
 {# Profile Toast Cards (fixed top-right) #}
 <div class="fixed top-4 right-4 z-50 space-y-3 pointer-events-none" style="max-width: 320px;">
@@ -55,6 +60,10 @@
 {% comment %}
     Live gender split of who is in the room. This is what the waitlist
     decision at the door depends on, and it was previously invisible here.
+    Numerator and denominator are both tagged, and all three buckets render
+    unconditionally: the summary endpoint always sends all three, and a
+    handler-side bump of a numerator whose denominator was render-time-only
+    is what could show "6 / 5" (#710 finding 5).
 {% endcomment %}
 <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 px-4 py-3 mb-6 flex items-center justify-between gap-4 text-sm">
     <span class="text-gray-500 dark:text-gray-400">{% trans "In the room" %}</span>
@@ -62,20 +71,18 @@
         <span class="inline-flex items-baseline gap-1">
             <span class="text-pink-500">&#9792;</span>
             <span class="font-semibold dark:text-white" id="gender-f-count">{{ gender_checked_in.F }}</span>
-            <span class="text-xs text-gray-400">/ {{ gender_expected.F }}</span>
+            <span class="text-xs text-gray-400">/ <span id="gender-f-expected">{{ gender_expected.F }}</span></span>
         </span>
         <span class="inline-flex items-baseline gap-1">
             <span class="text-blue-500">&#9794;</span>
             <span class="font-semibold dark:text-white" id="gender-m-count">{{ gender_checked_in.M }}</span>
-            <span class="text-xs text-gray-400">/ {{ gender_expected.M }}</span>
+            <span class="text-xs text-gray-400">/ <span id="gender-m-expected">{{ gender_expected.M }}</span></span>
         </span>
-        {% if gender_expected.other %}
         <span class="inline-flex items-baseline gap-1">
             <span class="text-purple-500">&#9895;</span>
             <span class="font-semibold dark:text-white" id="gender-other-count">{{ gender_checked_in.other }}</span>
-            <span class="text-xs text-gray-400">/ {{ gender_expected.other }}</span>
+            <span class="text-xs text-gray-400">/ <span id="gender-other-expected">{{ gender_expected.other }}</span></span>
         </span>
-        {% endif %}
     </div>
 </div>
 
@@ -176,7 +183,8 @@
     </div>
     {% endif %}
 
-    <div class="divide-y divide-gray-100 dark:divide-gray-700">
+    {# Tagged because the row-state applier inserts promoted attendees here — rows that were waitlist-only until their promotion #}
+    <div class="divide-y divide-gray-100 dark:divide-gray-700" id="attendee-list">
         {% for reg in registrations %}
         {% comment %}
             Filter haystack: the display name shown in the row plus the legal
@@ -208,9 +216,9 @@
                         </div>
                         {% endwith %}
                     {% endif %}
-                    {# Small check-in badge overlay #}
+                    {# Small check-in badge overlay. Carries checkin-overlay-badge like the JS-injected twin, so the shared applier can remove either with one selector (#710 finding 7) #}
                     {% if reg.status == 'attended' %}
-                    <span class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-green-500 rounded-full flex items-center justify-center">
+                    <span class="checkin-overlay-badge absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-green-500 rounded-full flex items-center justify-center">
                         <svg class="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 20 20">
                             <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
                         </svg>
@@ -220,7 +228,8 @@
 
                 {# Name + meta #}
                 <div class="min-w-0">
-                    <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                    {# data-name-line anchors the row-state applier's pill swap (#710) #}
+                    <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5" data-name-line>
                         <span class="font-medium text-sm dark:text-white truncate">
                             {% if reg.user.crushprofile %}{{ reg.user.crushprofile.display_name }}{% else %}{{ reg.user.first_name|default:reg.user.username }}{% endif %}
                         </span>
@@ -237,9 +246,9 @@
                             {% if reg.user.crushprofile.age_display %}
                             <span class="text-xs text-gray-500 dark:text-gray-400">{{ reg.user.crushprofile.age_display }}</span>
                             {% endif %}
-                            {# Verification badge #}
+                            {# Verification badge. All three variants carry data-verify-pill so the applier can swap whichever is rendered #}
                             {% if reg.user.crushprofile.is_approved %}
-                            <span class="inline-flex items-center gap-0.5 rounded-full bg-green-100 dark:bg-green-900/30 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:text-green-400">
+                            <span data-verify-pill class="inline-flex items-center gap-0.5 rounded-full bg-green-100 dark:bg-green-900/30 px-1.5 py-0.5 text-xs font-medium text-green-700 dark:text-green-400">
                                 <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
                                 {% trans "Verified" %}
                             </span>
@@ -260,7 +269,7 @@
                             nothing to verify, and the in-person Verify button
                             below is correctly absent for the same reason.
                             {% endcomment %}
-                            <span class="inline-flex items-center gap-0.5 rounded-full bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 text-xs font-medium text-red-700 dark:text-red-400">
+                            <span data-verify-pill class="inline-flex items-center gap-0.5 rounded-full bg-red-100 dark:bg-red-900/30 px-1.5 py-0.5 text-xs font-medium text-red-700 dark:text-red-400">
                                 <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10A8 8 0 112 10a8 8 0 0116 0zm-8-4a1 1 0 00-1 1v3a1 1 0 002 0V7a1 1 0 00-1-1zm0 8a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/></svg>
                                 {% trans "No profile" %}
                             </span>
@@ -282,9 +291,9 @@
                         {% trans "No coach yet" %}
                     </p>
                     {% endif %}
-                    {# Check-in time #}
+                    {# Check-in time. Tagged so the row-state applier can rewrite or drop it when an undo un-attends the row #}
                     {% if reg.checked_in_at %}
-                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{{ reg.checked_in_at|date:"g:i A" }}</p>
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5" data-arrival-time>{{ reg.checked_in_at|date:"g:i A" }}</p>
                     {% endif %}
                 </div>
             </div>
@@ -369,29 +378,35 @@
             </div>
         </div>
         {% empty %}
-        <p class="text-sm text-gray-500 dark:text-gray-400 py-4">{% trans "No confirmed registrations for this event." %}</p>
+        {# id'd so the applier can drop it the moment a promoted row makes the list non-empty #}
+        <p class="text-sm text-gray-500 dark:text-gray-400 py-4" id="attendee-empty">{% trans "No confirmed registrations for this event." %}</p>
         {% endfor %}
     </div>
 </div>
 
-{% if waitlisted %}
 {% comment %}
     Waitlisted walk-ups. Until now the scanner never received these rows, so
     the single most common door move on a night with no-shows — someone from
     the waitlist turns up — meant leaving the scanner for the event management
     page and coming back. Collapsed by default so it never competes with the
     confirmed list.
+
+    Rendered unconditionally and hidden while empty (the summary refetch
+    toggles it): undoing a mistaken promotion must be able to put a row BACK
+    here, which it cannot if the section only existed server-side (#710
+    findings 2 and 6).
 {% endcomment %}
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5 mt-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5 mt-6" id="waitlist-card"{% if not waitlisted %} style="display: none;"{% endif %}>
     <details>
         <summary class="cursor-pointer font-semibold text-lg dark:text-white marker:text-gray-400">
             {% trans "Waitlist" %}
-            <span class="ml-1 inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">{{ waitlist_count }}</span>
+            {# id'd so the summary refetch keeps this honest as rows leave and return #}
+            <span class="ml-1 inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400" id="waitlist-count-badge">{{ waitlist_count }}</span>
         </summary>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-3 mb-4">
             {% trans "Checking someone in from here takes their seat immediately. Capacity and gender limits are not re-checked — the counts above are the guide." %}
         </p>
-        <div class="divide-y divide-gray-100 dark:divide-gray-700">
+        <div class="divide-y divide-gray-100 dark:divide-gray-700" id="waitlist-list">
             {% for reg in waitlisted %}
             <div class="py-3 flex items-center justify-between gap-3" id="waitlist-reg-{{ reg.id }}">
                 <div class="flex items-center gap-3 min-w-0">
@@ -432,7 +447,6 @@
         </div>
     </details>
 </div>
-{% endif %}
 
 </div>{# end x-data="coachCheckin" #}
 
@@ -456,8 +470,12 @@ window._checkinI18n = {
     checkinFailed: '{% filter escapejs %}{% trans "Check-in failed" %}{% endfilter %}',
     networkError: '{% filter escapejs %}{% trans "Network error" %}{% endfilter %}',
     verified: '{% filter escapejs %}{% trans "Verified" %}{% endfilter %}',
+    unverifiedPill: '{% filter escapejs %}{% trans "Unverified" %}{% endfilter %}',
+    noProfile: '{% filter escapejs %}{% trans "No profile" %}{% endfilter %}',
+    promoteAction: '{% filter escapejs %}{% trans "Check in" %}{% endfilter %}',
     unverified: '{% filter escapejs %}{% trans "Unverified Profile" %}{% endfilter %}',
     coach: '{% filter escapejs %}{% trans "Coach" %}{% endfilter %}',
+    noCoachYet: '{% filter escapejs %}{% trans "No coach yet" %}{% endfilter %}',
     verifyAction: '{% filter escapejs %}{% trans "Verify" %}{% endfilter %}',
     verifyFailed: '{% filter escapejs %}{% trans "Verification failed" %}{% endfilter %}',
     torchOn: '{% filter escapejs %}{% trans "Flash On" %}{% endfilter %}',
@@ -492,6 +510,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Client-side attendee filter — hide/show the server-rendered rows.
     // Name/email search and the "not arrived" toggle compose: both must pass.
+    // Exposed as window._applyAttendeeFilters so the row-state applier can
+    // reapply it after any status change: a row checked in while "only who
+    // has not arrived" is on must leave the list immediately, not at the
+    // next keystroke (#710 finding 4).
+    window._applyAttendeeFilters = function () {};
     var searchInput = document.getElementById('attendee-search');
     if (searchInput) {
         var attendeeRows = document.querySelectorAll('[data-attendee-search]');
@@ -520,6 +543,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (outstandingOnly) {
             outstandingOnly.addEventListener('change', applyFilters);
         }
+        window._applyAttendeeFilters = applyFilters;
     }
 });
 </script>

--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -517,7 +517,6 @@ document.addEventListener('DOMContentLoaded', function() {
     window._applyAttendeeFilters = function () {};
     var searchInput = document.getElementById('attendee-search');
     if (searchInput) {
-        var attendeeRows = document.querySelectorAll('[data-attendee-search]');
         var searchEmpty = document.getElementById('attendee-search-empty');
         var outstandingOnly = document.getElementById('outstanding-only');
 
@@ -525,7 +524,13 @@ document.addEventListener('DOMContentLoaded', function() {
             var query = searchInput.value.trim().toLowerCase();
             var onlyMissing = outstandingOnly && outstandingOnly.checked;
             var visibleCount = 0;
-            attendeeRows.forEach(function(row) {
+            var rowCount = 0;
+            // The rows are RE-QUERIED each pass, not captured at page load:
+            // the row-state applier inserts promoted attendees later, and a
+            // static NodeList would never visit them — their search haystack
+            // and status would be invisible to an active filter.
+            document.querySelectorAll('[data-attendee-search]').forEach(function(row) {
+                rowCount++;
                 var haystack = (row.getAttribute('data-attendee-search') || '').toLowerCase();
                 // Read the attribute each pass, not a cached value: undo and
                 // check-in both rewrite it while the filter is on.
@@ -535,7 +540,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (matches) visibleCount++;
             });
             if (searchEmpty) {
-                searchEmpty.style.display = visibleCount === 0 && attendeeRows.length > 0 ? '' : 'none';
+                searchEmpty.style.display = visibleCount === 0 && rowCount > 0 ? '' : 'none';
             }
         };
 

--- a/crush_lu/tests/test_checkin_door_actions.py
+++ b/crush_lu/tests/test_checkin_door_actions.py
@@ -1279,8 +1279,11 @@ class TestSeatLockOrder:
         src = inspect.getsource(inspect.unwrap(fn))
         return [
             m.group(1)
-            for m in re.finditer(r"(QuizEvent|QuizTable)\.objects[\s\S]{0,120}?"
-                                 r"select_for_update\(\)", src)
+            for m in re.finditer(
+                r"(QuizEvent|QuizTable)\.objects[\s\S]{0,120}?"
+                r"select_for_update\(\)",
+                src,
+            )
         ]
 
     def test_the_release_takes_the_quiz_row_before_the_tables(self):
@@ -1356,9 +1359,7 @@ class TestSeatReleaseEdges:
         _scan(client, event, registration)
         # A second chair, as only the admin can create.
         spare = quiz.tables.exclude(
-            pk=QuizTableMembership.objects.get(
-                table__quiz=quiz, user=attendee
-            ).table_id
+            pk=QuizTableMembership.objects.get(table__quiz=quiz, user=attendee).table_id
         ).first()
         QuizTableMembership.objects.create(table=spare, user=attendee)
 
@@ -1434,3 +1435,301 @@ class TestSeatReleaseEdges:
             _broadcast_quiz_leaderboard(event)
 
         assert sent == [(f"quiz_{quiz.id}", "quiz.leaderboard")]
+
+
+def _summary_url(event):
+    event_id = getattr(event, "pk", event)
+    return reverse("event_checkin_summary", kwargs={"event_id": event_id})
+
+
+class TestCheckinSummary:
+    """`event_checkin_summary` — the read-only counters the door page refetches
+    after every door action, local or broadcast (#710).
+
+    The page used to bump these tiles by hand from whichever handler knew
+    about them; the endpoint makes the server the single source, so a path
+    that forgets a tile can only be late, never wrong."""
+
+    def test_anonymous_requests_are_sent_to_login(self, client):
+        response = client.get(_summary_url(_make_event()))
+        assert response.status_code == 302
+        assert "login" in response["Location"]
+
+    def test_non_coaches_do_not_get_counters(self, client):
+        plain = _make_attendee("plain@example.com")
+        client.force_login(plain)
+        response = client.get(_summary_url(_make_event()))
+        assert response.status_code == 302
+        assert response["Location"] == reverse("crush_lu:dashboard")
+
+    def test_unknown_event_is_a_404(self, client):
+        coach = _make_coach()
+        client.force_login(coach.user)
+        assert client.get(_summary_url(999999)).status_code == 404
+
+    def test_counts_split_arrived_outstanding_and_waitlist(self, client):
+        coach = _make_coach()
+        event = _make_event()
+        EventRegistration.objects.create(
+            event=event,
+            user=_make_attendee("here@example.com"),
+            status="attended",
+            checked_in_at=timezone.now(),
+        )
+        EventRegistration.objects.create(
+            event=event,
+            user=_make_attendee("missing@example.com"),
+            status="confirmed",
+        )
+        EventRegistration.objects.create(
+            event=event, user=_make_attendee("wait@example.com"), status="waitlist"
+        )
+        client.force_login(coach.user)
+
+        summary = client.get(_summary_url(event)).json()
+
+        assert summary["success"] is True
+        assert summary["attended_count"] == 1
+        assert summary["expected_count"] == 2
+        assert summary["outstanding_count"] == 1
+        assert summary["waitlist_count"] == 1
+
+    def test_cancelled_rows_count_nowhere_and_pending_seats_count_as_expected(
+        self, client
+    ):
+        """Mirrors the page's arithmetic exactly: a Pending Payment seat is
+        scannable at the door, so it is expected; a cancelled row is nothing
+        the door cares about."""
+        coach = _make_coach()
+        event = _make_event()
+        EventRegistration.objects.create(
+            event=event, user=_make_attendee("unpaid@example.com"), status="pending"
+        )
+        EventRegistration.objects.create(
+            event=event, user=_make_attendee("gone@example.com"), status="cancelled"
+        )
+        client.force_login(coach.user)
+
+        summary = client.get(_summary_url(event)).json()
+
+        assert summary["expected_count"] == 1
+        assert summary["outstanding_count"] == 1
+        assert summary["attended_count"] == 0
+        assert summary["waitlist_count"] == 0
+
+    def test_all_three_gender_buckets_are_always_present(self, client):
+        """The client writes numerators AND denominators for all three tiles,
+        so the endpoint may never omit a bucket — the render-time
+        `{% if gender_expected.other %}` guard is what let a promotion show
+        `6 / 5` (#710 finding 5)."""
+        coach = _make_coach()
+        event = _make_event()
+        EventRegistration.objects.create(
+            event=event,
+            user=_make_attendee("she@example.com"),
+            status="attended",
+            checked_in_at=timezone.now(),
+        )
+        client.force_login(coach.user)
+
+        summary = client.get(_summary_url(event)).json()
+
+        assert summary["gender_checked_in"] == {"F": 1, "M": 0, "other": 0}
+        assert summary["gender_expected"] == {"F": 1, "M": 0, "other": 0}
+
+    def test_the_gender_split_counts_only_seat_holders_who_arrived(self, client):
+        coach = _make_coach()
+        event = _make_event()
+        here = _make_attendee("she@example.com")
+        waiting = _make_attendee("waiting@example.com")
+        waiting.crushprofile.gender = "M"
+        waiting.crushprofile.save(update_fields=["gender"])
+        EventRegistration.objects.create(
+            event=event, user=here, status="attended", checked_in_at=timezone.now()
+        )
+        EventRegistration.objects.create(event=event, user=waiting, status="waitlist")
+        client.force_login(coach.user)
+
+        summary = client.get(_summary_url(event)).json()
+
+        assert summary["gender_checked_in"]["F"] == 1
+        # A waitlisted walk-up is not in the room yet.
+        assert summary["gender_expected"]["M"] == 0
+
+    def test_quiz_nights_carry_the_table_fill_grid(self, client):
+        from crush_lu.models.quiz import QuizEvent, QuizTableMembership
+
+        coach = _make_coach()
+        event = _make_event()
+        event.event_type = "quiz_night"
+        event.save(update_fields=["event_type"])
+        quiz = QuizEvent.objects.create(
+            event=event, status="draft", created_by=coach.user, num_tables=2
+        )
+        quiz.ensure_tables()
+        attendee = _make_attendee()
+        EventRegistration.objects.create(
+            event=event, user=attendee, status="attended", checked_in_at=timezone.now()
+        )
+        QuizTableMembership.objects.create(
+            table=quiz.tables.get(table_number=2), user=attendee
+        )
+        client.force_login(coach.user)
+
+        summary = client.get(_summary_url(event)).json()
+
+        assert summary["table_fill"] == [
+            {"number": 1, "count": 0},
+            {"number": 2, "count": 1},
+        ]
+
+    def test_ordinary_events_send_no_table_fill(self, client):
+        coach = _make_coach()
+        event = _make_event()
+        EventRegistration.objects.create(
+            event=event, user=_make_attendee(), status="confirmed"
+        )
+        client.force_login(coach.user)
+
+        summary = client.get(_summary_url(event)).json()
+
+        assert summary["table_fill"] == []
+
+    def test_post_is_refused(self, client):
+        coach = _make_coach()
+        client.force_login(coach.user)
+        response = client.post(_summary_url(_make_event()))
+        assert response.status_code == 405
+
+
+class TestRowStatePayload:
+    """Every door action now carries `row` — the input to the page's single
+    row-state applier, on the local response AND the broadcast of it (#710).
+    No handler may patch its own subset of the DOM any more."""
+
+    def test_a_scan_row_reports_the_coach_this_scan_granted(self, client):
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="confirmed"
+        )
+        client.force_login(coach.user)
+
+        row = _scan(client, event, registration).json()["row"]
+
+        assert row["registration_id"] == registration.pk
+        assert row["status"] == "attended"
+        assert row["checked_in_at"] is not None
+        # The grant happens in a signal during the save; the row must report
+        # it, not the pre-scan cache — this is the line finding 9 fixed.
+        assert row["coach_name"] == "Cam"
+        assert row["has_profile"] is True
+
+    def test_a_rescan_row_still_travels(self, client):
+        """The already-attended branch is the one a remote coach's page most
+        often sees (a re-scan that verifies) — it must carry the row too."""
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="confirmed"
+        )
+        client.force_login(coach.user)
+        _scan(client, event, registration)
+
+        payload = _scan(client, event, registration).json()
+
+        assert payload["already_checked_in"] is True
+        assert payload["row"]["status"] == "attended"
+
+    def test_an_attendee_with_no_profile_is_flagged(self, client):
+        coach = _make_coach()
+        bare = User.objects.create_user(
+            username="bare@example.com", email="bare@example.com", password="pass12345"
+        )
+        _grant_consent(bare)
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=bare, status="confirmed"
+        )
+        client.force_login(coach.user)
+
+        row = _scan(client, event, registration).json()["row"]
+
+        assert row["has_profile"] is False
+        assert row["is_approved"] is False
+        assert row["coach_name"] is None
+
+    def test_a_promotion_row_carries_what_the_confirmed_list_never_had(self, client):
+        """A promoted walk-up was never in the confirmed list, so the applier
+        builds their row from the payload — identity fields included (#710
+        finding 3)."""
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="waitlist"
+        )
+        client.force_login(coach.user)
+
+        row = client.post(_promote_url(event, registration)).json()["row"]
+
+        assert row["status"] == "attended"
+        assert row["checked_in_at"] is not None
+        assert row["coach_name"] == "Cam"
+        assert row["gender"] == "F"
+        assert row["age_display"]
+        assert "ada@example.com" in row["search"]
+
+    def test_an_undone_promotion_row_goes_back_to_the_waitlist(self, client):
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="waitlist"
+        )
+        client.force_login(coach.user)
+        client.post(_promote_url(event, registration))
+
+        payload = client.post(_undo_url(event, registration)).json()
+
+        assert payload["restored_status"] == "waitlist"
+        assert payload["row"]["status"] == "waitlist"
+        assert payload["row"]["checked_in_at"] is None
+        # The undo cleared the coach this promotion granted; the row the
+        # waitlist rebuild renders from must not still name them.
+        assert payload["row"]["coach_name"] is None
+
+    def test_an_undone_scan_row_returns_to_confirmed(self, client):
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="confirmed"
+        )
+        client.force_login(coach.user)
+        _scan(client, event, registration)
+
+        payload = client.post(_undo_url(event, registration)).json()
+
+        assert payload["row"]["status"] == "confirmed"
+        assert payload["row"]["checked_in_at"] is None
+        assert payload["row"]["coach_name"] is None
+
+    def test_a_verify_row_swaps_the_pill(self, client):
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="confirmed"
+        )
+        client.force_login(coach.user)
+
+        url = reverse(
+            "coach_mark_verified",
+            kwargs={"event_id": event.pk, "registration_id": registration.pk},
+        )
+        row = client.post(url).json()["row"]
+
+        assert row["is_approved"] is True

--- a/crush_lu/tests/test_checkin_door_actions.py
+++ b/crush_lu/tests/test_checkin_door_actions.py
@@ -1626,6 +1626,24 @@ class TestRowStatePayload:
         assert row["coach_name"] == "Cam"
         assert row["has_profile"] is True
 
+    def test_a_scan_row_carries_no_legal_name_or_email(self, client):
+        """`event_checkin_api` needs no coach session — the signed QR is the
+        credential and a member may POST their own check-in URL — so its
+        response must not include the search haystack. Only the coach-only
+        promotion payload carries it, because only that row is rebuilt
+        client-side."""
+        coach = _make_coach()
+        attendee = _make_attendee()
+        event = _make_event()
+        registration = EventRegistration.objects.create(
+            event=event, user=attendee, status="confirmed"
+        )
+        client.force_login(coach.user)
+
+        row = _scan(client, event, registration).json()["row"]
+
+        assert "search" not in row
+
     def test_a_rescan_row_still_travels(self, client):
         """The already-attended branch is the one a remote coach's page most
         often sees (a re-scan that verifies) — it must carry the row too."""

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -17,9 +17,10 @@ from django.utils.translation import gettext_lazy as _
 from django.core.signing import BadSignature, Signer
 from django.db import transaction
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_GET, require_POST
 
 from .decorators import coach_required
 from .models import CrushProfile, EventRegistration, ProfileSubmission
@@ -370,6 +371,7 @@ def event_checkin_api(request, registration_id, token):
             "message": f"{display_name} was already checked in.",
             "profile": _get_profile_data(registration),
             "auto_verified": rescan_verified is not None,
+            "row": _row_state(registration),
         }
         table_info = _get_existing_table_assignment(registration)
         if table_info:
@@ -446,6 +448,7 @@ def event_checkin_api(request, registration_id, token):
                 "message": f"{display_name} was already checked in.",
                 "profile": _get_profile_data(registration),
                 "auto_verified": already_verified_profile is not None,
+                "row": _row_state(registration),
             }
             table_info = _get_existing_table_assignment(registration)
             if table_info:
@@ -531,6 +534,9 @@ def event_checkin_api(request, registration_id, token):
         # just verified.
         "profile": _get_profile_data(registration),
         "auto_verified": auto_verified,
+        # What the shared row-state applier renders the manual row from, on
+        # this response AND the broadcast of it.
+        "row": _row_state(registration),
     }
     if table_assignment:
         response_data["table_number"] = table_assignment["table_number"]
@@ -624,6 +630,7 @@ def coach_mark_verified(request, event_id, registration_id):
                     "attendee_name": _get_display_name(registration),
                     "verification_method": profile.verification_method,
                     "message": str(_("Already verified.")),
+                    "row": _row_state(registration),
                 }
             )
 
@@ -658,6 +665,7 @@ def coach_mark_verified(request, event_id, registration_id):
                     "attendee_name": _get_display_name(registration),
                     "verification_method": profile.verification_method,
                     "message": str(_("Already verified.")),
+                    "row": _row_state(registration),
                 }
             )
 
@@ -686,6 +694,7 @@ def coach_mark_verified(request, event_id, registration_id):
         "message": str(_("%(name)s is now verified."))
         % {"name": _get_display_name(registration)},
         "profile": _get_profile_data(registration),
+        "row": _row_state(registration),
     }
     _broadcast_checkin(registration.event_id, response_data)
     return JsonResponse(response_data)
@@ -895,6 +904,10 @@ def coach_undo_checkin(request, event_id, registration_id):
         )
         or "",
         "message": str(_("Check-in undone for %(name)s.")) % {"name": display_name},
+        # The full row state the shared applier renders from — status,
+        # cleared coach line, table badge — for the local path AND the
+        # broadcast, which used to have no undo branch at all (#710).
+        "row": _row_state(registration),
     }
     # The *membership* table, not the current one. The door page's table-fill
     # grid is rendered from QuizTableMembership (views_coach.py), so it counts
@@ -902,14 +915,12 @@ def coach_undo_checkin(request, event_id, registration_id):
     # moved them — decrementing the current table would leave that tile short
     # and the round-0 tile still holding a seat nobody occupies.
     #
-    # Under its own key, never `table_number`: handleRemoteCheckin has no
-    # `undone` branch yet (#710), so an undo payload is still read as an
-    # arrival, and the arrival key would make the other coaches' pages count
-    # the freed seat *up*. `_updateUndoUI` reads this one, which only the
-    # acting coach runs — so the door page that issued the correction fixes
-    # its own table-fill grid, and no other page is misled into a bump. The
-    # quiz table group is a different channel, carries the current table, and
-    # reaches the players.
+    # Under its own key, never `table_number`: this payload is broadcast to
+    # every coach page, and the arrival key is what the check-in path reads.
+    # The door grid itself is put right by the summary refetch every path now
+    # runs; this key is what the acting coach's page and the tests name the
+    # freed seats by. The quiz table group is a different channel, carries
+    # the current table, and reaches the players.
     if released_table and released_table.get("membership_table_numbers"):
         response_data["released_table_numbers"] = released_table[
             "membership_table_numbers"
@@ -1081,6 +1092,9 @@ def coach_promote_from_waitlist(request, event_id, registration_id):
         % {"name": display_name},
         "profile": _get_profile_data(registration),
         "auto_verified": auto_verified,
+        # The confirmed list never contained this row, so the applier builds
+        # it from the identity fields carried here.
+        "row": _row_state(registration),
     }
     if table_assignment:
         response_data["table_number"] = table_assignment["table_number"]
@@ -1097,6 +1111,146 @@ def _get_display_name(registration):
         return registration.user.crushprofile.display_name
     except Exception:
         return _("Attendee")
+
+
+def _row_state(registration):
+    """Row-level state for the door page's shared row-state applier (#710).
+
+    Every door action returns this under ``row`` and the page applies it with
+    one ``_applyRowState`` on BOTH the local and the broadcast path, so no
+    handler patches its own subset of the DOM. It carries exactly what the
+    applier cannot know or derive: the status after the action, the arrival
+    time, which table badge to render, the permanent-coach line, the
+    verification pill — plus the identity fields a promoted row needs,
+    because the confirmed list never contained it.
+
+    The profile is re-read rather than taken from the registration's cached
+    ``user__crushprofile``: the coach grant is written by a signal on its own
+    profile instance during ``save()``, so the cached copy predates the very
+    field this is asked to report.
+    """
+    # str() coerces the lazy "Attendee" fallback — it must be a plain string
+    # both for the join below and for JsonResponse.
+    display_name = str(_get_display_name(registration))
+    row = {
+        "registration_id": registration.id,
+        "user_id": registration.user_id,
+        "status": registration.status,
+        "checked_in_at": (
+            registration.checked_in_at.isoformat()
+            if registration.checked_in_at
+            else None
+        ),
+        "display_name": display_name,
+        # The client-side search haystack a rebuilt row carries — matches the
+        # template's: a guest at the door gives the name on their ID or the
+        # email they booked with, neither of which need match display_name.
+        "search": " ".join(
+            part
+            for part in (
+                display_name,
+                registration.user.first_name,
+                registration.user.last_name,
+                registration.user.email,
+            )
+            if part
+        ),
+        "has_profile": False,
+        "is_approved": False,
+        "coach_name": None,
+    }
+    profile = (
+        CrushProfile.objects.select_related("assigned_coach__user")
+        .filter(user_id=registration.user_id)
+        .first()
+    )
+    if profile is not None:
+        row["has_profile"] = True
+        row["is_approved"] = profile.is_approved
+        row["gender"] = profile.gender or ""
+        row["age_display"] = profile.age_display or ""
+        if profile.photo_1:
+            row["photo_url"] = reverse(
+                "crush_lu:serve_profile_photo",
+                kwargs={"user_id": registration.user_id, "photo_field": "photo_1"},
+            )
+        if profile.assigned_coach_id:
+            coach_user = profile.assigned_coach.user
+            row["coach_name"] = (
+                f"{coach_user.first_name} {coach_user.last_name}".strip()
+                or coach_user.username
+            )
+    table_info = _get_existing_table_assignment(registration)
+    if table_info:
+        row["table_number"] = table_info["table_number"]
+    return row
+
+
+@coach_required
+@require_GET
+def event_checkin_summary(request, event_id):
+    """Read-only door counters, refetched by the page after every door action.
+
+    The check-in page used to maintain its tiles by bumping whichever counter
+    each handler knew about, which drifted on the first unhandled path and
+    could render a gender tile as ``6 / 5``. This endpoint is the single
+    source: the page refetches it after any scan, promote, undo or verify —
+    local or broadcast — and re-renders the counters wholesale (#710).
+
+    Mirrors the arithmetic of ``coach_event_checkin`` (views_coach.py) on
+    purpose: the tiles must not change their meaning between page load and
+    the first refetch. All three gender buckets are always present, so the
+    client can write numerators AND denominators without probing the DOM.
+    """
+    from .models import MeetupEvent
+
+    event = get_object_or_404(MeetupEvent, id=event_id)
+
+    registrations = (
+        EventRegistration.objects.filter(event=event)
+        .exclude(status="cancelled")
+        .select_related("user__crushprofile")
+    )
+    confirmed = [r for r in registrations if r.status in SEAT_HOLDING_STATUSES]
+    attended_count = sum(1 for r in confirmed if r.status == "attended")
+    waitlist_count = sum(1 for r in registrations if r.status == "waitlist")
+
+    gender_checked_in = {"F": 0, "M": 0, "other": 0}
+    gender_expected = {"F": 0, "M": 0, "other": 0}
+    for reg in confirmed:
+        gender = getattr(getattr(reg.user, "crushprofile", None), "gender", None)
+        key = gender if gender in ("F", "M") else "other"
+        gender_expected[key] += 1
+        if reg.status == "attended":
+            gender_checked_in[key] += 1
+
+    table_fill = []
+    quiz_event = getattr(event, "quiz", None)
+    if quiz_event and quiz_event.num_tables:
+        from collections import Counter
+
+        from .models.quiz import QuizTableMembership
+
+        fill_counts = Counter(
+            QuizTableMembership.objects.filter(table__quiz=quiz_event).values_list(
+                "table__table_number", flat=True
+            )
+        )
+        for number in range(1, quiz_event.num_tables + 1):
+            table_fill.append({"number": number, "count": fill_counts.get(number, 0)})
+
+    return JsonResponse(
+        {
+            "success": True,
+            "attended_count": attended_count,
+            "expected_count": len(confirmed),
+            "outstanding_count": len(confirmed) - attended_count,
+            "waitlist_count": waitlist_count,
+            "gender_checked_in": gender_checked_in,
+            "gender_expected": gender_expected,
+            "table_fill": table_fill,
+        }
+    )
 
 
 def _get_profile_data(registration):

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -1179,11 +1179,6 @@ def _row_state(registration, include_search=False):
         row["is_approved"] = profile.is_approved
         row["gender"] = profile.gender or ""
         row["age_display"] = profile.age_display or ""
-        if profile.photo_1:
-            row["photo_url"] = reverse(
-                "crush_lu:serve_profile_photo",
-                kwargs={"user_id": registration.user_id, "photo_field": "photo_1"},
-            )
         if profile.assigned_coach_id:
             coach_user = profile.assigned_coach.user
             row["coach_name"] = (

--- a/crush_lu/views_checkin.py
+++ b/crush_lu/views_checkin.py
@@ -1093,8 +1093,10 @@ def coach_promote_from_waitlist(request, event_id, registration_id):
         "profile": _get_profile_data(registration),
         "auto_verified": auto_verified,
         # The confirmed list never contained this row, so the applier builds
-        # it from the identity fields carried here.
-        "row": _row_state(registration),
+        # it from the identity fields carried here. Coach-only endpoint, so
+        # this is also the one row payload allowed to carry the legal
+        # name/email search haystack.
+        "row": _row_state(registration, include_search=True),
     }
     if table_assignment:
         response_data["table_number"] = table_assignment["table_number"]
@@ -1113,7 +1115,7 @@ def _get_display_name(registration):
         return _("Attendee")
 
 
-def _row_state(registration):
+def _row_state(registration, include_search=False):
     """Row-level state for the door page's shared row-state applier (#710).
 
     Every door action returns this under ``row`` and the page applies it with
@@ -1123,6 +1125,13 @@ def _row_state(registration):
     time, which table badge to render, the permanent-coach line, the
     verification pill — plus the identity fields a promoted row needs,
     because the confirmed list never contained it.
+
+    ``include_search`` adds the legal-name/email search haystack, and is set
+    ONLY by ``coach_promote_from_waitlist`` — the one action whose row the
+    page has to rebuild from scratch. ``event_checkin_api`` authenticates on
+    the signed QR alone (an attendee can POST their own check-in URL), so its
+    response must not hand them the account's legal name and email under a
+    key nothing on that path needs.
 
     The profile is re-read rather than taken from the registration's cached
     ``user__crushprofile``: the coach grant is written by a signal on its own
@@ -1142,10 +1151,15 @@ def _row_state(registration):
             else None
         ),
         "display_name": display_name,
+        "has_profile": False,
+        "is_approved": False,
+        "coach_name": None,
+    }
+    if include_search:
         # The client-side search haystack a rebuilt row carries — matches the
         # template's: a guest at the door gives the name on their ID or the
         # email they booked with, neither of which need match display_name.
-        "search": " ".join(
+        row["search"] = " ".join(
             part
             for part in (
                 display_name,
@@ -1154,11 +1168,7 @@ def _row_state(registration):
                 registration.user.email,
             )
             if part
-        ),
-        "has_profile": False,
-        "is_approved": False,
-        "coach_name": None,
-    }
+        )
     profile = (
         CrushProfile.objects.select_related("assigned_coach__user")
         .filter(user_id=registration.user_id)


### PR DESCRIPTION
## What

Replaces the door page's incremental DOM bookkeeping with the two-mechanism redesign proposed in #710 (instead of a fourth round of patching #703 findings):

1. **`GET /api/events/<id>/checkin-summary/`** (read-only, coach-only) — attended / expected / outstanding, waitlist count, the gender split with numerator **and** denominator (all three buckets always present), and the quiz table-fill grid. Refetched after **every** door action, local *or* broadcast; the counters are re-rendered wholesale.
2. **One shared `_applyRowState(regId, row)`** in `coachCheckin` — every action's own response (scan, rescan, verify, undo, promote) now carries a `row` object (status, arrival time, table badge, coach line, verification pill, identity fields for promoted walk-ups), and the broadcast carries it too. No handler patches its own subset of the DOM any more.

The ~20 hand-maintained DOM update sites collapse to these two, and the 3-actions × 2-paths matrix is correct by construction — `_updateCheckinUI`, `_updateUndoUI`, `_bumpCounter`, `_bumpGenderSplit` and `_markRowVerified` are gone.

## Findings closed (all nine from #710)

- [x] **1. Undo broadcasts misread as check-ins** — `handleRemoteCheckin` applies row state + summary refetch *before* the dedupe guard and has an explicit `undone` branch.
- [x] **2. Remote promotions leave a stale waitlist row** — `_applyRowState` removes `waitlist-reg-*` on every path (a verify broadcast can no longer bump counters either).
- [x] **3. Promoted row not immediately undoable** — the applier *builds* the attended row in the confirmed list, undo button included, from the `row` payload's identity fields.
- [x] **4. Outstanding filter not reapplied** — the template exposes `window._applyAttendeeFilters`; the applier calls it after any status change.
- [x] **5. Gender numerator without denominator** — denominators are tagged (`gender-*-expected`), the `{% if gender_expected.other %}` render guard is gone, and the summary always sends all three buckets.
- [x] **6. Waitlist badge never decremented** — `waitlist-count-badge` is written by the summary refetch; the section always renders (hidden while empty) so an undo can put a row back.
- [x] **7. Undo does not clear server-rendered markers** — the server-rendered overlay now carries `checkin-overlay-badge`, the timestamp is tagged `data-arrival-time`, both removed by the applier.
- [x] **8. Undone attendees stay in Recent Check-ins** — entries carry `regId`; an undo (local or broadcast) removes the matching entry.
- [x] **9. Coach line never refreshed** — every `row` carries `coach_name` (fresh DB read, since the grant is written by a signal); the applier renders it, or the amber "No coach yet" warning.

## Notes for reviewers

- The task brief named `door_checkin.html` / `door.js` / `test_door_checkin.py`; those files do not exist — the real surfaces are `coach_event_checkin.html`, the `coachCheckin` component in `alpine-components.js`, and `test_checkin_door_actions.py` (all per issue #710's own anchors).
- `released_table_numbers` keeps its own key and semantics (tests pin it); the door grid itself is now put right by the summary refetch.
- Arithmetic of the summary mirrors `coach_event_checkin` (views_coach.py) exactly — pending-payment seats count as expected, cancelled rows count nowhere, waitlisted walk-ups are in neither gender denominator.

## Validation

- `pytest crush_lu/tests/test_checkin_door_actions.py` — 74 passed (18 new: endpoint auth/shape/gender-buckets/table-fill + `row` payload on every action)
- `pytest` over the adjacent surfaces (`test_verify_on_checkin`, `test_coach_mark_verified`, `test_coach_event_detail`, `test_event_lobby`, `test_quiz`, `test_event_identity_surfaces`) — 426 passed
- `manage.py check`, `makemigrations --check --dry-run`, `check_translations` (no new strings — all reused msgids), `black`, `ruff`, `node --check`, design-token lint on the template

Closes #710. Tracking: #718.
