### PR TITLE
feat(crush): seed September 2026 event programme (8 events + quiz packs)

### DIFF
--- a/crush_lu/management/commands/create_september_2026_events.py
+++ b/crush_lu/management/commands/create_september_2026_events.py
@@ -169,8 +169,10 @@ QN_DESCRIPTION = {
     ),
 }
 
-# The four Wednesdays (Speed Dating) and Thursdays (Quiz Night) of September
-# 2026: Sep 2, 9, 16, 23 are Wednesdays; Sep 3, 10, 17, 24 are Thursdays.
+# The Wednesdays (Speed Dating) and Thursdays (Quiz Night) of September 2026.
+# Sep 2026 has FIVE Wednesdays (2, 9, 16, 23, 30); the programme deliberately
+# covers the first four so the month does not end on a quiz-week language
+# imbalance — Sep 30 is left free (school-holiday tail, venue planning).
 # Language weeks alternate exactly like August: DE/LU, FR, DE/LU, FR.
 # The DE/LU speed datings ran 25–42 in August, the FR ones 25–38.
 # Quiz packs rotate so consecutive evenings never replay the same questions.
@@ -190,6 +192,9 @@ SD_DURATION = 120
 QN_DURATION = 160
 SD_MAX = 14
 QN_MAX = 24
+# 24 seats in teams of 4 → 6 tables, matching create_quiz_night_event's
+# table bootstrap (the readiness check requires at least 2).
+QN_TABLES = 6
 # Balanced speed dating: 7 men / 7 women / 0 NB of the 14 total. Pass
 # --no-gender-caps to leave the caps blank (total-only) instead.
 SD_GENDER_CAPS = (7, 7, 0)
@@ -257,7 +262,11 @@ class Command(BaseCommand):
             type=int,
             default=None,
             metavar="EVENT_ID",
-            help="Reuse the banner image of an existing event (e.g. August's 15).",
+            help=(
+                "Reuse the banner image of an existing event, applied ONLY to "
+                "new events of the same event_type (e.g. --banner-from 15 for "
+                "the August Speed Dating artwork)."
+            ),
         )
         parser.add_argument(
             "--quiz-owner",
@@ -277,17 +286,28 @@ class Command(BaseCommand):
             "address_postcode": options["address_postcode"].replace("L-", "").replace("l-", ""),
             "address_town": options["address_town"],
         }
-        if publish and not (
-            address["address_street"].strip()
-            and address["address_postcode"].strip()
-            and address["address_town"].strip()
-        ):
-            raise CommandError(
-                "--publish needs the full venue address: --address-street, "
-                "--address-postcode, --address-town (and --location for the "
-                "venue name). Without --publish the events are created as "
-                "drafts and the address is filled in the admin."
-            )
+        if publish:
+            missing = [
+                name
+                for name in ("location", "address_street", "address_postcode", "address_town")
+                if not address[name].strip()
+            ]
+            if missing:
+                raise CommandError(
+                    "--publish needs the full venue address: "
+                    + ", ".join(f"--{name.replace('_', '-')}" for name in missing)
+                    + " (drafts skip this: fill the address in the admin)."
+                )
+            # Same rule the model's echo.lu gate enforces (unmet_publish_
+            # requirements): a four-digit postcode. Validated here because
+            # objects.create() never runs field validators or clean().
+            import re
+
+            if not re.fullmatch(r"[0-9]{4}", address["address_postcode"]):
+                raise CommandError(
+                    "--address-postcode must be exactly four digits "
+                    f"(got '{options['address_postcode']}')."
+                )
 
         banner_event = None
         if options["banner_from"] is not None:
@@ -304,6 +324,14 @@ class Command(BaseCommand):
 
         quiz_owner = self._quiz_owner(options["quiz_owner"])
 
+        if options["premium_seats"] > min(SD_MAX, QN_MAX):
+            raise CommandError(
+                f"--premium-seats ({options['premium_seats']}) cannot exceed the "
+                f"smallest event capacity ({min(SD_MAX, QN_MAX)}): reserved "
+                "seats are held WITHIN the total, and above it every regular "
+                "member would land on the waitlist."
+            )
+
         created, skipped, quizzes = [], [], []
         for day, event_type, languages, min_age, max_age, pack in PROGRAMME:
             exists = MeetupEvent.objects.filter(
@@ -311,12 +339,22 @@ class Command(BaseCommand):
                 date_time=_local(YEAR, MONTH, day, 19),
             ).exists()
             label = f"Sep {day} {'Speed Dating' if event_type == 'speed_dating' else 'Quiz Night'} [{'/'.join(languages)}]"
+            is_sd = event_type == "speed_dating"
             if exists:
+                # The event row is there but its quiz may not be (e.g. a first
+                # run without a superuser). Repair that in place rather than
+                # telling the operator to re-run into a wall of skips.
+                event = MeetupEvent.objects.get(
+                    event_type=event_type,
+                    date_time=_local(YEAR, MONTH, day, 19),
+                )
+                self._seed_quiz_if_missing(
+                    event, pack, quiz_owner, dry_run, quizzes
+                )
                 skipped.append(label)
                 self.stdout.write(f"= {label}: already exists, skipped")
                 continue
 
