### PR TITLE
fix(finops): polish price-change sign, sync diagnostics, query scope

### DIFF
--- a/azure-functions/finops-daily-sync/function_app.py
+++ b/azure-functions/finops-daily-sync/function_app.py
@@ -144,17 +144,47 @@ def daily_retail_price_sync(timer: func.TimerRequest) -> None:
     if timer.past_due:
         logging.warning(f"[{timestamp}] Retail price timer is past due")
 
-    response = requests.post(
-        webhook_url,
-        headers={
-            "X-Sync-Token": sync_token,
-            "User-Agent": "Azure-Function-Power-Hub-Retail-Price-Sync/1.0",
-        },
-        timeout=220,
-    )
-    response.raise_for_status()
-    result = response.json()
-    logging.info(
-        f"[{timestamp}] Retail price sync result: "
-        f"{result.get('message', 'No message provided')}"
-    )
+    logging.info(f"[{timestamp}] Initiating retail price sync")
+    logging.info(f"[{timestamp}] Target webhook: {webhook_url}")
+
+    try:
+        response = requests.post(
+            webhook_url,
+            headers={
+                "X-Sync-Token": sync_token,
+                "User-Agent": "Azure-Function-Power-Hub-Retail-Price-Sync/1.0",
+            },
+            timeout=220,
+        )
+        response.raise_for_status()
+        result = response.json()
+        logging.info(
+            f"[{timestamp}] Retail price sync result: "
+            f"{result.get('message', 'No message provided')}"
+        )
+
+    except requests.exceptions.Timeout:
+        logging.error(f"[{timestamp}] Retail price sync request timed out after 220s")
+        raise
+
+    except requests.exceptions.HTTPError as e:
+        logging.error(f"[{timestamp}] HTTP error during retail price sync: {e}")
+        logging.error(f"[{timestamp}] Response status: {e.response.status_code}")
+        logging.error(f"[{timestamp}] Response body: {e.response.text}")
+        raise
+
+    except requests.exceptions.RequestException as e:
+        logging.error(f"[{timestamp}] Network error during retail price sync: {str(e)}")
+        raise
+
+    except ValueError as e:
+        # JSON parsing error
+        logging.error(f"[{timestamp}] Invalid JSON response from webhook: {str(e)}")
+        logging.error(f"[{timestamp}] Response text: {response.text}")
+        raise
+
+    except Exception as e:
+        logging.error(f"[{timestamp}] Unexpected error during retail price sync: {str(e)}")
+        raise
+
+    logging.info(f"[{timestamp}] Retail price daily sync function completed")

