### PR TITLE
fix(crush): repair broken template comment and align check-in tooltip text

### DIFF
--- a/crush_lu/static/crush_lu/js/alpine-components.js
+++ b/crush_lu/static/crush_lu/js/alpine-components.js
@@ -1429,7 +1429,10 @@ document.addEventListener("alpine:init", function () {
                     "manual-undo-btn btn-link p-1.5 sm:px-2 sm:py-1.5 text-xs font-medium decoration-dotted transition-colors text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400";
                 undoBtn.setAttribute("data-undo-url", undoUrl);
                 undoBtn.setAttribute("data-reg-id", regId);
-                undoBtn.setAttribute("title", i18n.undoAction || "Undo");
+                undoBtn.setAttribute(
+                    "title",
+                    i18n.undoActionTitle || i18n.undoAction || "Undo check-in",
+                );
                 undoBtn.textContent = i18n.undoAction || "Undo";
                 // Bound directly rather than with x-on — Alpine only wires
                 // directives present when it walked the tree.
@@ -1452,7 +1455,7 @@ document.addEventListener("alpine:init", function () {
                 );
                 btn.setAttribute("data-reg-id", regId);
                 var label = i18n.printAction || "Print";
-                btn.setAttribute("title", label);
+                btn.setAttribute("title", i18n.reprintActionTitle || label);
                 btn.innerHTML =
                     '<svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>' +
                     '<span class="hidden sm:inline">' +

--- a/crush_lu/templates/crush_lu/coach_event_checkin.html
+++ b/crush_lu/templates/crush_lu/coach_event_checkin.html
@@ -12,7 +12,7 @@
 {% endcomment %}
 <div x-data="coachCheckin" data-event-id="{{ event.id }}" data-summary-url="/api/events/{{ event.id }}/checkin-summary/">
 
-{{# Profile Toast Cards (fixed top-4, full width on mobile, max-w-sm on desktop) #}
+{# Profile Toast Cards (fixed top-4, full width on mobile, max-w-sm on desktop) #}
 <div class="fixed top-4 right-4 left-4 sm:left-auto z-50 space-y-3 pointer-events-none sm:max-w-sm">
     <div id="checkin-toasts-container" class="space-y-3"></div>
 </div>
@@ -544,9 +544,11 @@ window._checkinI18n = {
     torchOn: '{% filter escapejs %}{% trans "Flash On" %}{% endfilter %}',
     torchOff: '{% filter escapejs %}{% trans "Flash Off" %}{% endfilter %}',
     undoAction: '{% filter escapejs %}{% trans "Undo" %}{% endfilter %}',
+    undoActionTitle: '{% filter escapejs %}{% trans "Undo check-in" %}{% endfilter %}',
     undoConfirm: '{% filter escapejs %}{% trans "Undo this check-in? They will be marked as not arrived again." %}{% endfilter %}',
     undoFailed: '{% filter escapejs %}{% trans "Could not undo this check-in" %}{% endfilter %}',
     printAction: '{% filter escapejs %}{% trans "Print" %}{% endfilter %}',
+    reprintActionTitle: '{% filter escapejs %}{% trans "Reprint Ticket" %}{% endfilter %}',
     printerOn: '{% filter escapejs %}{% trans "Printer: ON" %}{% endfilter %}',
     printerOff: '{% filter escapejs %}{% trans "Printer: OFF" %}{% endfilter %}',
     printerActiveTitle: '{% filter escapejs %}{% trans "Thermal printer active (RawBT)" %}{% endfilter %}',


### PR DESCRIPTION
## Purpose
Fixes issues found while reviewing #875 (`feat/crush-mobile-checkin-polish`). This PR targets that branch directly so it can be merged into #875 rather than opened as a separate change against `main`.

* Repairs a broken Django comment tag in `coach_event_checkin.html` that was corrupting template parsing on the live coach door check-in page.
* Aligns tooltip text between the server-rendered and JS-built reprint/undo buttons on that same page.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Render `coach_event_checkin.html` for any event (e.g. visit a coach's event check-in page) — before this fix, Django raises a `TemplateSyntaxError` because `{{# Profile Toast Cards ... #}` is parsed as the start of a variable tag rather than a comment, and everything up to the next literal `}}` (including a `{# Header #}` comment, a `<div>`, and a `{% url %}` tag) gets swallowed into one corrupted token.
* Confirmed the fix with a standalone check that replicates Django's tag-splitting regex (`{%.*?%}|{{.*?}}|{#.*?#}`) against the file and verified no anomalous multi-line tokens remain.
* Hover/long-press the reprint and undo buttons on a row inserted dynamically (e.g. via the WebSocket broadcast path or `manualCheckin`) and confirm the tooltip now reads "Reprint Ticket" / "Undo check-in", matching the server-rendered row.

## What to Check
Verify that the following are valid
* `coach_event_checkin.html` renders without a `TemplateSyntaxError`.
* The reprint and undo buttons' visible labels are unchanged ("Print" / "Undo") — only the `title` tooltip text changed.
* No other code referenced the old i18n keys in a way that would break (`manual-reprint-btn` / `manual-undo-btn` class-presence tests are unaffected).

## Other Information

### What was added/changed
1. **`crush_lu/templates/crush_lu/coach_event_checkin.html`**
   - Fixed `{{# Profile Toast Cards ... #}` → `{# Profile Toast Cards ... #}` (invalid comment tag → valid Django comment).
   - Added two new i18n keys to `window._checkinI18n`: `undoActionTitle` ("Undo check-in") and `reprintActionTitle` ("Reprint Ticket"), matching the server-rendered buttons' `title` text.
2. **`crush_lu/static/crush_lu/js/alpine-components.js`**
   - `_buildUndoButton`: `title` now uses `i18n.undoActionTitle` (falls back to the old `undoAction`/"Undo check-in"), while the visible button text stays `i18n.undoAction` ("Undo").
   - `_buildReprintButton`: `title` now uses `i18n.reprintActionTitle` (falls back to the previous label), while the visible label span is unchanged ("Print").

### Not changed (flagged for follow-up, not fixed here)
- The printer/torch toggle controls in `coach_event_checkin.html` are still duplicated as separate mobile and desktop `<button>` elements rather than one responsive element (unlike the label-hiding pattern used for the reprint button). Left as-is since consolidating them is a larger behavioral change (the desktop toolbar also has a "Test Bon" button the mobile toolbar doesn't) and out of scope for this fix-up.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Fds6ssXf1WutSWe29rdx1)_