### PR TITLE
fix(crush): use correct RawBT URI scheme for check-in ticket printing

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -1490,9 +1490,17 @@ document.addEventListener("alpine:init", function () {
                         iframe.style.display = "none";
                         document.body.appendChild(iframe);
                     }
-                    iframe.src = "rawbt:data:base64," + trimmed;
+                    // RawBT's raw-bytes channel is "rawbt:base64,<data>" — no
+                    // "data:" infix and no MIME type. That "data:mime;base64,"
+                    // form is a *different* RawBT feature for typed content
+                    // (rawbt:data:image/jpeg;base64,... / text/plain / pdf);
+                    // used here it left RawBT with no MIME segment to parse,
+                    // so the app opened but had nothing to print.
+                    // Ref: https://rawbt.ru/intents.html and the official
+                    // DemoRawBtPrinter sample (ru.a402d.demorawbt).
+                    iframe.src = "rawbt:base64," + trimmed;
                 } catch (e) {
-                    window.location.href = "rawbt:data:base64," + trimmed;
+                    window.location.href = "rawbt:base64," + trimmed;
                 }
             },
 


### PR DESCRIPTION
## Purpose
Fix the newly-merged (#870) 80mm ESC/POS check-in thermal printing relay: on staging, tapping/auto-triggering print opens the RawBT Android app but no print job appears. Root cause: `triggerRawBtPrint()` built the wrong RawBT URI scheme.

RawBT exposes two distinct URI channels:
- **Typed content** — `rawbt:data:<mimetype>;base64,<data>` (image/jpeg, application/pdf, text/plain, etc.) — RawBT renders/converts it.
- **Raw ESC/POS bytes** (what [`ticket_printer.py`](crush_lu/services/ticket_printer.py) actually generates) — `rawbt:base64,<data>`, no `data:` infix, no MIME type, sent straight to the printer.

The code used the first form's `data:` prefix with none of the required MIME segment (`rawbt:data:base64,...`). Android still resolves the `rawbt:` scheme and launches the app — which is exactly why the symptom was "RawBT opens, but nothing to print" rather than an outright failure — but RawBT has no valid body to parse once inside.

Confirmed against RawBT's own docs ([rawbt.ru/intents.html](https://rawbt.ru/intents.html)) and the official `DemoRawBtPrinter` sample app, both of which use `"rawbt:base64," + Base64.encodeToString(bytesToPrint, ...)` for raw printer commands.

This was invisible to the PR's existing tests because those only cover server-side ESC/POS payload generation ([`test_ticket_printing.py`](crush_lu/tests/test_ticket_printing.py)); the URI scheme itself is pure client-side JS with no test coverage.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
This bug and fix are entirely client-side (Android + RawBT app), so no server deploy is needed to verify — see "What to Check" below for a live, zero-deploy verification recipe against the currently-deployed staging build.

```
git fetch origin
git checkout claude/android-printing-relay-debug-204cb7
```

## What to Check
* On an Android phone with RawBT installed, open the coach check-in page (staging or prod) over USB with `chrome://inspect/#devices` remote debugging, and in the DevTools console run:
  ```js
  fetch('/api/events/<EVENT_ID>/test-ticket/')
    .then(r => r.json())
    .then(d => {
      document.getElementById('rawbt-print-frame')?.remove();
      const f = document.createElement('iframe');
      f.style.display = 'none';
      document.body.appendChild(f);
      f.src = 'rawbt:base64,' + d.print_payload_base64;
    });
  ```
  This should now produce an actual printed ticket, not just an app launch.
* Verify all three print entry points, since they share `triggerRawBtPrint()`: auto-print on QR scan, the "Test Print" button, and "Reprint Ticket".
* Auto-print-on-scan fires from inside a `fetch().then()` callback rather than a direct click handler — worth double-checking it isn't blocked by a browser user-gesture requirement independently of this fix.
* Real ticket payloads contain `+`/`/` base64 characters that a short manual test string might not — confirm printed output isn't garbled on a real ticket, not just on a trivial "hello world" test.

## Other Information
Single fix point: `triggerRawBtPrint()` in [`alpine-components.js`](crush_lu/static/crush_lu/js/alpine-components.js) is shared by every print call site, so this one change covers auto-print-on-scan, Test Print, and Reprint.
