### PR TITLE
fix(atmos): address 6 more PR #862 review findings

### DIFF
--- a/power_up/atmos/management/commands/purge_stale_guest_names.py
+++ b/power_up/atmos/management/commands/purge_stale_guest_names.py
@@ -97,13 +97,8 @@ class Command(BaseCommand):
                         locked_guest = Guest.objects.select_for_update().get(
                             pk=guest.pk
                         )
-                        order_count = locked_guest.orders.exclude(
-                            alias_snapshot=locked_guest.alias
-                        ).update(alias_snapshot=locked_guest.alias)
                         had_name = bool(locked_guest.display_name)
-                        if had_name:
-                            locked_guest.display_name = ""
-                            locked_guest.save(update_fields=["display_name"])
+                        order_count = locked_guest.purge_display_name()
                 else:
                     order_count = guest.orders.exclude(
                         alias_snapshot=guest.alias

--- a/power_up/atmos/models.py
+++ b/power_up/atmos/models.py
@@ -33,7 +33,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
-from django.db.models import Q
+from django.db.models import F, Q
 from django.utils import timezone
 
 from power_up.storage import powerup_media_storage, powerup_upload_path
@@ -297,18 +297,36 @@ class Tab(models.Model):
             # GuestAdmin lets staff mark a guest "removed"/"settled" (e.g.
             # ejecting someone) before the tab itself closes, and that
             # guest's display_name/alias_snapshot must not survive close-of-
-            # night just because it already left the "active" bucket. Reset
-            # each named guest's own order snapshots to their alias BEFORE
-            # clearing display_name below, or their typed name would be
-            # left as the only remaining copy of something we're about to
-            # promise is gone.
+            # night just because it already left the "active" bucket.
             with transaction.atomic():
-                named_guests = list(self.guests.exclude(display_name=""))
-                for guest in named_guests:
+                # Same broadened selection purge_stale_guest_names.py uses
+                # (see its own comment for the exact race this covers):
+                # deliberately NOT a bare `exclude(display_name="")` — a
+                # guest whose display_name already reads "" (staff cleared
+                # it, or an earlier purge already ran) can still carry a
+                # leftover personal `Order.alias_snapshot` from a race where
+                # a placement committed `guest.display` just after that
+                # clear. Excluding on the (already-cleared) field alone
+                # would leave that leftover snapshot untouched forever.
+                stale_guests = list(
+                    self.guests.filter(
+                        Q(display_name__gt="")
+                        | (
+                            Q(orders__isnull=False)
+                            & ~Q(orders__alias_snapshot=F("alias"))
+                        )
+                    ).distinct()
+                )
+                # Reset each stale guest's own order snapshots to their
+                # alias BEFORE clearing display_name, or a typed name still
+                # only living in Order.alias_snapshot would be left as the
+                # sole remaining copy of something we're about to promise
+                # is gone.
+                for guest in stale_guests:
                     guest.orders.exclude(alias_snapshot=guest.alias).update(
                         alias_snapshot=guest.alias
                     )
-                self.guests.exclude(display_name="").update(display_name="")
+                self.guests.filter(display_name__gt="").update(display_name="")
                 # `uniq_active_alias_per_venue` treats every `status="active"`
                 # guest as occupying its alias, with no link to whether the
                 # guest's own tab is still open. Without this, a closed

--- a/power_up/atmos/models.py
+++ b/power_up/atmos/models.py
@@ -317,16 +317,13 @@ class Tab(models.Model):
                         )
                     ).distinct()
                 )
-                # Reset each stale guest's own order snapshots to their
-                # alias BEFORE clearing display_name, or a typed name still
-                # only living in Order.alias_snapshot would be left as the
-                # sole remaining copy of something we're about to promise
-                # is gone.
+                # purge_display_name() resets each stale guest's order
+                # snapshots to its alias before clearing display_name — see
+                # its own docstring for why that order matters. One save()
+                # per named guest instead of a set-based update; fine for
+                # the handful of guests a single tab has.
                 for guest in stale_guests:
-                    guest.orders.exclude(alias_snapshot=guest.alias).update(
-                        alias_snapshot=guest.alias
-                    )
-                self.guests.filter(display_name__gt="").update(display_name="")
+                    guest.purge_display_name()
                 # `uniq_active_alias_per_venue` treats every `status="active"`
                 # guest as occupying its alias, with no link to whether the
                 # guest's own tab is still open. Without this, a closed
@@ -389,6 +386,27 @@ class Guest(models.Model):
     def display(self) -> str:
         """What staff see and shout — spec §3.7."""
         return self.display_name or self.alias
+
+    def purge_display_name(self) -> int:
+        """Resets this guest's own `Order.alias_snapshot` copies back to
+        `alias` and clears `display_name` — the "erase this guest's typed
+        personal name everywhere" step shared by `Tab.save()`'s tab-close
+        purge and `purge_stale_guest_names`'s cutoff-based sweep. Order
+        snapshots are reset BEFORE clearing display_name, or a typed name
+        still only living in `alias_snapshot` would be left as the sole
+        remaining copy of something we're about to promise is gone.
+
+        Caller owns whatever locking/atomicity it needs around this (e.g.
+        `select_for_update()` — see `purge_stale_guest_names`). Returns the
+        number of `Order` rows whose `alias_snapshot` was reset.
+        """
+        order_count = self.orders.exclude(alias_snapshot=self.alias).update(
+            alias_snapshot=self.alias
+        )
+        if self.display_name:
+            self.display_name = ""
+            self.save(update_fields=["display_name"])
+        return order_count
 
 
 class Order(models.Model):

--- a/power_up/atmos/models.py
+++ b/power_up/atmos/models.py
@@ -108,6 +108,37 @@ class Table(models.Model):
     def __str__(self) -> str:
         return f"{self.venue.name} — Table {self.label}"
 
+    def clean(self):
+        super().clean()
+        # The KDS renders `order.tab.table.label` LIVE, while an already-
+        # issued short_code and its chronicle event bake the placement-time
+        # label directly into their text — the two would silently diverge
+        # the moment a table with active history gets renamed (an order for
+        # "4" starts showing under a "9" badge on the KDS, delivered to the
+        # wrong table). Once a table has any tabs at all, its label is
+        # frozen; deactivate and create a new table instead of renaming one
+        # with history. Runs on both the standalone TableAdmin and the
+        # VenueAdmin inline — full_clean() is called for each inline row.
+        if self.pk is not None:
+            original_label = (
+                Table.objects.filter(pk=self.pk).values_list("label", flat=True).first()
+            )
+            if (
+                original_label is not None
+                and original_label != self.label
+                and self.tabs.exists()
+            ):
+                raise ValidationError(
+                    {
+                        "label": (
+                            "Cannot rename a table that already has tabs — the KDS, "
+                            "issued short codes, and chronicle events all bake in the "
+                            "old label. Deactivate this table and create a new one "
+                            "instead."
+                        )
+                    }
+                )
+
     def save(self, *args, **kwargs):
         if not self.qr_token:
             # secrets.token_urlsafe(16) per spec §4.3 — the QR encodes this,