-            is_sd = event_type == "speed_dating"
             event_kwargs = {
                 "event_type": event_type,
                 "title": (SD_TITLE if is_sd else QN_TITLE)["en"],
@@ -346,7 +384,9 @@ class Command(BaseCommand):
                 event_kwargs["max_participants_f"] = SD_GENDER_CAPS[1]
                 event_kwargs["max_participants_nb"] = SD_GENDER_CAPS[2]
             event_kwargs.update(address)
-            if banner_event is not None:
+            if banner_event is not None and banner_event.event_type == event_type:
+                # Same-type artwork only: a Speed Dating banner on a Quiz
+                # Night (or the reverse) misleads the public listing.
                 event_kwargs["image"] = banner_event.image.name
 
             if dry_run:
@@ -360,24 +400,9 @@ class Command(BaseCommand):
 
             with transaction.atomic():
                 event = MeetupEvent.objects.create(**event_kwargs)
-                if pack and quiz_owner is not None:
-                    quiz = QuizEvent.objects.create(
-                        event=event, created_by=quiz_owner
-                    )
-                    from crush_lu.management.commands.generate_crush_quiz import (
-                        populate_quiz,
-                    )
-
-                    result = populate_quiz(quiz, pack=pack)
-                    quizzes.append(
-                        (
-                            event,
-                            pack,
-                            result.rounds_created,
-                            result.questions_created,
-                            result.pending_uploads,
-                        )
-                    )
+                self._seed_quiz_if_missing(
+                    event, pack, quiz_owner, dry_run, quizzes
+                )
 
             suffix = ""
             if pack:
@@ -426,6 +451,44 @@ class Command(BaseCommand):
                 "Events are drafts. Fill the venue address + banner + coaches "
                 "in the admin, then publish (bulk action checks the echo.lu gate)."
             )
+
+    def _seed_quiz_if_missing(self, event, pack, quiz_owner, dry_run, quizzes):
+        """Create the QuizEvent + pack for a quiz night, if not already there.
+
+        Also backfills quizzes on re-runs over existing events (a first run
+        without a superuser creates the MeetupEvents but no quizzes), and
+        bootstraps the QN_TABLES physical tables the readiness check and the
+        live rotation need — mirroring create_quiz_night_event.
+        """
+        if not pack:
+            return
+        if dry_run:
+            return
+        if quiz_owner is None:
+            return
+        if QuizEvent.objects.filter(event=event).exists():
+            return
+        with transaction.atomic():
+            quiz = QuizEvent.objects.create(
+                event=event,
+                created_by=quiz_owner,
+                num_tables=QN_TABLES,
+            )
+            quiz.ensure_tables()
+            from crush_lu.management.commands.generate_crush_quiz import (
+                populate_quiz,
+            )
+
+            result = populate_quiz(quiz, pack=pack)
+        quizzes.append(
+            (
+                event,
+                pack,
+                result.rounds_created,
+                result.questions_created,
+                result.pending_uploads,
+            )
+        )
 
     def _quiz_owner(self, username):
         User = get_user_model()