--- a/power_up/finops/tests/test_retail_price_dashboard.py
+++ b/power_up/finops/tests/test_retail_price_dashboard.py
@@ -85,6 +85,42 @@ def test_authenticated_customer_sees_eur_european_comparison_and_change(
 
 
 @pytest.mark.django_db
+def test_price_decrease_renders_without_a_redundant_sign(client, regular_user):
+    """A price decrease must render as '▼ 16.67%', never '▼ -16.67%'.
+
+    change_percent is negative for a decrease -- the down arrow already
+    conveys direction, so the magnitude shown next to it must be unsigned.
+    Regression test for issue #896.
+    """
+    today = timezone.localdate()
+    first = {"Items": [azure_item("0.12000000")], "NextPageLink": None}
+    second = {"Items": [azure_item("0.10000000")], "NextPageLink": None}
+    sync_retail_prices(
+        snapshot_date=today - timedelta(days=1),
+        connector=FakeConnector(first),
+    )
+    sync_retail_prices(snapshot_date=today, connector=FakeConnector(second))
+    client.force_login(regular_user)
+
+    response = client.get(
+        "/finops/prices/",
+        {
+            "sku": "Standard_D2s_v5",
+            "currency": "EUR",
+            "region": "westeurope",
+            "price_type": "Consumption",
+            "purchase_model": "on_demand",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.context["decreased_count"] == 1
+    content = response.content.decode()
+    assert "▼ 16.67%" in content
+    assert "▼ -16.67%" not in content
+
+
+@pytest.mark.django_db
 def test_retail_sync_webhook_requires_token_and_invokes_command(
     client, settings, mocker
 ):

--- a/power_up/finops/views_prices.py
+++ b/power_up/finops/views_prices.py
@@ -130,10 +130,14 @@ def retail_price_dashboard(request):
     history_keys = {row.price_key for row in history_rows}
     history_by_key = defaultdict(list)
     if history_keys:
+        # Only price_key/snapshot_date/unit_price are read below -- .only()
+        # keeps the SELECT to those columns instead of the full row.
         previous_candidates = RetailPriceSnapshot.objects.filter(
             price_key__in=history_keys,
             snapshot_date__gte=start_date - timedelta(days=365),
-        ).order_by("price_key", "-snapshot_date")
+        ).only("price_key", "snapshot_date", "unit_price").order_by(
+            "price_key", "-snapshot_date"
+        )
         for candidate in previous_candidates:
             history_by_key[candidate.price_key].append(candidate)
 
@@ -149,12 +153,17 @@ def retail_price_dashboard(request):
         )
         row.previous_unit_price = previous.unit_price if previous else None
         row.change_percent = None
+        row.change_percent_abs = None
         row.change_direction = "new"
         if previous and previous.unit_price:
             change = (
                 (row.unit_price - previous.unit_price) / previous.unit_price
             ) * Decimal("100")
             row.change_percent = change.quantize(Decimal("0.01"))
+            # The template prefixes an explicit +/- arrow, so the magnitude
+            # shown alongside it must not carry its own redundant sign
+            # (e.g. "▼ -16.67%").
+            row.change_percent_abs = abs(row.change_percent)
             if change > 0:
                 row.change_direction = "up"
                 increased_count += 1

--- a/power_up/templates/finops/retail_price_dashboard.html
+++ b/power_up/templates/finops/retail_price_dashboard.html
@@ -175,7 +175,7 @@
                             <td class="px-4 py-3"><div class="text-gray-900">{{ row.purchase_model|title }}</div><div class="text-xs text-gray-500">{{ row.price_type }}{% if row.term %} · {{ row.term }}{% endif %}</div></td>
                             <td class="whitespace-nowrap px-4 py-3 text-right font-semibold text-gray-900">{{ row.unit_price }} {{ row.currency }}<div class="text-xs font-normal text-gray-500">{{ row.unit_of_measure }}</div></td>
                             <td class="whitespace-nowrap px-4 py-3 text-right font-semibold {% if row.change_direction == 'up' %}text-red-700{% elif row.change_direction == 'down' %}text-green-700{% else %}text-gray-500{% endif %}">
-                                {% if row.change_direction == 'up' %}▲ +{{ row.change_percent }}%{% elif row.change_direction == 'down' %}▼ {{ row.change_percent }}%{% elif row.change_direction == 'same' %}— 0.00%{% else %}New{% endif %}
+                                {% if row.change_direction == 'up' %}▲ +{{ row.change_percent_abs }}%{% elif row.change_direction == 'down' %}▼ {{ row.change_percent_abs }}%{% elif row.change_direction == 'same' %}— 0.00%{% else %}New{% endif %}
                             </td>
                         </tr>
                         {% endfor %}


### PR DESCRIPTION
Closes #896.

## Summary
Three non-blocking follow-ups from reviewing the merged European Azure VM price tracker (PR #898):

1. **Redundant sign on price decreases** — the dashboard rendered `▼ -16.67%` instead of `▼ 16.67%`. `change_percent` is (correctly) negative for a decrease, but the down-arrow already conveys direction, so the displayed magnitude shouldn't carry its own sign too. Added `row.change_percent_abs` for display; kept the signed `change_percent` as the underlying value in case anything else needs the true sign later.
2. **`daily_retail_price_sync` had no error handling** — a bare `response.raise_for_status()` / `response.json()`, unlike `daily_cost_sync` in the same file, which logs Timeout/HTTPError/RequestException/JSON diagnostics before re-raising. Brought it in line with that pattern so a real failure leaves a diagnosable trail in the Function App logs instead of a bare traceback.
3. **Previous-price lookup queried full rows** across up to 365 days of history when only `price_key`/`snapshot_date`/`unit_price` are read. Added `.only()` to restrict the SELECT.

## Tests
- New regression test for the decrease-sign bug — confirmed it fails against the unfixed template, then passes after the fix
- No test added for the Azure Function change: there's no existing test harness for any of the `azure-functions/*` timer functions in this repo, and the change is a mechanical alignment with the already-tested `daily_cost_sync` pattern in the same file, not new logic

## Verification
- `pytest power_up/finops/tests/` — 120 passed, 6 skipped
- `ruff check` — clean
- `manage.py check` / `makemigrations --check` — clean, no migrations
- `python -m py_compile` on the Azure Function file

🤖 Generated with [Claude Code](https://claude.com/claude-code)