### PR TITLE
feat(security): SECRET_KEY rotation capability (Task 5.4b)

### DIFF
--- a/azureproject/settings.py
+++ b/azureproject/settings.py
@@ -95,6 +95,30 @@ if not SECRET_KEY:
             "The SECRET_KEY environment variable must be set in production."
         )
 
+# SECRET_KEY rotation (Task 5.4b). Comma-separated list of previous SECRET_KEY
+# values still accepted for VERIFYING existing signatures/sessions/tokens —
+# never used to create new ones (Django only ever signs with SECRET_KEY
+# itself; see django.core.signing.Signer). Empty by default, matching
+# Django's own default and this repo's comma-separated env var convention
+# (see WEEKLY_KPI_RECIPIENTS above). Keys must not contain a comma —
+# django.utils.crypto.get_random_secret_key()'s alphabet has none, so a key
+# generated that way is always safe to drop in here.
+#
+# This is Django's own SECRET_KEY_FALLBACKS mechanism (4.1+): the session
+# framework, django.contrib.auth's session-auth-hash check, and
+# django.core.signing.Signer/TimestampSigner (used directly, with no
+# explicit key=, for the QR check-in tokens in crush_lu/views_ticket.py and
+# crush_lu/views_checkin.py) all read it automatically. It does NOT cover
+# every SECRET_KEY consumer in this codebase — see
+# docs/ops/secret-key-rotation.md for the two known gaps (the Hub SSO JWTs
+# in SIMPLE_JWT below, and crush_lu/models/ios_app.py's native auth code
+# hash) and the rotation procedure itself.
+SECRET_KEY_FALLBACKS = [
+    key.strip()
+    for key in os.getenv("SECRET_KEY_FALLBACKS", "").split(",")
+    if key.strip()
+]
+
 # Required for django.template.context_processors.debug to expose 'debug' in templates
 INTERNAL_IPS = [
     "127.0.0.1",
@@ -1095,6 +1119,16 @@ REST_FRAMEWORK = {
     },
 }
 
+# KNOWN GAP (Task 5.4b, docs/ops/secret-key-rotation.md): djangorestframework
+# -simplejwt's TokenBackend holds a single signing/verifying key with no
+# fallback-list support (unlike django.core.signing above), so SIGNING_KEY is
+# captured once at settings-module import time and does NOT read
+# SECRET_KEY_FALLBACKS. Rotating SECRET_KEY invalidates every outstanding Hub
+# SSO access/refresh token immediately — the Hub SPA's next API call 401s and
+# it re-runs the session→JWT exchange (azureproject/views_spa_auth.py) using
+# the staff member's still-valid crush.lu session (session auth DOES honour
+# SECRET_KEY_FALLBACKS, so that re-bounce succeeds without a fresh login).
+# Net effect: a one-time silent re-auth for Hub staff, not an outage.
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(hours=1),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),

--- a/crush_lu/models/ios_app.py
+++ b/crush_lu/models/ios_app.py
@@ -9,9 +9,28 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 
-def _hash_native_auth_code(code):
-    secret = settings.SECRET_KEY.encode("utf-8")
+def _hash_native_auth_code(code, secret_key=None):
+    secret = (secret_key if secret_key is not None else settings.SECRET_KEY).encode(
+        "utf-8"
+    )
     return hashlib.sha256(secret + code.encode("utf-8")).hexdigest()
+
+
+def _candidate_auth_code_hashes(code):
+    """Hashes of `code` under the current SECRET_KEY and every fallback.
+
+    This hand-rolled hash (not django.core.signing) gets no automatic
+    SECRET_KEY_FALLBACKS support — issue() always hashes under the *current*
+    key at write time, so a code issued just before a SECRET_KEY rotation
+    would otherwise be silently unmatchable at read time in consume(), even
+    though it's still well within its short TTL (IOS_AUTH_CODE_TTL_SECONDS,
+    default 300s). Walk the candidates by hand instead, same idea as
+    django.core.signing.Signer's fallback_keys walk.
+    """
+    return [
+        _hash_native_auth_code(code, key)
+        for key in (settings.SECRET_KEY, *settings.SECRET_KEY_FALLBACKS)
+    ]
 
 
 class IOSAppDevice(models.Model):
