### PR TITLE
feat(crush_lu): add HEIC/HEIF photo upload support for iOS devices

### DIFF
--- a/crush_lu/apps.py
+++ b/crush_lu/apps.py
@@ -14,3 +14,11 @@ class CrushLuConfig(AppConfig):
         # This fixes Android PWA OAuth issue where OAuth opens in system browser
         from crush_lu.oauth_statekit import patch_allauth_statekit
         patch_allauth_statekit()
+
+        # Register HEIF/HEIC decoder in Pillow for Apple/iOS photo uploads
+        try:
+            import pillow_heif
+            pillow_heif.register_heif_opener()
+        except ImportError:
+            pass
+

--- a/crush_lu/forms.py
+++ b/crush_lu/forms.py
@@ -428,11 +428,11 @@ class CrushProfileForm(forms.ModelForm):
             )
 
         # Check file extension
-        allowed_extensions = ['.jpg', '.jpeg', '.png', '.webp']
+        allowed_extensions = ['.jpg', '.jpeg', '.png', '.webp', '.heic', '.heif']
         ext = os.path.splitext(photo.name)[1].lower()
         if ext not in allowed_extensions:
             raise ValidationError(
-                f"{field_name} must be a JPEG, PNG, or WebP image. You uploaded: {ext}"
+                f"{field_name} must be a JPEG, PNG, WebP, or HEIC image. You uploaded: {ext}"
             )
 
         # Verify MIME type matches actual content (prevents disguised malicious files)
@@ -443,12 +443,16 @@ class CrushProfileForm(forms.ModelForm):
             photo.seek(0)  # Reset file pointer
 
             mime = magic.from_buffer(file_header, mime=True)
-            allowed_mimes = ['image/jpeg', 'image/png', 'image/webp']
+            allowed_mimes = [
+                'image/jpeg', 'image/png', 'image/webp',
+                'image/heic', 'image/heif', 'image/heic-sequence', 'image/heif-sequence',
+                'image/x-heic', 'image/x-heif',
+            ]
 
             if mime not in allowed_mimes:
                 raise ValidationError(
                     f"{field_name} content type ({mime}) does not match allowed image types. "
-                    f"Please upload a genuine JPEG, PNG, or WebP image."
+                    f"Please upload a genuine JPEG, PNG, WebP, or HEIC image."
                 )
         except ImportError:
             # python-magic not installed, skip MIME check

--- a/crush_lu/forms.py
+++ b/crush_lu/forms.py
@@ -450,10 +450,13 @@ class CrushProfileForm(forms.ModelForm):
             ]
 
             if mime not in allowed_mimes:
-                raise ValidationError(
-                    f"{field_name} content type ({mime}) does not match allowed image types. "
-                    f"Please upload a genuine JPEG, PNG, WebP, or HEIC image."
-                )
+                # Some older libmagic versions detect HEIC/HEIF as generic application/octet-stream.
+                # Allow it if the extension is .heic/.heif; Pillow verify() below strictly validates.
+                if not (mime == 'application/octet-stream' and ext in ('.heic', '.heif')):
+                    raise ValidationError(
+                        f"{field_name} content type ({mime}) does not match allowed image types. "
+                        f"Please upload a genuine JPEG, PNG, WebP, or HEIC image."
+                    )
         except ImportError:
             # python-magic not installed, skip MIME check
             # This allows graceful degradation in development

--- a/crush_lu/templates/crush_lu/partials/photo_card.html
+++ b/crush_lu/templates/crush_lu/partials/photo_card.html
@@ -55,7 +55,7 @@
                 <input type="file"
                        name="photo_{{ slot }}"
                        id="id_photo_{{ slot }}"
-                       accept="image/jpeg,image/png,image/webp"
+                       accept="image/jpeg,image/png,image/webp,image/heic,image/heif,.heic,.heif"
                        hx-post="{% url 'api_upload_profile_photo' slot %}"
                        hx-target="#photo-card-{{ slot }}"
                        hx-swap="innerHTML"

--- a/crush_lu/tests/test_admin_smoke.py
+++ b/crush_lu/tests/test_admin_smoke.py
@@ -405,3 +405,34 @@ class ImageUploadSizeTests(TestCase):
         raw = io.BytesIO(b"x" * (MAX_UPLOAD_BYTES + 1))
         with self.assertRaises(ValidationError):
             process_uploaded_image(raw)