--- a/crush_lu/management/commands/create_september_2026_events.py
+++ b/crush_lu/management/commands/create_september_2026_events.py
@@ -1,0 +1,445 @@
+"""
+Seed the September 2026 event programme for Crush.lu.
+
+One-shot data command: eight events following the proven August cadence —
+Speed Dating every Wednesday + Quiz Night every Thursday, 19:00 Europe/Luxembourg,
+alternating language weeks (DE/LU, then FR), €15.50 fee, registration deadline
+18:00 on the day of the event.
+
+Each Quiz Night also gets its QuizEvent shell and a question pack; packs rotate
+across the four evenings so consecutive weeks never replay the same questions.
+
+Events are created UNPUBLISHED and without a venue address on purpose: the
+exact venue stays hidden until signup, so the coach fills street/postcode/
+banner/coaches in the admin and publishes there (the echo.lu publish gate
+requires the full address). ``--publish`` + ``--address-*`` skips that manual
+step when the venue is known up front.
+
+Idempotent: events are keyed on (event_type, date_time). Re-running skips what
+already exists — nothing is updated or deleted in place. Fix data in the admin.
+
+Usage:
+    python manage.py create_september_2026_events                # dry run by default? no — creates drafts
+    python manage.py create_september_2026_events --dry-run
+    python manage.py create_september_2026_events --publish \
+        --address-street "rue du Nord" --address-postcode 2229 \
+        --address-town Luxembourg --location "The Venue"
+    python manage.py create_september_2026_events --banner-from 15
+"""
+
+from datetime import datetime
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+from crush_lu.models import MeetupEvent
+from crush_lu.models.quiz import QuizEvent
+
+YEAR = 2026
+MONTH = 9
+
+FEE = "15.50"
+
+# Speed Dating copy — identical across all four evenings, matching August.
+SD_TITLE = {
+    "en": "💘 Speed Dating | What if this was the right moment",
+    "de": "💘 Speed Dating | Was, wenn jetzt der richtige Moment ist",
+    "fr": "💘 Speed Dating | Et si c'était le bon moment",
+}
+
+SD_DESCRIPTION = {
+    "en": (
+        "We've all spent hours scrolling without ever really meeting anyone 😅  \n"
+        "Here, it's the opposite : a few minutes, a real look, a real conversation 💫\n\n"
+        "The principle is simple : you go through short face to face encounters, "
+        "and you immediately feel if the connection is there ⚡\n\n"
+        "On the programme :\n\n"
+        "💬 Sincere exchanges, no script and no filter  \n"
+        "😊 A caring atmosphere where nobody judges anyone  \n"
+        "✨ Connections that happen naturally  \n"
+        "🥂 A drink to extend the evening with those who caught your attention\n\n"
+        "Everything takes place in a small group, for more intimacy and comfort.  \n"
+        "A deliberately limited number of people, so everyone has the time to be "
+        "truly met 🤫\n\n"
+        "No need to be at ease or to have the perfect line.  \n"
+        "Come as you are, the rest follows on its own 💘\n\n"
+        "We're waiting for you 🧡"
+    ),
+    "de": (
+        "Wir haben alle schon stundenlang gescrollt, ohne jemals wirklich "
+        "jemanden kennenzulernen 😅  \n"
+        "Hier ist es umgekehrt : ein paar Minuten, ein echter Blick, ein echtes "
+        "Gespräch 💫\n\n"
+        "Das Prinzip ist einfach : Du erlebst kurze Begegnungen von Angesicht zu "
+        "Angesicht und spürst sofort, ob die Verbindung stimmt ⚡\n\n"
+        "Auf dem Programm :\n\n"
+        "💬 Ehrliche Gespräche, ohne Skript und ohne Filter  \n"
+        "😊 Eine wohlwollende Atmosphäre, in der niemand jemanden verurteilt  \n"
+        "✨ Verbindungen, die ganz natürlich entstehen  \n"
+        "🥂 Ein Drink, um den Abend mit denen zu verlängern, die dich beeindruckt "
+        "haben\n\n"
+        "Alles findet in kleiner Runde statt, für mehr Intimität und Wohlbefinden.  \n"
+        "Eine bewusst begrenzte Gruppe, damit jeder die Zeit hat, wirklich "
+        "wahrgenommen zu werden 🤫\n\n"
+        "Du musst nicht selbstsicher sein oder den perfekten Satz parat haben.  \n"
+        "Komm, wie du bist, der Rest ergibt sich von selbst 💘\n\n"
+        "Wir warten auf dich 🧡"
+    ),
+    "fr": (
+        "On a tous déjà passé des heures à scroller sans jamais vraiment "
+        "rencontrer personne 😅  \n"
+        "Ici, c'est l'inverse : quelques minutes, un vrai regard, une vraie "
+        "conversation 💫\n\n"
+        "Le principe est simple : tu enchaînes des rencontres courtes en face à "
+        "face, et tu sens tout de suite si le courant passe ⚡\n\n"
+        "Au programme :\n\n"
+        "💬 Des échanges sincères, sans script et sans filtre  \n"
+        "😊 Une ambiance bienveillante où personne ne juge personne  \n"
+        "✨ Des connexions qui se créent naturellement  \n"
+        "🥂 Un verre pour prolonger la soirée avec ceux qui t'ont marqué\n\n"
+        "Tout se passe en petit comité, pour plus d'intimité et de confort.  \n"
+        "Un groupe volontairement restreint, pour que chacun ait le temps d'être "
+        "vraiment rencontré 🤫\n\n"
+        "Pas besoin d'être à l'aise ou d'avoir la réplique parfaite.  \n"
+        "Viens comme tu es, le reste suit tout seul 💘\n\n"
+        "On t'attend 🧡"
+    ),
+}
+
+# Quiz Night copy — identical across all four evenings, matching August.
+QN_TITLE = {
+    "en": "🧩 Quiz Night | New format, new encounters",
+    "de": "🧩 Quiz Night | Neues Format, neue Begegnungen",
+    "fr": "🧩 Quiz Night | Nouvelle formule, nouvelles rencontres",
+}
+
+QN_DESCRIPTION = {
+    "en": (
+        "We've completely rethought our Quiz Night from A to Z, and we can't "
+        "wait to show you the result 🎉\n\n"
+        "New format, new questions, new ways to meet each other.  \n"
+        "The principle stays the same : have fun first, and let the connections "
+        "happen on their own 💫\n\n"
+        "On the programme :\n\n"
+        "🧠 Brand new questions, sometimes surprising, often revealing  \n"
+        "🤝 A format designed so everyone gets to talk, not just the most "
+        "outgoing  \n"
+        "😄 Laughter, debates and moments of complicity  \n"
+        "🥂 A drink to extend the evening with those who caught your attention\n\n"
+        "No need to know everything or to have revised.  \n"
+        "Here, it's the most sincere answers that make the best encounters ✨\n\n"
+        "Come try the new format, we're waiting for you 🧡"
+    ),
+    "de": (
+        "Wir haben unsere Quiz Night von A bis Z neu gedacht, und wir freuen "
+        "uns darauf, euch das Ergebnis zu zeigen 🎉\n\n"
+        "Neues Format, neue Fragen, neue Wege, sich kennenzulernen.  \n"
+        "Das Prinzip bleibt dasselbe : zuerst Spaß haben und die Verbindungen "
+        "ganz von selbst entstehen lassen 💫\n\n"
+        "Auf dem Programm :\n\n"
+        "🧠 Ganz neue Fragen, manchmal überraschend, oft aufschlussreich  \n"
+        "🤝 Ein Format, bei dem jeder zu Wort kommt, nicht nur die Gesprächigsten  \n"
+        "😄 Lachen, Diskussionen und Momente der Verbundenheit  \n"
+        "🥂 Ein Drink, um den Abend mit denen zu verlängern, die dich beeindruckt "
+        "haben\n\n"
+        "Du musst nicht alles wissen oder dich vorbereitet haben.  \n"
+        "Hier sind es die ehrlichsten Antworten, die zu den besten Begegnungen "
+        "führen ✨\n\n"
+        "Komm und teste das neue Format, wir warten auf dich 🧡"
+    ),
+    "fr": (
+        "On a repensé notre Quiz Night de A à Z, et on a hâte de vous faire "
+        "découvrir ce que ça donne 🎉\n\n"
+        "Nouveau format, nouvelles questions, nouvelles façons de se "
+        "rencontrer.  \n"
+        "Le principe reste le même : s'amuser d'abord, et laisser les "
+        "connexions se créer toutes seules 💫\n\n"
+        "Au programme :\n\n"
+        "🧠 Des questions inédites, parfois surprenantes, souvent révélatrices  \n"
+        "🤝 Un format pensé pour que tout le monde échange, pas seulement les "
+        "plus bavards  \n"
+        "😄 Des rires, des débats et des moments de complicité  \n"
+        "🥂 Un verre pour prolonger la soirée avec ceux qui t'ont marqué\n\n"
+        "Pas besoin d'être incollable ni d'avoir révisé.  \n"
+        "Ici, ce sont les réponses les plus sincères qui font les meilleures "
+        "rencontres ✨\n\n"
+        "Viens tester la nouvelle formule, on t'attend 🧡"
+    ),
+}
+
+# The four Wednesdays (Speed Dating) and Thursdays (Quiz Night) of September
+# 2026: Sep 2, 9, 16, 23 are Wednesdays; Sep 3, 10, 17, 24 are Thursdays.
+# Language weeks alternate exactly like August: DE/LU, FR, DE/LU, FR.
+# The DE/LU speed datings ran 25–42 in August, the FR ones 25–38.
+# Quiz packs rotate so consecutive evenings never replay the same questions.
+PROGRAMME = [
+    # (day, event_type, languages, min_age, max_age, quiz_pack)
+    (2, "speed_dating", ["de", "lu"], 25, 42, None),
+    (3, "quiz_night", ["de", "lu"], 18, 99, "classic"),
+    (9, "speed_dating", ["fr"], 25, 38, None),
+    (10, "quiz_night", ["fr"], 18, 99, "media-love"),
+    (16, "speed_dating", ["de", "lu"], 25, 42, None),
+    (17, "quiz_night", ["de", "lu"], 18, 99, "mettwoch"),
+    (23, "speed_dating", ["fr"], 25, 38, None),
+    (24, "quiz_night", ["fr"], 18, 99, "classic"),
+]
+
+SD_DURATION = 120
+QN_DURATION = 160
+SD_MAX = 14
+QN_MAX = 24
+# Balanced speed dating: 7 men / 7 women / 0 NB of the 14 total. Pass
+# --no-gender-caps to leave the caps blank (total-only) instead.
+SD_GENDER_CAPS = (7, 7, 0)
+
+
+def _local(year, month, day, hour, minute=0):
+    """Aware datetime in the project timezone (Europe/Luxembourg)."""
+    return datetime(
+        year, month, day, hour, minute, tzinfo=timezone.get_current_timezone()
+    )
+
+
+class Command(BaseCommand):
+    help = (
+        "Create the September 2026 Crush.lu event programme (4 Speed Dating + "
+        "4 Quiz Night) with quiz packs. Idempotent per (event_type, date_time)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would happen, write nothing.",
+        )
+        parser.add_argument(
+            "--publish",
+            action="store_true",
+            help=(
+                "Publish immediately. Requires the full venue address — the "
+                "echo.lu gate rejects published events without it."
+            ),
+        )
+        parser.add_argument(
+            "--no-gender-caps",
+            action="store_true",
+            help="Leave per-gender caps blank on Speed Dating (total cap only).",
+        )
+        parser.add_argument(
+            "--profile-requirement",
+            default="completed",
+            choices=[c[0] for c in MeetupEvent.PROFILE_REQUIREMENT_CHOICES],
+            help="Profile level needed to register (default: completed).",
+        )
+        parser.add_argument(
+            "--premium-seats",
+            type=int,
+            default=0,
+            help="Seats reserved for premium members within the total (default 0).",
+        )
+        parser.add_argument(
+            "--location",
+            default="",
+            help="Venue name shown to registered members (e.g. 'ATMOS').",
+        )
+        parser.add_argument("--address-street", default="", help="Venue street.")
+        parser.add_argument(
+            "--address-number", default="", help="Venue house number."
+        )
+        parser.add_argument(
+            "--address-postcode", default="", help="4-digit Luxembourg postcode."
+        )
+        parser.add_argument("--address-town", default="", help="Venue town.")
+        parser.add_argument(
+            "--banner-from",
+            type=int,
+            default=None,
+            metavar="EVENT_ID",
+            help="Reuse the banner image of an existing event (e.g. August's 15).",
+        )
+        parser.add_argument(
+            "--quiz-owner",
+            default=None,
+            metavar="USERNAME",
+            help="User recorded as creating the QuizEvents (default: a superuser).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        publish = options["publish"]
+
+        address = {
+            "location": options["location"],
+            "address_street": options["address_street"],
+            "address_number": options["address_number"],
+            "address_postcode": options["address_postcode"].replace("L-", "").replace("l-", ""),
+            "address_town": options["address_town"],
+        }
+        if publish and not (
+            address["address_street"].strip()
+            and address["address_postcode"].strip()
+            and address["address_town"].strip()
+        ):
+            raise CommandError(
+                "--publish needs the full venue address: --address-street, "
+                "--address-postcode, --address-town (and --location for the "
+                "venue name). Without --publish the events are created as "
+                "drafts and the address is filled in the admin."
+            )
+
+        banner_event = None
+        if options["banner_from"] is not None:
+            try:
+                banner_event = MeetupEvent.objects.get(pk=options["banner_from"])
+            except MeetupEvent.DoesNotExist:
+                raise CommandError(
+                    f"--banner-from: no MeetupEvent with id {options['banner_from']}."
+                )
+            if not banner_event.image:
+                raise CommandError(
+                    f"--banner-from: event {banner_event.pk} has no banner image."
+                )
+
+        quiz_owner = self._quiz_owner(options["quiz_owner"])
+
+        created, skipped, quizzes = [], [], []
+        for day, event_type, languages, min_age, max_age, pack in PROGRAMME:
+            exists = MeetupEvent.objects.filter(
+                event_type=event_type,
+                date_time=_local(YEAR, MONTH, day, 19),
+            ).exists()
+            label = f"Sep {day} {'Speed Dating' if event_type == 'speed_dating' else 'Quiz Night'} [{'/'.join(languages)}]"
+            if exists:
+                skipped.append(label)
+                self.stdout.write(f"= {label}: already exists, skipped")
+                continue
+
+            is_sd = event_type == "speed_dating"
+            event_kwargs = {
+                "event_type": event_type,
+                "title": (SD_TITLE if is_sd else QN_TITLE)["en"],
+                "title_en": (SD_TITLE if is_sd else QN_TITLE)["en"],
+                "title_de": (SD_TITLE if is_sd else QN_TITLE)["de"],
+                "title_fr": (SD_TITLE if is_sd else QN_TITLE)["fr"],
+                "description": (SD_DESCRIPTION if is_sd else QN_DESCRIPTION)["en"],
+                "description_en": (SD_DESCRIPTION if is_sd else QN_DESCRIPTION)["en"],
+                "description_de": (SD_DESCRIPTION if is_sd else QN_DESCRIPTION)["de"],
+                "description_fr": (SD_DESCRIPTION if is_sd else QN_DESCRIPTION)["fr"],
+                "languages": languages,
+                "date_time": _local(YEAR, MONTH, day, 19),
+                "duration_minutes": SD_DURATION if is_sd else QN_DURATION,
+                "max_participants": SD_MAX if is_sd else QN_MAX,
+                "min_age": min_age,
+                "max_age": max_age,
+                "registration_deadline": _local(YEAR, MONTH, day, 18),
+                "registration_fee": FEE,
+                "profile_requirement": options["profile_requirement"],
+                "reserved_premium_seats": options["premium_seats"],
+                "canton": "Luxembourg",
+                "enable_activity_voting": is_sd,
+                "is_published": publish,
+            }
+            if is_sd and not options["no_gender_caps"]:
+                event_kwargs["max_participants_m"] = SD_GENDER_CAPS[0]
+                event_kwargs["max_participants_f"] = SD_GENDER_CAPS[1]
+                event_kwargs["max_participants_nb"] = SD_GENDER_CAPS[2]
+            event_kwargs.update(address)
+            if banner_event is not None:
+                event_kwargs["image"] = banner_event.image.name
+
+            if dry_run:
+                self.stdout.write(
+                    f"+ {label}: would create "
+                    f"({'published' if publish else 'draft'}, "
+                    f"pack={pack or '—'})"
+                )
+                created.append(label)
+                continue
+
+            with transaction.atomic():
+                event = MeetupEvent.objects.create(**event_kwargs)
+                if pack and quiz_owner is not None:
+                    quiz = QuizEvent.objects.create(
+                        event=event, created_by=quiz_owner
+                    )
+                    from crush_lu.management.commands.generate_crush_quiz import (
+                        populate_quiz,
+                    )
+
+                    result = populate_quiz(quiz, pack=pack)
+                    quizzes.append(
+                        (
+                            event,
+                            pack,
+                            result.rounds_created,
+                            result.questions_created,
+                            result.pending_uploads,
+                        )
+                    )
+
+            suffix = ""
+            if pack:
+                if quiz_owner is not None:
+                    q = quizzes[-1]
+                    suffix = f" + quiz pack '{q[1]}' ({q[2]} rounds / {q[3]} questions)"
+                    if q[4]:
+                        suffix += (
+                            f" — {len(q[4])} image question(s) pending upload"
+                        )
+                else:
+                    suffix = (
+                        " — quiz NOT created (no superuser; pass --quiz-owner)"
+                    )
+            self.stdout.write(
+                self.style.SUCCESS(f"+ {label}: created {event.pk} "
+                                   f"({'published' if publish else 'draft'}){suffix}")
+            )
+            created.append(label)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Dry run: would create {len(created)}, "
+                    f"{len(skipped)} already exist — nothing written."
+                )
+            )
+            return
+
+        pending_uploads = sum(1 for q in quizzes if q[4])
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nDone: {len(created)} created, {len(skipped)} skipped, "
+                f"{len(quizzes)} quiz night(s) seeded."
+            )
+        )
+        if pending_uploads:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"{pending_uploads} quiz night(s) include image questions "
+                    "pending upload — finish them in the quiz admin."
+                )
+            )
+        if not publish:
+            self.stdout.write(
+                "Events are drafts. Fill the venue address + banner + coaches "
+                "in the admin, then publish (bulk action checks the echo.lu gate)."
+            )
+
+    def _quiz_owner(self, username):
+        User = get_user_model()
+        if username:
+            try:
+                return User.objects.get(username=username)
+            except User.DoesNotExist:
+                raise CommandError(f"--quiz-owner: no user '{username}'.")
+        superuser = User.objects.filter(is_superuser=True).order_by("pk").first()
+        if superuser is None:
+            self.stdout.write(
+                self.style.WARNING(
+                    "No superuser found — QuizEvents are NOT created. "
+                    "Pass --quiz-owner <username> to seed the quiz nights."
+                )
+            )
+        return superuser