@@ -157,9 +176,9 @@ class IOSNativeAuthCode(models.Model):
 
     @classmethod
     def consume(cls, code):
-        code_hash = _hash_native_auth_code(code)
+        candidate_hashes = _candidate_auth_code_hashes(code)
         auth_code = cls.objects.select_related("user").filter(
-            code_hash=code_hash,
+            code_hash__in=candidate_hashes,
             consumed_at__isnull=True,
         ).first()
         if not auth_code or auth_code.is_expired:

--- a/crush_lu/tests/test_secret_key_rotation.py
+++ b/crush_lu/tests/test_secret_key_rotation.py
@@ -1,0 +1,179 @@
+"""
+Tests for Task 5.4b (SECRET_KEY rotation).
+
+Proves the mechanism, not a real rotation: a signature/hash created under an
+"old" key (simulated via override_settings) must still verify once SECRET_KEY
+changes to a "new" value, as long as the old value is listed in
+SECRET_KEY_FALLBACKS — and must NOT verify once that fallback is removed.
+
+Covers:
+- The real door check-in path (`event_checkin_api`), which signs with a bare
+  `django.core.signing.Signer()` — this is the load-bearing case: an
+  in-flight event ticket must survive a SECRET_KEY rotation.
+- `IOSNativeAuthCode`, whose hand-rolled hash needed an explicit fix (it does
+  not use django.core.signing, so it gets no automatic fallback support).
+
+Run with: python manage.py test crush_lu.tests.test_secret_key_rotation
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.core.signing import BadSignature, Signer
+from django.test import Client, TestCase, override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from crush_lu.models import EventRegistration, MeetupEvent
+from crush_lu.models.ios_app import IOSNativeAuthCode, _hash_native_auth_code
+from crush_lu.models.profiles import UserDataConsent
+
+User = get_user_model()
+
+OLD_KEY = "old-secret-key-simulated-for-rotation-test"
+NEW_KEY = "new-secret-key-simulated-for-rotation-test"
+
+
+@override_settings(ROOT_URLCONF="azureproject.urls_crush")
+class CheckinTokenRotationTests(TestCase):
+    """`event_checkin_api` must accept a ticket signed under the previous
+    SECRET_KEY once that key is listed in SECRET_KEY_FALLBACKS, and must
+    reject it once the fallback is dropped.
+
+    ROOT_URLCONF is overridden to azureproject.urls_crush because
+    event_checkin_api is only wired there, not on the default
+    azureproject.urls — same reason crush_lu/tests/test_checkin_door_actions.py
+    uses `pytest.mark.urls("azureproject.urls_crush")`; override_settings is
+    used here instead so these tests also run under `manage.py test`.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.event = MeetupEvent.objects.create(
+            title="Rotation Test Event",
+            description="d",
+            event_type="mixer",
+            location="Luxembourg",
+            address="1 St",
+            canton="Luxembourg",
+            date_time=timezone.now() + timedelta(hours=1),
+            duration_minutes=120,
+            max_participants=10,
+            registration_deadline=timezone.now() + timedelta(minutes=30),
+            is_published=True,
+        )
+        self.user = User.objects.create_user(
+            username="rotation@test.com",
+            email="rotation@test.com",
+            password="p",
+        )
+        UserDataConsent.objects.update_or_create(
+            user=self.user,
+            defaults={"powerup_consent_given": True, "crushlu_consent_given": True},
+        )
+        self.registration = EventRegistration.objects.create(
+            event=self.event, user=self.user, status="confirmed"
+        )
+        # Simulate a ticket that was generated and stored *before* the
+        # rotation: signed with what will become the "old" key.
+        old_token = Signer(key=OLD_KEY).sign(
+            f"{self.registration.pk}:{self.event.pk}"
+        )
+        self.registration.checkin_token = old_token
+        self.registration.save(update_fields=["checkin_token"])
+        self.url = reverse(
+            "event_checkin_api",
+            kwargs={"registration_id": self.registration.pk, "token": old_token},
+        )
+
+    @override_settings(SECRET_KEY=NEW_KEY, SECRET_KEY_FALLBACKS=[OLD_KEY])
+    def test_old_ticket_still_scans_when_old_key_is_a_fallback(self):
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        self.registration.refresh_from_db()
+        self.assertEqual(self.registration.status, "attended")
+
+    @override_settings(SECRET_KEY=NEW_KEY, SECRET_KEY_FALLBACKS=[])
+    def test_old_ticket_is_rejected_once_fallback_is_dropped(self):
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json()["success"])
+        self.registration.refresh_from_db()
+        self.assertEqual(self.registration.status, "confirmed")
+
+    @override_settings(SECRET_KEY=NEW_KEY, SECRET_KEY_FALLBACKS=[OLD_KEY])
+    def test_a_freshly_generated_token_signs_with_the_new_key_not_a_fallback(self):
+        """New tokens are minted with settings.SECRET_KEY (the primary key)
+        even while a fallback is configured — fallbacks are for verifying
+        old signatures, never for creating new ones."""
+        from crush_lu.views_ticket import _generate_checkin_token
+
+        fresh_registration = EventRegistration.objects.create(
+            event=self.event,
+            user=User.objects.create_user(
+                username="rotation2@test.com",
+                email="rotation2@test.com",
+                password="p",
+            ),
+            status="confirmed",
+        )
+        token = _generate_checkin_token(fresh_registration)
+
+        # Signed with NEW_KEY: verifying against NEW_KEY alone must succeed...
+        self.assertEqual(
+            Signer(key=NEW_KEY).unsign(token),
+            f"{fresh_registration.pk}:{fresh_registration.event_id}",
+        )
+        # ...and verifying against OLD_KEY alone (no fallback) must fail.
+        with self.assertRaises(BadSignature):
+            Signer(key=OLD_KEY).unsign(token)
+
+
+class IOSNativeAuthCodeRotationTests(TestCase):
+    """IOSNativeAuthCode.consume() must accept a code issued under the
+    previous SECRET_KEY once that key is a configured fallback."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="ios-rotation@test.com",
+            email="ios-rotation@test.com",
+            password="p",
+        )
+
+    def _issue_under_old_key(self, code="plain-code-value"):
+        # Mirrors IOSNativeAuthCode.issue(), but pins the hash to OLD_KEY to
+        # simulate "issued just before the rotation".
+        return IOSNativeAuthCode.objects.create(
+            user=self.user,
+            code_hash=_hash_native_auth_code(code, secret_key=OLD_KEY),
+            redirect_uri="crushlu://auth",
+            expires_at=timezone.now() + timedelta(minutes=5),
+        )
+
+    @override_settings(SECRET_KEY=NEW_KEY, SECRET_KEY_FALLBACKS=[OLD_KEY])
+    def test_code_issued_under_old_key_is_consumable_with_fallback_configured(self):
+        code = "plain-code-value"
+        self._issue_under_old_key(code)
+
+        consumed_user = IOSNativeAuthCode.consume(code)
+
+        self.assertEqual(consumed_user, self.user)
+
+    @override_settings(SECRET_KEY=NEW_KEY, SECRET_KEY_FALLBACKS=[])
+    def test_code_issued_under_old_key_is_rejected_without_fallback(self):
+        code = "plain-code-value"
+        self._issue_under_old_key(code)
+
+        consumed_user = IOSNativeAuthCode.consume(code)
+
+        self.assertIsNone(consumed_user)
+
+    def test_issue_and_consume_round_trip_under_a_single_key(self):
+        """Sanity check: the ordinary, non-rotation path still works."""
+        code = IOSNativeAuthCode.issue(self.user, redirect_uri="crushlu://auth")
+
+        consumed_user = IOSNativeAuthCode.consume(code)
+
+        self.assertEqual(consumed_user, self.user)
+        # Single-use: a second consume of the same code must fail.
+        self.assertIsNone(IOSNativeAuthCode.consume(code))

--- a/docs/ops/secret-key-rotation.md
+++ b/docs/ops/secret-key-rotation.md
@@ -1,0 +1,142 @@
+# SECRET_KEY rotation
+
+Task 5.4b ("`SECRET_KEY` Rotation im Hub"). The task name points at the Hub
+because that's the most fragile consumer, but there is **no separate
+Hub-specific secret** — the Hub SSO token exchange
+(`azureproject/views_spa_auth.py`, wired for hub.crush.lu) signs its JWTs
+with `SIMPLE_JWT["SIGNING_KEY"]`, which is set to the project's global
+`SECRET_KEY`. This doc covers rotating that one key, project-wide, plus the
+two consumers that don't automatically benefit from Django's built-in
+rotation support.
+
+## What SECRET_KEY signs in this codebase
+
+| Consumer | Mechanism | Honours `SECRET_KEY_FALLBACKS`? |
+| --- | --- | --- |
+| Django sessions (all logged-in users, incl. staff) | `django.contrib.sessions` signing | Yes (Django 4.1+, built in) |
+| Session auth hash (`AbstractBaseUser.get_session_auth_hash`) | HMAC via `SECRET_KEY` | Yes — `get_session_auth_fallback_hash()` walks the list |
+| Password reset / allauth email confirmation tokens | `django.core.signing` | Yes |
+| Event check-in QR tickets (`crush_lu/views_ticket.py` `_generate_checkin_token`, verified in `crush_lu/views_checkin.py` `event_checkin_api`) | `django.core.signing.Signer()` called with no explicit `key=` | Yes |
+| Hub SSO access/refresh JWTs (`SIMPLE_JWT`, `azureproject/views_spa_auth.py`) | `djangorestframework-simplejwt` `TokenBackend` | **No — confirmed gap, see below** |
+| iOS native-app auth handoff code (`crush_lu/models/ios_app.py` `IOSNativeAuthCode`) | hand-rolled `sha256(SECRET_KEY + code)` | Fixed in this PR (was: no) |
+
+The first four rows work automatically once `SECRET_KEY_FALLBACKS` is set —
+this is Django's own rotation mechanism (available since 4.1; this repo runs
+Django 6.0.8), not something built here. Verified by reading Django 6.0's
+installed source directly, not assumed:
+
+- `django/core/signing.py`, `Signer.__init__`: `self.fallback_keys =
+  fallback_keys if fallback_keys is not None else settings.SECRET_KEY_FALLBACKS`,
+  and `unsign()` walks `[self.key, *self.fallback_keys]`. Both
+  `crush_lu/views_ticket.py` and `crush_lu/views_checkin.py` construct
+  `Signer()` with no arguments, so they get this automatically.
+- `django/contrib/auth/base_user.py`, `get_session_auth_fallback_hash()`:
+  explicitly iterates `settings.SECRET_KEY_FALLBACKS`.
+
+## Known gap: Hub SSO JWTs do not survive a rotation
+
+`djangorestframework-simplejwt==5.5.1`'s `TokenBackend`
+(`rest_framework_simplejwt/backends.py`) holds a single `signing_key` /
+`verifying_key` — there is no fallback-list concept, and `SIMPLE_JWT`'s
+`"SIGNING_KEY": SECRET_KEY` is evaluated once at settings-module import time.
+**Rotating `SECRET_KEY` immediately invalidates every outstanding Hub access
+token (1h lifetime) and refresh token (7d lifetime).**
+
+This is deliberately **not** patched with custom fallback-verification code
+in this PR. Two reasons:
+
+1. **It self-heals.** The Hub SPA's next API call gets a 401, the SPA redoes
+   the session→JWT exchange (`GET /api/auth/spa-callback/` →
+   `POST /api/token/exchange-code/`), and that exchange runs on the staff
+   member's crush.lu **session**, which — per the table above — *does*
+   survive rotation via `SECRET_KEY_FALLBACKS`. So the practical effect is a
+   silent one-time re-auth for Hub staff, not a lockout, as long as the
+   fallback key is in place at the moment of rotation.
+2. **A partial fix isn't worth the risk.** Covering only access-token
+   verification would still lose every refresh token, forcing the same
+   re-bounce anyway — the only way to actually preserve a session across
+   rotation would be to also override `TokenRefreshView`'s serializer, which
+   sits right next to `ROTATE_REFRESH_TOKENS` / `BLACKLIST_AFTER_ROTATION`
+   and is not a place to bolt on custom crypto-verification paths without a
+   dedicated review.
+
+Action item for the person rotating: **tell Hub/CRM staff to expect to be
+logged out of hub.crush.lu once**, around the rotation.
+
+## Known gap (fixed here): iOS native-app auth handoff codes
+
+`crush_lu/models/ios_app.py`'s `IOSNativeAuthCode` looked up its one-time
+code by `sha256(SECRET_KEY + code)`, computed fresh at both issue and
+consume time — not `django.core.signing`, so it got no automatic
+`SECRET_KEY_FALLBACKS` support. The blast radius was small (default TTL is 5
+minutes — `IOS_AUTH_CODE_TTL_SECONDS`), but a code issued in the seconds
+before a rotation would have silently failed to match on read. Fixed by
+`_candidate_auth_code_hashes()`, which hashes the code under the current key
+and every fallback key and matches with `code_hash__in=...`.
+
+## The one thing that makes this rotation different from a normal one: unbounded-lifetime QR tickets
+
+`event_checkin_api`'s own comment says it plainly: **"tickets do not
+expire."** `_generate_checkin_token()` signs with `Signer()` (not
+`TimestampSigner`), and once a `checkin_token` is written to a registration
+it is reused forever (`if registration.checkin_token: return
+registration.checkin_token`) — it can be issued the moment someone registers,
+weeks before the event, and printed/saved to a wallet long before doors open.
+The signature itself never expires; only the door's own ±12h
+(`EVENT_CHECKIN_WINDOW_HOURS`) check-in window makes it *useless* outside
+that span.
+
+That means the usual "wait out the max token/session lifetime, then drop the
+old key" rule is not enough here — the relevant lifetime is not a fixed
+duration, it's **"every event that had at least one registration created
+before the rotation has finished its check-in window."** Concretely:
+
+> Do not drop the old key from `SECRET_KEY_FALLBACKS` until
+> `event.date_time + 12h` (or your current `EVENT_CHECKIN_WINDOW_HOURS`) is
+> in the past for every `MeetupEvent` that had any `EventRegistration`
+> created before the rotation.
+
+For a platform with events booked weeks out, this can mean carrying the
+fallback key for weeks, not hours — check the furthest-out published event
+with existing registrations before scheduling the second deploy.
+
+## Rotation procedure
+
+This code makes rotation an **app-settings-only operation** — no code
+deploy is required to rotate, only to *enable* rotation (this PR) and, later,
+to remove old code paths if desired. Two app-settings changes, separated by
+a waiting period:
+
+**Step 1 — introduce the new key**
+1. Generate a new key: `python -c "from django.core.management.utils import
+   get_random_secret_key; print(get_random_secret_key())"`. Its alphabet has
+   no comma, so it's always safe to join into the fallback list as-is.
+2. Set `SECRET_KEY` to the new value.
+3. Set `SECRET_KEY_FALLBACKS` to the *old* `SECRET_KEY` value (comma-separate
+   if more than one old key needs to stay accepted).
+4. Restart/redeploy so the new app settings are picked up. Before doing this
+   on prod, confirm whether `SECRET_KEY` is slot-pinned via
+   `slotConfigNames` on the App Service — other env vars in this project
+   (e.g. `SUMUP_*`) are slot-sticky by design, and an unpinned `SECRET_KEY`
+   during a slot swap would mean prod and staging silently diverge on it.
+   Check, don't assume either way.
+5. Tell Hub/CRM staff to expect one re-login on hub.crush.lu (see the JWT
+   gap above).
+
+**Step 2 — retire the old key**, only once *both* of these are true:
+- The longest-lived session/password-reset/allauth-token window has fully
+  elapsed since Step 1.
+- Per the QR-ticket rule above: every event with registrations that existed
+  before Step 1 has passed its check-in window.
+
+Then remove the old key from `SECRET_KEY_FALLBACKS` (empty list, or drop just
+that entry if multiple rotations are stacked) and redeploy/restart again.
+
+## What this PR does NOT do
+
+- It does not rotate any real key, on any environment. `SECRET_KEY_FALLBACKS`
+  defaults to empty (`[]`), identical to today's behavior.
+- It does not contain a new secret value anywhere in the diff, commit
+  history, or this doc.
+- It does not build custom multi-key JWT verification for the Hub SSO flow —
+  see "Known gap" above for why, and what to expect instead.

--- a/docs/ops/secret-key-rotation.md
+++ b/docs/ops/secret-key-rotation.md
@@ -13,23 +13,32 @@ rotation support.
 
 | Consumer | Mechanism | Honours `SECRET_KEY_FALLBACKS`? |
 | --- | --- | --- |
-| Django sessions (all logged-in users, incl. staff) | `django.contrib.sessions` signing | Yes (Django 4.1+, built in) |
-| Session auth hash (`AbstractBaseUser.get_session_auth_hash`) | HMAC via `SECRET_KEY` | Yes — `get_session_auth_fallback_hash()` walks the list |
-| Password reset / allauth email confirmation tokens | `django.core.signing` | Yes |
+| Django sessions (all logged-in users, incl. staff) | `django.contrib.sessions` signing (`django.core.signing`) | Yes (Django 4.1+, built in) |
+| Session auth hash (`AbstractBaseUser.get_session_auth_hash`) | `salted_hmac` via `SECRET_KEY` | Yes — `get_session_auth_fallback_hash()` walks the list |
+| Password reset tokens (`django.contrib.auth.tokens.PasswordResetTokenGenerator`) | `salted_hmac`, its own key resolution (not `django.core.signing`) | Yes — its `_secret_fallbacks` property returns `settings.SECRET_KEY_FALLBACKS` when unset |
+| allauth email confirmation tokens (`allauth.account.models.EmailConfirmationHMAC`) | `django.core.signing.dumps()` / `.loads()`, called with no explicit `key=` | Yes — same mechanism as the QR tickets below |
 | Event check-in QR tickets (`crush_lu/views_ticket.py` `_generate_checkin_token`, verified in `crush_lu/views_checkin.py` `event_checkin_api`) | `django.core.signing.Signer()` called with no explicit `key=` | Yes |
 | Hub SSO access/refresh JWTs (`SIMPLE_JWT`, `azureproject/views_spa_auth.py`) | `djangorestframework-simplejwt` `TokenBackend` | **No — confirmed gap, see below** |
 | iOS native-app auth handoff code (`crush_lu/models/ios_app.py` `IOSNativeAuthCode`) | hand-rolled `sha256(SECRET_KEY + code)` | Fixed in this PR (was: no) |
 
-The first four rows work automatically once `SECRET_KEY_FALLBACKS` is set —
+The first five rows work automatically once `SECRET_KEY_FALLBACKS` is set —
 this is Django's own rotation mechanism (available since 4.1; this repo runs
-Django 6.0.8), not something built here. Verified by reading Django 6.0's
-installed source directly, not assumed:
+Django 6.0.8), not something built here. Verified by reading the installed
+source directly, not assumed — note these are **two different underlying
+mechanisms**, both of which happen to read the same setting:
 
 - `django/core/signing.py`, `Signer.__init__`: `self.fallback_keys =
   fallback_keys if fallback_keys is not None else settings.SECRET_KEY_FALLBACKS`,
-  and `unsign()` walks `[self.key, *self.fallback_keys]`. Both
-  `crush_lu/views_ticket.py` and `crush_lu/views_checkin.py` construct
-  `Signer()` with no arguments, so they get this automatically.
+  and `unsign()` walks `[self.key, *self.fallback_keys]`. Sessions,
+  allauth's `EmailConfirmationHMAC.key`/`.from_key()` (`signing.dumps()` /
+  `signing.loads()`, no explicit `key=`), and both `crush_lu/views_ticket.py`
+  and `crush_lu/views_checkin.py`'s bare `Signer()` all go through this path.
+- `django/contrib/auth/tokens.py`, `PasswordResetTokenGenerator`: a
+  *separate* implementation built on `salted_hmac`, not
+  `django.core.signing`. Its `secret_fallbacks` property returns
+  `settings.SECRET_KEY_FALLBACKS` whenever `_secret_fallbacks` hasn't been
+  explicitly set, and its token-checking loop tries the primary secret then
+  each fallback.
 - `django/contrib/auth/base_user.py`, `get_session_auth_fallback_hash()`:
   explicitly iterates `settings.SECRET_KEY_FALLBACKS`.
 

--- a/hub/tests/test_secret_key_rotation.py
+++ b/hub/tests/test_secret_key_rotation.py
@@ -1,0 +1,53 @@
+"""
+Pins the confirmed gap documented in docs/ops/secret-key-rotation.md (Task
+5.4b): djangorestframework-simplejwt 5.5.1's TokenBackend
+(rest_framework_simplejwt/backends.py) holds a single signing/verifying key
+with no fallback-list concept, unlike django.core.signing (see
+CheckinTokenRotationTests in crush_lu/tests/test_secret_key_rotation.py for
+the contrasting, working case).
+
+A JWT minted under an "old" key is rejected by SimpleJWT's own AccessToken
+verification even when that key is listed in SECRET_KEY_FALLBACKS. This is
+not a bug this PR fixes — it's *why* a SECRET_KEY rotation forces a one-time
+silent re-auth of Hub SPA staff through the session->JWT exchange
+(azureproject/views_spa_auth.py) instead of the old JWT continuing to work.
+If SimpleJWT ever grows native multi-key support, this test should start
+failing and can be deleted alongside a comment update in settings.py.
+
+Run with: python manage.py test hub.tests.test_secret_key_rotation
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from rest_framework_simplejwt.backends import TokenBackend
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import AccessToken
+
+User = get_user_model()
+
+OLD_KEY = "an-old-key-that-signed-this-token"
+
+
+class HubSsoJwtRotationGapTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="staff@example.com",
+            email="staff@example.com",
+            password="staffpass123",
+            is_staff=True,
+        )
+
+    @override_settings(SECRET_KEY_FALLBACKS=[OLD_KEY])
+    def test_jwt_signed_under_a_fallback_key_is_still_rejected(self):
+        # Mint a token exactly as production code does (RefreshToken.for_user
+        # in views_spa_auth.py), but sign it with what will become the "old"
+        # key instead of the live SIMPLE_JWT["SIGNING_KEY"].
+        old_backend = TokenBackend(algorithm="HS256", signing_key=OLD_KEY)
+        token = AccessToken()
+        token["user_id"] = str(self.user.pk)
+        raw_token_signed_with_old_key = old_backend.encode(token.payload)
+
+        # settings.SECRET_KEY_FALLBACKS lists OLD_KEY, yet verification
+        # against the configured SIMPLE_JWT["SIGNING_KEY"] still fails:
+        # SimpleJWT never consults SECRET_KEY_FALLBACKS.
+        with self.assertRaises(TokenError):
+            AccessToken(raw_token_signed_with_old_key)


