### PR TITLE
feat(hub): dynamize team-management endpoint from live CrushCoach roster

### DIFF
--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -390,6 +390,73 @@ class SocialPostSerializer(serializers.ModelSerializer):
         return value
 
 
+TEAM_GRADIENT_PALETTE = [
+    "linear-gradient(135deg, #6366f1, #ec4899)",
+    "linear-gradient(135deg, #ec4899, #f43f5e)",
+]
+
+
+class TeamMemberSerializer(serializers.Serializer):
+    """Read-only shape for the CRM's ``/team`` page.
+
+    Field names mirror the SPA's ``TeamMember`` type in
+    ``Codex_Marketing_CRM/frontend/app/team/page.tsx`` exactly (``name``,
+    ``role``, ``initial``, ``gradient``, ``events``, ``presence``), so that
+    page can swap its hardcoded ``MEMBERS`` array for a fetch against this
+    endpoint without any shape change. Serializes a live
+    ``crush_lu.CrushCoach`` queryset (see ``hub/views_team.py``) rather than
+    a hub-only model -- there is no hub-specific write state the roster
+    needs.
+
+    Two fields have no CrushCoach-native source and are assumptions the PR
+    flags for Tom/frontend to confirm:
+      - ``role``: CrushCoach has no job-title field, so this falls back to
+        ``specializations`` (e.g. "Young professionals, Students") or the
+        literal string "Coach" when blank. It will not read "Fondateur" /
+        "Co-fondateur" the way the current mock does.
+      - ``presence``: there is no coach-attendance data source at all --
+        ``MeetupEvent.coaches`` is a plain M2M with no through/check-in
+        model -- so this always returns "-", the same placeholder value the
+        SPA mock itself uses today.
+    """
+
+    name = serializers.SerializerMethodField()
+    role = serializers.SerializerMethodField()
+    initial = serializers.SerializerMethodField()
+    gradient = serializers.SerializerMethodField()
+    events = serializers.SerializerMethodField()
+    presence = serializers.SerializerMethodField()
+
+    def _display_name(self, obj):
+        user = obj.user
+        return user.get_full_name() or user.first_name or user.get_username()
+
+    def get_name(self, obj):
+        return self._display_name(obj)
+
+    def get_role(self, obj):
+        return obj.specializations or "Coach"
+
+    def get_initial(self, obj):
+        name = self._display_name(obj)
+        return name[0].upper() if name else "?"
+
+    def get_gradient(self, obj):
+        return TEAM_GRADIENT_PALETTE[obj.pk % len(TEAM_GRADIENT_PALETTE)]
+
+    def get_events(self, obj):
+        # The view annotates `events_count` (Count("assigned_events")) to
+        # avoid an N+1; fall back to a live count so this serializer stays
+        # correct if ever used against an un-annotated instance.
+        events_count = getattr(obj, "events_count", None)
+        if events_count is None:
+            events_count = obj.assigned_events.count()
+        return events_count
+
+    def get_presence(self, obj):
+        return "—"  # em dash, same placeholder value the SPA mock uses
+
+
 class WhatsAppInboundMessageSerializer(serializers.ModelSerializer):
     id = serializers.CharField(read_only=True)
 