+
+    def test_heic_image_converted_to_jpeg(self):
+        """HEIC uploads must be decoded and converted to JPEG (.jpg)."""
+        import pillow_heif
+        from PIL import Image
+
+        pillow_heif.register_heif_opener()
+
+        # Create a sample HEIF/HEIC image buffer
+        buffer = io.BytesIO()
+        Image.new("RGB", (800, 600), color="blue").save(buffer, format="HEIF")
+        heic_upload = ContentFile(buffer.getvalue(), name="1001177160.heic")
+
+        processed = process_uploaded_image(heic_upload)
+
+        self.assertEqual(processed.name, "1001177160.jpg")
+        self.assertEqual(processed.content_type, "image/jpeg")
+        self.assertLessEqual(processed.size, MAX_UPLOAD_BYTES)
+
+        # Verify the output image is valid JPEG and readable by PIL
+        processed.seek(0)
+        output_img = Image.open(processed)
+        self.assertEqual(output_img.format, "JPEG")
+        self.assertEqual(output_img.size, (800, 600))
+
+    def test_corrupt_image_raises_validation_error(self):
+        """Corrupt or non-image files under size limit must raise ValidationError."""
+        corrupt_file = ContentFile(b"not an image data at all", name="bad.jpg")
+        with self.assertRaises(ValidationError):
+            process_uploaded_image(corrupt_file)
+

--- a/crush_lu/tests/test_admin_smoke.py
+++ b/crush_lu/tests/test_admin_smoke.py
@@ -436,3 +436,17 @@ class ImageUploadSizeTests(TestCase):
         with self.assertRaises(ValidationError):
             process_uploaded_image(corrupt_file)
 
+    def test_truncated_image_with_valid_header_raises_validation_error(self):
+        """Files with valid headers but truncated body (lazy decode) must raise ValidationError."""
+        from PIL import Image
+
+        buf = io.BytesIO()
+        Image.new("RGB", (200, 200), color="green").save(buf, format="JPEG")
+        # Truncate image stream to simulate interrupted mobile upload
+        truncated_bytes = buf.getvalue()[:200]
+        truncated_file = ContentFile(truncated_bytes, name="interrupted.jpg")
+
+        with self.assertRaises(ValidationError):
+            process_uploaded_image(truncated_file)
+
+

--- a/crush_lu/tests/test_profile_draft.py
+++ b/crush_lu/tests/test_profile_draft.py
@@ -266,3 +266,55 @@ class WizardResumePositionTests(_SiteMixin, TestCase):
     def test_incomplete_basics_resumes_on_step1(self):
         profile = self._profile(gender="")
         self.assertEqual(profile.wizard_step, 1)