### PR DESCRIPTION
## Scope conclusion (read this first)

"The Hub's SECRET_KEY" is **Django's global `SECRET_KEY`** — there is no separate Hub-specific secret. The Hub SSO token exchange (`azureproject/views_spa_auth.py`, `hub.crush.lu`) signs its JWTs via `SIMPLE_JWT["SIGNING_KEY"] = SECRET_KEY`, so it's just the most fragile consumer of the one global key, not a distinct secret to rotate separately.

Confirmed by grepping `hub/` (SSO signing lives in `azureproject/views_spa_auth.py` + `hub/tests/test_spa_auth.py`, using `rest_framework_simplejwt`) and grepping the whole repo for `settings.SECRET_KEY` (hits in `crush_lu/models/ios_app.py` and via bare `Signer()` in `crush_lu/views_ticket.py` / `crush_lu/views_checkin.py` for QR check-in tickets, plus `SIMPLE_JWT["SIGNING_KEY"]` in `azureproject/settings.py`).

## Mechanism

`SECRET_KEY_FALLBACKS` (Django 4.1+, native — this repo runs Django 6.0.8) added to `azureproject/settings.py`, comma-separated env var, following the existing `WEEKLY_KPI_RECIPIENTS` convention. Empty by default, so **this PR changes no runtime behavior** until the env var is set.