--- a/hub/tests/test_team.py
+++ b/hub/tests/test_team.py
@@ -1,0 +1,142 @@
+"""Tests for the Hub team-directory endpoint backing the CRM's ``/team`` page."""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from crush_lu.models import CrushCoach, MeetupEvent
+
+User = get_user_model()
+
+
+class TeamAPITestCase(TestCase):
+    def setUp(self):
+        # No password: every test authenticates via ``force_authenticate``, and
+        # hashing one per test costs ~2s each under ``manage.py test`` (the MD5
+        # hasher in conftest.py only applies to pytest runs).
+        self.staff = User.objects.create_user(
+            username="team_staff",
+            email="staff@crush.lu",
+            is_staff=True,
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.staff)
+
+    def _event(self, **overrides):
+        now = timezone.now()
+        values = {
+            "title": "Speed Dating — August",
+            "description": "Une soirée de rencontres.",
+            "event_type": "speed_dating",
+            "location": "Casino 2000, Mondorf-les-Bains",
+            "address": "Rue Flammang, Mondorf-les-Bains",
+            "date_time": now + timedelta(days=7),
+            "registration_deadline": now + timedelta(days=5),
+            "is_published": True,
+        }
+        values.update(overrides)
+        return MeetupEvent.objects.create(**values)
+
+
+class TeamMembersViewTests(TeamAPITestCase):
+    def test_non_staff_cannot_access_team_endpoint(self):
+        non_staff = User.objects.create_user(username="member")
+        self.client.force_authenticate(user=non_staff)
+
+        response = self.client.get("/hub/team")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_staff_can_list_team_members_with_frontend_contract(self):
+        coach_user = User.objects.create_user(
+            username="tom@crush.lu",
+            email="tom@crush.lu",
+            first_name="Tom",
+            last_name="Scheuer",
+        )
+        coach = CrushCoach.objects.create(
+            user=coach_user,
+            is_active=True,
+            specializations="Young professionals, Students",
+        )
+        event = self._event()
+        event.coaches.add(coach)
+
+        response = self.client.get("/hub/team")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(len(payload["items"]), 1)
+        member = payload["items"][0]
+        # Contract-exact key set: name, role, initial, gradient, events,
+        # presence -- matches Codex_Marketing_CRM/frontend/app/team/page.tsx's
+        # `TeamMember` type.
+        self.assertEqual(
+            set(member.keys()),
+            {"name", "role", "initial", "gradient", "events", "presence"},
+        )
+        self.assertEqual(member["name"], "Tom Scheuer")
+        self.assertEqual(member["role"], "Young professionals, Students")
+        self.assertEqual(member["initial"], "T")
+        self.assertEqual(member["events"], 1)
+        self.assertEqual(member["presence"], "—")
+        self.assertTrue(member["gradient"].startswith("linear-gradient("))
+
+    def test_role_falls_back_to_coach_when_no_specialization(self):
+        coach_user = User.objects.create_user(
+            username="wesley@crush.lu", email="wesley@crush.lu", first_name="Wesley"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=True, specializations="")
+
+        response = self.client.get("/hub/team")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["items"][0]["role"], "Coach")
+
+    def test_name_falls_back_to_username_without_first_name(self):
+        coach_user = User.objects.create_user(
+            username="noname@crush.lu", email="noname@crush.lu"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=True)
+
+        response = self.client.get("/hub/team")
+
+        item = response.json()["items"][0]
+        self.assertEqual(item["name"], "noname@crush.lu")
+        self.assertEqual(item["initial"], "N")
+
+    def test_inactive_coach_is_excluded(self):
+        coach_user = User.objects.create_user(
+            username="away@crush.lu", email="away@crush.lu", first_name="Away"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=False)
+
+        response = self.client.get("/hub/team")
+
+        self.assertEqual(response.json()["items"], [])
+
+    def test_events_count_excludes_unassigned_events(self):
+        coach_user = User.objects.create_user(
+            username="busy@crush.lu", email="busy@crush.lu", first_name="Busy"
+        )
+        coach = CrushCoach.objects.create(user=coach_user, is_active=True)
+        self._event()  # not assigned to this coach
+
+        response = self.client.get("/hub/team")
+
+        self.assertEqual(response.json()["items"][0]["events"], 0)
+        self.assertEqual(coach.assigned_events.count(), 0)
+
+    def test_trailing_slash_route_also_works(self):
+        coach_user = User.objects.create_user(
+            username="slash@crush.lu", email="slash@crush.lu", first_name="Slash"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=True)
+
+        response = self.client.get("/hub/team/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["items"]), 1)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -25,6 +25,7 @@ from .views_social import (
     SocialPostsView,
     SocialUpcomingEventsView,
 )
+from .views_team import TeamMembersView
 
 app_name = "hub"
 
