### PR TITLE
ci(codeql): bump codeql-action v3 -> v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What

Bumps `github/codeql-action` from `@v3` to `@v4` in `.github/workflows/codeql.yml` (`init`, `autobuild`, `analyze`). Three lines, no other changes.

## Why

Every CodeQL run currently emits two deprecation warnings:

- `CodeQL Action v3 will be deprecated in December 2026.`
- `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: github/codeql-action/*@v3`

The second is a consequence of the first, so the bump clears both.

## Why this is low risk

v4's first release is **v4.31.0** (24 Oct 2025), published alongside v3.31.0 — it is not a rewrite or a new API, but the same codebase continuing its version sequence, with the major bump signalling the Node 24 runtime requirement. The runner already forces v3 onto Node 24 today, so we are effectively on that runtime already.

v4.31.0 lists two substantive changes:

- Minimum CodeQL bundle version raised to 2.17.6 — not applicable, GitHub-hosted runners fetch a current bundle.
- SARIF post-processing now always runs, even when files are not uploaded. The release notes scope this explicitly to workflows that *"specify a value other than `always` for the `upload` input."* This workflow passes no `upload` input, so it is on the `always` default and is unaffected.

The workflow uses only `languages:` on `init` and no inputs on `autobuild`/`analyze` — none of which changed in v4.

Also brings this file in line with `.github/workflows/bicep-audit.yml:32`, already on `upload-sarif@v4`.

## Verification

CodeQL runs on `pull_request` to `main`, so this PR's own CodeQL run is the verification — both language legs should go green with the two warnings above gone.

⚠️ Note for whoever reads the checks: GitHub was mid-incident (`Partial System Outage`, sporadic auth failures / HTTP 503) when this was opened, which was already failing CodeQL and Claude Code Review runs on unrelated PRs for reasons that have nothing to do with their contents. If a check is red, confirm the incident is cleared and re-run before reading it as a verdict on this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
