### PR TITLE
Fix Power-Up login page on staging

### DIFF
--- a/crush_lu/templates/account/login.html
+++ b/crush_lu/templates/account/login.html
@@ -2,7 +2,9 @@
 {# Routes to appropriate login template based on the request domain #}
 {# NOTE: login_powerup.html extends entreprinder's base.html which uses {% url 'entreprinder:...' %} #}
 {# so it can ONLY be used when the entreprinder namespace is registered (i.e. on entreprinder.lu) #}
-{% if 'entreprinder' in request.get_host %}
+{% if 'powerup' in request.get_host or 'power-up' in request.get_host %}
+{% include "account/login_power_up.html" %}
+{% elif 'entreprinder' in request.get_host %}
 {% include "account/login_powerup.html" %}
 {% else %}
 {# Default to Crush template - handles crush.lu, powerup.lu, vinsdelux.com, azurewebsites.net, #}

--- a/crush_lu/templates/account/login_power_up.html
+++ b/crush_lu/templates/account/login_power_up.html
@@ -1,0 +1,44 @@
+{% extends "power_up/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Sign in - Power Up" %}{% endblock %}
+
+{% block content %}
+<section class="min-h-[70vh] bg-slate-50 px-4 py-16">
+  <div class="mx-auto max-w-md rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+    <div class="mb-6">
+      <p class="text-sm font-semibold uppercase tracking-wide text-orange-600">Power Hub</p>
+      <h1 class="mt-2 text-3xl font-bold text-slate-900">{% trans "Sign in" %}</h1>
+      <p class="mt-2 text-sm text-slate-600">{% trans "Access the protected Azure price tracker." %}</p>
+    </div>
+
+    <form method="post" novalidate>
+      {% csrf_token %}
+      {% if form.non_field_errors %}
+        <div class="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <label for="id_login" class="mb-1 block text-sm font-medium text-slate-700">{% trans "Email" %}</label>
+      <input id="id_login" name="login" type="email" value="{{ form.login.value|default:'' }}"
+             autocomplete="email" required
+             class="mb-1 w-full rounded-lg border border-slate-300 px-4 py-3 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-200">
+      {% if form.login.errors %}<p class="mb-4 text-sm text-red-600">{{ form.login.errors.0 }}</p>{% else %}<div class="mb-4"></div>{% endif %}
+
+      <label for="id_password" class="mb-1 block text-sm font-medium text-slate-700">{% trans "Password" %}</label>
+      <input id="id_password" name="password" type="password" autocomplete="current-password" required
+             class="mb-1 w-full rounded-lg border border-slate-300 px-4 py-3 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-200">
+      {% if form.password.errors %}<p class="mb-4 text-sm text-red-600">{{ form.password.errors.0 }}</p>{% else %}<div class="mb-6"></div>{% endif %}
+
+      {% if redirect_field_value %}
+        <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
+      {% endif %}
+
+      <button type="submit" class="w-full rounded-lg bg-orange-600 px-4 py-3 font-semibold text-white transition hover:bg-orange-700">
+        {% trans "Sign in" %}
+      </button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/power_up/finops/tests/test_retail_price_dashboard.py
+++ b/power_up/finops/tests/test_retail_price_dashboard.py
@@ -28,6 +28,19 @@ def test_price_dashboard_requires_login(client):
 
 
 @pytest.mark.django_db
+def test_power_up_login_page_uses_domain_safe_template(client):
+    response = client.get(
+        "/accounts/login/?next=/finops/prices/",
+        HTTP_HOST="test.powerup.lu",
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Power Hub" in content
+    assert "Access the protected Azure price tracker." in content
+
+
+@pytest.mark.django_db
 def test_authenticated_customer_sees_eur_european_comparison_and_change(
     client, regular_user
 ):


### PR DESCRIPTION
## Summary\n- route Power-Up hosts to a dedicated, domain-safe allauth login template\n- avoid resolving Crush.lu URLs under the Power-Up URL configuration\n- add a regression test for the exact staging login request used by the protected FinOps dashboard\n\n## Verification\n- pytest power_up/finops/tests/test_retail_price_dashboard.py -q -n 0 (4 passed)\n- git diff --check\n\n## Staging evidence\nGET /finops/prices/ redirected correctly, but GET /accounts/login/?next=/finops/prices/ returned HTTP 500 with NoReverseMatch: 'crush_lu' is not a registered namespace on the Power-Up domain.