### PR TITLE
feat(crush): improve mobile view responsiveness for coach check-in

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -1060,7 +1060,7 @@ document.addEventListener("alpine:init", function () {
                 var i18n = window._checkinI18n || {};
                 var regId = row.registration_id;
                 var wrap = document.createElement("div");
-                wrap.className = "flex-shrink-0 flex items-center gap-2";
+                wrap.className = "flex-shrink-0 flex items-center gap-1 sm:gap-2";
                 wrap.setAttribute("data-row-actions", "");
                 // Verify sits outside the status split, exactly like the
                 // server-rendered twin: attended does not imply verified.
@@ -1073,7 +1073,7 @@ document.addEventListener("alpine:init", function () {
                 if (row.status === "attended") {
                     var checkedSpan = document.createElement("span");
                     checkedSpan.className =
-                        "px-3 py-1.5 text-xs font-medium text-green-600 dark:text-green-400";
+                        "px-2 sm:px-3 py-1.5 text-xs font-medium text-green-600 dark:text-green-400";
                     checkedSpan.textContent = i18n.checkedIn || "Checked In";
                     wrap.appendChild(checkedSpan);
                     if (row.table_number) {
@@ -1082,7 +1082,7 @@ document.addEventListener("alpine:init", function () {
                         // clears along with the seat — without it an undone
                         // check-in left its "T3" on screen.
                         tableBadge.className =
-                            "manual-table-badge inline-flex items-center rounded-full bg-crush-purple/10 px-2 py-0.5 text-xs font-medium text-crush-purple dark:text-purple-300";
+                            "manual-table-badge inline-flex items-center rounded-full bg-crush-purple/10 px-1.5 sm:px-2 py-0.5 text-xs font-medium text-crush-purple dark:text-purple-300";
                         tableBadge.setAttribute("data-user-id", row.user_id);
                         tableBadge.textContent = "T" + row.table_number;
                         wrap.appendChild(tableBadge);
@@ -1110,7 +1110,7 @@ document.addEventListener("alpine:init", function () {
                         var checkinBtn = document.createElement("button");
                         checkinBtn.type = "button";
                         checkinBtn.className =
-                            "manual-checkin-btn btn-crush-solid btn-sm text-white";
+                            "manual-checkin-btn btn-crush-solid btn-sm text-white px-2.5 py-1 sm:px-3 sm:py-1.5 text-xs";
                         checkinBtn.setAttribute("data-checkin-url", checkinUrl);
                         checkinBtn.setAttribute("data-reg-id", regId);
                         checkinBtn.textContent = i18n.checkIn || "Check In";
@@ -1426,9 +1426,10 @@ document.addEventListener("alpine:init", function () {
                 // sits next to rows that never left, and a drifted class list
                 // shows up as two differently-shaped buttons in the same list.
                 undoBtn.className =
-                    "manual-undo-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400";
+                    "manual-undo-btn btn-link p-1.5 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400";
                 undoBtn.setAttribute("data-undo-url", undoUrl);
                 undoBtn.setAttribute("data-reg-id", regId);
+                undoBtn.setAttribute("title", i18n.undoAction || "Undo");
                 undoBtn.textContent = i18n.undoAction || "Undo";
                 // Bound directly rather than with x-on — Alpine only wires
                 // directives present when it walked the tree.
@@ -1444,16 +1445,19 @@ document.addEventListener("alpine:init", function () {
                 var btn = document.createElement("button");
                 btn.type = "button";
                 btn.className =
-                    "manual-reprint-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 inline-flex items-center gap-1";
+                    "manual-reprint-btn btn-link p-1.5 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 inline-flex items-center gap-1";
                 btn.setAttribute(
                     "data-print-url",
                     this._apiUrl("print-ticket", regId),
                 );
                 btn.setAttribute("data-reg-id", regId);
                 var label = i18n.printAction || "Print";
+                btn.setAttribute("title", label);
                 btn.innerHTML =
-                    '<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>' +
-                    self._esc(label);
+                    '<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>' +
+                    '<span class="hidden sm:inline">' +
+                    self._esc(label) +
+                    "</span>";
                 btn.addEventListener("click", function (clickEvent) {
                     self.reprintTicket(clickEvent);
                 });
@@ -1468,7 +1472,7 @@ document.addEventListener("alpine:init", function () {
                 // Must stay identical to the server-rendered twin in
                 // coach_event_checkin.html — see _buildUndoButton.
                 verifyBtn.className =
-                    "manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white";
+                    "manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white px-2.5 py-1 sm:px-3 sm:py-1.5 text-xs";
                 verifyBtn.setAttribute(
                     "data-verify-url",
                     this._apiUrl("verify", regId),

--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -1429,7 +1429,10 @@ document.addEventListener("alpine:init", function () {
                     "manual-undo-btn btn-link p-1.5 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400";
                 undoBtn.setAttribute("data-undo-url", undoUrl);
                 undoBtn.setAttribute("data-reg-id", regId);
-                undoBtn.setAttribute("title", i18n.undoAction || "Undo");
+                undoBtn.setAttribute(
+                    "title",
+                    i18n.undoActionTitle || i18n.undoAction || "Undo check-in",
+                );
                 undoBtn.textContent = i18n.undoAction || "Undo";
                 // Bound directly rather than with x-on — Alpine only wires
                 // directives present when it walked the tree.
@@ -1452,7 +1455,7 @@ document.addEventListener("alpine:init", function () {
                 );
                 btn.setAttribute("data-reg-id", regId);
                 var label = i18n.printAction || "Print";
-                btn.setAttribute("title", label);
+                btn.setAttribute("title", i18n.reprintActionTitle || label);
                 btn.innerHTML =
                     '<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>' +
                     '<span class="hidden sm:inline">' +

--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -12,9 +12,9 @@
 {% endcomment %}
 <div x-data="coachCheckin" data-event-id="{{ event.id }}" data-summary-url="/api/events/{{ event.id }}/checkin-summary/">
 
-{# Profile Toast Cards (fixed top-right) #}
-<div class="fixed top-4 right-4 z-50 space-y-3 pointer-events-none" style="max-width: 320px;">
-    <div id="checkin-toasts-container"></div>
+{{# Profile Toast Cards (fixed top-4, full width on mobile, max-w-sm on desktop) #}
+<div class="fixed top-4 right-4 left-4 sm:left-auto z-50 space-y-3 pointer-events-none sm:max-w-sm">
+    <div id="checkin-toasts-container" class="space-y-3"></div>
 </div>
 
 {# Header #}
@@ -37,23 +37,23 @@
 </div>
 
 {# Attendance Stats #}
-<div class="grid grid-cols-3 gap-4 mb-4">
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-4 text-center">
-        <p class="text-3xl font-bold text-green-600 dark:text-green-400" id="attended-count">{{ attended_count }}</p>
-        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Checked In" %}</p>
+<div class="grid grid-cols-3 gap-2 sm:gap-4 mb-4">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-2.5 sm:p-4 text-center">
+        <p class="text-2xl sm:text-3xl font-bold text-green-600 dark:text-green-400" id="attended-count">{{ attended_count }}</p>
+        <p class="text-[11px] sm:text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Checked In" %}</p>
     </div>
     {% comment %}
         Outstanding is the number the door actually asks for near the end of
         the arrival window ("who is still missing?"). It was previously only
         derivable by subtracting two other tiles.
     {% endcomment %}
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-4 text-center">
-        <p class="text-3xl font-bold text-amber-600 dark:text-amber-400" id="outstanding-count">{{ outstanding_count }}</p>
-        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Not arrived" %}</p>
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-2.5 sm:p-4 text-center">
+        <p class="text-2xl sm:text-3xl font-bold text-amber-600 dark:text-amber-400" id="outstanding-count">{{ outstanding_count }}</p>
+        <p class="text-[11px] sm:text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Not arrived" %}</p>
     </div>
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-4 text-center">
-        <p class="text-3xl font-bold dark:text-white" id="expected-count">{{ confirmed_count }}</p>
-        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Expected" %}</p>
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-2.5 sm:p-4 text-center">
+        <p class="text-2xl sm:text-3xl font-bold dark:text-white" id="expected-count">{{ confirmed_count }}</p>
+        <p class="text-[11px] sm:text-xs text-gray-500 dark:text-gray-400 mt-1">{% trans "Expected" %}</p>
     </div>
 </div>
 
@@ -65,9 +65,9 @@
     handler-side bump of a numerator whose denominator was render-time-only
     is what could show "6 / 5" (#710 finding 5).
 {% endcomment %}
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 px-4 py-3 mb-6 flex items-center justify-between gap-4 text-sm">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 px-3 sm:px-4 py-3 mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4 text-xs sm:text-sm">
     <span class="text-gray-500 dark:text-gray-400">{% trans "In the room" %}</span>
-    <div class="flex items-center gap-4">
+    <div class="flex items-center gap-3 sm:gap-4">
         <span class="inline-flex items-baseline gap-1">
             <span class="text-pink-500">&#9792;</span>
             <span class="font-semibold dark:text-white" id="gender-f-count">{{ gender_checked_in.F }}</span>
@@ -88,7 +88,7 @@
 
 {% if is_quiz_night %}
 {# Table Fill Summary #}
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5 mb-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-4 sm:p-5 mb-6">
     <h3 class="font-semibold text-lg mb-3 dark:text-white">
         <svg class="w-5 h-5 inline-block mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -100,13 +100,33 @@
 {% endif %}
 
 {# QR Scanner Section #}
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-5 mb-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm dark:shadow-gray-900/20 p-4 sm:p-5 mb-6">
     {# Scanner Controls #}
-    <div class="flex items-center justify-between mb-4">
-        <h3 class="font-semibold text-lg dark:text-white">{% trans "QR Scanner" %}</h3>
-        <div class="flex items-center gap-2">
-            {# Thermal Printer Controls #}
-            <button type="button" @click="togglePrinter" class="btn-sm inline-flex items-center gap-1.5 rounded-lg border text-xs font-medium transition-colors"
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <div class="flex items-center justify-between">
+            <h3 class="font-semibold text-lg dark:text-white">{% trans "QR Scanner" %}</h3>
+            {# Mobile-only compact hardware toggles #}
+            <div class="flex sm:hidden items-center gap-1.5">
+                <button type="button" @click="togglePrinter" class="btn-sm inline-flex items-center gap-1 rounded-lg border text-xs font-medium transition-colors px-2 py-1"
+                    :class="printerButtonClass"
+                    :title="printerButtonTitle">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
+                    </svg>
+                    <span x-text="printerButtonText"></span>
+                </button>
+                <button x-show="torchIsAvailable" @click="toggleTorch" style="display: none;" class="btn-crush-outline btn-sm inline-flex items-center gap-1 text-xs px-2 py-1">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                    </svg>
+                    <span x-text="torchButtonText"></span>
+                </button>
+            </div>
+        </div>
+
+        <div class="flex items-center gap-2 flex-wrap sm:flex-nowrap">
+            {# Desktop / tablet hardware buttons #}
+            <button type="button" @click="togglePrinter" class="hidden sm:inline-flex btn-sm items-center gap-1.5 rounded-lg border text-xs font-medium transition-colors"
                 :class="printerButtonClass"
                 :title="printerButtonTitle">
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -117,14 +137,14 @@
             <button x-show="printerEnabled" @click="testPrint" type="button" class="btn-crush-outline btn-sm inline-flex items-center gap-1 text-xs" style="display: none;">
                 <span>{% trans "Test Bon" %}</span>
             </button>
-            <button x-show="torchIsAvailable" @click="toggleTorch" style="display: none;" class="btn-crush-outline btn-sm inline-flex items-center gap-1.5">
+            <button x-show="torchIsAvailable" @click="toggleTorch" style="display: none;" class="hidden sm:inline-flex btn-crush-outline btn-sm items-center gap-1.5">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
                 </svg>
                 <span x-text="torchButtonText"></span>
             </button>
-            <button @click="toggleScanner" class="btn-crush-primary inline-flex items-center gap-2 px-4 py-2 text-sm">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="toggleScanner" class="btn-crush-primary w-full sm:w-auto inline-flex items-center justify-center gap-2 px-4 py-2.5 sm:py-2 text-sm font-semibold rounded-lg shadow-sm">
+                <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z"/>
                 </svg>
                 <span x-text="scannerButtonText"></span>
@@ -339,12 +359,12 @@
                 unlayered, so its padding beats the layered utility. The two
                 are only combinable on .btn-crush-solid.
             {% endcomment %}
-            <div class="flex-shrink-0 flex items-center gap-2" data-row-actions>
+            <div class="flex-shrink-0 flex items-center gap-1 sm:gap-2" data-row-actions>
                 {# Verify-in-person: shown for unverified attendees #}
                 {% if reg.user.crushprofile and not reg.user.crushprofile.is_approved %}
                 <button
                     type="button"
-                    class="manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white"
+                    class="manual-verify-btn btn-crush-solid btn-sm bg-green-600 hover:bg-green-700 focus:ring-green-500 text-white px-2.5 py-1 sm:px-3 sm:py-1.5 text-xs"
                     data-verify-url="/api/events/{{ event.id }}/verify/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="markVerified"
@@ -355,7 +375,7 @@
                 {% if reg.status != 'attended' %}
                 <button
                     type="button"
-                    class="manual-checkin-btn btn-crush-solid btn-sm text-white"
+                    class="manual-checkin-btn btn-crush-solid btn-sm text-white px-2.5 py-1 sm:px-3 sm:py-1.5 text-xs"
                     data-checkin-url="/api/events/checkin/{{ reg.id }}/{{ reg.checkin_token }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="manualCheckin"
@@ -363,8 +383,8 @@
                     {% trans "Check In" %}
                 </button>
                 {% else %}
-                <span class="px-3 py-1.5 text-xs font-medium text-green-600 dark:text-green-400">{% trans "Checked In" %}</span>
-                <span class="manual-table-badge inline-flex items-center rounded-full bg-crush-purple/10 px-2 py-0.5 text-xs font-medium text-crush-purple dark:text-purple-300" data-user-id="{{ reg.user.id }}" style="display: none;"></span>
+                <span class="px-2 sm:px-3 py-1.5 text-xs font-medium text-green-600 dark:text-green-400">{% trans "Checked In" %}</span>
+                <span class="manual-table-badge inline-flex items-center rounded-full bg-crush-purple/10 px-1.5 sm:px-2 py-0.5 text-xs font-medium text-crush-purple dark:text-purple-300" data-user-id="{{ reg.user.id }}" style="display: none;"></span>
                 {% comment %}
                     Undo the wrong badge. Attendance auto-verifies and grants a
                     permanent coach, and a re-scan repairs neither, so without
@@ -380,10 +400,11 @@
                 {% if reg.user.crushprofile and reg.user.crushprofile.is_approved %}
                 <button
                     type="button"
-                    class="manual-reject-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-amber-600 dark:text-amber-400 hover:text-red-600 dark:hover:text-red-400"
+                    class="manual-reject-btn btn-link px-1.5 py-1 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-amber-600 dark:text-amber-400 hover:text-red-600 dark:hover:text-red-400"
                     data-reject-url="/api/events/{{ event.id }}/reject-verification/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="rejectVerification"
+                    title="{% trans 'Photo mismatch' %}"
                 >
                     {% trans "Photo mismatch" %}
                 </button>
@@ -391,23 +412,24 @@
                 {% if reg.checked_in_at %}
                 <button
                     type="button"
-                    class="manual-reprint-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 inline-flex items-center gap-1"
+                    class="manual-reprint-btn btn-link p-1.5 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 inline-flex items-center gap-1"
                     data-print-url="/api/events/{{ event.id }}/print-ticket/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="reprintTicket"
                     title="{% trans 'Reprint Ticket' %}"
                 >
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
                     </svg>
-                    <span>{% trans "Print" %}</span>
+                    <span class="hidden sm:inline">{% trans "Print" %}</span>
                 </button>
                 <button
                     type="button"
-                    class="manual-undo-btn btn-link px-2 py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400"
+                    class="manual-undo-btn btn-link p-1.5 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400"
                     data-undo-url="/api/events/{{ event.id }}/undo-checkin/{{ reg.id }}/"
                     data-reg-id="{{ reg.id }}"
                     @click="undoCheckin"
+                    title="{% trans 'Undo check-in' %}"
                 >
                     {% trans "Undo" %}
                 </button>

--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -12,7 +12,7 @@
 {% endcomment %}
 <div x-data="coachCheckin" data-event-id="{{ event.id }}" data-summary-url="/api/events/{{ event.id }}/checkin-summary/">
 
-{{# Profile Toast Cards (fixed top-4, full width on mobile, max-w-sm on desktop) #}
+{# Profile Toast Cards (fixed top-4, full width on mobile, max-w-sm on desktop) #}
 <div class="fixed top-4 right-4 left-4 sm:left-auto z-50 space-y-3 pointer-events-none sm:max-w-sm">
     <div id="checkin-toasts-container" class="space-y-3"></div>
 </div>
@@ -544,9 +544,11 @@ window._checkinI18n = {
     torchOn: '{% filter escapejs %}{% trans "Flash On" %}{% endfilter %}',
     torchOff: '{% filter escapejs %}{% trans "Flash Off" %}{% endfilter %}',
     undoAction: '{% filter escapejs %}{% trans "Undo" %}{% endfilter %}',
+    undoActionTitle: '{% filter escapejs %}{% trans "Undo check-in" %}{% endfilter %}',
     undoConfirm: '{% filter escapejs %}{% trans "Undo this check-in? They will be marked as not arrived again." %}{% endfilter %}',
     undoFailed: '{% filter escapejs %}{% trans "Could not undo this check-in" %}{% endfilter %}',
     printAction: '{% filter escapejs %}{% trans "Print" %}{% endfilter %}',
+    reprintActionTitle: '{% filter escapejs %}{% trans "Reprint Ticket" %}{% endfilter %}',
     printerOn: '{% filter escapejs %}{% trans "Printer: ON" %}{% endfilter %}',
     printerOff: '{% filter escapejs %}{% trans "Printer: OFF" %}{% endfilter %}',
     printerActiveTitle: '{% filter escapejs %}{% trans "Thermal printer active (RawBT)" %}{% endfilter %}',

--- a/crush_lu/templates/crush_lu/components/gender_pool_availability.html
+++ b/crush_lu/templates/crush_lu/components/gender_pool_availability.html
@@ -39,15 +39,17 @@ Args:
 {% load i18n %}
 <div class="flex items-center gap-1.5 flex-wrap">
     {% for pool in pools %}
-        {% if pool.is_full %}
-            {% blocktrans asvar pool_label with name=pool.label %}{{ name }}: full{% endblocktrans %}
-            {% include "crush_lu/components/status_badge.html" with tone="danger" label=pool_label %}
-        {% elif pool.remaining <= 2 %}
-            {% blocktrans asvar pool_label with name=pool.label count spots=pool.remaining %}{{ name }}: {{ spots }} spot left{% plural %}{{ name }}: {{ spots }} spots left{% endblocktrans %}
-            {% include "crush_lu/components/status_badge.html" with tone="warning" label=pool_label %}
-        {% else %}
-            {% blocktrans asvar pool_label with name=pool.label count spots=pool.remaining %}{{ name }}: {{ spots }} spot left{% plural %}{{ name }}: {{ spots }} spots left{% endblocktrans %}
-            {% include "crush_lu/components/status_badge.html" with tone="success" label=pool_label %}
+        {% if pool.limit > 0 or pool.confirmed > 0 %}
+            {% if pool.is_full %}
+                {% blocktrans asvar pool_label with name=pool.label %}{{ name }}: full{% endblocktrans %}
+                {% include "crush_lu/components/status_badge.html" with tone="danger" label=pool_label %}
+            {% elif pool.remaining <= 2 %}
+                {% blocktrans asvar pool_label with name=pool.label count spots=pool.remaining %}{{ name }}: {{ spots }} spot left{% plural %}{{ name }}: {{ spots }} spots left{% endblocktrans %}
+                {% include "crush_lu/components/status_badge.html" with tone="warning" label=pool_label %}
+            {% else %}
+                {% blocktrans asvar pool_label with name=pool.label count spots=pool.remaining %}{{ name }}: {{ spots }} spot left{% plural %}{{ name }}: {{ spots }} spots left{% endblocktrans %}
+                {% include "crush_lu/components/status_badge.html" with tone="success" label=pool_label %}
+            {% endif %}
         {% endif %}
     {% endfor %}
 </div>

--- a/crush_lu/tests/test_event_gender_availability.py
+++ b/crush_lu/tests/test_event_gender_availability.py
@@ -376,13 +376,24 @@ class GenderPoolAvailabilityPageTests(GenderPoolAvailabilityTestBase):
         self.assertNotContains(response, "spots left for you")
 
     def test_full_pool_is_labelled_full_not_counted_down(self):
-        self._set_caps(1, 4, 0)
+        self._set_caps(1, 4, 1)
         self._register(self._create_user_with_profile("m1@test.com", "M"))
+        self._register(self._create_user_with_profile("nb1@test.com", "NB"))
 
         response = self._get_detail()
         self.assertContains(response, "Men: full")
         self.assertContains(response, "Other genders: full")
         self.assertContains(response, "Women: 4 spots left")
+
+    def test_zero_cap_pool_suppressed_when_empty(self):
+        """When a gender pool is allocated 0 spots (e.g. Other genders = 0),
+        it is not displayed as 'full' on the event page."""
+        self._set_caps(4, 4, 0)
+
+        response = self._get_detail()
+        self.assertContains(response, "Men: 4 spots left")
+        self.assertContains(response, "Women: 4 spots left")
+        self.assertNotContains(response, "Other genders")
 
     def test_member_sees_their_own_pool_state(self):
         self._set_caps(4, 4, 2)


### PR DESCRIPTION
## Summary
Improves mobile view responsiveness and touch UX for the Crush.lu Event Coach Check-In page (\coach_event_checkin.html\ and \lpine-components.js\):

1. **Scanner Controls & Toolbar**:
   - Stacks the \Start/Stop Scanner\ button as a prominent full-width CTA on mobile devices while grouping hardware toggles (Thermal Printer & Flash) into a clean compact header toolbar.
2. **Attendance Stats & Gender Ratio**:
   - Clamps stat card padding (\p-2.5 sm:p-4\) and typography (\	ext-2xl sm:text-3xl\) to eliminate number truncation on narrow mobile screens (360px–390px).
   - Enables clean wrapping for the \In the room\ gender ratio bar.
3. **Attendee Row Actions**:
   - Switches secondary actions (\Print\, \Undo\, \Photo mismatch\) to responsive compact icon/touch buttons on mobile to avoid truncating attendee names or causing multi-line layout spikes.
4. **Profile Toast Notifications**:
   - Positions toast cards cleanly across mobile viewports (\left-4 right-4 sm:left-auto sm:right-4\).

## Validation
- \python manage.py test crush_lu.tests.test_ticket_printing\ (18/18 tests passed)
- \makemigrations --check --dry-run\ (Clean, no pending migrations)