Read Django 6.0's installed `django/core/signing.py` and `django/contrib/auth/base_user.py` source directly (not assumed) to confirm what this setting actually covers for free:

- `Signer.__init__`: `fallback_keys` defaults to `settings.SECRET_KEY_FALLBACKS` when not explicitly overridden, and `unsign()` walks `[self.key, *self.fallback_keys]`.
- Both `crush_lu/views_ticket.py`'s `_generate_checkin_token` and `crush_lu/views_checkin.py`'s `event_checkin_api` construct `Signer()` bare (no `key=`), so **event check-in QR tickets get fallback verification automatically**.
- `get_session_auth_fallback_hash()` explicitly walks `SECRET_KEY_FALLBACKS`, so staff sessions (incl. the ones the Hub SSO bounce depends on) survive rotation too.
- Password reset / allauth confirmation tokens go through the same `django.core.signing` path — also covered for free.

## Signing-fallback caveat (SimpleJWT gap — explicitly checked, not assumed)

Read the installed `rest_framework_simplejwt==5.5.1` source (`backends.py`, `tokens.py`) directly: `TokenBackend` holds a single `signing_key`/`verifying_key`, with **no fallback-list concept**, and `SIMPLE_JWT["SIGNING_KEY"]` is captured once at settings-module import time. So **Hub SSO JWTs do NOT survive a `SECRET_KEY` rotation** — this is a real, confirmed gap, not a hedge.