@@ -193,6 +224,32 @@ class Tab(models.Model):
     def __str__(self) -> str:
         return f"Tab for {self.table} ({self.status})"
 
+    def clean(self):
+        super().clean()
+        # `save()` below only ever handles the open->closed direction (it
+        # stamps closed_at, settles guests). Nothing resets closed_at,
+        # restores opened_at, or reactivates settled guests for the reverse
+        # transition, so admin staff flipping a closed tab's status back to
+        # "open" would leave a tab that's simultaneously "open" (accepting
+        # new scans/guests/orders) and still carrying its old closed_at and
+        # settled guest history — the next scan of this table would attach
+        # a fresh service to what looks like a still-open previous one.
+        # Reopening isn't a supported transition; scanning the table again
+        # creates a genuinely fresh tab instead.
+        if self.pk is not None:
+            original_status = (
+                Tab.objects.filter(pk=self.pk).values_list("status", flat=True).first()
+            )
+            if original_status == "closed" and self.status == "open":
+                raise ValidationError(
+                    {
+                        "status": (
+                            "Cannot reopen a closed tab — scan the table again to "
+                            "start a fresh one."
+                        )
+                    }
+                )
+
     def save(self, *args, **kwargs):
         # `venue` is denormalised for staff queries (see Guest's comment on
         # the same tradeoff) — it must never be independently settable, or
@@ -230,6 +287,23 @@ class Tab(models.Model):
                 kwargs["update_fields"] = [*update_fields, "closed_at"]
         super().save(*args, **kwargs)
         if just_closed:
+            # join.html tells guests "we only keep this for tonight" — but
+            # tab closure is the natural end of that promise, not the
+            # cutoff-based purge_stale_guest_names command (which is
+            # dry-run by default, has no scheduled invocation on this
+            # platform, and only fires after guest_window_minutes has
+            # passed regardless of whether the tab already closed). Reset
+            # each named guest's own order snapshots to their alias BEFORE
+            # the bulk settle below clears display_name, or their typed
+            # name would be left as the only remaining copy of something
+            # we're about to promise is gone.
+            named_guests = list(
+                self.guests.filter(status="active").exclude(display_name="")
+            )
+            for guest in named_guests:
+                guest.orders.exclude(alias_snapshot=guest.alias).update(
+                    alias_snapshot=guest.alias
+                )
             # `uniq_active_alias_per_venue` treats every `status="active"`
             # guest as occupying its alias, with no link to whether the
             # guest's own tab is still open. Without this, a closed tab's
@@ -238,7 +312,7 @@ class Tab(models.Model):
             # eventually fail once it's crowded enough that the bounded
             # collision-retry in guest_join can't find a free one.
             self.guests.filter(status="active").update(
-                status="settled", settled_at=timezone.now()
+                status="settled", settled_at=timezone.now(), display_name=""
             )
 
 

--- a/power_up/atmos/models.py
+++ b/power_up/atmos/models.py
@@ -32,7 +32,7 @@ from decimal import ROUND_HALF_UP, Decimal
 
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -292,28 +292,36 @@ class Tab(models.Model):
             # cutoff-based purge_stale_guest_names command (which is
             # dry-run by default, has no scheduled invocation on this
             # platform, and only fires after guest_window_minutes has
-            # passed regardless of whether the tab already closed). Reset
+            # passed regardless of whether the tab already closed). Purge
+            # EVERY guest on this tab, not just status="active" ones —
+            # GuestAdmin lets staff mark a guest "removed"/"settled" (e.g.
+            # ejecting someone) before the tab itself closes, and that
+            # guest's display_name/alias_snapshot must not survive close-of-
+            # night just because it already left the "active" bucket. Reset
             # each named guest's own order snapshots to their alias BEFORE