@@ -39,6 +40,8 @@ urlpatterns = [
     path("timeline/", views.TimelineView.as_view()),
     path("locations", views.LocationsView.as_view(), name="locations"),
     path("locations/", views.LocationsView.as_view()),
+    path("team", TeamMembersView.as_view(), name="team"),
+    path("team/", TeamMembersView.as_view()),
     # Financials & Accounting Routes
     path("payments-in", PaymentsInView.as_view(), name="payments_in"),
     path("payments-in/", PaymentsInView.as_view()),

--- a/hub/views_team.py
+++ b/hub/views_team.py
@@ -1,0 +1,46 @@
+"""Read-only team-directory endpoint backing the CRM's ``/team`` page.
+
+There is no hub-only team model. The roster is the live set of active
+``crush_lu.CrushCoach`` rows -- the same "hub reads crush_lu live" pattern
+as ``SocialUpcomingEventsView`` (``hub/views_social.py``) and
+``SocialPost.featured_profile`` (``hub/models.py``): a cross-app FK/query
+into crush_lu rather than a duplicated hub model, because the SPA has no
+hub-only write state to persist here (see ``hub/serializers.py``'s
+``TeamMemberSerializer`` docstring for the two fields -- ``role`` and
+``presence`` -- that had to be derived/placeholder-ed for lack of a
+CrushCoach-native source).
+"""
+
+from django.db.models import Count
+from rest_framework import generics
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+
+from crush_lu.models import CrushCoach
+
+from .serializers import TeamMemberSerializer
+
+
+class TeamMembersView(generics.ListAPIView):
+    """Staff-only list endpoint using the hub's ``{"items": [...]}`` envelope.
+
+    Mirrors ``FinanceListView`` (``hub/views_finance.py``) -- kept as a
+    self-contained ``list()`` override here rather than importing that class,
+    since it's a finance-specific name for a shape every hub list view reuses.
+    """
+
+    permission_classes = [IsAdminUser]
+    serializer_class = TeamMemberSerializer
+
+    def get_queryset(self):
+        return (
+            CrushCoach.objects.filter(is_active=True)
+            .select_related("user")
+            .annotate(events_count=Count("assigned_events", distinct=True))
+            .order_by("created_at")
+        )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return Response({"items": serializer.data})


### PR DESCRIPTION
Contract source: real SPA file (`Codex_Marketing_CRM/frontend/app/team/page.tsx`) — its `TeamMember` TS type (`name, role, initial, gradient, events, presence`) is the exact shape this endpoint reproduces, not the CrushCoach-fallback shape from the task brief.

## What changed

`hub/` had zero team/coach model, endpoint, or admin — greenfield. This adds a staff-only, read-only `GET /hub/team` (and `/hub/team/`) that lists the live `crush_lu.CrushCoach` roster, following the `SocialUpcomingEventsView` / `SocialPost.featured_profile` precedent: hub reads crush_lu live via a cross-app query, no new hub model or migration, because the SPA's team page has no hub-only write state to persist (the mock's "Envoyer invitation" button is inert — `type="button"`, no handler — so no write endpoint was added either).

- `hub/serializers.py` — `TeamMemberSerializer` (plain `Serializer`, not a `ModelSerializer`, since several fields are derived) producing the SPA's exact 6-key shape.
- `hub/views_team.py` — `TeamMembersView`, `IsAdminUser`-protected, the hub's `{"items": [...]}` envelope (mirrors `FinanceListView`'s shape, kept local rather than imported since that name is finance-specific).
- `hub/urls.py` — `/hub/team` and `/hub/team/` routes.
- `hub/tests/test_team.py` — contract shape, staff/non-staff auth, role/name fallbacks, inactive-coach exclusion, live events count, trailing-slash route.

## Field-by-field notes (please confirm)

Backed by `CrushCoach.objects.filter(is_active=True)`:

- **name** — `user.get_full_name() or user.first_name or user.get_username()`.
- **role** — **assumption, needs confirmation**: `CrushCoach` has no job-title field, so this falls back to `specializations` (e.g. "Young professionals, Students") or the literal string `"Coach"` when blank. It will **not** read "Fondateur" / "Co-fondateur" the way today's hardcoded mock does — those are founder titles with no backing field anywhere in the codebase (confirmed: no role/title concept exists on `User` or `CrushCoach`). If Tom/frontend want founder-style titles surfaced, that's genuinely new state (a small hub-only field), which this PR deliberately did not add without confirmation first.
- **initial** — first character of the resolved name, uppercased.
- **gradient** — deterministic pick (by `pk`) from a 2-entry palette reusing the mock's own two gradient strings. Computed, not stored.
- **events** — real live count: `Count("assigned_events")`, i.e. `MeetupEvent.coaches` (a plain M2M) assigned to this coach. This is the one live, non-placeholder metric.
- **presence** — **assumption, needs confirmation**: always returns `"—"`, the same placeholder the SPA mock itself uses. There is no coach-attendance data source in the codebase — `MeetupEvent.coaches` is a plain M2M with no through/check-in model, so an actual attendance percentage would require new schema (out of scope here).

## Validation

- `python manage.py test hub.tests.test_team` — 7/7 passed
- `python manage.py test hub` — 94/94 passed
- `python manage.py makemigrations --check --dry-run` — no changes detected
- `python manage.py check` — no issues
- `black` / `ruff check` — clean on all changed files

## Remaining risks / open questions

- `role` and `presence` are honest placeholders/derivations, not the founder-specific data the current mock shows for Tom/Wesley. Needs a product decision (see above) before the frontend swaps its hardcoded array for this endpoint.
- If Tom/Wesley aren't `CrushCoach` rows in prod (only regular staff `User`s), the roster would come back empty — the task brief's own fallback assumes team members are the crush_lu concept of "coach"; if that's wrong, the model choice needs revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)