### PR TITLE
fix(crush): harden enrich_staging_candidates against claude-review findings

### DIFF
--- a/.github/workflows/enrich-staging.yml
+++ b/.github/workflows/enrich-staging.yml
@@ -46,6 +46,15 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Fetch Staging App Settings & Run Enrichment
+        env:
+          # workflow_dispatch inputs must never be interpolated directly into
+          # a run: shell block (classic script-injection-to-secret-exfil
+          # path) -- especially not in the same step that exports
+          # DATABASE_URL/AZURE_ACCOUNT_KEY/SECRET_KEY below. Route them
+          # through env: and reference as shell variables instead.
+          CREATE_MISSING: ${{ github.event.inputs.create_missing }}
+          LEAVE_PENDING: ${{ github.event.inputs.leave_pending }}
+          REFRESH_DROPS: ${{ github.event.inputs.refresh_drops }}
         run: |
           echo "🔑 Fetching staging configuration from Azure..."
           SETTINGS_JSON=$(az webapp config appsettings list \
@@ -61,26 +70,39 @@ jobs:
           export AZURE_CRUSH_PRIVATE_CONTAINER="crush-lu-private"
           export SECRET_KEY=$(echo "$SETTINGS_JSON" | jq -r '.[] | select(.name=="SECRET_KEY").value // empty')
 
+          # GitHub only auto-masks values sourced from the `secrets` context,
+          # not ones computed at runtime like these -- mask explicitly so an
+          # error whose message embeds the DSN (common with psycopg2) can't
+          # land the connection string in plaintext in the Actions log.
+          echo "::add-mask::$DATABASE_URL"
+          echo "::add-mask::$POSTGRESQLCONNSTR_DJANGO"
+          echo "::add-mask::$AZURE_ACCOUNT_KEY"
+          echo "::add-mask::$SECRET_KEY"
+
           if [ -z "$SECRET_KEY" ]; then
             export SECRET_KEY="ci-staging-run-key"
           fi
 
           REFRESH_FLAG=""
-          if [ "${{ github.event.inputs.refresh_drops }}" = "true" ]; then
+          if [ "$REFRESH_DROPS" = "true" ]; then
             REFRESH_FLAG="--refresh-drops"
           fi
 
           echo "🚀 Running enrich_staging_candidates..."
           python manage.py enrich_staging_candidates \
             --all \
-            --create-missing ${{ github.event.inputs.create_missing }} \
-            --leave-pending ${{ github.event.inputs.leave_pending }} \
+            --create-missing "$CREATE_MISSING" \
+            --leave-pending "$LEAVE_PENDING" \
             $REFRESH_FLAG
 
       - name: Post Summary
+        env:
+          CREATE_MISSING: ${{ github.event.inputs.create_missing }}
+          LEAVE_PENDING: ${{ github.event.inputs.leave_pending }}
+          REFRESH_DROPS: ${{ github.event.inputs.refresh_drops }}
         run: |
           echo "## ✅ Staging Candidates Enriched Successfully" >> $GITHUB_STEP_SUMMARY
-          echo "- **Target candidates:** ${{ github.event.inputs.create_missing }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Left pending for coach QA:** ${{ github.event.inputs.leave_pending }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Refresh Daily Drops:** ${{ github.event.inputs.refresh_drops }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Target candidates:** $CREATE_MISSING" >> $GITHUB_STEP_SUMMARY
+          echo "- **Left pending for coach QA:** $LEAVE_PENDING" >> $GITHUB_STEP_SUMMARY
+          echo "- **Refresh Daily Drops:** $REFRESH_DROPS" >> $GITHUB_STEP_SUMMARY
           echo "- **Test site:** [test.crush.lu](https://test.crush.lu)" >> $GITHUB_STEP_SUMMARY

--- a/crush_lu/management/commands/enrich_staging_candidates.py
+++ b/crush_lu/management/commands/enrich_staging_candidates.py
@@ -23,6 +23,7 @@ Usage:
 import io
 import logging
 import random
+import secrets
 import requests
 from datetime import date
 
@@ -398,6 +399,18 @@ class Command(BaseCommand):
             help="Enrich all existing candidate/test profiles in the database",
         )
         parser.add_argument(
+            "--include-any-profile",
+            action="store_true",
+            help=(
+                "With --all, if no username/email matches the candidate naming "
+                "convention, also allow falling back to every non-staff user "
+                "with a CrushProfile. Off by default -- on a live-reachable "
+                "site this would silently overwrite real testers' bio/photos/"
+                "DOB/verification and reset their password. Only pass this on "
+                "a database you know holds nothing but seeded candidates."
+            ),
+        )
+        parser.add_argument(
             "--create-missing",
             type=int,
             default=0,
@@ -421,8 +434,13 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--password",
-            default="connect2025",
-            help="Default password for created/reset accounts",
+            default=None,
+            help=(
+                "Password for created/reset accounts. Omit to generate a "
+                "random one per run (printed once at the end) -- a fixed "
+                "default would be a predictable, publicly-visible credential "
+                "for every seeded account on a live-reachable site."
+            ),
         )
         parser.add_argument(
             "--dry-run",
@@ -436,6 +454,16 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.WARNING("DRY-RUN MODE — no changes will be saved")
             )