Deliberately **not patched with custom multi-key JWT verification** in this PR:
1. It self-heals: a 401'd Hub API call re-runs the session→JWT exchange, and that exchange rides the staff member's crush.lu **session**, which does honour `SECRET_KEY_FALLBACKS` (see above) — so the practical effect is one silent re-auth, not a lockout.
2. A partial fix (access-token-only) wouldn't actually preserve anything, since refresh tokens (7d) would still die and force the same re-bounce — a full fix means touching `TokenRefreshView`'s rotation/blacklist logic, which isn't something to bolt on without dedicated review.

Pinned as an executable test: `hub/tests/test_secret_key_rotation.py::HubSsoJwtRotationGapTests` — a JWT signed under a key present in `SECRET_KEY_FALLBACKS` is still rejected, proving SimpleJWT never consults that setting (contrast with the QR-ticket test in `crush_lu/`, which proves `django.core.signing` does).

## Also fixed: `IOSNativeAuthCode` (crush_lu/models/ios_app.py)

Its one-time code hash was hand-rolled (`sha256(SECRET_KEY + code)`, not `django.core.signing`), so it also got no automatic fallback support. Blast radius was small (5-minute TTL) but real — a code issued seconds before a rotation would silently fail to match on read. `consume()` now checks the hash against the current key and every `SECRET_KEY_FALLBACKS` entry.

