### PR TITLE
Improve FinOps VM selection and European region coverage

### DIFF
--- a/power_up/admin.py
+++ b/power_up/admin.py
@@ -81,6 +81,9 @@ class PowerUpAdminSite(admin.AdminSite):
             "costforecast": {"order": 4, "icon": "🔮", "group": "FinOps Hub"},
             "reservationcost": {"order": 5, "icon": "🏷️", "group": "FinOps Hub"},
             "costbudget": {"order": 6, "icon": "💵", "group": "FinOps Hub"},
+            "retailpricesyncrun": {"order": 7, "icon": "🔄", "group": "FinOps Hub"},
+            "retailpricerawpage": {"order": 8, "icon": "🗄️", "group": "FinOps Hub"},
+            "retailpricesnapshot": {"order": 9, "icon": "🧾", "group": "FinOps Hub"},
         }
 
         # Ordered display groups

--- a/power_up/finops/admin.py
+++ b/power_up/finops/admin.py
@@ -15,6 +15,9 @@ from .models import (
     CostForecast,
     ReservationCost,
     CostBudget,
+    RetailPriceRawPage,
+    RetailPriceSnapshot,
+    RetailPriceSyncRun,
 )
 
 
@@ -273,6 +276,63 @@ class CostBudgetAdmin(admin.ModelAdmin):
     search_fields = ['name', 'dimension_value']
 
 
+class ImmutableRetailPriceAdmin(admin.ModelAdmin):
+    """Read-only inspection for append-only public price history."""
+
+    actions = None
+
+    def get_readonly_fields(self, request, obj=None):
+        return [field.name for field in self.model._meta.fields]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class RetailPriceSyncRunAdmin(ImmutableRetailPriceAdmin):
+    list_display = [
+        "snapshot_date", "provider", "currency", "status", "page_count",
+        "raw_item_count", "normalized_item_count", "invalid_item_count",
+        "started_at", "completed_at",
+    ]
+    list_filter = ["provider", "currency", "status", "snapshot_date"]
+    search_fields = ["connector_name", "source_endpoint"]
+    date_hierarchy = "snapshot_date"
+
+
+class RetailPriceRawPageAdmin(ImmutableRetailPriceAdmin):
+    list_display = [
+        "sync_run", "page_number", "item_count", "response_sha256", "fetched_at"
+    ]
+    list_filter = ["sync_run__provider", "sync_run__snapshot_date"]
+    search_fields = ["response_sha256", "source_url"]
+    list_select_related = ["sync_run"]
+    exclude = ["payload_gzip"]
+
+
+class RetailPriceSnapshotAdmin(ImmutableRetailPriceAdmin):
+    list_display = [
+        "snapshot_date", "provider_sku", "operating_system", "region_code",
+        "purchase_model", "term", "unit_price", "currency", "unit_of_measure",
+    ]
+    list_filter = [
+        "snapshot_date", "region_code", "operating_system", "purchase_model",
+        "price_type", "currency",
+    ]
+    search_fields = [
+        "provider_sku", "product_name", "meter_name", "provider_product_id",
+        "provider_meter_id",
+    ]
+    date_hierarchy = "snapshot_date"
+    list_select_related = ["sync_run", "source_page"]
+    list_per_page = 100
+
+
 # Register models with power_up_admin_site
 power_up_admin_site.register(CostExport, CostExportAdmin)
 power_up_admin_site.register(CostRecord, CostRecordAdmin)
@@ -281,3 +341,6 @@ power_up_admin_site.register(CostAnomaly, CostAnomalyAdmin)
 power_up_admin_site.register(CostForecast, CostForecastAdmin)
 power_up_admin_site.register(ReservationCost, ReservationCostAdmin)
 power_up_admin_site.register(CostBudget, CostBudgetAdmin)
+power_up_admin_site.register(RetailPriceSyncRun, RetailPriceSyncRunAdmin)
+power_up_admin_site.register(RetailPriceRawPage, RetailPriceRawPageAdmin)
+power_up_admin_site.register(RetailPriceSnapshot, RetailPriceSnapshotAdmin)