+
+        password = options["password"]
+        password_was_generated = password is None
+        if password_was_generated:
+            # A fixed default would be a predictable, publicly-visible
+            # credential (this file is in the OSS repo) for every seeded
+            # account on a live-reachable site -- generate one per run
+            # instead and print it once, below.
+            password = secrets.token_urlsafe(12)
+        options["password"] = password
 
         coach = CrushCoach.objects.filter(is_active=True).first()
         if not coach and not dry_run:
@@ -465,10 +493,27 @@ class Command(BaseCommand):
                 | User.objects.filter(username__startswith="debug_cand_")
                 | User.objects.filter(email__contains="candidate")
             )
-            if not targets:
-                # Fallback: all non-staff users with a CrushProfile
+            if not targets and options["include_any_profile"]:
+                # Opt-in only: every non-staff user with a CrushProfile. On a
+                # live-reachable site this would silently overwrite real
+                # testers' data and reset their password, so it never fires
+                # unless explicitly requested.
+                self.stdout.write(
+                    self.style.WARNING(
+                        "No candidate-named profiles found -- --include-any-profile "
+                        "is set, falling back to ALL non-staff CrushProfile users."
+                    )
+                )
                 targets = list(
                     User.objects.filter(is_staff=False, crushprofile__isnull=False)
+                )
+            elif not targets:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "No candidate-named profiles found. Pass --include-any-profile "
+                        "to fall back to every non-staff CrushProfile user (only safe "
+                        "on a database that holds nothing but seeded candidates)."
+                    )
                 )
 
         self.stdout.write(
@@ -565,6 +610,10 @@ class Command(BaseCommand):
                 f"✅ Successfully enriched {enriched_count} candidates on staging!"
             )
         )