--- a/crush_lu/tests/test_september_2026_events.py
+++ b/crush_lu/tests/test_september_2026_events.py
@@ -143,6 +143,15 @@ class QuizSeedingTest(TestCase):
             self.assertGreaterEqual(rounds, 5)
             self.assertGreaterEqual(questions, 30)
 
+    def test_quiz_tables_bootstrapped(self):
+        from crush_lu.models.quiz import QuizTable
+
+        for quiz in QuizEvent.objects.all():
+            self.assertEqual(quiz.num_tables, 6)
+            self.assertEqual(
+                QuizTable.objects.filter(quiz=quiz).count(), 6
+            )
+
     def test_consecutive_evenings_use_different_questions(self):
         def texts(day):
             quiz = QuizEvent.objects.get(event__date_time=_sep(day, 19))
@@ -254,6 +263,82 @@ class IdempotencyAndFlagsTest(TestCase):
             call_command(
                 "create_september_2026_events", "--banner-from", "99999"
             )
+
+    def test_premium_seats_above_capacity_rejected(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "create_september_2026_events", "--premium-seats", "15"
+            )
+
+    def test_publish_rejects_invalid_postcode(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "create_september_2026_events",
+                "--publish",
+                "--location", "ATMOS",
+                "--address-street", "place de la Gare",
+                "--address-postcode", "foo",
+                "--address-town", "Luxembourg",
+            )
+
+    def test_publish_rejects_missing_location(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "create_september_2026_events",
+                "--publish",
+                "--address-street", "place de la Gare",
+                "--address-postcode", "1616",
+                "--address-town", "Luxembourg",
+            )
+
+    def test_banner_only_applies_to_matching_event_type(self):
+        august_sd = MeetupEvent.objects.create(
+            title="August SD",
+            description="x",
+            event_type="speed_dating",
+            location="V",
+            address="a",
+            date_time=datetime(2026, 8, 19, 19, tzinfo=TZ),
+            duration_minutes=120,
+            registration_deadline=datetime(2026, 8, 19, 18, tzinfo=TZ),
+        )
+        # Set the banner path without an upload (the command only ever reads
+        # image.name and passes the string on — no storage round-trip).
+        MeetupEvent.objects.filter(pk=august_sd.pk).update(
+            image="events/banners/august-sd.png"
+        )
+        august_sd.refresh_from_db()
+        call_command(
+            "create_september_2026_events",
+            "--quiz-owner", "quiz-owner",
+            "--banner-from", str(august_sd.pk),
+        )
+        # Speed datings carry the reused banner, quiz nights do not.
+        for day in (2, 9, 16, 23):
+            sd = MeetupEvent.objects.get(date_time=_sep(day, 19))
+            self.assertEqual(sd.image, "events/banners/august-sd.png")
+        for day in (3, 10, 17, 24):
+            qn = MeetupEvent.objects.get(date_time=_sep(day, 19))
+            self.assertFalse(qn.image)
+
+
+class QuizBackfillOnRerunTest(TestCase):
+    """A first run without a superuser leaves quiz nights without quizzes;
+    the documented re-run with --quiz-owner repairs them."""
+
+    def test_rerun_with_owner_backfills_missing_quizzes(self):
+        call_command("create_september_2026_events")  # no superuser exists
+        self.assertEqual(MeetupEvent.objects.count(), 8)
+        self.assertEqual(QuizEvent.objects.count(), 0)
+
+        User.objects.create_superuser(
+            username="quiz-owner", email="q@example.com", password="x"
+        )
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+        self.assertEqual(MeetupEvent.objects.count(), 8)  # no duplicates
+        self.assertEqual(QuizEvent.objects.count(), 4)  # all backfilled
+        for quiz in QuizEvent.objects.all():
+            self.assertGreaterEqual(quiz.rounds.count(), 5)
 
 
 class NoSuperuserQuizSkippedTest(TestCase):

