### PR TITLE
fix(echo): send the experience-level purchaseLink, not just the date one

### DIFF
--- a/crush_lu/services/echo_lu.py
+++ b/crush_lu/services/echo_lu.py
@@ -1144,6 +1144,25 @@ def build_experience_payload(event, venue_ids=None):
         "venues": list(venue_ids or []),
         "location": {"address": address_payload(event)},
         "tickets": _build_tickets(event),
+        # The experience-level purchase link, and the one that actually backs
+        # the "Commander des billets" button. This is NOT a duplicate of the
+        # `dates[].purchaseLink` above, and sending only that one is what left
+        # every listing with a price, a buy button and nowhere to buy — found
+        # on the live portal 2026-08-15.
+        #
+        # The schema settles which field wins. Top-level `purchaseLink` is
+        # documented as "url of the ticketing page **if not present in the
+        # Tickets**" / "in case if any of tickets don't have link to the
+        # purchase page, this will be used" — and `Ticket` carries **no link
+        # field at all** (title, price, currency, quantity, salesStart,
+        # salesEnd, and nothing else). So the fallback is not a fallback: it is
+        # the only place an experience-wide purchase URL can live.
+        #
+        # `dates[].purchaseLink` stays. It is the per-occurrence link, which
+        # the docs describe for the recurring case ("a direct link to the
+        # repeating events from the rrule"); it is right for a multi-date
+        # experience and simply never reaches the main buy button.
+        "purchaseLink": event_url,
     }
 
     tags = _setting_list("ECHO_LU_DEFAULT_TAGS")

--- a/crush_lu/tests/test_echo_lu_sync.py
+++ b/crush_lu/tests/test_echo_lu_sync.py
@@ -462,6 +462,28 @@ class PayloadTests(TestCase):
             f"https://crush.lu/en/events/{event.pk}/",
         )
 
+    def test_the_experience_level_purchase_link_is_sent_too(self):
+        # The date-level link alone leaves the listing with a price, a
+        # "Commander des billets" button and nowhere to buy — seen on the live
+        # portal 2026-08-15. `Ticket` has no link field of its own, so the
+        # top-level `purchaseLink` is the ONLY field that can back that button.
+        # Deleting this assertion silently un-sells every event.
+        event = make_event()
+        payload = echo_lu.build_experience_payload(event)
+        self.assertEqual(
+            payload["purchaseLink"], f"https://crush.lu/en/events/{event.pk}/"
+        )
+
+    def test_both_purchase_links_travel_on_every_payload(self):
+        # They are different fields for different jobs — per-occurrence vs
+        # experience-wide — so neither one substitutes for the other. Guard the
+        # pair, because "we already send purchaseLink" is exactly the reading
+        # that let this ship.
+        payload = echo_lu.build_experience_payload(make_event())
+        self.assertIn("purchaseLink", payload)
+        self.assertIn("purchaseLink", payload["dates"][0])
+        self.assertEqual(payload["purchaseLink"], payload["dates"][0]["purchaseLink"])
+
     @override_settings(ECHO_LU_CONTACT_WEBSITE="https://crush.lu")
     @override_settings(ECHO_LU_CONTACT_PHONE="+352123456")
     def test_contact_website_uses_the_configured_organiser_site(self):

--- a/docs/integrations/echo-lu-sync.md
+++ b/docs/integrations/echo-lu-sync.md
@@ -525,7 +525,8 @@ row says so; the recovery is:
 | `title` / `description` | `title_en` / `description_en`, falling back through the other languages |
 | `subtitle` | `get_event_type_display()` |
 | `dates[0].from` / `.to` | `date_time` / `end_time`, RFC 3339 in UTC |
-| `dates[0].purchaseLink` | the event detail page |
+| `dates[0].purchaseLink` | the event detail page — the *per-occurrence* link |
+| `purchaseLink` (top level) | the event detail page — the **experience-wide** link, and the one that backs the "Commander des billets" button. Not a duplicate of the date-level field: `Ticket` has no link of its own, so this is the only place an experience-wide purchase URL can live. Sending only the date-level one leaves the listing with a price, a buy button and nowhere to buy (seen live 2026-08-15). |
 | `venues` | `location` (venue name) |
 | `location.address` | `address_street` / `address_number` / `address_postcode` / `address_town`; `commune` gets the town too |
 | `location.address.latitude/longitude` | `latitude` / `longitude`, as strings, omitted when unset |


### PR DESCRIPTION
## What

Every synced echo.lu listing went out with a price and a **"Commander des billets" button that led nowhere**. Tom spotted it on the live portal after submitting the 19/08 Speed Dating.

## Why it happened

We only ever sent `dates[].purchaseLink`. The echo.lu schema has a **second, top-level `purchaseLink`**, documented as:

> "Purchase link: url of the ticketing page **if not present in the Tickets**"
> "in case if any of tickets don't have link to the purchase page, this will be used"

And the `Ticket` object has **no link field at all** — `title`, `price`, `currency`, `quantity`, `salesStart`, `salesEnd`, and nothing else. So that "fallback" is not a fallback: it is the only place an experience-wide purchase URL can live, and it is what backs the buy button.

Verified against the live API docs at `https://api.echo.lu/`, not inferred.

## What changed

- `build_experience_payload` now also sets the top-level `purchaseLink`.
- The date-level link **stays**. It is the per-occurrence link — the docs describe it for the recurring case ("a direct link to the repeating events from the rrule") — and it is correct for a multi-date experience. It simply never reaches the main button.
- Two tests: one pinning the top-level field, one guarding that *both* travel, because "we already send purchaseLink" is exactly the reading that let this ship.
- Field-mapping table in `docs/integrations/echo-lu-sync.md` now distinguishes the two.

## Deploy note

The payload gains a key, so `payload_fingerprint` changes and the **next sweep re-sends every listing once**. That was already true of #837's `videos` key — the two land together, one re-send covers both.

The 19/08 listing is already submitted; it picks the link up on that sweep. The other three can have it set by hand in wizard step 3 (Billetterie) in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)