+        if password_was_generated and not dry_run:
+            self.stdout.write(
+                self.style.WARNING(f"🔑 Generated password for this run: {password}")
+            )
         self.stdout.write("=" * 60)
 
     def _enrich_user(
@@ -708,8 +757,8 @@ class Command(BaseCommand):
                         "picked_week": week,
                     },
                 )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Could not set gate questions for %s: %s", user.email, exc)
 
         # Waitlist tester status
         CrushConnectWaitlist.objects.update_or_create(

--- a/crush_lu/tests/test_enrich_staging_candidates.py
+++ b/crush_lu/tests/test_enrich_staging_candidates.py
@@ -1,3 +1,5 @@
+from io import StringIO
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
@@ -7,6 +9,14 @@ from crush_lu.models.crush_connect import CrushConnectMembership
 from crush_lu.models.profiles import CrushCoach
 
 User = get_user_model()
+
+
+def _fake_get(*args, **kwargs):
+    class FakeResp:
+        status_code = 200
+        content = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00`\x00`\x00\x00\xff\xdb\x00C\x00"
+
+    return FakeResp()
 
 
 @pytest.mark.django_db
@@ -116,3 +126,97 @@ class TestEnrichStagingCandidatesCommand:
             assert sub.profile.verification_status == "pending"
             assert sub.profile.is_approved is False
             assert sub.coach == coach
+
+    def test_all_without_candidates_does_not_touch_real_profiles(self, monkeypatch):
+        """Regression test for the claude-review finding on PR #899 (#2).
+
+        With no candidate-named accounts and no --include-any-profile, --all
+        must leave real, unrelated non-staff profiles completely untouched
+        -- not silently overwrite their bio/photos/verification/password.
+        """
+        monkeypatch.setattr("requests.get", _fake_get)
+
+        coach_user = User.objects.create_user(
+            username="test_coach4", email="coach4@crush.lu"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=True)
+
+        real_user = User.objects.create_user(
+            username="a_real_tester",
+            email="real.tester@example.com",
+            first_name="Real",
+            last_name="Tester",
+        )
+        real_profile = CrushProfile.objects.create(
+            user=real_user,
+            is_approved=False,
+            verification_status="incomplete",
+        )
+        real_user.set_password("their-own-chosen-password")
+        real_user.save()
+        original_password_hash = real_user.password
+
+        call_command("enrich_staging_candidates", all=True)
+
+        real_user.refresh_from_db()
+        real_profile.refresh_from_db()
+        assert real_user.first_name == "Real"
+        assert real_user.password == original_password_hash
+        assert real_profile.is_approved is False
+        assert real_profile.verification_status == "incomplete"
+        assert not CrushConnectMembership.objects.filter(user=real_user).exists()
+
+    def test_all_with_include_any_profile_opt_in_falls_back(self, monkeypatch):
+        """The fallback still works -- but only when explicitly requested."""
+        monkeypatch.setattr("requests.get", _fake_get)
+
+        coach_user = User.objects.create_user(
+            username="test_coach5", email="coach5@crush.lu"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=True)
+
+        real_user = User.objects.create_user(
+            username="a_real_tester2", email="real.tester2@example.com"
+        )
+        CrushProfile.objects.create(
+            user=real_user, is_approved=False, verification_status="incomplete"
+        )
+
+        call_command("enrich_staging_candidates", all=True, include_any_profile=True)
+
+        real_user.refresh_from_db()
+        assert real_user.crushprofile.is_approved is True
+        assert real_user.crushprofile.verification_status == "verified"
+
+    def test_password_is_random_per_run_when_not_specified(self, monkeypatch):
+        """No fixed default -- a hardcoded password would be a predictable,
+        publicly-visible credential (this file is in the OSS repo) for
+        every seeded account on a live-reachable site.
+        """
+        monkeypatch.setattr("requests.get", _fake_get)
+
+        coach_user = User.objects.create_user(
+            username="test_coach6", email="coach6@crush.lu"
+        )
+        CrushCoach.objects.create(user=coach_user, is_active=True)
+
+        out1, out2 = StringIO(), StringIO()
+        call_command("enrich_staging_candidates", create_missing=1, stdout=out1)
+        call_command("enrich_staging_candidates", create_missing=2, stdout=out2)
+
+        assert "connect2025" not in out1.getvalue()
+        assert "Generated password for this run:" in out1.getvalue()
+        first_password = (
+            out1.getvalue()
+            .split("Generated password for this run: ")[1]
+            .split("\n")[0]
+            .strip()
+        )
+        second_password = (
+            out2.getvalue()
+            .split("Generated password for this run: ")[1]
+            .split("\n")[0]
+            .strip()
+        )
+        assert first_password != second_password
+        assert len(first_password) >= 12


### PR DESCRIPTION
## Summary

Addresses the High/Medium claude-review findings on PR #899 — flagged on three separate review passes, none fixed before merge.

### 1. (High) Script injection in `enrich-staging.yml`
`create_missing`/`leave_pending`/`refresh_drops` workflow_dispatch inputs were interpolated directly into a `run:` shell block, in the same step that exports `DATABASE_URL`/`AZURE_ACCOUNT_KEY`/`SECRET_KEY`. Anyone able to trigger `workflow_dispatch` could inject shell commands via the input field. Moved all three into `env:` and reference them as shell variables.

### 2. (High) `--all` could silently sweep up real, non-candidate profiles
The workflow always passes `--all`. If the candidate-naming query returned zero rows, the command silently fell back to *every* non-staff user with a `CrushProfile` — on live-reachable `test.crush.lu` this would overwrite real testers' bio/photos/DOB/verification and reset their password. Replaced the silent fallback with an explicit `--include-any-profile` opt-in. Regression test confirms `--all` now leaves an unrelated real profile completely untouched by default, and that the fallback still works when explicitly requested.

### 3. (Medium) Hardcoded default password
`--password` defaulted to the literal `connect2025`, applied to every enriched account (including pre-existing ones) — a predictable, publicly-visible credential since this file is in the OSS repo. Now generates a random password per run via `secrets.token_urlsafe(12)` when `--password` isn't given, printed once at the end. Regression test confirms two runs produce different passwords and the old default never appears.

### 4. (Low/Med) Unmasked runtime secrets in the workflow log
`DATABASE_URL`/`AZURE_ACCOUNT_KEY`/`SECRET_KEY` are extracted from `az webapp config appsettings list` at runtime — GitHub only auto-masks values from the `secrets` context, not these. Added explicit `::add-mask::` for each.

### Minor
The gate-question block's bare `except Exception: pass` now logs a warning, matching the convention the photo-fallback block a few lines above already uses.

## Verification
- `pytest crush_lu/tests/test_enrich_staging_candidates.py` — 6 passed (3 new)
- `ruff check` — clean
- `manage.py check` — clean
- YAML syntax verified
- No migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