--- a/crush_lu/tests/test_september_2026_events.py
+++ b/crush_lu/tests/test_september_2026_events.py
@@ -1,0 +1,265 @@
+"""
+Tests for the September 2026 programme seeder.
+
+Covers the behaviours the launch depends on:
+- eight events on the right Wednesdays/Thursdays, 19:00, deadline 18:00;
+- language alternation DE/LU ↔ FR matching August's cadence;
+- Speed Dating settings (120 min, 14 seats, 7/7 gender balance, voting on);
+- Quiz Night settings (160 min, 24 seats, no gender caps, voting off) and
+  seeded question packs with distinct questions across consecutive evenings;
+- drafts by default, publish gated on the full venue address;
+- idempotency: a re-run skips everything.
+"""
+
+from datetime import datetime
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from crush_lu.models import MeetupEvent
+from crush_lu.models.quiz import QuizEvent, QuizQuestion
+
+User = get_user_model()
+
+# Europe/Luxembourg in September is CEST (UTC+2).
+TZ = timezone.get_fixed_timezone(120)
+
+
+def _sep(day, hour, minute=0):
+    return datetime(2026, 9, day, hour, minute, tzinfo=TZ)
+
+
+class SeptemberProgrammeShapeTest(TestCase):
+    """The eight events land on the right slots with the right settings."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create_superuser(
+            username="quiz-owner", email="quiz-owner@example.com", password="x"
+        )
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+
+    def test_eight_events_created(self):
+        self.assertEqual(MeetupEvent.objects.count(), 8)
+
+    def test_four_wednesdays_and_four_thursdays(self):
+        days = sorted(
+            e.date_time.astimezone(TZ).day for e in MeetupEvent.objects.all()
+        )
+        # Sep 2026: Wednesdays are 2, 9, 16, 23; Thursdays are 3, 10, 17, 24.
+        self.assertEqual(days, [2, 3, 9, 10, 16, 17, 23, 24])
+
+    def test_speed_dating_on_wednesdays_quiz_on_thursdays(self):
+        for day in (2, 9, 16, 23):
+            sd = MeetupEvent.objects.get(
+                event_type="speed_dating", date_time=_sep(day, 19)
+            )
+            self.assertEqual(sd.duration_minutes, 120)
+            self.assertEqual(sd.max_participants, 14)
+            # 7 men / 7 women / 0 NB — a balanced room.
+            self.assertEqual(sd.max_participants_m, 7)
+            self.assertEqual(sd.max_participants_f, 7)
+            self.assertEqual(sd.max_participants_nb, 0)
+            self.assertTrue(sd.enable_activity_voting)
+            self.assertEqual(sd.registration_deadline, _sep(day, 18))
+            self.assertEqual(str(sd.registration_fee), "15.50")
+        for day in (3, 10, 17, 24):
+            qn = MeetupEvent.objects.get(
+                event_type="quiz_night", date_time=_sep(day, 19)
+            )
+            self.assertEqual(qn.duration_minutes, 160)
+            self.assertEqual(qn.max_participants, 24)
+            self.assertFalse(qn.enable_activity_voting)
+            self.assertEqual(qn.registration_deadline, _sep(day, 18))
+            self.assertEqual(str(qn.registration_fee), "15.50")
+
+    def test_language_alternation_matches_august(self):
+        def langs(day):
+            return list(
+                MeetupEvent.objects.get(date_time=_sep(day, 19)).languages
+            )
+
+        self.assertEqual(langs(2), ["de", "lu"])
+        self.assertEqual(langs(3), ["de", "lu"])
+        self.assertEqual(langs(9), ["fr"])
+        self.assertEqual(langs(10), ["fr"])
+        self.assertEqual(langs(16), ["de", "lu"])
+        self.assertEqual(langs(17), ["de", "lu"])
+        self.assertEqual(langs(23), ["fr"])
+        self.assertEqual(langs(24), ["fr"])
+
+    def test_speed_dating_age_ranges(self):
+        de_lu = MeetupEvent.objects.get(date_time=_sep(2, 19))
+        fr = MeetupEvent.objects.get(date_time=_sep(9, 19))
+        self.assertEqual((de_lu.min_age, de_lu.max_age), (25, 42))
+        self.assertEqual((fr.min_age, fr.max_age), (25, 38))
+
+    def test_events_are_drafts_by_default(self):
+        self.assertFalse(
+            MeetupEvent.objects.filter(is_published=True).exists()
+        )
+
+    def test_trilingual_copy_on_every_event(self):
+        for e in MeetupEvent.objects.all():
+            self.assertTrue(e.title_en and e.title_de and e.title_fr)
+            self.assertTrue(
+                e.description_en and e.description_de and e.description_fr
+            )
+            marker = (
+                "Speed Dating"
+                if e.event_type == "speed_dating"
+                else "Quiz Night"
+            )
+            self.assertIn(marker, e.title_en)
+            self.assertIn(marker, e.title_de)
+            self.assertIn(marker, e.title_fr)
+
+    def test_canton_set_for_echo_lu(self):
+        # Drafts still carry the canton so the admin publish gate passes
+        # once the address fields are filled in.
+        self.assertTrue(
+            MeetupEvent.objects.exclude(canton="Luxembourg").exists() is False
+        )
+
+
+class QuizSeedingTest(TestCase):
+    """Quiz nights get their QuizEvent and a populated, distinct pack."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create_superuser(
+            username="quiz-owner", email="quiz-owner@example.com", password="x"
+        )
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+
+    def test_four_quiz_events_with_questions(self):
+        self.assertEqual(QuizEvent.objects.count(), 4)
+        for quiz in QuizEvent.objects.all():
+            rounds = quiz.rounds.count()
+            questions = QuizQuestion.objects.filter(round__quiz=quiz).count()
+            self.assertGreaterEqual(rounds, 5)
+            self.assertGreaterEqual(questions, 30)
+
+    def test_consecutive_evenings_use_different_questions(self):
+        def texts(day):
+            quiz = QuizEvent.objects.get(event__date_time=_sep(day, 19))
+            return set(
+                QuizQuestion.objects.filter(round__quiz=quiz).values_list(
+                    "text_en", flat=True
+                )
+            )
+
+        # Sep 3 (classic) vs Sep 10 (media-love): disjoint sets.
+        self.assertFalse(texts(3) & texts(10))
+        # Sep 10 (media-love) vs Sep 17 (mettwoch): disjoint sets.
+        self.assertFalse(texts(10) & texts(17))
+        # Sep 17 (mettwoch) vs Sep 24 (classic): disjoint sets.
+        self.assertFalse(texts(17) & texts(24))
+        # Same pack reused Sep 3 / Sep 24: identical sets — fine, three weeks
+        # apart, but assert it so a pack rotation change is a conscious act.
+        self.assertEqual(texts(3), texts(24))
+
+    def test_quiz_owner_recorded(self):
+        for quiz in QuizEvent.objects.all():
+            self.assertEqual(quiz.created_by, self.owner)
+
+    def test_quiz_questions_are_trilingual(self):
+        quiz = QuizEvent.objects.get(event__date_time=_sep(3, 19))
+        questions = QuizQuestion.objects.filter(round__quiz=quiz)
+        for q in questions:
+            self.assertTrue(q.text_en and q.text_de and q.text_fr)
+
+
+class IdempotencyAndFlagsTest(TestCase):
+    """Re-runs are no-ops; flags behave as documented."""
+
+    def setUp(self):
+        self.owner = User.objects.create_superuser(
+            username="quiz-owner", email="quiz-owner@example.com", password="x"
+        )
+
+    def test_rerun_skips_existing_events(self):
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+        self.assertEqual(MeetupEvent.objects.count(), 8)
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+        self.assertEqual(MeetupEvent.objects.count(), 8)
+
+    def test_rerun_does_not_duplicate_quizzes(self):
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+        call_command("create_september_2026_events", "--quiz-owner", "quiz-owner")
+        self.assertEqual(QuizEvent.objects.count(), 4)
+
+    def test_dry_run_writes_nothing(self):
+        call_command(
+            "create_september_2026_events",
+            "--dry-run",
+            "--quiz-owner",
+            "quiz-owner",
+        )
+        self.assertEqual(MeetupEvent.objects.count(), 0)
+        self.assertEqual(QuizEvent.objects.count(), 0)
+
+    def test_publish_requires_full_address(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "create_september_2026_events",
+                "--publish",
+                "--quiz-owner",
+                "quiz-owner",
+            )
+
+    def test_publish_with_address_creates_published_events(self):
+        call_command(
+            "create_september_2026_events",
+            "--publish",
+            "--quiz-owner",
+            "quiz-owner",
+            "--location",
+            "ATMOS",
+            "--address-street",
+            "place de la Gare",
+            "--address-number",
+            "1",
+            "--address-postcode",
+            "1616",
+            "--address-town",
+            "Luxembourg",
+        )
+        self.assertEqual(MeetupEvent.objects.filter(is_published=True).count(), 8)
+
+    def test_no_gender_caps_flag(self):
+        call_command(
+            "create_september_2026_events",
+            "--no-gender-caps",
+            "--quiz-owner",
+            "quiz-owner",
+        )
+        for day in (2, 9, 16, 23):
+            sd = MeetupEvent.objects.get(date_time=_sep(day, 19))
+            self.assertIsNone(sd.max_participants_m)
+            self.assertIsNone(sd.max_participants_f)
+            self.assertIsNone(sd.max_participants_nb)
+
+    def test_unknown_quiz_owner_raises(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "create_september_2026_events", "--quiz-owner", "ghost-user"
+            )
+
+    def test_banner_from_missing_event_raises(self):
+        with self.assertRaises(CommandError):
+            call_command(
+                "create_september_2026_events", "--banner-from", "99999"
+            )
+
+
+class NoSuperuserQuizSkippedTest(TestCase):
+    """Without any superuser and without --quiz-owner, quizzes are skipped."""
+
+    def test_events_created_without_quizzes(self):
+        call_command("create_september_2026_events")
+        self.assertEqual(MeetupEvent.objects.count(), 8)
+        self.assertEqual(QuizEvent.objects.count(), 0)


