### PR TITLE
fix(crush): guard WebSocket connect() group_add against Redis drops

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -85,12 +85,12 @@ def _build_round_data(round_obj):
 
 
 class BaseCrushWebsocketConsumer(AsyncJsonWebsocketConsumer):
-    """Base WebSocket consumer with defensive channel group discard."""
+    """Base WebSocket consumer with defensive channel group join/discard."""
 
-    DISCARD_TIMEOUT_SECONDS: float = 2.0
+    GROUP_OP_TIMEOUT_SECONDS: float = 2.0
 
     async def _safe_group_discard(
-        self, group_name: str | None, timeout: float = DISCARD_TIMEOUT_SECONDS
+        self, group_name: str | None, timeout: float = GROUP_OP_TIMEOUT_SECONDS
     ) -> None:
         """Discard single group membership safely without crashing disconnect on Redis hiccup."""
         if not group_name or not getattr(self, "channel_layer", None):
@@ -109,7 +109,7 @@ class BaseCrushWebsocketConsumer(AsyncJsonWebsocketConsumer):
             )
 
     async def _safe_group_discards(
-        self, *group_names: str | None, timeout: float = DISCARD_TIMEOUT_SECONDS
+        self, *group_names: str | None, timeout: float = GROUP_OP_TIMEOUT_SECONDS
     ) -> None:
         """Concurrently discard multiple groups bounded by a single timeout window.
 
@@ -127,6 +127,64 @@ class BaseCrushWebsocketConsumer(AsyncJsonWebsocketConsumer):
             ),
             return_exceptions=True,
         )
+
+    async def _safe_group_add(
+        self, group_name: str | None, timeout: float = GROUP_OP_TIMEOUT_SECONDS
+    ) -> bool:
+        """Join a single channel group; return False (never raise) on a Redis hiccup.
+
+        Used during connect() so a dropped/reset Redis connection produces a
+        clean reject-and-reconnect instead of an unhandled exception that
+        Channels surfaces to the ASGI server as a 500 (prod incident: a
+        connection reset mid group_add crashed CheckinConsumer.connect,
+        logged as "Exception in ASGI application" / "connection rejected
+        (500 Internal Server Error)"). The client's WS reconnect loop already
+        backs off and retries on any close, so failing closed here is safe.
+        """
+        if not group_name or not getattr(self, "channel_layer", None):
+            return False
+        try:
+            await asyncio.wait_for(
+                self.channel_layer.group_add(group_name, self.channel_name),
+                timeout=timeout,
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "Failed to add group %s for channel %s during connect: %s",
+                group_name,
+                getattr(self, "channel_name", "unknown"),
+                exc,
+            )
+            return False
+
+    async def _safe_group_adds(
+        self, *group_names: str | None, timeout: float = GROUP_OP_TIMEOUT_SECONDS
+    ) -> bool:
+        """Join every listed group, or none.
+
+        Groups are joined sequentially (not concurrently, unlike the discard
+        helper) so a failure can stop early instead of racing more doomed
+        calls on an already-broken connection. If a later group fails,
+        whatever this call already joined is unwound via
+        ``_safe_group_discards`` — a socket must never end up subscribed to
+        only some of its groups, since that would silently drop a subset of
+        its broadcasts instead of visibly failing to connect.
+
+        Returns True (vacuously) when there are no groups to join, so
+        callers can uniformly gate ``accept()`` on the result.
+        """
+        valid_groups = [g for g in group_names if g]
+        if not valid_groups or not getattr(self, "channel_layer", None):
+            return True
+        joined: list[str] = []
+        for group in valid_groups:
+            if await self._safe_group_add(group, timeout=timeout):
+                joined.append(group)
+            else:
+                await self._safe_group_discards(*joined, timeout=timeout)
+                return False
+        return True
 
 
 class QuizConsumer(BaseCrushWebsocketConsumer):
@@ -160,10 +218,9 @@ class QuizConsumer(BaseCrushWebsocketConsumer):
                 self.display_group = f"quiz_{quiz_id}_display"
                 self.table_group = None
 
-                await self.channel_layer.group_add(self.quiz_group, self.channel_name)
-                await self.channel_layer.group_add(
-                    self.display_group, self.channel_name
-                )
+                if not await self._safe_group_adds(self.quiz_group, self.display_group):
+                    await self.close()
+                    return
                 await self.accept()
 
                 try:
@@ -232,9 +289,6 @@ class QuizConsumer(BaseCrushWebsocketConsumer):
             await self.close()
             return
 
-        # Join the quiz group
-        await self.channel_layer.group_add(self.quiz_group, self.channel_name)
-
         # A group for whoever is running the room. The host panel's table
         # overview has to refresh on a door action, and none of the existing
         # groups can carry that: `quiz_<id>_table_<pk>` reaches the players at
@@ -251,9 +305,9 @@ class QuizConsumer(BaseCrushWebsocketConsumer):
         self.host_group = None
         if await self.is_host(user):
             self.host_group = f"quiz_{self.quiz_id}_host"
-            await self.channel_layer.group_add(self.host_group, self.channel_name)
 
-        # Try to join table-specific group
+        # Resolve the table-specific group before joining anything below, so
+        # a failed lookup can't leave connect() half-subscribed.
         if user.is_authenticated:
             try:
                 table_id = await self.get_user_table_id(user.id)
@@ -266,7 +320,16 @@ class QuizConsumer(BaseCrushWebsocketConsumer):
                 table_id = None
             if table_id:
                 self.table_group = f"quiz_{self.quiz_id}_table_{table_id}"
-                await self.channel_layer.group_add(self.table_group, self.channel_name)
+
+        # Join the quiz group plus whichever of host_group/table_group apply,
+        # all-or-nothing: a Redis hiccup here must not leave the socket
+        # subscribed to only some of its groups (it would silently miss a
+        # subset of broadcasts instead of visibly failing to connect).
+        if not await self._safe_group_adds(
+            self.quiz_group, self.host_group, self.table_group
+        ):
+            await self.close()
+            return
 
         await self.accept()
 
@@ -1999,7 +2062,9 @@ class CheckinConsumer(BaseCrushWebsocketConsumer):
         self.event_id = self.scope["url_route"]["kwargs"]["event_id"]
         self.checkin_group = f"checkin_{self.event_id}"
 
-        await self.channel_layer.group_add(self.checkin_group, self.channel_name)
+        if not await self._safe_group_adds(self.checkin_group):
+            await self.close()
+            return
         await self.accept()
 
     async def disconnect(self, close_code):
@@ -2043,13 +2108,13 @@ class CacheHuntConsumer(BaseCrushWebsocketConsumer):
             return
 
         self.cache_group = f"cache_{self.hunt_id}"
-        await self.channel_layer.group_add(self.cache_group, self.channel_name)
+        self.cache_coach_group = (
+            f"cache_{self.hunt_id}_coach" if await self._cache_is_host(user) else None
+        )
 
-        if await self._cache_is_host(user):
-            self.cache_coach_group = f"cache_{self.hunt_id}_coach"
-            await self.channel_layer.group_add(
-                self.cache_coach_group, self.channel_name
-            )
+        if not await self._safe_group_adds(self.cache_group, self.cache_coach_group):
+            await self.close()
+            return
 
         await self.accept()
 

--- a/crush_lu/consumers_event_lobby.py
+++ b/crush_lu/consumers_event_lobby.py
@@ -41,8 +41,9 @@ class EventLobbyConsumer(BaseCrushWebsocketConsumer):
 
         self.lobby_group = f"event_lobby_{self.event_id}"
         self.user_group = f"event_lobby_{self.event_id}_user_{user.pk}"
-        await self.channel_layer.group_add(self.lobby_group, self.channel_name)
-        await self.channel_layer.group_add(self.user_group, self.channel_name)
+        if not await self._safe_group_adds(self.lobby_group, self.user_group):
+            await self.close()
+            return
         await self.accept()
 
     async def disconnect(self, close_code):

--- a/crush_lu/tests/test_websocket_redis_resilience.py
+++ b/crush_lu/tests/test_websocket_redis_resilience.py
@@ -196,3 +196,223 @@ class TestWebsocketConsumerSafeDisconnect:
 
         consumer.channel_layer.group_add.assert_not_awaited()
         assert consumer.table_group == "quiz_10_table_1"
+
+
+class TestWebsocketConsumerSafeConnect:
+    """Connect()-side counterpart to TestWebsocketConsumerSafeDisconnect.
+
+    Reproduces the prod incident: a Redis TCP connection reset mid
+    ``group_add`` propagated out of ``CheckinConsumer.connect()`` as an
+    unhandled ``ConnectionError``, which Channels surfaced to the ASGI
+    server as "Exception in ASGI application" / "connection rejected
+    (500 Internal Server Error)" instead of a clean reject the client's
+    existing backoff-reconnect loop could recover from.
+    """
+
+    def test_safe_group_add_handles_connection_reset(self, caplog):
+        consumer = BaseCrushWebsocketConsumer()
+        consumer.channel_name = "test_channel_123"
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock(
+            side_effect=ConnectionResetError("Connection lost")
+        )
+
+        with caplog.at_level(logging.WARNING):
+            # Should not raise any exception
+            result = asyncio.run(consumer._safe_group_add("test_group"))
+
+        assert result is False
+        assert (
+            "Failed to add group test_group for channel test_channel_123" in caplog.text
+        )
+
+    def test_safe_group_add_handles_timeout(self, caplog):
+        consumer = BaseCrushWebsocketConsumer()
+        consumer.channel_name = "test_channel_timeout"
+        consumer.channel_layer = MagicMock()
+
+        async def hanging_add(group, channel):
+            await asyncio.sleep(5.0)
+
+        consumer.channel_layer.group_add = AsyncMock(side_effect=hanging_add)
+
+        with caplog.at_level(logging.WARNING):
+            # Should time out after 0.1s without hanging the test
+            result = asyncio.run(consumer._safe_group_add("test_group", timeout=0.1))
+
+        assert result is False
+        assert (
+            "Failed to add group test_group for channel test_channel_timeout"
+            in caplog.text
+        )
+
+    def test_safe_group_add_success(self):
+        consumer = BaseCrushWebsocketConsumer()
+        consumer.channel_name = "test_channel_ok"
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock()
+
+        result = asyncio.run(consumer._safe_group_add("test_group"))
+
+        assert result is True
+        consumer.channel_layer.group_add.assert_awaited_once_with(
+            "test_group", "test_channel_ok"
+        )
+
+    def test_safe_group_adds_all_succeed(self):
+        consumer = BaseCrushWebsocketConsumer()
+        consumer.channel_name = "ch1"
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock()
+
+        result = asyncio.run(consumer._safe_group_adds("g1", None, "g2"))
+
+        assert result is True
+        assert consumer.channel_layer.group_add.await_count == 2
+
+    def test_safe_group_adds_empty_returns_true(self):
+        """No groups to join is a vacuous success, so callers can uniformly
+        gate accept() on the return value without a special-case."""
+        consumer = BaseCrushWebsocketConsumer()
+        consumer.channel_name = "ch_empty"
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock()
+
+        result = asyncio.run(consumer._safe_group_adds(None, None))
+
+        assert result is True
+        consumer.channel_layer.group_add.assert_not_awaited()
+
+    def test_safe_group_adds_unwinds_already_joined_groups_on_failure(self):
+        """A socket must never end up subscribed to only some of its groups:
+        if a later group fails, whatever already joined is discarded and the
+        whole call reports failure, so the caller rejects the connection
+        cleanly instead of leaving it half-subscribed."""
+        consumer = BaseCrushWebsocketConsumer()
+        consumer.channel_name = "ch2"
+        consumer.channel_layer = MagicMock()
+
+        add_calls = []
+
+        async def mock_add(group, channel):
+            add_calls.append(group)
+            if group == "g2":
+                raise ConnectionResetError("Redis dropped")
+
+        consumer.channel_layer.group_add = AsyncMock(side_effect=mock_add)
+        consumer.channel_layer.group_discard = AsyncMock()
+
+        result = asyncio.run(consumer._safe_group_adds("g1", "g2", "g3"))
+
+        assert result is False
+        # Stops at the first failure — never attempts g3 on an already-broken connection.
+        assert add_calls == ["g1", "g2"]
+        consumer.channel_layer.group_discard.assert_awaited_once_with("g1", "ch2")
+
+    def test_checkin_consumer_connect_closes_cleanly_when_redis_down(self, caplog):
+        consumer = CheckinConsumer()
+        consumer.channel_name = "checkin_ch_new"
+        consumer.scope = {
+            "user": MagicMock(id=5, is_authenticated=True),
+            "url_route": {"kwargs": {"event_id": "38"}},
+        }
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock(
+            side_effect=ConnectionResetError("Connection lost")
+        )
+        consumer._is_coach = AsyncMock(return_value=True)
+        consumer.close = AsyncMock()
+        consumer.accept = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            # Should not raise — the prod incident was an unhandled
+            # ConnectionError propagating out of connect() as a 500.
+            asyncio.run(consumer.connect())
+
+        consumer.accept.assert_not_awaited()
+        consumer.close.assert_awaited_once()
+
+    def test_checkin_consumer_connect_succeeds_when_redis_healthy(self):
+        consumer = CheckinConsumer()
+        consumer.channel_name = "checkin_ch_ok"
+        consumer.scope = {
+            "user": MagicMock(id=5, is_authenticated=True),
+            "url_route": {"kwargs": {"event_id": "38"}},
+        }
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock()
+        consumer._is_coach = AsyncMock(return_value=True)
+        consumer.close = AsyncMock()
+        consumer.accept = AsyncMock()
+
+        asyncio.run(consumer.connect())
+
+        consumer.accept.assert_awaited_once()
+        consumer.close.assert_not_awaited()
+        assert consumer.checkin_group == "checkin_38"
+
+    def test_cache_hunt_consumer_connect_closes_cleanly_when_redis_down(self):
+        consumer = CacheHuntConsumer()
+        consumer.channel_name = "cache_ch_new"
+        consumer.scope = {
+            "user": MagicMock(id=9, is_authenticated=True),
+            "url_route": {"kwargs": {"hunt_id": "5"}},
+        }
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock(
+            side_effect=ConnectionResetError("Connection lost")
+        )
+        consumer._can_join = AsyncMock(return_value=True)
+        consumer._cache_is_host = AsyncMock(return_value=False)
+        consumer.close = AsyncMock()
+        consumer.accept = AsyncMock()
+
+        asyncio.run(consumer.connect())
+
+        consumer.accept.assert_not_awaited()
+        consumer.close.assert_awaited_once()
+
+    def test_quiz_consumer_connect_closes_cleanly_when_redis_down(self):
+        """A Redis hiccup while joining quiz_group/host_group/table_group
+        must reject the connection instead of crashing connect()."""
+        consumer = QuizConsumer()
+        consumer.channel_name = "quiz_ch_new"
+        consumer.scope = {
+            "user": MagicMock(id=3, is_authenticated=True),
+            "url_route": {"kwargs": {"quiz_id": "10"}},
+        }
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock(
+            side_effect=ConnectionResetError("Connection lost")
+        )
+        consumer.is_host = AsyncMock(return_value=False)
+        consumer._is_staff_viewer = AsyncMock(return_value=False)
+        consumer._has_event_registration = AsyncMock(return_value=True)
+        consumer.get_user_table_id = AsyncMock(return_value=None)
+        consumer.close = AsyncMock()
+        consumer.accept = AsyncMock()
+
+        asyncio.run(consumer.connect())
+
+        consumer.accept.assert_not_awaited()
+        consumer.close.assert_awaited_once()
+
+    def test_event_lobby_consumer_connect_closes_cleanly_when_redis_down(self):
+        consumer = EventLobbyConsumer()
+        consumer.channel_name = "lobby_ch_new"
+        consumer.scope = {
+            "user": MagicMock(pk=2, is_authenticated=True),
+            "url_route": {"kwargs": {"event_id": "1"}},
+        }
+        consumer.channel_layer = MagicMock()
+        consumer.channel_layer.group_add = AsyncMock(
+            side_effect=ConnectionResetError("Connection lost")
+        )
+        consumer._can_join = AsyncMock(return_value=True)
+        consumer.close = AsyncMock()
+        consumer.accept = AsyncMock()
+
+        asyncio.run(consumer.connect())
+
+        consumer.accept.assert_not_awaited()
+        consumer.close.assert_awaited_once()


### PR DESCRIPTION
## Purpose
A production log showed `CheckinConsumer.connect()` crashing with an unhandled `redis.exceptions.ConnectionError` when the Redis TCP connection reset mid-`group_add`, which Channels surfaced to the ASGI server as `Exception in ASGI application` / `connection rejected (500 Internal Server Error)` instead of a clean reject.

The root cause: [#860](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/pull/860) added `BaseCrushWebsocketConsumer._safe_group_discard`/`_safe_group_discards` — a defensive wrapper around Redis calls — but wired it only into `disconnect()`. Every `connect()` still called `channel_layer.group_add(...)` bare, so a Redis hiccup during the handshake crashed the connection instead of failing closed.

This PR adds the `connect()`-side counterpart:
* `_safe_group_add`/`_safe_group_adds` on `BaseCrushWebsocketConsumer`, mirroring the discard helpers. Groups are joined all-or-nothing — if a later group fails, whatever was already joined is unwound, so a socket is never left subscribed to only some of its groups.
* Wired into every `connect()` that calls `group_add`: `QuizConsumer` (both the display-token branch and the main branch, including its optional `host_group`/`table_group`), `CheckinConsumer`, `CacheHuntConsumer`, `EventLobbyConsumer`.
* On a Redis failure, each now logs a warning and closes cleanly instead of crashing. The client's existing exponential-backoff reconnect loop and Live/Offline indicator (`alpine-components.js`) already handle a clean close correctly — no new client-facing notification needed.
* Left the one deliberate exception untouched: the mid-quiz table-rotation `group_add`/`group_discard` in `quiz_rotate()` still fails loud on purpose (documented, tested) to avoid a split-brain table assignment during an active rotation — that's a different failure mode than the initial handshake.

Note on observability: a Redis-drop rejection now logs the same way an auth rejection does (`connection rejected (403)` in uvicorn) — the new `Failed to add group … during connect` warning is the only discriminator between the two. That's intentional (the warning *is* the "notification" the branch name refers to), just worth knowing if debugging a future outage by grepping for 500s.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform.git
cd Multi-Domain-Django-Platform
git checkout claude/redis-connection-notifications-80029f
```

* Run the resilience suite plus everything touching the affected consumers:
```
DBHOST='' python -m pytest crush_lu/tests/test_websocket_redis_resilience.py crush_lu/tests/test_quiz.py crush_lu/tests/test_crush_cache.py crush_lu/tests/test_event_lobby.py crush_lu/tests/test_coach_event_detail.py -n 0
```
320 tests pass. `ruff check` and `black --check` are clean on the changed files.

## What to Check
* `_safe_group_adds` new connect()-side tests in `test_websocket_redis_resilience.py` reproduce the exact prod failure (patched `group_add` raising `ConnectionResetError`) and assert `accept()` is never called while `close()` is.
* Existing `test_quiz.py` assertions on `group_add` call args/counts still pass unchanged — the QuizConsumer refactor reorders when group names are *computed* (host/table lookups happen before the join, not interleaved) but not what gets joined.
* `EventLobbyConsumer.connect()` in `consumers_event_lobby.py` gets the same treatment for consistency, even though it wasn't in the original traceback.

## Other Information
Filed as a follow-up, not in this PR: the HTTP-side `async_to_sync(channel_layer.group_send)` calls in `views_checkin.py`, `views_crush_cache.py`, `views_event_lobby.py`, and `api_quiz.py` have the same unguarded-Redis-call shape, but a drop there would 500 the actual mutating HTTP action (e.g. a check-in scan/undo), not just the WS relay — worse blast radius, different fix shape (sync call sites), tracked separately.
