### PR TITLE
ci(claude-review): stop comment-triggered reviews from cancelling each other

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,11 +8,17 @@ on:
   issue_comment:
     types: [created]
 
-# A new push to the PR (or a fresh comment trigger) cancels the still-running
-# review of the previous one.
+# A new push to the PR cancels the still-running review of the previous
+# (now-stale) commit. Comment-triggered reviews (`@claude review`) do NOT
+# cancel each other: two triggers landing close together — e.g. a duplicate
+# webhook delivery, or two people nudging it — used to race under
+# cancel-in-progress:true, with the newer run winning even when it resolved
+# to a no-op (skipped) and killed a genuinely in-flight review. Scoping
+# cancellation to `pull_request` events only keeps the original "stale code"
+# intent without that self-cancellation failure mode.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   claude-review:


### PR DESCRIPTION
## What

`claude-code-review.yml`'s concurrency group applied `cancel-in-progress: true` across **every** trigger type — `pull_request` opens/pushes *and* every `@claude review` comment, all sharing one `claude-review-<PR#>` slot.

## Why

Caught live on #878: two `issue_comment` triggers landing 21 seconds apart cancelled a review that was already mid-run (past SDK init, actively working) in favor of a second run that itself resolved to `skipped`. Checked the full history for that workflow — **every single comment-triggered run since PR open was either `skipped` or `cancelled`; none ever completed.**

## Fix

Scope `cancel-in-progress` to `pull_request` events only:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

A new push still cancels a stale review of old code (the original intent, per the workflow's own comment). `@claude review` comments no longer race each other — including duplicate/near-simultaneous deliveries.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"` — YAML parses clean.
- Behavioral fix only (concurrency scoping), no logic/job changes — verified by reading the diff; can't unit-test GH Actions concurrency locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)