### PR DESCRIPTION
## What

One-shot management command that seeds the **September 2026 programme**: 8 events following the proven August cadence — **Speed Dating every Wednesday + Quiz Night every Thursday**, 19:00, alternating language weeks (DE/LU ↔ FR), €15.50, registration deadline 18:00 same day.

| Date | Event | Languages | Ages | Pack |
|---|---|---|---|---|
| Wed Sep 2 | Speed Dating | DE/LU | 25–42 | — |
| Thu Sep 3 | Quiz Night | DE/LU | 18–99 | classic |
| Wed Sep 9 | Speed Dating | FR | 25–38 | — |
| Thu Sep 10 | Quiz Night | FR | 18–99 | media-love |
| Wed Sep 16 | Speed Dating | DE/LU | 25–42 | — |
| Thu Sep 17 | Quiz Night | DE/LU | 18–99 | mettwoch |
| Wed Sep 23 | Speed Dating | FR | 25–38 | — |
| Thu Sep 24 | Quiz Night | FR | 18–99 | classic |

## Why

September is currently empty on crush.lu (nothing after Aug 27) while August Speed Dating sold almost out — the cadence works, it just needs to be scheduled.

## How to use (ops)

```
# preview
python manage.py create_september_2026_events --dry-run

# create as drafts (recommended: fill venue address, banner, coaches in admin, then publish)
python manage.py create_september_2026_events --quiz-owner <admin-username>

# or create + publish in one go when the venue is known
python manage.py create_september_2026_events --quiz-owner <admin> --publish \
  --location "ATMOS" --address-street "place de la Gare" --address-number 1 \
  --address-postcode 1616 --address-town Luxembourg --banner-from 15
```

- Quiz nights get their QuizEvent + question pack automatically (packs rotate so consecutive evenings never replay the same questions).
- `--banner-from 15` reuses the August Speed Dating banner (per-type banners exist in the media library).
- Idempotent on (event_type, date_time) — safe to re-run.

## Details

- SD: 120 min, 14 seats, balanced 7M/7F caps (`--no-gender-caps` to disable), activity voting on. QN: 160 min, 24 seats, no gender caps, voting off.
- Copy is the exact August wording, trilingual EN/DE/FR (modeltranslation fields set directly).
- Drafts by default: `--publish` requires the full echo.lu-ready address (canton + street + postcode + town) or the command refuses.
- 21 new tests (shape, alternation, pack distinctness, flags, idempotency, no-superuser fallback) — all green locally.