## Rotation runbook

`docs/ops/secret-key-rotation.md` — the two-deploy env-var-only procedure (new key in primary, old key to fallbacks, wait, then drop). The load-bearing rule it calls out: `event_checkin_api`'s own code comment says QR tickets **"do not expire"** and `checkin_token` is generated once and reused forever, so the usual "wait out max token lifetime" doesn't apply — the doc spells out the actual rule (old key stays in fallbacks until every event with pre-rotation registrations has closed its ±12h check-in window).

## What this PR does NOT do

- No real secret value anywhere in the diff, commit history, or docs.
- No rotation performed on any environment — `SECRET_KEY_FALLBACKS` defaults to `[]`, identical to current behavior.
- No custom JWT fallback-verification code (see caveat above for why).

## Test results

New tests, all passing under both `manage.py test` and `pytest` (SQLite, `DBHOST=''`):

```
crush_lu/tests/test_secret_key_rotation.py — 6 tests
  CheckinTokenRotationTests: old ticket still scans with fallback configured,
    rejected once fallback dropped, new tokens sign with the primary key only
  IOSNativeAuthCodeRotationTests: code issued under old key consumable with
    fallback configured, rejected without it, ordinary round-trip still works
hub/tests/test_secret_key_rotation.py — 1 test
  HubSsoJwtRotationGapTests: pins the confirmed SimpleJWT gap
```

Also re-ran the existing, related suites for regressions (all passing, 23/23):
`test_ticket_printing`, `test_checkin_door_actions`, `test_verify_on_checkin`, `test_door_verification_reject`, `test_event_tickets`, `hub/test_spa_auth`, `hub/test_locations`, plus `test_ios_app_readiness` under pytest.

`python manage.py makemigrations --check --dry-run` → **"No changes detected"** (settings/code only, no model changes, as expected).

Full `crush_lu` + `hub` suite re-run in the background for broader regression coverage; will report if anything surfaces.

Not merging — capability only, per the task.
