### PR TITLE
docs(atmos): sync bar-ordering spec to shipped guest-identity code

### DIFF
--- a/docs/specs/atmos-bar-ordering.md
+++ b/docs/specs/atmos-bar-ordering.md
@@ -7,6 +7,8 @@
 **Changes in v2:** per-guest identity with funny aliases (§3), guests split from tabs in the data model (§4), a 2-hour per-guest ordering window with staff *settle-or-extend* (§5), settlement records (§4.9).
 **Out of scope:** online payment, venue self-service backoffice — see [Deferred](#12-deferred-post-mvp).
 
+> **Implementation status (synced 2026-08-20):** Guests, Tabs, Orders, the KDS, the alias/persona system, and thermal-ticket printing shipped in PR [#862](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/pull/862) / [#865](https://github.com/EuphoriaLux/Multi-Domain-Django-Platform/pull/865). Three pieces of this v2 draft were **never built** and this doc has been updated in place to describe what actually shipped instead of what was drafted: the rank-escalating alias (§3.3 — replaced by a single stable persona), the `Settlement` model (§4.9 — not built), and the 2-hour guest window (§5 — not enforced). `power_up/atmos/models.py`'s own module docstring is the authoritative deferred list; every "shipped vs. spec" note below traces back to it. §12 (Remote Treat) is a **later, separate proposal that was never built at all** — see its banner.
+
 ---
 
 ## 1. Concept
@@ -15,7 +17,7 @@ Guests in a bar scan a QR code glued to their table. No app install, no login. T
 
 Payment stays offline for the MVP: the guest pays the server at the table or at the counter as they do today. This removes PSP onboarding, PCI scope, and refund handling from the prototype while still proving the core value.
 
-**What makes Atmos different from every other QR ordering system:** the delivery moment. When the barkeeper arrives with a tray and says *"two Pilsner for Colonel Pretzel?"*, the table laughs. That laugh is the product. Ordinary QR ordering systems remove a human interaction and give you nothing back; Atmos removes the *waiting* and keeps the *contact*, with a joke attached.
+**What makes Atmos different from every other QR ordering system:** the delivery moment. When the barkeeper arrives with a tray and says *"two Pilsner for The Whispering Gambler?"*, the table laughs. That laugh is the product. Ordinary QR ordering systems remove a human interaction and give you nothing back; Atmos removes the *waiting* and keeps the *contact*, with a joke attached.
 
 Each person at the table gets their own identity — scanned individually from the same table QR — so the barkeeper knows whose drink is whose without asking, and every guest gets their own moment.
 
@@ -57,7 +59,7 @@ Atmos follows the existing `power_up` submodule pattern already used by `crm`, `
 
 ### 2.1 Why language-neutral rather than `i18n_patterns`
 
-The guest UI needs EN/DE/FR — this is Luxembourg. But putting it inside `i18n_patterns` means every QR code encodes a language prefix, and a table's printed QR would be locked to one language forever. Instead: mount language-neutral, ask for the language on the name screen (it is the guest's first interaction anyway), and store the choice on the guest record.
+The guest UI needs EN/DE/FR — this is Luxembourg. But putting it inside `i18n_patterns` means every QR code encodes a language prefix, and a table's printed QR would be locked to one language forever. Instead: mount language-neutral, ask for the language on the name screen (it is the guest's first interaction anyway), and store the choice on the guest record. **Shipped vs. spec:** the language-neutral mount happened; the ask-and-store half never did — there is no language field on `Guest` and no language prompt on the join screen (§3.1). The guest UI is English-only today.
 
 ### 2.2 Background work
 
@@ -69,38 +71,38 @@ None. Per `CLAUDE.md`, production runs the `ImmediateBackend` inline and no `db_
 
 ### 3.1 The screen
 
-The first thing a guest sees after scanning. One question, two ways out, both fast.
+**Shipped vs. spec:** the two-step mock below (blank screen → tap to roll → confirm) was the pre-build draft. What shipped (`power_up/templates/atmos/join.html`) skips the blank first step: a persona is already rolled and shown the moment the join page renders, so the guest's first sight of the screen already has a name to react to.
 
 ```
-        You're at Table 12.
-   What should we shout when
-     your drink is ready?
+        📍 Table 12
+   Welcome to The Velvet Hour
+ What should we shout when
+   your drinks are ready?
 
   ┌───────────────────────────┐
-  │  🎲  Give me a silly one  │   ← primary, big, thumb-height
+  │   🎲 Tonight's Persona    │
+  │                           │
+  │  THE WHISPERING GAMBLER   │
+  │                           │
+  │ [ That's me, enter bar → ]│
+  │ [ 🎲 Roll another persona ]│
   └───────────────────────────┘
 
-     ─────  or type it  ─────
+    ── or enter your name ──
 
   ┌───────────────────────────┐
-  │  Your name                │
+  │  Your name or nickname    │
   └───────────────────────────┘
-          [ That's me → ]
+       [ Use this name ]
 
-        EN · DE · FR
+  🔒 Anonymous & temporary
 ```
 
-Tapping **"Give me a silly one"** rolls an alias and shows it instantly with the roll button still there:
+"Roll another persona" is a plain link back to the same `guest_join` view (a full page reload with a freshly rolled persona), not an HTMX partial or a separate `/join/roll/` endpoint (see §6.1) — but it is still free, unlimited, and writes nothing to the database before confirming, so the "thirty seconds of rerolling before a drink is ordered" reasoning below still holds.
 
-```
-     You are now
+There is **no EN · DE · FR language toggle** on this screen or anywhere in the guest flow. `/atmos/` is mounted language-neutral per §2.1, but no per-guest language field or `set_language` endpoint was built (`Guest` has no `language` column) — the guest UI is English-only today.
 
-   CAPTAIN PRETZEL
-
-  [ 🎲 Roll again ]  [ Let's go → ]
-```
-
-Rolling is free and unlimited *before* confirming. This is where the fun is manufactured — a table of four rerolling and reading names out to each other is thirty seconds of entertainment before a single drink is ordered, and it costs one database-free function call per tap.
+Rolling is free and unlimited *before* confirming. This is where the fun is manufactured — a table of four rerolling and reading names out to each other is thirty seconds of entertainment before a single drink is ordered.
 
 ### 3.2 Anonymous is the default, and that is deliberate
 
@@ -108,69 +110,62 @@ The alias button is visually dominant, listed first, and requires one tap versus
 
 1. **It is faster.** Typing on a phone in a dark, loud bar is the single worst step in the flow.
 2. **It is funnier**, which is the point of the product.
-3. **It avoids collecting personal data.** A typed first name is personal data under GDPR; "Captain Pretzel" is not. Making the privacy-preserving option also the fun option means we do not have to talk anyone into it. See §8.4 for retention.
+3. **It avoids collecting personal data.** A typed first name is personal data under GDPR; "The Whispering Gambler" is not. Making the privacy-preserving option also the fun option means we do not have to talk anyone into it. See §8.4 for retention.
 
-### 3.3 Alias structure: stable noun, escalating rank
+### 3.3 Alias structure: a single stable persona (rank ladder was never built)
 
-An alias is **`<Rank> <Noun>`** — e.g. *Captain Pretzel*, *Major Otter*, *Colonel Waffle*.
+**Shipped vs. spec:** the rank ladder below (`<Rank> <Noun>`, escalating *Captain Pretzel* → *Supreme Overlord Pretzel*) was the pre-build design and was **never built**. What shipped instead: `Guest.alias` is one plain string, rolled once from a fixed catalog of hand-written noir personas — *The Whispering Gambler*, *The Velvet Silhouette*, *The Midnight Chemist* — and held unchanged for the life of the guest record (`power_up/atmos/lore/personas.py`). There is no noun/rank split, no `RANKS` table, no per-venue `alias_escalation_enabled` toggle, and no rank field on `Guest` at all — see §4.7.
 
-You asked whether names could rotate to keep things fun. Straight rotation breaks the product: if a guest is *Captain Pretzel* when they order and *Baroness Gherkin* when the tray lands, the barkeeper cannot deliver the drink and the joke becomes an argument. So the rotation is put where it is safe:
+The core reasoning that motivated the rank ladder still holds, and the shipped design satisfies it more simply: an order must still say the same name it was placed under when the tray lands, or the barkeeper can't deliver it and the joke becomes an argument (§4.8's `alias_snapshot` exists for exactly this). A single alias that never changes gets that guarantee for free, without needing a time-based promotion mechanic to keep the name "the same but visibly different" — because there is no window mechanic (§5) to escalate against in the first place.
 
-- **The noun never changes** for the life of the guest record. It is the delivery key. Staff learn it, guests answer to it.
-- **The rank escalates** as the evening goes on, so the same person is *Captain Pretzel* at 9pm and *Supreme Overlord Pretzel* at midnight. Same recognisable name, visibly promoted, and the escalation is itself the running joke.
-- **Rerolling is unlimited before confirming**, none after.
+- **The alias never changes** for the life of the guest record. It is the delivery key. Staff learn it, guests answer to it.
+- **Rerolling is unlimited before confirming**, none after — this part of the original design shipped as written.
 
-Rank ladder (deliberately gender-neutral — an anonymous guest has no gender to assume):
+If a future pass wants a running joke that develops over the course of the evening, the original "reward dwell time, not drink volume" constraint (§8.5 still enforces this principle for the shipped alcohol-safety copy) is the right one to design against — it just has nothing to hook into today, since nothing tracks how long a guest has been seated.
 
-| Tier | Rank | Unlocked at |
-|---|---|---|
-| 1 | Captain | on join |
-| 2 | Major | 30 min at the table |
-| 3 | Colonel | 60 min |
-| 4 | General | 90 min |
-| 5 | Supreme Overlord | 120 min |
+### 3.4 The persona catalog (shipped)
 
-**Escalation is tied to time seated, not to drinks ordered.** This is a deliberate reversal of the obvious design. Ranking people up per drink is the more natural gamification and it is the wrong thing to build: it makes the app reward faster drinking, in a bar, where the app also removes the friction of catching a waiter's eye. Time-based escalation produces exactly the same joke, rewards guests for staying, and gives the venue longer table dwell — which is what the venue actually wants anyway. If a future version wants order-linked flourishes, tie them to *variety* (trying a new category) rather than volume.
+**Shipped vs. spec:** a single curated, human-reviewed, **English-only** catalog of ~48 full noir personas lives in `power_up/atmos/lore/personas.py` (`NOIR_PERSONAS`) — not the per-language EN/DE/FR animal-noun lists sketched below in the original draft. Since there is no separate rank word (§3.3), there is nothing to combine the noun with either — each catalog entry is already the complete, final alias.
 
-### 3.4 Word lists
+Constraints every entry obeys — the underlying reasoning is unchanged from the original draft, plus one shipped-specific addition:
 
-Curated static lists per language, not a free-form generator. Combining unreviewed adjectives with unreviewed nouns eventually produces something that gets the bar in trouble; a fixed list of ~60 nouns can be read once by a human and signed off.
+- ≤ 26 characters, so a persona centres on a 58mm thermal ticket (32 columns) without wrapping — the shipped equivalent of the original's "≤ 20 characters for a KDS card".
+- Pronounceable by an EN, DE and FR speaker alike — still the design goal, even though the catalog itself is English-only today.
+- **Encodable in CP858**, the thermal printer's native code page (`power_up/atmos/printing/escpos.py`) — a constraint the original draft couldn't have anticipated, since printing (§3.7) wasn't designed yet when this section was first written.
+- Absurd or mysterious rather than "silly" — a tonal shift from the original's animal-noun humour to noir atmosphere, but the same underlying rule: nothing that mocks appearance, and nothing that reads as a comment on how much someone has had.
 
-Constraints on every noun, all of which come from the fact that a stressed barkeeper has to **shout it across a noisy room**:
+Examples actually in the shipped catalog: *The Whispering Gambler, The Velvet Silhouette, The Midnight Chemist, The Cloakroom Oracle, The Hatcheck Ghost, The Last Tram Home.*
 
-- Maximum 3 syllables, ideally 2. *Bartholomew Quixotic-Fizzwhistle* is unusable.
-- Total alias ≤ 20 characters so it fits on a KDS card without wrapping.
-- Pronounceable by an EN, DE and FR speaker alike.
-- Absurd but affectionate. Nothing that mocks appearance, and nothing drink-related that reads as a comment on how much someone has had.
+**A native-speaker DE/FR (or Luxembourgish) pass remains open work**, same caution as the original draft: an innocuous word or image can be a slang insult in one language and not visible as one from the other side. The original per-language animal-noun starter lists below were never built and are kept here only as a record of the pre-build direction:
 
-Starter lists (illustrative, to be finalised):
-
-| Lang | Nouns |
+| Lang | Nouns (never shipped — superseded by the noir persona catalog above) |
 |---|---|
 | EN | Pretzel, Waffle, Pickle, Noodle, Muffin, Popcorn, Cashew, Olive, Radish, Truffle, Otter, Puffin, Walrus, Ferret, Hedgehog, Wombat, Gecko, Toucan, Llama, Moose, Penguin, Flamingo, Hamster |
 | DE | Brezel, Waffel, Gurke, Nudel, Muffin, Olive, Rettich, Trüffel, Otter, Walross, Frettchen, Igel, Wombat, Gecko, Tukan, Lama, Elch, Pinguin, Flamingo, Hamster |
 | FR | Bretzel, Gaufre, Cornichon, Nouille, Muffin, Olive, Radis, Truffe, Loutre, Macareux, Morse, Furet, Hérisson, Wombat, Gecko, Toucan, Lama, Élan, Manchot, Flamant, Hamster |
 
-**Each list needs a native-speaker pass, not a translation.** Innocuous animals are slang insults in one language and not another — French *blaireau* (badger) means "idiot", English *beaver* carries crude slang, and neither problem is visible from the other side. Both are already excluded above. The lists deliberately do not mirror each other one-for-one for this reason.
-
 ### 3.5 Uniqueness
 
-Two *Captain Pretzels* in one venue is a delivery failure, so the noun is unique **per venue among non-settled guests**. The generator picks from the unused pool; if a venue somehow exhausts ~60 nouns with concurrent guests, it falls back to appending a digit (*Pretzel II*) rather than failing the scan. A guest scanning in must never see an error because the bar is busy.
+Two guests both called *The Whispering Gambler* at one venue is a delivery failure, so the alias is unique **per venue among `status="active"` guests** (`random_persona(exclude=...)` in `lore/personas.py`, backed by the DB-level `uniq_active_alias_per_venue` constraint on `Guest`). This is narrower than the original draft's "non-settled" framing: a guest staff mark **`removed`** also releases their persona for immediate reuse, not just a `settled` one — there's no state where an alias is reserved without an active guest holding it.
+
+The generator picks from the unused pool; if a venue somehow exhausts the catalog with concurrent guests, it falls back to appending a roman numeral (*The Whispering Gambler II*, *III*, …) and, if even those collide, a random two-digit suffix — rather than failing the scan. A guest scanning in must never see an error because the bar is busy, which was the original goal and still holds exactly as drafted.
 
 ### 3.6 Typed names need moderation
 
-The free-text path puts guest-controlled text on a staff screen that gets read aloud. Untreated, someone will type a slur on their first visit and a member of staff will shout it. Minimum handling:
+The free-text path puts guest-controlled text on a staff screen that gets read aloud — and, in the shipped design, also into an LLM prompt for the printed vignette (§3.7). Untreated, someone will type a slur or a prompt-injection attempt on their first visit. **Shipped, this is a mixed picture against the original draft** — stronger against prompt injection, slightly weaker on charset, and missing the staff-side backstop entirely:
 
-- Length capped at 20 characters, letters/spaces/hyphens/apostrophes only.
-- Checked against a blocklist per language. On a hit, no scolding — just *"Let's try a silly one instead"* and a pre-rolled alias. Never explain what was rejected; that turns the filter into a game.
-- Staff can override any name from the KDS to a fresh alias in one tap, which is the real backstop. Filters miss things; a barkeeper does not.
+- Length capped at 20 characters (`Guest.display_name`'s `max_length`), enforced by `sanitize_persona()` in `power_up/atmos/lore/safety.py` — matches the original draft's number.
+- Charset is letters plus space, hyphen, apostrophe, **and period** — one character wider than the draft's "letters/spaces/hyphens/apostrophes only".
+- Checked against a blocklist **and** a set of prompt-injection markers (`"ignore previous"`, `"system prompt"`, …) and AI-assistant-voice tells — a defence the original draft couldn't have anticipated, since it predates the vignette/chronicle feature. The blocklist itself is a single English placeholder list today, **not** the per-language lists the draft called for.
+- On rejection: no scolding — the guest sees *"Let's try a noir one instead"* and a pre-rolled persona. The message wording changed, the never-explain-the-rule policy did not.
+- **Not shipped:** the staff KDS override ("rename any guest to a fresh alias in one tap") described as the real backstop below. There is no `guest_rename` endpoint or equivalent staff action (§6.2) — the only staff mutation route that ships is `order_set_status`. A typed name that gets past `sanitize_persona()` today has no staff-side undo short of the Django admin.
 
 ### 3.7 Where the alias shows up
 
 - KDS order card, largest text on the card.
-- The guest's own status page (*"Colonel Waffle — 2 Pilsner on the way"*).
-- The printable table receipt if one is ever added.
-- **Not** in analytics, exports, or logs beyond the venue's own order history.
+- The guest's own status page (*"The Whispering Gambler — 2 Pilsner on the way"*).
+- **The printed thermal ticket — shipped, not hypothetical.** `power_up/atmos/printing/` (`escpos.py`, `layout.py`, `art.py`, `transport.py`) is real, wired into order placement in `views.py`, and prints the alias on 58mm ESC/POS paper. The original draft's "if one is ever added" is stale in the other direction: this shipped before some of the mechanics (§5, §4.9) that were drafted alongside it.
+- **Not** in analytics, exports, or logs beyond the venue's own order history — unchanged from the original draft.
 
 ---
 
@@ -182,11 +177,11 @@ Single `power_up/atmos/models.py`. All primary keys are `UUIDField(primary_key=T
 
 The v1 `TableSession` splits in two. A **Tab** is the table's visit; a **Guest** is one person on it. Orders hang off the Guest.
 
+**Shipped vs. spec:** the `Settlement` branch below was never built — see §4.9. Closing a `Tab` settles its guests directly (a status flip + timestamp on `Guest`, no separate record of amount or payment method).
+
 ```
-Venue ─┬─ Table ──── Tab ──┬── Guest ──── Order ──── OrderItem
-       │                   │                │
-       │                   └── Settlement ──┘
-       └─ MenuCategory ──── MenuItem ────────┘
+Venue ─┬─ Table ──── Tab ──── Guest ──── Order ──── OrderItem
+       └─ MenuCategory ──── MenuItem
 ```
 
 ### 4.2 `Venue`
@@ -199,11 +194,12 @@ Venue ─┬─ Table ──── Tab ──┬── Guest ──── Order 
 | `address` | CharField(255), blank | |
 | `currency` | CharField(3), default `"EUR"` | |
 | `service_open` | BooleanField, default `True` | Master switch |
-| `accepts_orders_from` / `_until` | TimeField, null | Soft service window |
-| `guest_window_minutes` | PositiveSmallIntegerField, default `120` | The 2-hour window, per venue |
-| `guest_window_extension_minutes` | PositiveSmallIntegerField, default `120` | What "+time" grants |
-| `alias_escalation_enabled` | BooleanField, default `True` | Lets a venue turn the rank ladder off |
-| `order_note_enabled` | BooleanField, default `True` | |
+| `accepts_orders_from` / `_until` | TimeField, null | Soft service window — **not shipped**, no such fields on `Venue` |
+| `guest_window_minutes` | PositiveSmallIntegerField, default `120` | Shipped, but **not enforced for ordering** — see §5. Its only reader is `purge_stale_guest_names`'s cutoff (§8.4), not the order-placement path |
+| `guest_window_extension_minutes` | PositiveSmallIntegerField, default `120` | **Not shipped** — there's no extend action to grant time (§5, §6.2) |
+| `alias_escalation_enabled` | BooleanField, default `True` | **Not shipped** — nothing to toggle, since rank escalation itself was never built (§3.3) |
+| `order_note_enabled` | BooleanField, default `True` | **Not shipped** |
+| `next_order_number` | PositiveIntegerField, default `1` | Shipped, not in the original draft — a monotonic per-venue counter for `short_code` (§4.8) that survives admin deletions, where a plain `count() + 1` wouldn't |
 | `created_at` / `updated_at` | DateTimeField | |
 
 ### 4.3 `Table`
@@ -265,40 +261,36 @@ One open Tab per table, enforced by `UniqueConstraint(fields=["table"], conditio
 
 One person. Created on scan, bound to that phone by cookie.
 
+**Shipped vs. spec:** the table below is the actual `power_up/atmos/models.py` field set, not the original draft — this is the section that changed the most. There is no `alias_noun` / `alias_rank` split (§3.3), no `is_anonymous` flag (`display_name` being empty already tells you that), no `language` field (§3.1), no `expires_at` / `extension_count` (§5), and no `expired` status (only `active`, `settled`, `removed`).
+
 | Field | Type | Notes |
 |---|---|---|
 | `id` | UUID PK | Stored in the guest's signed cookie |
 | `tab` | FK → Tab, `related_name="guests"` | |
-| `alias_noun` | CharField(24) | Stable. The delivery key |
-| `alias_rank` | PositiveSmallIntegerField, default 1 | 1–5, derived from time seated |
-| `display_name` | CharField(20), blank | Only if typed. Purged on settle (§8.4) |
-| `is_anonymous` | BooleanField, default `True` | False when `display_name` is set |
-| `language` | CharField(5), default `"en"` | |
+| `venue` | FK → Venue, `related_name="guests"` | Denormalised — shipped-beyond-spec, mirrors `Tab.venue` and `Order.venue`'s same reasoning: Django can't constrain uniqueness across the `tab → venue` join, so the FK is duplicated and always re-derived in `save()`, never independently settable |
+| `alias` | CharField(32) | The rolled noir persona (§3.3, §3.4). Stable for the life of the record — the delivery key |
+| `display_name` | CharField(20), blank | Only if typed. Purged on tab close, not on a per-guest "settle" moment alone (§8.4) |
 | `joined_at` | DateTimeField, auto_now_add | |
-| `expires_at` | DateTimeField | `joined_at + venue.guest_window_minutes` |
-| `extension_count` | PositiveSmallIntegerField, default 0 | |
 | `last_activity_at` | DateTimeField, auto_now | |
-| `status` | CharField: `active`, `expired`, `settled`, `removed` | |
+| `status` | CharField: `active`, `settled`, `removed` | No `expired` state — see §5 |
 | `settled_at` | DateTimeField, null | |
 
-Constraint: `UniqueConstraint(fields=["tab__venue", "alias_noun"], condition=~Q(status="settled"))` — expressed in practice as a partial unique index on a denormalised `venue` FK, since Django cannot constrain across a join.
+Constraint: `UniqueConstraint(fields=["venue", "alias"], condition=Q(status="active"), name="uniq_active_alias_per_venue")` — narrower than the draft's `~Q(status="settled")`: a `removed` guest's alias frees up immediately too (§3.5).
 
 ```python
 @property
 def display(self) -> str:
-    """What staff see and shout."""
-    if self.display_name:
-        return self.display_name
-    if not self.tab.venue.alias_escalation_enabled:
-        return f"Captain {self.alias_noun}"
-    return f"{RANKS[self.alias_rank]} {self.alias_noun}"
+    """What staff see and shout — spec §3.7."""
+    return self.display_name or self.alias
 ```
 
-`alias_rank` is **recomputed on read** from `joined_at`, never by a background job — see §2.2.
+No rank to recompute on read (§2.2's "expiry is computed on read, never a background job" reasoning still applies to nothing here, since there is no time-based mechanic left to compute — see §5).
 
 ### 4.8 `Order` / `OrderItem`
 
 `Order` gains a `guest` FK; everything else is unchanged from v1.
+
+**Shipped vs. spec:** `short_code` is `CharField(12)`, not 6 — a fixed 8-char format (`"T" + label[:3] + "-" + order_number`) turned out to need room for `order_number` to grow past 3 digits over a venue's lifetime. `cancel_reason` and `idempotency_key` (§8.2) were **never built** — there is no idempotent-replay guard on order placement today. Two fields ship **beyond** the original draft:
 
 | Field | Type | Notes |
 |---|---|---|
@@ -306,24 +298,35 @@ def display(self) -> str:
 | `guest` | FK → Guest, `related_name="orders"` | |
 | `tab` | FK → Tab, `related_name="orders"` | Denormalised |
 | `venue` | FK → Venue, `related_name="orders"` | Denormalised for the KDS query |
-| `short_code` | CharField(6), db_index | `T12-04` |
+| `short_code` | **CharField(12)**, db_index | `T12-04` — width fixed up from the draft's 6, see above |
 | `alias_snapshot` | CharField(32) | **The alias as displayed when placed** |
 | `status` | CharField: `placed`, `accepted`, `preparing`, `served`, `cancelled` | |
 | `note` | TextField, blank | |
 | `placed_at` / `accepted_at` / `served_at` / `cancelled_at` | DateTimeField | Timestamps are the prototype's metrics |
-| `cancel_reason` | CharField(160), blank | |
-| `idempotency_key` | UUIDField, unique | §8.2 |
+| ~~`cancel_reason`~~ | — | **Not shipped** |
+| ~~`idempotency_key`~~ | — | **Not shipped** — §8.2's double-submit guard doesn't exist |
 | `total_amount` | DecimalField(9,2) | Snapshot at placement |
+| `currency` | CharField(3), default `"EUR"` | **Shipped-beyond-spec.** Snapshots `venue.currency` at placement, same reasoning as every other `*_snapshot` field: a venue's currency changing later must not silently relabel a historical ticket |
+| `vignette` / `vignette_source` | TextField / CharField(16), blank | **Shipped-beyond-spec.** Holds the AI-generated (or procedural-fallback) noir vignette text printed on the ticket (§3.7) — the original draft's data model had nowhere to store this, since the chronicle feature postdates it |
 
-`alias_snapshot` exists because rank escalates. An order placed by *Major Otter* must still say *Major Otter* on the KDS ten minutes later, even though the guest is now *Colonel Otter* — otherwise the card the barkeeper picked up no longer matches the tray they are carrying.
+`alias_snapshot` exists **not** because rank escalates (it doesn't — §3.3), but because `display_name` gets purged when the tab closes (§8.4): an order placed under a typed name must still show that name on the KDS and the printed ticket after the purge clears it from the live `Guest` row, or the card the barkeeper picked up no longer matches what they're carrying.
 
 Index on `("venue", "status", "placed_at")` — the KDS's only hot query.
 
-`OrderItem`: `order` FK, `menu_item` FK (`on_delete=PROTECT`), `name_snapshot`, `unit_price_snapshot`, `quantity`, `note`, `line_total`. Snapshots because the menu changes during service and an order is a record of what was agreed at that moment; recomputing from live prices silently rewrites last night's receipts.
+`OrderItem`: `order` FK, `menu_item` FK (`on_delete=PROTECT`), `name_snapshot`, `unit_price_snapshot`, `contains_alcohol_snapshot` (shipped-beyond-spec — backs the `Order.contains_alcohol` property used by §8.5), `quantity`, `note`, `line_total`. Snapshots because the menu changes during service and an order is a record of what was agreed at that moment; recomputing from live prices silently rewrites last night's receipts.
 
-### 4.9 `Settlement`
+### 4.9 `Settlement` — **not built**
 
-Not a payment integration — a record that a human paid a human, so the tab can close cleanly and the window mechanic has a resolution.
+Not a payment integration — a record that a human paid a human, so the tab can close cleanly and the window mechanic has a resolution. This model **does not exist in the shipped code** (`power_up/atmos/models.py`'s own docstring lists it first among things "deliberately deferred… to get a vertical slice live quickly"). No amount, payment method, or settling-staff-member is ever recorded anywhere.
+
+What shipped instead is much thinner: closing a `Tab` (staff flip its `status` to `closed`, e.g. via the Django admin) runs `Tab.save()`, which — inside one `transaction.atomic()` block —
+
+1. purges every guest's `display_name` back to `""` (with their past orders' `alias_snapshot` reset to `alias` first, so no typed name survives as the sole remaining copy — §8.4), and
+2. flips every still-`active` guest on that tab to `status="settled"` with a `settled_at` timestamp.
+
+There is no concept of "settle just this guest" (`Guest.status` can still be set to `settled` or `removed` directly, e.g. from the admin, but no staff-facing action does this), no amount pre-filled from unsettled orders, and no cash/card/other method captured. If a bar needs a record of how much was actually paid and by what method, it currently lives nowhere in Atmos — it's on the till, same as before Atmos existed.
+
+The original draft's table is kept below as the design target if this gets built:
 
 | Field | Type | Notes |
 |---|---|---|
@@ -336,8 +339,6 @@ Not a payment integration — a record that a human paid a human, so the tab can
 | `settled_at` | DateTimeField, auto_now_add | |
 | `note` | CharField(160), blank | |
 
-Settling every active guest closes the Tab.
-
 ### 4.10 Status model
 
 ```
@@ -346,15 +347,17 @@ placed ──→ accepted ──→ preparing ──→ served
    └───────────┴────────────┴──────→ cancelled
 ```
 
-Validated in `Order.transition_to(new_status, by_user)` on the model, not the view. Illegal transitions raise `ValidationError`; `served` and `cancelled` are terminal.
+Validated in `Order.transition_to(new_status)` on the model, not the view — shipped without the draft's `by_user` argument; the model records no audit trail of which staff member made a transition. Illegal transitions raise `ValidationError`; `served` and `cancelled` are terminal.
 
 ---
 
-## 5. The 2-hour window
+## 5. The 2-hour window — **not enforced**
 
-Each guest can order for `venue.guest_window_minutes` (default 120) from joining. When it runs out, staff are prompted to **settle up** or **add time**. This is the mechanic that turns an unpaid-online system into something a bar can actually run: it forces a payment conversation at a predictable moment instead of hoping someone remembers to ask.
+**Shipped vs. spec:** none of the ordering-time mechanic below is built. `Venue.guest_window_minutes` exists as a field (default 120, per §4.2) and is read by exactly one thing — `purge_stale_guest_names`'s cutoff (§8.4) — but nothing in the ordering path checks it: no `expires_at` on `Guest`, no `active` / `warning` / `expired` / `settled` state machine, no staff extend-or-settle prompt, no "Needs attention" tray. A guest can order for as long as three things all remain true: their signed cookie hasn't expired, their `Guest.status` is still `active`, and their `Tab` is still `open` on an active `Table`.
 
-It also quietly solves the photographed-QR problem (§8.6) — a leaked sticker grants at most two hours of nuisance ordering, and only while the venue is open.
+The only functional time bound today is the guest's **signed cookie's own `max_age`** — 6 hours (`GUEST_COOKIE_MAX_AGE` in `views.py`, matching what §7.1 already specified for the cookie itself), after which `signing.loads()` raises and the guest can no longer be resolved from it. That's an incidental side effect of the cookie's signing parameters, not a designed "window" mechanic — there's no warning state before it lapses, and nothing distinguishes "cookie expired" from "never had a cookie" once it does.
+
+Each guest was meant to be able to order for `venue.guest_window_minutes` (default 120) from joining, with staff prompted to **settle up** or **add time** once it ran out. This was the mechanic meant to turn an unpaid-online system into something a bar can actually run: it forces a payment conversation at a predictable moment instead of hoping someone remembers to ask. It was also meant to quietly solve the photographed-QR problem (§8.6) — a leaked sticker granting at most two hours of nuisance ordering, and only while the venue is open. Neither benefit is realised today: a table's tab stays orderable for as long as staff leave it open, with no automatic prompt to resolve it.
 
 ### 5.1 States
 
@@ -396,6 +399,8 @@ Two zones, cleanly separated — this separation is the security boundary of the
 
 ### 6.1 Guest zone — anonymous, cookie-scoped
 
+> **Shipped routes** (`power_up/atmos/urls.py`): `guest_scan`, `guest_join`, `guest_menu`, `cart_add`, `cart_update`, `cart_detail`, `order_place`, `order_status` — eight of the twelve below. `guest_join` folds the drafted `guest_name` / `alias_roll` / `guest_confirm` split into one view (§3.1): there is no separate DB-free `/join/roll/` endpoint, and no `/atmos/lang/` / `set_language` route (no per-guest language field exists — §3.1). `order_status_poll` isn't a separate route either; see §5 for why "409 if guest expired" doesn't apply — nothing expires a guest anymore.
+
 | Method | Path | Name | Purpose |
 |---|---|---|---|
 | GET | `/atmos/t/<qr_token>/` | `guest_scan` | QR landing. Resolves table, joins/opens Tab, recognises returning cookie, else redirects to naming |
@@ -418,6 +423,8 @@ After the initial scan, guest views take **no** table, tab or guest parameter. E
 ### 6.2 Staff zone — `@staff_member_required`
 
 Matching `power_up.crm`, which uses `django.contrib.admin.views.decorators.staff_member_required` throughout.
+
+> **Shipped routes:** `staff_home`, `kds`, `order_set_status` — three of the twelve below. None of the window/settlement staff actions (`guest_extend`, `tab_extend`, `guest_rename`, `tab_settle`, `guest_settle`) exist, consistent with §4.9 and §5 not being built. `kds_poll` isn't a separate route. `item_toggle` (the 86-button) and `qr_sheet` (printable QR sheet) aren't standalone staff URLs either — menu/table/venue management runs entirely through Django admin today, further than the "MVP" scoping below already conceded. `qr_rotate` exists, but as a **`TableAdmin` admin action**, not this staff URL (§8.6).
 
 | Method | Path | Name | Purpose |
 |---|---|---|---|
@@ -442,15 +449,17 @@ Menu, table and venue CRUD run through **Django admin** for the MVP, registered 
 
 ### 7.1 First guest at a table
 
+**Shipped vs. spec:** the flow below is materially unchanged except step 6 — there is no `expires_at` to set (§5), and step 5's "taps Give me a silly one" is really "sees a persona already rolled and taps confirm, or rerolls first" (§3.1).
+
 1. Scan → `GET /atmos/t/<qr_token>/`.
 2. Resolve `Table` by token; 404 on unknown or inactive.
 3. If `venue.service_open` is false → "ordering closed", stop.
 4. No `atmos_guest` cookie → join the table's open Tab or create one, then redirect to `/atmos/join/`.
-5. Guest taps **"Give me a silly one"**, rerolls twice, laughs, confirms.
-6. `guest_confirm` creates the Guest inside `transaction.atomic()`, sets `expires_at`, sets a signed cookie (`HttpOnly`, `SameSite=Lax`, `Secure` in production, `max_age` 6 h), redirects to the menu.
+5. Guest sees a rolled persona, optionally rerolls (a page reload, not an HTMX call — §3.1), laughs, confirms — or types a name instead.
+6. `guest_join`'s POST handler creates the Guest inside `transaction.atomic()`, sets a signed cookie (`HttpOnly`, `SameSite=Lax`, `Secure` in production, `max_age` 6 h — this part shipped exactly as drafted), redirects to the menu.
 7. Browse → cart (server-side Django session, **not** `localStorage` — phones get shared and browsers drop storage; a server-side cart is one staff can recover) → `POST /atmos/order/place/`.
-8. Order created atomically; totals computed server-side from current prices, then snapshotted along with the alias.
-9. Status page polls every 5 s, showing the `short_code` and the alias.
+8. Order created atomically; totals computed server-side from current prices, then snapshotted along with the alias — and a thermal ticket prints (§3.7).
+9. Status page shows the `short_code` and the alias.
 
 ### 7.2 Second person at the same table
 
@@ -477,32 +486,33 @@ Cookie present and the Guest is `active` → straight to the menu, no naming scr
 
 ### 8.1 Guest authorisation
 
-Every guest view resolves the Guest from the signed cookie and 403s if absent, settled or removed. Object access always goes *through* the guest: `guest.orders.get(pk=...)`, never `Order.objects.get(pk=...)`. Knowing another order's UUID is not enough to view it. A guest can see their own orders, not their table-mates'.
+**Shipped vs. spec:** the security boundary holds, but the mechanics differ from "403s if absent, settled or removed." Most guest views use `_get_guest()`, which requires `status="active"` — an absent, settled, or removed guest resolves to `None` and gets a normal `no_session.html` page, not a 403. `order_status` deliberately uses a more permissive resolver, `_get_guest_for_viewing()`, that drops the `active`/tab-open requirement — a **settled** guest can still open their own already-placed order's status page after the tab closes, on purpose (otherwise the guest loses visibility into an order the bar is still fulfilling the moment staff close the tab). Object access still always goes *through* the guest either way: `guest.orders.get(pk=...)`, never `Order.objects.get(pk=...)`. Knowing another order's UUID is not enough to view it. A guest can see their own orders, not their table-mates' — that boundary is intact even where the resolver is looser.
 
-### 8.2 Double-submission
+### 8.2 Double-submission — **not built**
 
-Bar wifi is bad and guests tap twice. `order_place` carries an `idempotency_key` minted when the cart page renders, stored with a unique constraint; a replay returns the existing order instead of a second round of drinks. Without this the first real service produces duplicates and staff stop trusting the screen.
+Bar wifi is bad and guests tap twice. The design below (`order_place` carrying an `idempotency_key` minted when the cart page renders, stored with a unique constraint, so a replay returns the existing order instead of a second round of drinks) was never implemented — `Order` has no `idempotency_key` field (§4.8). A double-tap on `POST /atmos/order/place/` today places two orders. This is the one open correctness gap the doc sync (2026-08-20) didn't have an existing mitigation to point to instead of the drafted one — worth prioritising if a real bar runs on this.
 
-### 8.3 Alias-roll abuse
+### 8.3 Alias-roll abuse — shipped, stricter than drafted
 
-`alias_roll` is cheap but unauthenticated. Rate-limit per IP and per Tab (e.g. 60 rolls / 5 min) so it cannot be turned into a load generator, and keep it DB-free so the ceiling is high.
+Rerolling (§3.1) is cheap but unauthenticated, and there's no separate `alias_roll` endpoint to target (§6.1) — the whole `guest_join` view is rate-limited instead, keyed on (client IP, tab, HTTP method) via `_join_rate_limited()`. Shipped limit is **60 requests / 60 seconds** per key, tighter than the draft's "60 rolls / 5 min." Fails open (returns not-limited) on a cache/Redis outage rather than 500ing the join page.
 
 ### 8.4 Personal data and retention
 
-- `alias_noun` / `alias_rank` are not personal data. They are kept with the order history as the venue's own record.
-- `display_name` **is** personal data. It is purged (set to `""`) when the guest is settled or the tab closes; `alias_snapshot` on past orders keeps history readable without it.
+- `alias` is not personal data (no `alias_noun` / `alias_rank` split — §3.3, §4.7). It is kept with the order history as the venue's own record.
+- `display_name` **is** personal data. It is purged (set to `""`, with its guest's past `Order.alias_snapshot` rows reset first) when the **tab closes** (`Tab.save()`, §4.9) — not on a per-guest "settle" moment in isolation, since there is no such staff action (§4.9). A guest an admin marks `removed` before the tab closes keeps its `display_name` until the tab-close purge runs, not the other way round.
+- A separate management command, `purge_stale_guest_names`, exists for a cutoff-based sweep independent of tab closure — but per its own code comment it is **dry-run by default and has no scheduled invocation on this platform** (no cron/Function calls it). The tab-close purge above is what actually protects the "we only keep this for tonight" promise in production today; the standalone sweep is a manual/future backstop, not a running safeguard.
 - No IP, device fingerprint, or contact detail is stored against a Guest. The cookie holds a UUID and nothing else.
-- Guests are told, in one line on the naming screen: *"We only keep this for tonight."* Say it because it is true and because it makes the alias button feel like the safe choice as well as the fast one.
+- Guests are told, in one line on the naming screen: *"Anonymous & temporary."* Wording shipped slightly differently from the draft's *"We only keep this for tonight"*, same intent.
 
 ### 8.5 Alcohol
 
 Luxembourg prohibits selling alcohol to under-16s (under-18 for spirits). A QR web app cannot verify age and should not pretend to. Atmos therefore shows a non-blocking notice on alcohol items, flags alcohol-containing orders on the KDS card so staff **check at delivery**, and records nothing about any guest's age. The legal check stays with the human handing over the glass — which is where it already is, and where it is defensible.
 
-The alias system must not undercut this. Ranks escalate on time, not drinks (§3.3), and no alias, badge or copy anywhere in the product congratulates a guest for volume.
+The alias system must not undercut this. There is no rank or escalation to tie to drinks in the first place (§3.3), and no alias, badge or copy anywhere in the product congratulates a guest for volume.
 
 ### 8.6 Abuse from a photographed QR
 
-Anyone who photographs a sticker can order to that table from outside. Mitigations: the 2-hour window caps exposure, `service_open` kills all ordering, staff can settle or remove a guest, per-Tab rate limits apply, and `qr_rotate` invalidates a leaked token. Since payment is on delivery, financial exposure is zero — an unserved order costs nothing.
+Anyone who photographs a sticker can order to that table from outside. Of the drafted mitigations, the **2-hour window does not cap exposure today** — it isn't enforced (§5), so a leaked sticker is good for as long as the tab stays open, not two hours. What does hold: `service_open` kills all ordering venue-wide, staff can remove or settle a guest via the admin (§4.7/§4.9), per-Tab join rate limits apply (§8.3), and `qr_rotate` invalidates a leaked token — shipped as a **Django admin action** on `TableAdmin`, not the `/atmos/staff/table/<uuid:pk>/rotate-qr/` staff URL drafted in §6.2. Since payment is on delivery, financial exposure is zero either way — an unserved order costs nothing.
 
 ### 8.7 CSRF, CSP
 
@@ -556,12 +566,14 @@ Steps 1–5 make the model real and demoable through admin alone. **Step 6 is th
 2. **Is 2 hours right,** and should the clock start on join or on first order? A guest who scans, gets distracted, and orders 40 minutes later loses a third of their window for no reason.
 3. **Does the bar want an *accept* step at all,** or should `placed` go straight to `preparing`? An extra tap per order is real friction on a busy night.
 4. **One KDS for the venue, or split bar/kitchen queues?** Drinks and food have very different timings and mixing them hides the slow item.
-5. **Rank escalation on or off for the pilot?** Running it off for the first hour and on for the second is a cheap way to see whether the ladder adds anything over a plain alias.
+5. **Rank escalation on or off for the pilot?** Running it off for the first hour and on for the second is a cheap way to see whether the ladder adds anything over a plain alias. *Resolved by omission: the pilot shipped with the plain single-alias design and no ladder at all (§3.3) — this remains open only if a future pass wants to revisit it.*
 6. **Which bar is the pilot,** and on what hardware — their till browser or a tablet you supply?
 
 ---
 
 ## 12. Remote Treat & Social Drink Gifting (Spec Extension)
+
+> ⚠️ **NOT YET BUILT.** Everything in this section is a proposal, not a shipped feature. There is no `TreatLink` or `TreatPayment` model, no `/atmos/treat/<token>/` route, and no gift-related field on `Order` (`is_gift`, `payment_status`, or otherwise) anywhere in `power_up/atmos/` — confirmed by a repo-wide search: these names appear only in this document. The thermal-ticket printing infrastructure this section assumes (§12.2 step 3) *is* real and shipped (§3.7), but nothing wires a paid remote gift into it yet. Treat this section as a design record for future work, not a description of current behavior.
 
 ### 12.1 Concept & Value Proposition
 A guest at a table (e.g. Table 4 with persona *"The Whispering Gambler"*) can share a link over social media (Instagram Story, WhatsApp, Discord, X/Twitter, SMS) allowing anyone—friends, dates, admirers, followers, or remote family—to **buy them a drink at their table in real-time**.


### PR DESCRIPTION
## Summary

Tom decided: update the spec to match reality, not the other way round. `docs/specs/atmos-bar-ordering.md`'s guest-identity section described a `Settlement` model, a 2-hour guest window, and rank escalation — none of which were built. The shipped code (`power_up/atmos/models.py`, merged via #862/#865) took a simpler approach. This PR rewrites the stale subsections in place to describe the actual shipped behavior.

**Doc-only change — no code, model, or migration changes.**

## What changed

- **Guest identity (§3):** the rank-escalating alias (`<Rank> <Noun>`, Captain → Supreme Overlord) was never built. What shipped: `Guest.alias` is a single stable string rolled once from a fixed noir persona catalog (`power_up/atmos/lore/personas.py`, ~48 entries), held for the life of the guest record. Rewrote 3.1–3.7 to describe the actual join screen, catalog constraints, uniqueness rule (unique among `status="active"` guests, not "non-settled"), typed-name moderation (`lore/safety.py`'s `sanitize_persona`), and the now-real thermal-ticket printing (`power_up/atmos/printing/`).
- **`Guest` (§4.7) and `Order` (§4.8) model tables:** rewrote to match `models.py` exactly — no `alias_noun`/`alias_rank` split, no `expires_at`/`extension_count`, no `idempotency_key`/`cancel_reason`; added the two shipped-beyond-spec `Order` fields (`vignette`/`vignette_source`) that the model's own module docstring explicitly asked this doc to document.
- **`Settlement` (§4.9): marked not built.** Closing a `Tab` auto-settles active guests and purges display names instead; no amount, payment method, or settling staff member is recorded anywhere in Atmos today.
- **The 2-hour window (§5): marked not enforced.** `guest_window_minutes` is read only by the unscheduled `purge_stale_guest_names` cutoff, not by the order-placement path. The only live time bound today is the guest cookie's own 6h signing `max_age`.
- **Idempotency (§8.2): marked not built.** No `idempotency_key` field, no double-submit guard on order placement — confirmed by reading `order_place`/`_create_order_atomic`.
- **Remote Treat / Social Drink Gifting (§12):** confirmed via a repo-wide search that `TreatLink`/`TreatPayment` exist only in this document, nowhere in `power_up/atmos/`. Added a prominent "NOT YET BUILT" banner rather than deleting the design — it's a legitimate future proposal, just not shipped.
- Lighter annotations (not full rewrites, per scope) on §2.1 (language selection never built), §6 URL surface (annotated actual shipped routes without rewriting the drafted tables), §8.1 (guest authorisation mechanics — `_get_guest` vs `_get_guest_for_viewing`), §8.3 (alias-roll rate limiting — shipped, stricter than drafted), §8.4 (personal-data retention — tab-close purge vs. the unscheduled sweep command), §8.6 (photographed-QR mitigations), and §11 Q5 (rank escalation — resolved by omission).
- Left §9 (Testing) and §11 (Open questions, except Q5) untouched — they're plans/speculative questions, not claims about shipped behavior.
- **Preserved all section numbers** — `power_up/atmos/models.py`'s docstring and `views.py` cite `§4.9`, `§5`, `§3.3`, `§8.2`, etc. by number in code comments, so nothing was renumbered or deleted, only rewritten/annotated in place.

## Noted, not fixed (out of scope for this PR)

- **§10's build plan** names `seed_atmos_demo` at "12 tables, ~25 items". The shipped command currently seeds fewer (confirmed: `seed_atmos_demo.py`'s own docstring says "One venue, a few tables, a small menu"). A parallel task (`atmos-seed-expand`) is closing that gap separately — the spec's numbers are correct as a target, no doc change needed there.
- **`views.py` line 882** has `render(request, "atmos\closed.html", ...)` — a literal backslash in the template path. This works by accident on this Windows dev box and would raise `TemplateDoesNotExist` → 500 on Linux prod the moment a venue is closed mid-session at order placement. Noticed while reading the order-placement flow for §8.2; not fixed here since this PR is doc-only.

## Validation

- `python manage.py makemigrations --check --dry-run` → "No changes detected" (confirms zero code/model drift, as expected for a doc-only PR).
- `git diff --stat` confirms only `docs/specs/atmos-bar-ordering.md` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