--- a/power_up/finops/retail_prices/connectors/azure.py
+++ b/power_up/finops/retail_prices/connectors/azure.py
@@ -14,18 +14,25 @@ from ...models import CloudProvider, RetailPriceSnapshot
 from .base import ConnectorPage, RetailPriceConnector
 
 EUROPEAN_AZURE_REGIONS = {
-    "westeurope": {
-        "label": "West Europe",
-        "data_residency_scope": "EU",
-    },
-    "northeurope": {
-        "label": "North Europe",
-        "data_residency_scope": "EU",
-    },
-    "germanywestcentral": {
-        "label": "Germany West Central",
-        "data_residency_scope": "EU",
-    },
+    "austriaeast": {"label": "Austria East", "data_residency_scope": "EU"},
+    "belgiumcentral": {"label": "Belgium Central", "data_residency_scope": "EU"},
+    "denmarkeast": {"label": "Denmark East", "data_residency_scope": "EU"},
+    "francecentral": {"label": "France Central", "data_residency_scope": "EU"},
+    "francesouth": {"label": "France South", "data_residency_scope": "EU", "restricted_access": True},
+    "germanynorth": {"label": "Germany North", "data_residency_scope": "EU", "restricted_access": True},
+    "germanywestcentral": {"label": "Germany West Central", "data_residency_scope": "EU"},
+    "italynorth": {"label": "Italy North", "data_residency_scope": "EU"},
+    "northeurope": {"label": "North Europe", "data_residency_scope": "EU"},
+    "norwayeast": {"label": "Norway East", "data_residency_scope": "Europe (non-EU)"},
+    "norwaywest": {"label": "Norway West", "data_residency_scope": "Europe (non-EU)", "restricted_access": True},
+    "polandcentral": {"label": "Poland Central", "data_residency_scope": "EU"},
+    "spaincentral": {"label": "Spain Central", "data_residency_scope": "EU"},
+    "swedencentral": {"label": "Sweden Central", "data_residency_scope": "EU"},
+    "switzerlandnorth": {"label": "Switzerland North", "data_residency_scope": "Europe (non-EU)"},
+    "switzerlandwest": {"label": "Switzerland West", "data_residency_scope": "Europe (non-EU)", "restricted_access": True},
+    "uksouth": {"label": "UK South", "data_residency_scope": "Europe (non-EU)"},
+    "ukwest": {"label": "UK West", "data_residency_scope": "Europe (non-EU)"},
+    "westeurope": {"label": "West Europe", "data_residency_scope": "EU"},
 }
 
 DEFAULT_EUROPEAN_REGIONS = list(EUROPEAN_AZURE_REGIONS)
@@ -68,9 +75,11 @@ class AzureRetailPricesConnector(RetailPriceConnector):
         params = {
             "api-version": self.api_version,
             "currencyCode": f"'{currency.upper()}'",
-            # Keep every regional service, not only Compute. This captures
-            # Storage, Networking, Monitor, databases, Backup, Security, etc.
-            "$filter": f"armRegionName eq '{region}'",
+            # MVP scope is deliberately limited to public VM Compute prices.
+            "$filter": (
+                f"armRegionName eq '{region}' "
+                "and serviceName eq 'Virtual Machines'"
+            ),
         }
 
         while url:

--- a/power_up/finops/tests/test_retail_price_admin.py
+++ b/power_up/finops/tests/test_retail_price_admin.py
@@ -1,0 +1,30 @@
+import pytest
+
+from power_up.admin import power_up_admin_site
+from power_up.finops.admin import (
+    RetailPriceRawPageAdmin,
+    RetailPriceSnapshotAdmin,
+    RetailPriceSyncRunAdmin,
+)
+from power_up.finops.models import (
+    RetailPriceRawPage,
+    RetailPriceSnapshot,
+    RetailPriceSyncRun,
+)
+
+
+@pytest.mark.parametrize(
+    ("model", "admin_class"),
+    [
+        (RetailPriceSyncRun, RetailPriceSyncRunAdmin),
+        (RetailPriceRawPage, RetailPriceRawPageAdmin),
+        (RetailPriceSnapshot, RetailPriceSnapshotAdmin),
+    ],
+)
+def test_retail_price_history_is_registered_read_only(model, admin_class):
+    model_admin = power_up_admin_site._registry[model]
+
+    assert isinstance(model_admin, admin_class)
+    assert model_admin.has_add_permission(None) is False
+    assert model_admin.has_change_permission(None) is False
+    assert model_admin.has_delete_permission(None) is False