+
+
+@override_settings(**CRUSH_LU_URL_SETTINGS)
+class UploadPhotoDraftTests(_SiteMixin, TestCase):
+    """The wizard's upload-photo endpoint must handle HEIC uploads and gracefully reject corrupt files."""
+
+    def setUp(self):
+        self.client, self.user = _make_logged_in_client()
+
+    def test_upload_heic_photo_draft_success(self):
+        import io
+        import pillow_heif
+        from PIL import Image
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        pillow_heif.register_heif_opener()
+
+        buffer = io.BytesIO()
+        Image.new("RGB", (600, 600), color="purple").save(buffer, format="HEIF")
+        uploaded_heic = SimpleUploadedFile(
+            "1001177160.heic", buffer.getvalue(), content_type="image/heic"
+        )
+
+        response = self.client.post(
+            "/api/profile/draft/upload-photo/",
+            {"photo": uploaded_heic, "photo_number": "1"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["photo_number"], 1)
+
+        profile = CrushProfile.objects.get(user=self.user)
+        self.assertTrue(profile.photo_1)
+        self.assertTrue(profile.photo_1.name.endswith(".jpg"))
+
+    def test_upload_corrupt_photo_draft_returns_400(self):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        corrupt_file = SimpleUploadedFile(
+            "fake.jpg", b"corrupt-non-image-data", content_type="image/jpeg"
+        )
+
+        response = self.client.post(
+            "/api/profile/draft/upload-photo/",
+            {"photo": corrupt_file, "photo_number": "1"},
+        )
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertFalse(data["success"])
+        self.assertIn("error", data)
+

--- a/crush_lu/tests/test_profile_draft.py
+++ b/crush_lu/tests/test_profile_draft.py
@@ -318,3 +318,27 @@ class UploadPhotoDraftTests(_SiteMixin, TestCase):
         self.assertFalse(data["success"])
         self.assertIn("error", data)
 
+    def test_upload_truncated_photo_draft_returns_400(self):
+        """Interrupted/truncated upload with valid header must return 400, not 500."""
+        import io
+        from PIL import Image
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        buf = io.BytesIO()
+        Image.new("RGB", (300, 300), color="yellow").save(buf, format="JPEG")
+        truncated_bytes = buf.getvalue()[:250]
+
+        truncated_file = SimpleUploadedFile(
+            "broken.jpg", truncated_bytes, content_type="image/jpeg"
+        )
+
+        response = self.client.post(
+            "/api/profile/draft/upload-photo/",
+            {"photo": truncated_file, "photo_number": "1"},
+        )
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertFalse(data["success"])
+        self.assertIn("error", data)
+
+

--- a/crush_lu/tests/test_profile_draft.py
+++ b/crush_lu/tests/test_profile_draft.py
@@ -342,3 +342,40 @@ class UploadPhotoDraftTests(_SiteMixin, TestCase):
         self.assertIn("error", data)
 
 
+@override_settings(**CRUSH_LU_URL_SETTINGS)
+class UploadProfilePhotoHtmxTests(_SiteMixin, TestCase):
+    """The HTMX upload-photo slot endpoint (/api/profile/upload-photo/<slot>/) must convert HEIC to JPEG."""
+
+    def setUp(self):
+        self.client, self.user = _make_logged_in_client()
+
+    def test_upload_heic_photo_slot_converts_to_jpeg(self):
+        import io
+        import pillow_heif
+        from PIL import Image
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        pillow_heif.register_heif_opener()
+
+        buffer = io.BytesIO()
+        Image.new("RGB", (500, 500), color="cyan").save(buffer, format="HEIF")
+        uploaded_heic = SimpleUploadedFile(
+            "my_avatar.heic", buffer.getvalue(), content_type="image/heic"
+        )
+
+        response = self.client.post(
+            "/api/profile/upload-photo/1/",
+            {"photo_1": uploaded_heic},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        profile = CrushProfile.objects.get(user=self.user)
+        self.assertTrue(profile.photo_1)
+        self.assertTrue(profile.photo_1.name.endswith(".jpg"))
+
+        # Verify the partial rendered without error
+        self.assertContains(response, "photo-preview")
+        self.assertNotContains(response, "Photo validation failed")
+
+
+

--- a/crush_lu/utils/image_processing.py
+++ b/crush_lu/utils/image_processing.py
@@ -73,6 +73,46 @@ def process_uploaded_image(image_file, filename=None):
         img = Image.open(image_file)
         # Fix orientation from EXIF before stripping metadata
         img = ImageOps.exif_transpose(img)
+
+        # Force decode to catch corrupted/truncated bodies early
+        img.load()
+
+        # Convert non-RGB/L modes (RGBA, P, CMYK, etc.) to RGB for safe JPEG output
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+
+        # Resize if larger than MAX_DIMENSION on longest edge
+        # thumbnail() modifies in-place, preserves aspect ratio, only downsizes
+        img.thumbnail((MAX_DIMENSION, MAX_DIMENSION), Image.LANCZOS)
+
+        # Determine output format
+        original_name = filename or getattr(image_file, "name", "photo.jpg")
+        ext = os.path.splitext(original_name)[1].lower()
+
+        if ext == ".png":
+            output_format = "PNG"
+            content_type = "image/png"
+        elif ext == ".webp":
+            output_format = "WEBP"
+            content_type = "image/webp"
+        else:
+            output_format = "JPEG"
+            content_type = "image/jpeg"
+            # Ensure .jpg extension
+            if ext not in (".jpg", ".jpeg"):
+                original_name = os.path.splitext(original_name)[0] + ".jpg"
+
+        # Save to buffer (Pillow strips EXIF by default on save)
+        buffer = io.BytesIO()
+        save_kwargs = {}
+        if output_format == "JPEG":
+            save_kwargs["quality"] = JPEG_QUALITY
+            save_kwargs["optimize"] = True
+        elif output_format == "WEBP":
+            save_kwargs["quality"] = JPEG_QUALITY
+
+        img.save(buffer, format=output_format, **save_kwargs)
+        buffer.seek(0)
     except ValidationError:
         raise
     except Exception as exc:
@@ -80,43 +120,6 @@ def process_uploaded_image(image_file, filename=None):
         raise ValidationError(
             _("The uploaded file is not a valid or supported image.")
         ) from exc
-
-    # Convert non-RGB/L modes (RGBA, P, CMYK, etc.) to RGB for safe JPEG output
-    if img.mode not in ("RGB", "L"):
-        img = img.convert("RGB")
-
-    # Resize if larger than MAX_DIMENSION on longest edge
-    # thumbnail() modifies in-place, preserves aspect ratio, only downsizes
-    img.thumbnail((MAX_DIMENSION, MAX_DIMENSION), Image.LANCZOS)
-
-    # Determine output format
-    original_name = filename or getattr(image_file, "name", "photo.jpg")
-    ext = os.path.splitext(original_name)[1].lower()
-
-    if ext == ".png":
-        output_format = "PNG"
-        content_type = "image/png"
-    elif ext == ".webp":
-        output_format = "WEBP"
-        content_type = "image/webp"
-    else:
-        output_format = "JPEG"
-        content_type = "image/jpeg"
-        # Ensure .jpg extension
-        if ext not in (".jpg", ".jpeg"):
-            original_name = os.path.splitext(original_name)[0] + ".jpg"
-
-    # Save to buffer (Pillow strips EXIF by default on save)
-    buffer = io.BytesIO()
-    save_kwargs = {}
-    if output_format == "JPEG":
-        save_kwargs["quality"] = JPEG_QUALITY
-        save_kwargs["optimize"] = True
-    elif output_format == "WEBP":
-        save_kwargs["quality"] = JPEG_QUALITY
-
-    img.save(buffer, format=output_format, **save_kwargs)
-    buffer.seek(0)
 
     processed = InMemoryUploadedFile(
         file=buffer,

--- a/crush_lu/utils/image_processing.py
+++ b/crush_lu/utils/image_processing.py
@@ -13,6 +13,12 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.utils.translation import gettext_lazy as _
 from PIL import Image, ImageOps
 
+try:
+    import pillow_heif
+    pillow_heif.register_heif_opener()
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 # Max dimension on longest edge after processing
@@ -42,6 +48,9 @@ def process_uploaded_image(image_file, filename=None):
     """
     Process an uploaded image: fix orientation, strip EXIF, resize.
 
+    Supports JPEG, PNG, WebP, and HEIC/HEIF (Apple iOS photos). Non-JPEG/PNG/WebP
+    formats (such as HEIC) are automatically converted to optimized JPEG (.jpg).
+
     Args:
         image_file: A file-like object (UploadedFile, ContentFile, etc.)
         filename: Optional filename override. If None, uses image_file.name.
@@ -50,7 +59,7 @@ def process_uploaded_image(image_file, filename=None):
         InMemoryUploadedFile with processed image data.
 
     Raises:
-        ValidationError: If the file exceeds MAX_UPLOAD_BYTES.
+        ValidationError: If the file exceeds MAX_UPLOAD_BYTES or is invalid/unsupported.
     """
     size = _file_size(image_file)
     if size > MAX_UPLOAD_BYTES:
@@ -60,13 +69,20 @@ def process_uploaded_image(image_file, filename=None):
         )
 
     image_file.seek(0)
-    img = Image.open(image_file)
+    try:
+        img = Image.open(image_file)
+        # Fix orientation from EXIF before stripping metadata
+        img = ImageOps.exif_transpose(img)
+    except ValidationError:
+        raise
+    except Exception as exc:
+        logger.warning("Failed to decode uploaded image: %s", exc)
+        raise ValidationError(
+            _("The uploaded file is not a valid or supported image.")
+        ) from exc
 
-    # Fix orientation from EXIF before stripping metadata
-    img = ImageOps.exif_transpose(img)
-
-    # Convert RGBA/P to RGB for JPEG output
-    if img.mode in ("RGBA", "P"):
+    # Convert non-RGB/L modes (RGBA, P, CMYK, etc.) to RGB for safe JPEG output
+    if img.mode not in ("RGB", "L"):
         img = img.convert("RGB")
 
     # Resize if larger than MAX_DIMENSION on longest edge

--- a/crush_lu/views_profile.py
+++ b/crush_lu/views_profile.py
@@ -40,7 +40,7 @@ def save_profile_step1(request):
         # Coaches with existing profiles can still edit them
         if created:
             try:
-                coach = CrushCoach.objects.get(user=request.user, is_active=True)
+                CrushCoach.objects.get(user=request.user, is_active=True)
                 # Delete the just-created profile and block
                 profile.delete()
                 return JsonResponse(
@@ -584,7 +584,7 @@ def save_profile_step3(request):
                 return JsonResponse(
                     {
                         "success": False,
-                        "error": "Invalid photo. Please upload a JPEG or PNG under 10MB.",
+                        "error": "Invalid photo. Please upload a JPEG, PNG, WebP, or HEIC image under 10MB.",
                     },
                     status=400,
                 )

--- a/crush_lu/views_profile.py
+++ b/crush_lu/views_profile.py
@@ -1054,8 +1054,12 @@ def upload_profile_photo(request, slot):
         photo_field_name = f"photo_{slot}"
         if temp_form.fields.get(photo_field_name):
             try:
-                cleaned_photo = temp_form.fields[photo_field_name].clean(photo_file)
-                setattr(profile, photo_field_name, cleaned_photo)
+                from .utils.image_processing import process_uploaded_image
+
+                processed_photo = process_uploaded_image(
+                    photo_file, filename=photo_file.name
+                )
+                setattr(profile, photo_field_name, processed_photo)
                 profile.save(update_fields=[photo_field_name])
 
                 logger.info(f"Photo {slot} uploaded for user {request.user.id}")
@@ -1068,6 +1072,21 @@ def upload_profile_photo(request, slot):
                         "photo": getattr(profile, photo_field_name),
                         "is_main": slot == 1,
                         "just_uploaded": True,
+                        "social_photos": social_photos,
+                    },
+                )
+            except ValidationError as e:
+                logger.warning(f"Photo validation failed: {e}")
+                return render(
+                    request,
+                    "crush_lu/partials/photo_card.html",
+                    {
+                        "slot": slot,
+                        "photo": getattr(profile, photo_field_name),
+                        "is_main": slot == 1,
+                        "error": " ".join(e.messages)
+                        if hasattr(e, "messages")
+                        else str(e),
                         "social_photos": social_photos,
                     },
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ azure-identity==1.25.3  # Managed Identity & Azure CLI authentication
 
 # Image processing
 Pillow==12.3.0  # Updated from 11.0.0 (security fixes)
+pillow-heif==1.5.0  # HEIC/HEIF decoding support for iOS uploads
 olefile==0.47
 # MIME type detection - platform-specific packages
 # Linux (Azure): python-magic requires libmagic1 (pre-installed on most Linux distros)


### PR DESCRIPTION
## Summary
Resolves production Azure error: \PIL.UnidentifiedImageError: cannot identify image file <InMemoryUploadedFile: ... (image/heic)>\ caused by iPhone / iOS users uploading camera-roll HEIC photos during onboarding photo upload.

## Key Changes
- **Dependency**: Added \pillow-heif==1.5.0\ to \equirements.txt\ (prebuilt wheels bundled with \libheif\).
- **App Startup**: Registered \pillow_heif.register_heif_opener()\ in \CrushLuConfig.ready()\ and \crush_lu/utils/image_processing.py\.
- **Conversion**: \process_uploaded_image()\ decodes HEIC/HEIF, preserves orientation via EXIF, converts to RGB mode, downscales to 1200px max edge, and saves as optimized standard \.jpg\ JPEG.
- **Validation**:
  - Added \.heic\, \.heif\ and \image/heic\, \image/heif\ MIME types to \CrushProfileForm._validate_photo\.
  - Added \.heic\, \.heif\ to file picker \ccept\ in \crush_lu/templates/crush_lu/partials/photo_card.html\.
  - Wrapped image decoding to catch corrupt/unsupported files as \ValidationError\ returning clean HTTP 400 responses instead of unhandled 500 server crashes.
- **Automated Tests**:
  - \	est_heic_image_converted_to_jpeg\ in \	est_admin_smoke.py\
  - \	est_corrupt_image_raises_validation_error\ in \	est_admin_smoke.py\
  - \UploadPhotoDraftTests\ in \	est_profile_draft.py\

## Test Plan
- Ran \pytest crush_lu/tests/test_admin_smoke.py crush_lu/tests/test_profile_draft.py crush_lu/tests/test_profiles.py crush_lu/tests/test_profile_registration_e2e.py\ (all 55 tests passed).
- Ran \uff check\ on modified files (clean).