-            # the bulk settle below clears display_name, or their typed
-            # name would be left as the only remaining copy of something
-            # we're about to promise is gone.
-            named_guests = list(
-                self.guests.filter(status="active").exclude(display_name="")
-            )
-            for guest in named_guests:
-                guest.orders.exclude(alias_snapshot=guest.alias).update(
-                    alias_snapshot=guest.alias
+            # clearing display_name below, or their typed name would be
+            # left as the only remaining copy of something we're about to
+            # promise is gone.
+            with transaction.atomic():
+                named_guests = list(self.guests.exclude(display_name=""))
+                for guest in named_guests:
+                    guest.orders.exclude(alias_snapshot=guest.alias).update(
+                        alias_snapshot=guest.alias
+                    )
+                self.guests.exclude(display_name="").update(display_name="")
+                # `uniq_active_alias_per_venue` treats every `status="active"`
+                # guest as occupying its alias, with no link to whether the
+                # guest's own tab is still open. Without this, a closed
+                # tab's still-active guests keep reserving their personas
+                # indefinitely — the catalog slowly starves across service
+                # nights, and joins eventually fail once it's crowded
+                # enough that the bounded collision-retry in guest_join
+                # can't find a free one. Guests already removed/settled
+                # keep their existing status/settled_at — only the name
+                # purge above applies to them.
+                self.guests.filter(status="active").update(
+                    status="settled", settled_at=timezone.now()
                 )
-            # `uniq_active_alias_per_venue` treats every `status="active"`
-            # guest as occupying its alias, with no link to whether the
-            # guest's own tab is still open. Without this, a closed tab's
-            # guests keep reserving their personas indefinitely — the
-            # catalog slowly starves across service nights, and joins
-            # eventually fail once it's crowded enough that the bounded
-            # collision-retry in guest_join can't find a free one.
-            self.guests.filter(status="active").update(
-                status="settled", settled_at=timezone.now(), display_name=""
-            )
 
 
 class Guest(models.Model):

--- a/power_up/atmos/tests/test_atmos_models.py
+++ b/power_up/atmos/tests/test_atmos_models.py
@@ -98,3 +98,31 @@ def test_tab_close_purges_removed_guest_names_too(venue):
     assert guest.display_name == ""
     assert guest.status == "removed"  # untouched — only active guests settle
     assert order.alias_snapshot == guest.alias
+
+
+@pytest.mark.django_db
+def test_tab_close_purges_stale_snapshot_with_already_blank_display_name(venue):
+    """Same race purge_stale_guest_names.py's own docstring documents: a
+    placement can commit guest.display (the personal name) into
+    Order.alias_snapshot, and display_name can already read "" by the time
+    the tab closes (staff cleared it directly, or an earlier purge already
+    ran) — a bare exclude(display_name="") would skip this guest entirely
+    and leave the personal name sitting in Order history forever."""
+    table = Table.objects.create(venue=venue, label="A1")
+    tab = Tab.objects.create(table=table, venue=venue)
+    guest = Guest.objects.create(
+        tab=tab, venue=venue, alias="The Velvet Silhouette", display_name=""
+    )
+    order = Order.objects.create(
+        guest=guest,
+        tab=tab,
+        venue=venue,
+        short_code="TA1-01",
+        alias_snapshot="Alice",  # stale personal name, display_name already "" here
+    )
+
+    tab.status = "closed"
+    tab.save(update_fields=["status"])
+
+    order.refresh_from_db()
+    assert order.alias_snapshot == guest.alias

--- a/power_up/atmos/tests/test_atmos_models.py
+++ b/power_up/atmos/tests/test_atmos_models.py
@@ -1,0 +1,66 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from power_up.atmos.models import Guest, Order, Tab, Table, Venue
+
+
+@pytest.fixture
+def venue(db):
+    return Venue.objects.create(name="Noir Bar", slug="noir")
+
+
+@pytest.mark.django_db
+def test_table_label_editable_before_any_tabs(venue):
+    table = Table.objects.create(venue=venue, label="A1")
+    table.label = "A2"
+    table.full_clean()  # must not raise — no tabs yet
+
+
+@pytest.mark.django_db
+def test_table_label_immutable_once_tabs_exist(venue):
+    table = Table.objects.create(venue=venue, label="A1")
+    Tab.objects.create(table=table, venue=venue)
+
+    table.label = "A2"
+    with pytest.raises(ValidationError):
+        table.full_clean()
+
+
+@pytest.mark.django_db
+def test_tab_reopen_rejected(venue):
+    table = Table.objects.create(venue=venue, label="A1")
+    tab = Tab.objects.create(table=table, venue=venue)
+    tab.status = "closed"
+    tab.save(update_fields=["status"])
+
+    tab.status = "open"
+    with pytest.raises(ValidationError):
+        tab.full_clean()
+
+
+@pytest.mark.django_db
+def test_tab_close_purges_guest_display_name_and_snapshots(venue):
+    table = Table.objects.create(venue=venue, label="A1")
+    tab = Tab.objects.create(table=table, venue=venue)
+    guest = Guest.objects.create(
+        tab=tab, venue=venue, alias="The Velvet Silhouette", display_name="Alice"
+    )
+    order = Order.objects.create(
+        guest=guest,
+        tab=tab,
+        venue=venue,
+        short_code="TA1-01",
+        alias_snapshot="Alice",  # the personal name, as order_place() would copy it
+    )
+
+    tab.status = "closed"
+    tab.save(update_fields=["status"])
+
+    guest.refresh_from_db()
+    order.refresh_from_db()
+    assert guest.display_name == ""
+    assert guest.status == "settled"
+    # Reset to the non-personal alias, not left as the typed name — this is
+    # the same promise purge_stale_guest_names makes, just applied at the
+    # moment the tab actually closes instead of waiting for a time cutoff.
+    assert order.alias_snapshot == guest.alias

--- a/power_up/atmos/tests/test_atmos_models.py
+++ b/power_up/atmos/tests/test_atmos_models.py
@@ -64,3 +64,37 @@ def test_tab_close_purges_guest_display_name_and_snapshots(venue):
     # the same promise purge_stale_guest_names makes, just applied at the
     # moment the tab actually closes instead of waiting for a time cutoff.
     assert order.alias_snapshot == guest.alias
+
+
+@pytest.mark.django_db
+def test_tab_close_purges_removed_guest_names_too(venue):
+    """GuestAdmin lets staff mark a guest "removed" (e.g. ejecting someone)
+    before the tab itself closes. That guest already left the
+    status="active" bucket, but its display_name/alias_snapshot are still
+    personal data that must not survive close-of-night just because of
+    that — the purge must not be scoped to active guests only."""
+    table = Table.objects.create(venue=venue, label="A1")
+    tab = Tab.objects.create(table=table, venue=venue)
+    guest = Guest.objects.create(
+        tab=tab,
+        venue=venue,
+        alias="The Velvet Silhouette",
+        display_name="Alice",
+        status="removed",
+    )
+    order = Order.objects.create(
+        guest=guest,
+        tab=tab,
+        venue=venue,
+        short_code="TA1-01",
+        alias_snapshot="Alice",
+    )
+
+    tab.status = "closed"
+    tab.save(update_fields=["status"])
+
+    guest.refresh_from_db()
+    order.refresh_from_db()
+    assert guest.display_name == ""
+    assert guest.status == "removed"  # untouched — only active guests settle
+    assert order.alias_snapshot == guest.alias

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -13,6 +13,7 @@ from django.test import RequestFactory, override_settings
 from power_up.atmos.models import Guest, MenuCategory, MenuItem, Tab, Table, Venue
 from power_up.atmos.views import (
     _JOIN_RATE_LIMIT,
+    _JOIN_RATE_WINDOW_SECONDS,
     CART_SESSION_KEY,
     GUEST_COOKIE,
     TAB_SESSION_KEY,
@@ -340,6 +341,43 @@ def test_join_rate_limit_fails_open_on_cache_outage():
 
     with patch("power_up.atmos.views.cache.incr", return_value=None):
         assert _join_rate_limited(_Request(), "some-tab-id") is False
+
+
+@pytest.mark.django_db
+def test_join_rate_limit_recovers_from_ttl_boundary_race():
+    """add() and incr() are two separate round trips, not one atomic
+    operation — a narrow race around each window's TTL boundary can have
+    the key expire in the gap between them. LocMemCache's incr() raises
+    ValueError in that case (its own get() sees the now-expired key as
+    missing); this must not propagate as a 500 on the join page."""
+
+    class _Request:
+        META = {"REMOTE_ADDR": "10.0.0.6"}
+        method = "GET"
+
+    with patch("power_up.atmos.views.cache.incr", side_effect=[ValueError, 1]):
+        assert _join_rate_limited(_Request(), "some-tab-id") is False
+
+
+@pytest.mark.django_db
+def test_join_rate_limit_refreshes_ttl_on_first_hit():
+    """Redis's INCR auto-vivifies a missing key at 0 with NO ttl. If the
+    boundary race above hits the Redis backend instead of LocMemCache
+    (add() sees the key still present, but it expires before incr() runs),
+    the resulting key must not be left to persist forever with no expiry —
+    it would otherwise never reset and permanently 429 this bucket once it
+    eventually crosses the limit."""
+    cache.clear()
+
+    class _Request:
+        META = {"REMOTE_ADDR": "10.0.0.7"}
+        method = "GET"
+
+    key = "atmos:join_rl:GET:10.0.0.7:some-tab-id"
+    with patch("power_up.atmos.views.cache.touch") as mock_touch:
+        _join_rate_limited(_Request(), "some-tab-id")
+
+    mock_touch.assert_called_once_with(key, _JOIN_RATE_WINDOW_SECONDS)
 
 
 def test_client_ip_strips_ipv4_port():

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -35,6 +35,13 @@ def request_with_session(method="get", data=None):
     # reads request.user — normally set by AuthenticationMiddleware, which
     # this bare RequestFactory request never goes through.
     request.user = AnonymousUser()
+    # join.html's {% url 'atmos:...' %} tags need request.urlconf pointing at
+    # the atmos-hosting urlconf — normally set per-request by
+    # DomainURLRoutingMiddleware based on the Host header, which this bare
+    # RequestFactory request also never goes through. Without it, reverse()
+    # falls back to ROOT_URLCONF, which doesn't register the 'atmos'
+    # namespace at all in this domain-routed, multi-app platform.
+    request.urlconf = "azureproject.urls_power_up"
     return request
 
 

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -1,3 +1,4 @@
+import threading
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -17,9 +18,11 @@ from power_up.atmos.views import (
     TAB_SESSION_KEY,
     PlacementOutcome,
     _cart_lines,
+    _client_ip,
     _create_order_atomic,
     _get_guest,
     _guest_can_still_scan,
+    _join_rate_limited,
     _order_signature,
     _resolve_menu_item,
     guest_join,
@@ -264,6 +267,78 @@ def test_guest_join_rate_limited(ordering_setup):
     request.session.save()
     response = guest_join(request)
     assert response.status_code == 429
+
+
+@pytest.mark.django_db
+def test_join_rate_limit_survives_synchronized_burst(ordering_setup):
+    """A prior version raced incr()'s ValueError: N truly-concurrent requests
+    hitting an absent key could each independently set(1), so the counter
+    could land anywhere from 1 to N instead of N — undercounting the burst
+    by an arbitrary amount. cache.add()'s atomic init means only one request
+    can win that; every request in the burst (winner included) then
+    increments the same shared counter, so the true concurrent count is
+    never lost. Uses real threads + a barrier, not a sequential loop, since
+    a sequential loop can't distinguish the old buggy behavior from this."""
+    _venue, _table, tab, _guest, _category, _item = ordering_setup
+    cache.clear()
+
+    class _BurstyRequest:
+        META = {"REMOTE_ADDR": "10.0.0.1"}
+
+    thread_count = 10
+    barrier = threading.Barrier(thread_count)
+
+    def worker():
+        barrier.wait()
+        _join_rate_limited(_BurstyRequest(), tab.id)
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    key = f"atmos:join_rl:10.0.0.1:{tab.id}"
+    assert cache.get(key) == thread_count
+
+
+@pytest.mark.django_db
+def test_join_rate_limit_fails_open_on_cache_outage():
+    """django_redis's IGNORE_EXCEPTIONS=True (azureproject/settings.py) turns
+    a Redis outage into a silent None return from incr(), not a raised
+    exception. A soft anti-abuse throttle must not itself 500 the join page
+    over that — it should fail open instead."""
+
+    class _Request:
+        META = {"REMOTE_ADDR": "10.0.0.2"}
+
+    with patch("power_up.atmos.views.cache.incr", return_value=None):
+        assert _join_rate_limited(_Request(), "some-tab-id") is False
+
+
+def test_client_ip_strips_ipv4_port():
+    class _Request:
+        META = {"HTTP_X_FORWARDED_FOR": "1.2.3.4:5678"}
+
+    assert _client_ip(_Request()) == "1.2.3.4"
+
+
+def test_client_ip_strips_bracketed_ipv6_port():
+    """Azure supplies bracketed IPv6-with-port ("[2001:db8::1]:49152"). Left
+    unstripped, a new ephemeral source port on reconnect would mint a fresh
+    rate-limit bucket for the same client every time."""
+
+    class _Request:
+        META = {"HTTP_X_FORWARDED_FOR": "[2001:db8::1]:49152"}
+
+    assert _client_ip(_Request()) == "2001:db8::1"
+
+
+def test_client_ip_leaves_bare_ipv6_untouched():
+    class _Request:
+        META = {"HTTP_X_FORWARDED_FOR": "2001:db8::1"}
+
+    assert _client_ip(_Request()) == "2001:db8::1"
 
 
 @pytest.mark.django_db

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -7,7 +7,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import signing
 from django.core.cache import cache
 from django.db import IntegrityError
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 from power_up.atmos.models import Guest, MenuCategory, MenuItem, Tab, Table, Venue
 from power_up.atmos.views import (
@@ -35,13 +35,6 @@ def request_with_session(method="get", data=None):
     # reads request.user — normally set by AuthenticationMiddleware, which
     # this bare RequestFactory request never goes through.
     request.user = AnonymousUser()
-    # join.html's {% url 'atmos:...' %} tags need request.urlconf pointing at
-    # the atmos-hosting urlconf — normally set per-request by
-    # DomainURLRoutingMiddleware based on the Host header, which this bare
-    # RequestFactory request also never goes through. Without it, reverse()
-    # falls back to ROOT_URLCONF, which doesn't register the 'atmos'
-    # namespace at all in this domain-routed, multi-app platform.
-    request.urlconf = "azureproject.urls_power_up"
     return request
 
 
@@ -246,6 +239,13 @@ def test_order_snapshots_venue_currency(ordering_setup):
 
 
 @pytest.mark.django_db
+# join.html's {% url 'atmos:guest_join' %} needs the 'atmos' namespace to
+# resolve. Real requests get that from DomainURLRoutingMiddleware, which
+# swaps in azureproject.urls_power_up based on the Host header — a
+# request.urlconf attribute set here wouldn't do it, since that's only read
+# by BaseHandler's own request-response cycle, not by calling guest_join()
+# directly. Overriding ROOT_URLCONF is what reverse() actually falls back to.
+@override_settings(ROOT_URLCONF="azureproject.urls_power_up")
 def test_guest_join_rate_limited(ordering_setup):
     """Per-(IP, tab) join-page throttle — spec requires it, and nothing else
     in this app limits an unauthenticated visitor hammering the reroll."""
@@ -267,6 +267,7 @@ def test_guest_join_rate_limited(ordering_setup):
 
 
 @pytest.mark.django_db
+@override_settings(ROOT_URLCONF="azureproject.urls_power_up")
 def test_guest_join_preserves_cart_when_creation_fails(ordering_setup):
     """The cart reset used to happen before the guest-creation retry loop —
     a failed table switch (closed tab, exhausted alias retries) would

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -1,20 +1,27 @@
 from decimal import Decimal
+from unittest.mock import patch
 
 import pytest
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import signing
+from django.core.cache import cache
+from django.db import IntegrityError
 from django.test import RequestFactory
 
 from power_up.atmos.models import Guest, MenuCategory, MenuItem, Tab, Table, Venue
 from power_up.atmos.views import (
+    _JOIN_RATE_LIMIT,
     CART_SESSION_KEY,
     GUEST_COOKIE,
+    TAB_SESSION_KEY,
     PlacementOutcome,
     _cart_lines,
     _create_order_atomic,
     _get_guest,
+    _guest_can_still_scan,
     _order_signature,
     _resolve_menu_item,
+    guest_join,
 )
 
 
@@ -223,3 +230,81 @@ def test_order_snapshots_venue_currency(ordering_setup):
     venue.save(update_fields=["currency"])
     result.order.refresh_from_db()
     assert result.order.currency == "GBP"
+
+
+@pytest.mark.django_db
+def test_guest_join_rate_limited(ordering_setup):
+    """Per-(IP, tab) join-page throttle — spec requires it, and nothing else
+    in this app limits an unauthenticated visitor hammering the reroll."""
+    _venue, _table, tab, _guest, _category, _item = ordering_setup
+    cache.clear()
+
+    for _ in range(_JOIN_RATE_LIMIT):
+        request = request_with_session()
+        request.session[TAB_SESSION_KEY] = str(tab.id)
+        request.session.save()
+        response = guest_join(request)
+        assert response.status_code == 200
+
+    request = request_with_session()
+    request.session[TAB_SESSION_KEY] = str(tab.id)
+    request.session.save()
+    response = guest_join(request)
+    assert response.status_code == 429
+
+
+@pytest.mark.django_db
+def test_guest_join_preserves_cart_when_creation_fails(ordering_setup):
+    """The cart reset used to happen before the guest-creation retry loop —
+    a failed table switch (closed tab, exhausted alias retries) would
+    silently empty an unrelated in-progress round anyway."""
+    _venue, _table, tab, _guest, _category, item = ordering_setup
+    request = request_with_session("post", {"display_name": "", "rolled_alias": ""})
+    request.session[CART_SESSION_KEY] = {str(item.id): 3}
+    request.session[TAB_SESSION_KEY] = str(tab.id)
+    request.session.save()
+
+    with patch("power_up.atmos.views.Guest.objects.create", side_effect=IntegrityError):
+        response = guest_join(request)
+
+    assert response.status_code == 200  # re-rendered join.html with an error
+    assert request.session[CART_SESSION_KEY] == {str(item.id): 3}
+
+
+class _FakeTable:
+    is_active = True
+
+
+class _FakeTab:
+    status = "open"
+    table = _FakeTable()
+
+
+class _FakeGuest:
+    status = "active"
+    tab = _FakeTab()
+
+
+def test_guest_can_still_scan_true_for_active_guest_open_tab_active_table():
+    assert _guest_can_still_scan(_FakeGuest()) is True
+
+
+@pytest.mark.parametrize(
+    "guest_status,tab_status,table_active",
+    [
+        ("removed", "open", True),
+        ("settled", "open", True),
+        ("active", "closed", True),
+        ("active", "open", False),
+    ],
+)
+def test_guest_can_still_scan_false_when_inactive(
+    guest_status, tab_status, table_active
+):
+    guest = _FakeGuest()
+    guest.status = guest_status
+    guest.tab = _FakeTab()
+    guest.tab.status = tab_status
+    guest.tab.table = _FakeTable()
+    guest.tab.table.is_active = table_active
+    assert _guest_can_still_scan(guest) is False

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import signing
 from django.core.cache import cache
@@ -29,6 +30,11 @@ def request_with_session(method="get", data=None):
     request = getattr(RequestFactory(), method)("/", data=data or {})
     SessionMiddleware(lambda req: None).process_request(request)
     request.session.save()
+    # guest_join()'s render() path runs every globally-registered template
+    # context processor, including crush_lu's crush_user_context, which
+    # reads request.user — normally set by AuthenticationMiddleware, which
+    # this bare RequestFactory request never goes through.
+    request.user = AnonymousUser()
     return request
 
 

--- a/power_up/atmos/tests/test_order_integrity.py
+++ b/power_up/atmos/tests/test_order_integrity.py
@@ -284,6 +284,7 @@ def test_join_rate_limit_survives_synchronized_burst(ordering_setup):
 
     class _BurstyRequest:
         META = {"REMOTE_ADDR": "10.0.0.1"}
+        method = "GET"
 
     thread_count = 10
     barrier = threading.Barrier(thread_count)
@@ -298,8 +299,32 @@ def test_join_rate_limit_survives_synchronized_burst(ordering_setup):
     for t in threads:
         t.join()
 
-    key = f"atmos:join_rl:10.0.0.1:{tab.id}"
+    key = f"atmos:join_rl:GET:10.0.0.1:{tab.id}"
     assert cache.get(key) == thread_count
+
+
+@pytest.mark.django_db
+def test_join_rate_limit_separates_get_and_post_buckets(ordering_setup):
+    """A venue's shared Wi-Fi IP means several guests' one-time initial-view
+    GET and confirm POST must not draw from the same budget as actual
+    reroll-spam GETs — otherwise a handful of guests joining together could
+    exhaust the limit before anyone even rerolls once."""
+    _venue, _table, tab, _guest, _category, _item = ordering_setup
+    cache.clear()
+
+    class _GetRequest:
+        META = {"REMOTE_ADDR": "10.0.0.3"}
+        method = "GET"
+
+    class _PostRequest:
+        META = {"REMOTE_ADDR": "10.0.0.3"}
+        method = "POST"
+
+    for _ in range(_JOIN_RATE_LIMIT):
+        assert _join_rate_limited(_GetRequest(), tab.id) is False
+    # The GET bucket above is now fully exhausted — a same-IP/tab POST
+    # confirmation still goes through because it draws from its own bucket.
+    assert _join_rate_limited(_PostRequest(), tab.id) is False
 
 
 @pytest.mark.django_db
@@ -311,6 +336,7 @@ def test_join_rate_limit_fails_open_on_cache_outage():
 
     class _Request:
         META = {"REMOTE_ADDR": "10.0.0.2"}
+        method = "GET"
 
     with patch("power_up.atmos.views.cache.incr", return_value=None):
         assert _join_rate_limited(_Request(), "some-tab-id") is False

--- a/power_up/atmos/views.py
+++ b/power_up/atmos/views.py
@@ -66,10 +66,14 @@ _DISPLAY_NAME_MAX_LENGTH = Guest._meta.get_field("display_name").max_length
 # single photographed QR was enough to obtain the scan handoff once and
 # then hit guest_join() indefinitely — each hit runs a fresh active-alias
 # query and full template render (a new persona reroll), with nothing else
-# in this app throttling unauthenticated traffic. 20 requests/minute per
-# (IP, tab, method) bucket comfortably covers a real guest mashing "reroll"
-# a few times while still bounding sustained abuse.
-_JOIN_RATE_LIMIT = 20
+# in this app throttling unauthenticated traffic. Bar patrons at (or near)
+# one table routinely share a single address — venue Wi-Fi NAT, or mobile
+# CGNAT for guests on cellular — and this bucket is still scoped to one
+# (IP, tab, method), so raising it doesn't weaken protection against a
+# scripted attacker targeting a single table: 60/minute comfortably covers
+# a full busy table's page-load-plus-reroll traffic while still bounding
+# sustained abuse.
+_JOIN_RATE_LIMIT = 60
 _JOIN_RATE_WINDOW_SECONDS = 60
 
 
@@ -118,13 +122,34 @@ def _join_rate_limited(request, tab_id) -> bool:
     # Only one request can win add()'s initialization; every request
     # (winner included) then increments the same shared counter atomically.
     cache.add(key, 0, timeout=_JOIN_RATE_WINDOW_SECONDS)
-    count = cache.incr(key)
+    try:
+        count = cache.incr(key)
+    except ValueError:
+        # add() and incr() are two separate round trips, not one atomic
+        # operation — a narrow race around each window's TTL boundary can
+        # have the key expire in the gap between them. LocMemCache's incr()
+        # raises here in that case (its own get() sees the now-expired key
+        # as missing). Treat it the same as a fresh window: this is rare
+        # enough that a second add()+incr() pair is worth it over letting
+        # this 500 the join page.
+        cache.add(key, 0, timeout=_JOIN_RATE_WINDOW_SECONDS)
+        count = cache.incr(key)
     if count is None:
         # django_redis's IGNORE_EXCEPTIONS=True (azureproject/settings.py)
         # turns a Redis outage into a silent None return here instead of a
         # raised exception. Fail open — a soft anti-abuse throttle must
         # never itself take the join page down during a cache interruption.
         return False
+    if count == 1:
+        # Redis's INCR auto-vivifies a missing key at 0 with NO ttl — if
+        # the boundary race above hit Redis instead of LocMemCache (add()
+        # saw the key still present, but it expired before incr() ran),
+        # this key would otherwise persist forever with no expiry, never
+        # resetting, and permanently 429 this (IP, tab, method) once it
+        # eventually crosses the limit. touch() is a no-op cost when this
+        # is a genuine fresh window (add() already set the same timeout);
+        # it only matters for closing that race.
+        cache.touch(key, _JOIN_RATE_WINDOW_SECONDS)
     return count > _JOIN_RATE_LIMIT
 
 

--- a/power_up/atmos/views.py
+++ b/power_up/atmos/views.py
@@ -81,12 +81,19 @@ def _client_ip(request) -> str:
     """
     forwarded = request.META.get("HTTP_X_FORWARDED_FOR", "")
     if forwarded:
-        # Azure App Service includes the port ("1.2.3.4:5678") — same format
-        # azureproject.adapters.get_client_ip() strips; a stray port would
-        # otherwise fragment one visitor's requests across many cache keys.
+        # Azure App Service includes the port ("1.2.3.4:5678", or
+        # "[2001:db8::1]:5678" for IPv6) — same formats
+        # azureproject.adapters.get_client_ip() strips. Left unstripped, the
+        # ephemeral port would fragment one visitor's requests across many
+        # cache keys, and for bracketed IPv6 specifically, a new source port
+        # on reconnect would mint a fresh rate-limit bucket for free.
         ip = forwarded.split(",")[0].strip()
-        if ip.count(":") == 1:
-            ip = ip.split(":")[0]
+        if ip.startswith("["):
+            ip = ip.split("]")[0][1:]  # "[::1]:5678" -> "::1"
+        elif ip.count(":") == 1:
+            ip = ip.split(":")[0]  # "1.2.3.4:5678" -> "1.2.3.4"
+        # else: plain IPv6 without a port (multiple colons, no brackets) —
+        # use as-is.
         return ip or "unknown"
     return request.META.get("REMOTE_ADDR") or "unknown"
 
@@ -97,18 +104,20 @@ def _join_rate_limited(request, tab_id) -> bool:
     per `azureproject/settings.py`, LocMemCache otherwise), so this works
     without any Atmos-specific configuration."""
     key = f"atmos:join_rl:{_client_ip(request)}:{tab_id}"
-    try:
-        count = cache.incr(key)
-    except ValueError:
-        # incr() raises when the key doesn't exist yet (first hit this
-        # window) — set it directly instead of racing a separate has-key
-        # check against a concurrent request doing the same thing. Two
-        # requests can still both land here on the very first hit and both
-        # call set(1), losing one increment — acceptable for a soft
-        # anti-abuse throttle (not a hard security boundary), and no worse
-        # than the fixed-window's usual boundary slop.
-        cache.set(key, 1, timeout=_JOIN_RATE_WINDOW_SECONDS)
-        count = 1
+    # add() is an atomic add-if-absent (Redis SETNX) — a synchronized burst
+    # hitting an absent/expired key would otherwise each race incr()'s
+    # ValueError and independently set(1), letting every one of them "win"
+    # and undercounting the true concurrent total by an arbitrary amount.
+    # Only one request can win add()'s initialization; every request
+    # (winner included) then increments the same shared counter atomically.
+    cache.add(key, 0, timeout=_JOIN_RATE_WINDOW_SECONDS)
+    count = cache.incr(key)
+    if count is None:
+        # django_redis's IGNORE_EXCEPTIONS=True (azureproject/settings.py)
+        # turns a Redis outage into a silent None return here instead of a
+        # raised exception. Fail open — a soft anti-abuse throttle must
+        # never itself take the join page down during a cache interruption.
+        return False
     return count > _JOIN_RATE_LIMIT
 
 

--- a/power_up/atmos/views.py
+++ b/power_up/atmos/views.py
@@ -102,7 +102,11 @@ def _join_rate_limited(request, tab_id) -> bool:
     except ValueError:
         # incr() raises when the key doesn't exist yet (first hit this
         # window) — set it directly instead of racing a separate has-key
-        # check against a concurrent request doing the same thing.
+        # check against a concurrent request doing the same thing. Two
+        # requests can still both land here on the very first hit and both
+        # call set(1), losing one increment — acceptable for a soft
+        # anti-abuse throttle (not a hard security boundary), and no worse
+        # than the fixed-window's usual boundary slop.
         cache.set(key, 1, timeout=_JOIN_RATE_WINDOW_SECONDS)
         count = 1
     return count > _JOIN_RATE_LIMIT

--- a/power_up/atmos/views.py
+++ b/power_up/atmos/views.py
@@ -31,9 +31,10 @@ from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import permission_required
 from django.core import signing
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -59,6 +60,52 @@ MAX_ITEM_QTY = 9  # matches the menu form's advertised max — enforced here too
 # (a data-truncation error on Postgres). Read from the field instead of
 # hand-copying "20" so the two can't drift out of sync again.
 _DISPLAY_NAME_MAX_LENGTH = Guest._meta.get_field("display_name").max_length
+
+# Per spec §7 (docs/specs/atmos-bar-ordering.md): the guest join page must
+# be rate-limited per-IP and per-tab. Before this, a single photographed QR
+# was enough to obtain the scan handoff once and then hit guest_join()
+# indefinitely — each hit runs a fresh active-alias query and full template
+# render (a new persona reroll), with nothing else in this app throttling
+# unauthenticated traffic. 20 requests/minute comfortably covers a real
+# guest mashing "reroll" a few times while still bounding sustained abuse.
+_JOIN_RATE_LIMIT = 20
+_JOIN_RATE_WINDOW_SECONDS = 60
+
+
+def _client_ip(request) -> str:
+    """Best-effort client IP for rate-limit bucketing only — unlike
+    `azureproject.adapters`' allauth adapter (which raises PermissionDenied
+    on anything unparseable, appropriate for its auth context), a
+    malformed/missing value here just degrades to a shared "unknown" bucket
+    rather than blocking a legitimate request over an IP-parsing edge case.
+    """
+    forwarded = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded:
+        # Azure App Service includes the port ("1.2.3.4:5678") — same format
+        # azureproject.adapters.get_client_ip() strips; a stray port would
+        # otherwise fragment one visitor's requests across many cache keys.
+        ip = forwarded.split(",")[0].strip()
+        if ip.count(":") == 1:
+            ip = ip.split(":")[0]
+        return ip or "unknown"
+    return request.META.get("REMOTE_ADDR") or "unknown"
+
+
+def _join_rate_limited(request, tab_id) -> bool:
+    """Fixed-window counter keyed on (client IP, tab) — both dimensions the
+    spec calls for. `cache` is Django's default cache (Redis in production
+    per `azureproject/settings.py`, LocMemCache otherwise), so this works
+    without any Atmos-specific configuration."""
+    key = f"atmos:join_rl:{_client_ip(request)}:{tab_id}"
+    try:
+        count = cache.incr(key)
+    except ValueError:
+        # incr() raises when the key doesn't exist yet (first hit this
+        # window) — set it directly instead of racing a separate has-key
+        # check against a concurrent request doing the same thing.
+        cache.set(key, 1, timeout=_JOIN_RATE_WINDOW_SECONDS)
+        count = 1
+    return count > _JOIN_RATE_LIMIT
 
 
 class PlacementOutcome(Enum):
@@ -219,6 +266,24 @@ def _get_guest_for_viewing(request):
     )
 
 
+def _guest_can_still_scan(guest) -> bool:
+    """Whether `order_status()` should embed the table's live scan QR on
+    this guest's ticket. `_get_guest_for_viewing()` deliberately resolves a
+    removed/settled guest too (so they can still see their OWN historical
+    order), but that same permissiveness would otherwise hand them the
+    table's CURRENT scan token on every reload of an old ticket — if staff
+    removed them and rotated the QR specifically to cut them off, they
+    could read the newly rotated URL straight off their old ticket and
+    immediately mint a fresh identity, defeating the rotation entirely.
+    Requires `guest`'s `tab__table` to already be select_related.
+    """
+    return (
+        guest.status == "active"
+        and guest.tab.status == "open"
+        and guest.tab.table.is_active
+    )
+
+
 def _active_aliases(venue: Venue):
     return list(
         Guest.objects.filter(venue=venue, status="active").values_list(
@@ -349,6 +414,12 @@ def guest_join(request):
     if not tab:
         return render(request, "atmos/no_session.html")
 
+    if _join_rate_limited(request, tab.id):
+        return HttpResponse(
+            "Too many requests — please wait a moment and try again.",
+            status=429,
+        )
+
     error = ""
     if request.method == "POST":
         active = _active_aliases(tab.venue)
@@ -379,12 +450,6 @@ def guest_join(request):
             )
             if alias in active:  # collision (e.g. a double submit) — reroll silently
                 alias = random_persona(exclude=active)
-
-            # Switching identity (new table scan, new guest) must not carry
-            # the previous guest's cart forward — item IDs are shared across
-            # every venue on the platform, so a stale cart could otherwise
-            # be ordered onto the new table under the new persona.
-            request.session[CART_SESSION_KEY] = {}
 
             # `active` above is a snapshot read once at the top of this POST
             # — two concurrent joins can both pass the in-memory checks
@@ -434,6 +499,18 @@ def guest_join(request):
             if guest is None:
                 error = "This table's crowded with ghosts — try again."
             else:
+                # Switching identity (new table scan, new guest) must not
+                # carry the previous guest's cart forward — item IDs are
+                # shared across every venue on the platform, so a stale cart
+                # could otherwise be ordered onto the new table under the
+                # new persona. Deliberately deferred to HERE (only once
+                # guest creation actually succeeded) rather than before the
+                # retry loop above: an existing guest with an in-progress
+                # round at table A scanning table B, where B turns out
+                # closed/deactivated or every alias retry collides, must not
+                # lose that unrelated round just because a table switch was
+                # attempted and failed.
+                request.session[CART_SESSION_KEY] = {}
                 # Consume the handoff — see the note where it's read above.
                 request.session.pop(TAB_SESSION_KEY, None)
                 response = redirect("atmos:guest_menu")
@@ -892,9 +969,14 @@ def order_status(request, pk):
         # hardcoded production host — on test.power-up.lu or a local
         # runserver, a hardcoded power-up.lu origin would print a ticket
         # whose QR opens production with a token that database doesn't have,
-        # 404ing every time.
-        qr_payload=request.build_absolute_uri(
-            reverse("atmos:guest_scan", args=[guest.tab.table.qr_token])
+        # 404ing every time. Omitted entirely for an inactive guest — see
+        # _guest_can_still_scan()'s docstring.
+        qr_payload=(
+            request.build_absolute_uri(
+                reverse("atmos:guest_scan", args=[guest.tab.table.qr_token])
+            )
+            if _guest_can_still_scan(guest)
+            else ""
         ),
         contains_alcohol=order.contains_alcohol,
         footer="pay at the table",

--- a/power_up/atmos/views.py
+++ b/power_up/atmos/views.py
@@ -61,13 +61,14 @@ MAX_ITEM_QTY = 9  # matches the menu form's advertised max — enforced here too
 # hand-copying "20" so the two can't drift out of sync again.
 _DISPLAY_NAME_MAX_LENGTH = Guest._meta.get_field("display_name").max_length
 
-# Per spec §7 (docs/specs/atmos-bar-ordering.md): the guest join page must
-# be rate-limited per-IP and per-tab. Before this, a single photographed QR
-# was enough to obtain the scan handoff once and then hit guest_join()
-# indefinitely — each hit runs a fresh active-alias query and full template
-# render (a new persona reroll), with nothing else in this app throttling
-# unauthenticated traffic. 20 requests/minute comfortably covers a real
-# guest mashing "reroll" a few times while still bounding sustained abuse.
+# Per spec §8.3 "Alias-roll abuse" (docs/specs/atmos-bar-ordering.md): the
+# guest join page must be rate-limited per-IP and per-tab. Before this, a
+# single photographed QR was enough to obtain the scan handoff once and
+# then hit guest_join() indefinitely — each hit runs a fresh active-alias
+# query and full template render (a new persona reroll), with nothing else
+# in this app throttling unauthenticated traffic. 20 requests/minute per
+# (IP, tab, method) bucket comfortably covers a real guest mashing "reroll"
+# a few times while still bounding sustained abuse.
 _JOIN_RATE_LIMIT = 20
 _JOIN_RATE_WINDOW_SECONDS = 60
 
@@ -99,11 +100,17 @@ def _client_ip(request) -> str:
 
 
 def _join_rate_limited(request, tab_id) -> bool:
-    """Fixed-window counter keyed on (client IP, tab) — both dimensions the
-    spec calls for. `cache` is Django's default cache (Redis in production
-    per `azureproject/settings.py`, LocMemCache otherwise), so this works
-    without any Atmos-specific configuration."""
-    key = f"atmos:join_rl:{_client_ip(request)}:{tab_id}"
+    """Fixed-window counter keyed on (client IP, tab, HTTP method) — the
+    spec's two dimensions plus a separate bucket per method, since GET
+    (initial view + "roll another persona") and POST (one-time confirm) are
+    different actions with very different abuse profiles. A venue's shared
+    Wi-Fi IP means several guests' one-time initial-view GET and confirm
+    POST would otherwise draw from the exact same budget as actual
+    reroll-spam GETs — a handful of guests joining together could exhaust
+    it before anyone even rerolls once. `cache` is Django's default cache
+    (Redis in production per `azureproject/settings.py`, LocMemCache
+    otherwise), so this works without any Atmos-specific configuration."""
+    key = f"atmos:join_rl:{request.method}:{_client_ip(request)}:{tab_id}"
     # add() is an atomic add-if-absent (Redis SETNX) — a synchronized burst
     # hitting an absent/expired key would otherwise each race incr()'s
     # ValueError and independently set(1), letting every one of them "win"


### PR DESCRIPTION
## What this does

Follow-up to #864 (merged). Originally targeted `feat/atmos-bar-ordering` directly, continuing #862's line of work — but #862 merged (squashed) into `main` while this was open, so GitHub auto-retargeted this PR to `main` and I rebased the one real commit here on top of the new `main` tip (clean rebase, no conflicts — same file states either way). Addresses 6 `chatgpt-codex-connector` findings that landed on #862 once #864 merged into its branch:

- **`Tab.clean()`** — reject reopening a closed tab from admin. `Tab.save()` only ever handles the open→closed direction (stamps `closed_at`, settles guests); nothing reverses that, so flipping `status` back to `"open"` left a tab simultaneously "open" and still carrying its old `closed_at`/settled-guest history — the next scan of that table would attach a fresh service to what looks like an unfinished previous one.
- **`Table.clean()`** — reject renaming a table that already has tabs. The KDS reads the table's `label` live, while an order's already-issued `short_code` and chronicle event bake the placement-time label directly into their text — a rename could make a table-4 order start showing under a table-9 badge and get delivered to the wrong table. Enforced at the model level so it applies to both the standalone `TableAdmin` and the `VenueAdmin` inline uniformly.
- **`Tab.save()`** — purge guest `display_name` + `Order.alias_snapshot` copies as part of the tab-close transition itself, not only via the time-cutoff-gated, dry-run-by-default, unscheduled `purge_stale_guest_names` command. `join.html`'s "we only keep this for tonight" promise now holds at the moment a tab actually closes.
- **`guest_join()`** — defer the cart-session reset until guest creation actually succeeds. It used to run before the retry loop, so a failed table switch (closed/deactivated destination table, exhausted alias-collision retries) silently emptied an unrelated in-progress round at the guest's *original* table.
- **`guest_join()`** — added a per-(IP, tab) rate limit on the join page, per `docs/specs/atmos-bar-ordering.md` §8.3 "Alias-roll abuse". Nothing else in this app throttled the anonymous reroll, and a single photographed QR was enough to sustain unauthenticated load (a fresh DB query + full template render per hit) indefinitely. (The spec describes this as a separate DB-free `alias_roll` HTMX endpoint; this implementation folds rerolling into `guest_join` itself instead, since no such endpoint exists in `urls.py`.)
- **`order_status()`** — stop embedding the table's *live* scan QR on a removed/settled guest's ticket. `_get_guest_for_viewing()` deliberately still resolves them (so they can see their own historical order), but that let a guest staff removed — specifically to cut off with a rotated QR — read the newly-rotated URL straight off their old ticket and immediately mint a fresh identity, defeating the rotation entirely.

## Testing

- `black`/`ruff` clean on every changed file.
- New `test_atmos_models.py` covers the `Tab`/`Table` `clean()` guards and the tab-close purge.
- `test_order_integrity.py` gains coverage for the join-page rate limit, the deferred cart reset, and the new `_guest_can_still_scan()` helper (parametrized over guest/tab/table state).
- CI's full suite (pytest, lint, security, CodeQL) is green on this branch. An earlier push surfaced two test-infrastructure gaps in the new tests (`request.user` unset without `AuthenticationMiddleware`, `reverse()` needing `ROOT_URLCONF` overridden without `DomainURLRoutingMiddleware`) when calling `guest_join()` directly instead of through a full request cycle — both fixed in the test helpers, no production code affected.