--- a/power_up/finops/tests/test_retail_price_connector.py
+++ b/power_up/finops/tests/test_retail_price_connector.py
@@ -28,7 +28,7 @@ class FakeSession:
         return next(self.responses)
 
 
-def test_azure_connector_follows_next_page_and_scopes_european_catalogue_eur():
+def test_azure_connector_follows_next_page_and_scopes_european_vm_prices_eur():
     next_url = "https://prices.azure.com/api/retail/prices?$skip=1000"
     session = FakeSession(
         [
@@ -51,6 +51,5 @@ def test_azure_connector_follows_next_page_and_scopes_european_catalogue_eur():
     assert session.calls[1][1]["params"] is None
     first_params = session.calls[0][1]["params"]
     assert first_params["currencyCode"] == "'EUR'"
-    assert "serviceName" not in first_params["$filter"]
-    assert "serviceFamily" not in first_params["$filter"]
+    assert "serviceName eq 'Virtual Machines'" in first_params["$filter"]
     assert "armRegionName eq 'westeurope'" in first_params["$filter"]

--- a/power_up/finops/tests/test_retail_price_dashboard.py
+++ b/power_up/finops/tests/test_retail_price_dashboard.py
@@ -69,6 +69,14 @@ def test_authenticated_customer_sees_eur_european_comparison_and_change(
     assert response.context["currency"] == "EUR"
     assert response.context["selected_regions"] == ["westeurope"]
     assert response.context["increased_count"] == 1
+    assert len(response.context["region_options"]) == 19
+    germany_north = next(
+        item
+        for item in response.context["region_options"]
+        if item["code"] == "germanynorth"
+    )
+    assert germany_north["restricted_access"] is True
+    assert germany_north["has_snapshot"] is False
     assert len(response.context["chart_series"][0]["data"]) == 2
     content = response.content.decode()
     assert "European Azure VM retail prices" in content

--- a/power_up/finops/views_prices.py
+++ b/power_up/finops/views_prices.py
@@ -46,6 +46,8 @@ def retail_price_dashboard(request):
     base = RetailPriceSnapshot.objects.filter(
         provider=provider,
         currency=currency,
+        service_category="compute",
+        resource_type="virtual_machines",
         snapshot_date__gte=start_date,
         snapshot_date__lte=end_date,
     )
@@ -164,14 +166,12 @@ def retail_price_dashboard(request):
             else:
                 row.change_direction = "same"
 
-    region_codes = list(
+    captured_region_codes = set(
         RetailPriceSnapshot.objects.filter(provider=provider)
         .values_list("region_code", flat=True)
         .distinct()
-        .order_by("region_code")
     )
-    if not region_codes:
-        region_codes = list(EUROPEAN_AZURE_REGIONS)
+    region_codes = sorted(set(EUROPEAN_AZURE_REGIONS) | captured_region_codes)
     region_options = [
         {
             "code": code,
@@ -179,17 +179,52 @@ def retail_price_dashboard(request):
             "scope": EUROPEAN_AZURE_REGIONS.get(code, {}).get(
                 "data_residency_scope", ""
             ),
+            "restricted_access": EUROPEAN_AZURE_REGIONS.get(code, {}).get(
+                "restricted_access", False
+            ),
+            "has_snapshot": code in captured_region_codes,
         }
         for code in region_codes
     ]
+    sku_options_query = RetailPriceSnapshot.objects.filter(
+        provider=provider,
+        currency=currency,
+        service_category="compute",
+        resource_type="virtual_machines",
+    )
+    if os_filter:
+        sku_options_query = sku_options_query.filter(operating_system=os_filter)
     sku_options = list(
-        RetailPriceSnapshot.objects.filter(provider=provider, currency=currency)
+        sku_options_query
         .values_list("provider_sku", flat=True)
         .distinct()
         .order_by("provider_sku")[:500]
     )
+    product_options_query = RetailPriceSnapshot.objects.filter(
+        provider=provider,
+        currency=currency,
+        service_category="compute",
+        resource_type="virtual_machines",
+    )
+    if active_sku:
+        product_options_query = product_options_query.filter(
+            provider_sku__iexact=active_sku
+        )
+    if os_filter:
+        product_options_query = product_options_query.filter(
+            operating_system=os_filter
+        )
+    product_options = list(
+        product_options_query.values_list("product_name", flat=True)
+        .distinct()
+        .order_by("product_name")[:200]
+    )
     os_options = list(
-        RetailPriceSnapshot.objects.filter(provider=provider)
+        RetailPriceSnapshot.objects.filter(
+            provider=provider,
+            service_category="compute",
+            resource_type="virtual_machines",
+        )
         .exclude(operating_system="")
         .values_list("operating_system", flat=True)
         .distinct()
@@ -221,6 +256,7 @@ def retail_price_dashboard(request):
             "sku_options": sku_options,
             "active_sku": active_sku,
             "product_filter": product_filter,
+            "product_options": product_options,
             "os_filter": os_filter,
             "os_options": os_options,
             "price_type": price_type,

--- a/power_up/templates/finops/retail_price_dashboard.html
+++ b/power_up/templates/finops/retail_price_dashboard.html
@@ -39,40 +39,45 @@
         </div>
 
         <div class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
-            <strong>European-region focus:</strong> the default comparison includes West Europe, North Europe, and Germany West Central. Region labels support data-residency review, but the cheapest public price alone does not establish legal or contractual compliance.
+            <strong>European-region focus:</strong> the selector lists all 19 regions in Microsoft's current Azure Europe geography. Restricted-access regions are identified separately. Region labels support data-residency review, but the cheapest public price alone does not establish legal or contractual compliance.
         </div>
 
         <form method="get" class="mb-8 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <div class="mb-5">
+                <h2 class="text-lg font-semibold text-gray-900">Choose one comparable VM offer</h2>
+                <p class="mt-1 text-sm text-gray-500">Use the same operating system, VM size, product variant, and purchase model before comparing regions.</p>
+            </div>
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-                <label class="block text-sm font-medium text-gray-700">
+                <label class="block text-sm font-medium text-gray-700 lg:order-5">
                     Cloud provider
                     <select name="provider" class="mt-1 block w-full rounded-md border-gray-300">
                         <option value="azure" selected>Microsoft Azure</option>
                     </select>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
-                    VM SKU
+                <label class="block text-sm font-medium text-gray-700 lg:order-2">
+                    2. VM size / SKU
                     <input name="sku" list="sku-options" value="{{ active_sku }}" placeholder="Standard_D2s_v5" class="mt-1 block w-full rounded-md border-gray-300">
                     <datalist id="sku-options">{% for sku in sku_options %}<option value="{{ sku }}">{% endfor %}</datalist>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
-                    Product contains
-                    <input name="product" value="{{ product_filter }}" placeholder="Dsv5 Series" class="mt-1 block w-full rounded-md border-gray-300">
+                <label class="block text-sm font-medium text-gray-700 lg:order-3">
+                    3. Product / licensing variant
+                    <input name="product" list="product-options" value="{{ product_filter }}" placeholder="Select or search a matching product" class="mt-1 block w-full rounded-md border-gray-300">
+                    <datalist id="product-options">{% for product in product_options %}<option value="{{ product }}">{% endfor %}</datalist>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
-                    Operating system
+                <label class="block text-sm font-medium text-gray-700 lg:order-1">
+                    1. Operating system
                     <select name="os" class="mt-1 block w-full rounded-md border-gray-300">
                         <option value="">All / unspecified</option>
                         {% for os in os_options %}<option value="{{ os }}" {% if os_filter == os %}selected{% endif %}>{{ os }}</option>{% endfor %}
                     </select>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
+                <label class="block text-sm font-medium text-gray-700 lg:order-6">
                     Currency
                     <select name="currency" class="mt-1 block w-full rounded-md border-gray-300">
                         {% for item in currency_options %}<option value="{{ item }}" {% if currency == item %}selected{% endif %}>{{ item }}</option>{% endfor %}
                     </select>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
+                <label class="block text-sm font-medium text-gray-700 lg:order-7">
                     Price type
                     <select name="price_type" class="mt-1 block w-full rounded-md border-gray-300">
                         <option value="" {% if not price_type %}selected{% endif %}>All</option>
@@ -82,8 +87,8 @@
                         <option value="SavingsPlan" {% if price_type == 'SavingsPlan' %}selected{% endif %}>Savings plan</option>
                     </select>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
-                    Purchase model
+                <label class="block text-sm font-medium text-gray-700 lg:order-4">
+                    4. Purchase model
                     <select name="purchase_model" class="mt-1 block w-full rounded-md border-gray-300">
                         <option value="" {% if not purchase_model %}selected{% endif %}>All</option>
                         <option value="on_demand" {% if purchase_model == 'on_demand' %}selected{% endif %}>On demand</option>
@@ -93,7 +98,7 @@
                         <option value="dev_test" {% if purchase_model == 'dev_test' %}selected{% endif %}>Dev/Test</option>
                     </select>
                 </label>
-                <label class="block text-sm font-medium text-gray-700">
+                <label class="block text-sm font-medium text-gray-700 lg:order-8">
                     Time period
                     <select name="period" class="mt-1 block w-full rounded-md border-gray-300">
                         <option value="30" {% if period == 30 %}selected{% endif %}>30 days</option>
@@ -103,13 +108,14 @@
                     </select>
                 </label>
             </div>
-            <fieldset class="mt-5">
-                <legend class="text-sm font-medium text-gray-700">European Azure regions</legend>
-                <div class="mt-2 flex flex-wrap gap-4">
+            <fieldset class="mt-7 rounded-xl border-2 border-orange-100 bg-orange-50/40 p-5">
+                <legend class="px-2 text-base font-semibold text-gray-900">5. European Azure regions</legend>
+                <p class="mb-4 text-sm text-gray-600">Select any Azure region in Microsoft's Europe geography. Regions without today's snapshot become comparable after the next full import.</p>
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                     {% for region in region_options %}
-                    <label class="inline-flex items-center gap-2 text-sm text-gray-700">
-                        <input type="checkbox" name="region" value="{{ region.code }}" {% if region.code in selected_regions %}checked{% endif %} class="rounded border-gray-300 text-orange-600">
-                        <span>{{ region.label }}{% if region.scope %} <span class="text-xs text-gray-500">({{ region.scope }})</span>{% endif %}</span>
+                    <label class="flex min-h-20 cursor-pointer items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-700 shadow-sm hover:border-orange-300">
+                        <input type="checkbox" name="region" value="{{ region.code }}" {% if region.code in selected_regions %}checked{% endif %} class="mt-1 h-5 w-5 rounded border-gray-300 text-orange-600">
+                        <span><span class="block font-semibold text-gray-900">{{ region.label }}</span><span class="mt-1 block text-xs text-gray-500">{{ region.scope }}{% if region.restricted_access %} · Restricted access{% endif %}{% if not region.has_snapshot %} · Awaiting snapshot{% endif %}</span></span>
                     </label>
                     {% endfor %}
                 </div>


### PR DESCRIPTION
## Summary\n- make VM offer selection clearer with guided OS, SKU, product/licensing, and purchase-model steps\n- expand the region selector to all 19 regions in Microsoft's current Azure Europe geography\n- mark restricted-access regions and regions awaiting their first snapshot\n- keep future imports within the Azure VM Compute MVP scope while preserving Reservation and Savings Plan variants\n- expose sync runs, compressed raw pages, and normalized price snapshots as read-only Power-Up admin views\n\n## Verification\n- 10 focused FinOps tests passed\n- Django system check passed\n- Ruff passed\n- git diff --check passed\n\n## Operational note\nToday's immutable snapshot contains the original three regions. Newly added regions will populate on the next daily snapshot after this connector change is deployed.