### PR TITLE
feat(crush): SumUp tier-2 refund reconciliation sweep (reconcile_sumup_payments)

### DIFF
--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -53,12 +53,20 @@ def _to_decimal(value) -> Decimal:
     """
     if value is None:
         return Decimal("0")
-    if isinstance(value, Decimal):
-        return value
     try:
-        return Decimal(str(value))
+        parsed = value if isinstance(value, Decimal) else Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         return Decimal("0")
+
+    # "Infinity" and "NaN" are valid Decimal literals, and the stdlib json
+    # module parses those tokens by default — so response.json() can hand us
+    # either. Neither raises here; NaN raises InvalidOperation later, from the
+    # max() comparison in refunded_amount(), which sits outside the caller's
+    # try/except and would kill the sweep. Same guard as the donation-amount
+    # parse in views_payments.
+    if not parsed.is_finite():
+        return Decimal("0")
+    return parsed
 
 
 def refunded_amount(data: dict) -> Decimal:

--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -231,10 +231,20 @@ class Command(BaseCommand):
 
             try:
                 remote_data = client.get_checkout(tx_obj.sumup_checkout_id)
-            except SumUpError as exc:
+            except (SumUpError, ValueError) as exc:
+                # ValueError too: get_checkout() wraps only requests.RequestException,
+                # so a 2xx with a malformed or non-JSON body (a proxy returning an
+                # HTML error page, a truncated response) makes response.json() raise
+                # JSONDecodeError — a ValueError, not a RequestException — which
+                # would escape uncaught and kill the sweep.
+                #
+                # Fixed here rather than in SumUpClient because get_checkout has five
+                # callers including the live payment path in views_payments; making
+                # it raise SumUpError for malformed bodies is the better contract but
+                # changes behaviour for callers this PR does not test.
                 errors_count += 1
                 logger.error(
-                    "Failed to fetch SumUp checkout %s: %s",
+                    "Failed to fetch or parse SumUp checkout %s: %s",
                     tx_obj.sumup_checkout_id,
                     exc,
                 )

--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -1,0 +1,319 @@
+"""
+reconcile_sumup_payments — background reconciliation sweep for SumUp payments.
+
+Tier-2 refund reconciliation: SumUp sends no webhook for refunds initiated
+directly in its own merchant portal or on a POS terminal. This command polls
+recently-settled (PAID) SumUp transactions, detects external refunds, and
+brings Django's financial, registration, credit, and membership state back in sync.
+
+Usage::
+
+    # Sweep PAID checkouts from the last 30 days
+    python manage.py reconcile_sumup_payments
+
+    # Preview changes without modifying the database
+    python manage.py reconcile_sumup_payments --dry-run
+
+    # Check a custom lookback window (e.g. 60 days) quietly
+    python manage.py reconcile_sumup_payments --days 60 --quiet
+
+    # Reconcile a single checkout
+    python manage.py reconcile_sumup_payments --checkout-id <sumup_checkout_id>
+"""
+
+import logging
+import time
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from crush_lu.models.credits import CrushCredit
+from crush_lu.models.events import EventRegistration
+from crush_lu.models.payments import PaymentTransaction
+from crush_lu.models.profiles import PremiumMembership
+from crush_lu.services.sumup import SumUpClient, SumUpError
+
+logger = logging.getLogger(__name__)
+
+
+def is_checkout_refunded(data: dict) -> bool:
+    """Determine if a SumUp checkout resource indicates an external refund.
+
+    Checks:
+    - Checkout-level status == "REFUNDED"
+    - Any transaction entry status == "REFUNDED"
+    - Any transaction entry has non-empty "refunds" list or amount_refunded > 0
+    - Top-level amount_refunded > 0
+    """
+    if not isinstance(data, dict):
+        return False
+
+    status = (data.get("status") or "").upper()
+    if status == "REFUNDED":
+        return True
+
+    if (data.get("amount_refunded") or 0) > 0:
+        return True
+
+    transactions = data.get("transactions") or []
+    for tx in transactions:
+        if not isinstance(tx, dict):
+            continue
+        tx_status = (tx.get("status") or "").upper()
+        if tx_status == "REFUNDED":
+            return True
+        if tx.get("refunds") or (tx.get("amount_refunded") or 0) > 0:
+            return True
+
+    return False
+
+
+class Command(BaseCommand):
+    help = "Reconcile recent PAID SumUp transactions against SumUp to catch external refunds."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=30,
+            help="Number of lookback days for PAID transactions (default: 30)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Simulate the sweep and print actions without saving database changes",
+        )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="Only output actionable desyncs and errors",
+        )
+        parser.add_argument(
+            "--checkout-id",
+            help="Reconcile a specific SumUp checkout ID",
+        )
+        parser.add_argument(
+            "--reference",
+            help="Reconcile a specific transaction reference",
+        )
+        parser.add_argument(
+            "--batch-delay",
+            type=float,
+            default=0.05,
+            help="Delay in seconds between SumUp API requests (default: 0.05s)",
+        )
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        dry_run = options["dry_run"]
+        quiet = options["quiet"]
+        checkout_id = options.get("checkout_id")
+        reference = options.get("reference")
+        delay = options["batch_delay"]
+
+        if days < 1:
+            raise CommandError("--days must be at least 1")
+
+        if checkout_id and reference:
+            raise CommandError("Provide either --checkout-id or --reference, not both.")
+
+        qs = PaymentTransaction.objects.filter(
+            provider=PaymentTransaction.Provider.SUMUP,
+            status=PaymentTransaction.Status.PAID,
+        )
+
+        if checkout_id:
+            qs = qs.filter(sumup_checkout_id=checkout_id)
+        elif reference:
+            qs = qs.filter(transaction_reference=reference)
+        else:
+            cutoff = timezone.now() - timedelta(days=days)
+            qs = qs.filter(
+                created_at__gte=cutoff,
+                sumup_checkout_id__isnull=False,
+            ).exclude(sumup_checkout_id="")
+
+        qs = qs.order_by("-created_at")
+        total_count = qs.count()
+
+        if not quiet:
+            prefix = "[DRY RUN] " if dry_run else ""
+            self.stdout.write(
+                f"{prefix}Starting SumUp refund reconciliation sweep: {total_count} transactions to check."
+            )
+
+        if total_count == 0:
+            if not quiet:
+                self.stdout.write("No matching PAID transactions found.")
+            return
+
+        client = SumUpClient()
+        checked = 0
+        refunded_count = 0
+        errors_count = 0
+
+        for tx_obj in qs:
+            checked += 1
+            if delay > 0 and checked > 1:
+                time.sleep(delay)
+
+            try:
+                remote_data = client.get_checkout(tx_obj.sumup_checkout_id)
+            except SumUpError as exc:
+                errors_count += 1
+                logger.error(
+                    "Failed to fetch SumUp checkout %s: %s",
+                    tx_obj.sumup_checkout_id,
+                    exc,
+                )
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Error fetching checkout {tx_obj.sumup_checkout_id} ({tx_obj.transaction_reference}): {exc}"
+                    )
+                )
+                continue
+
+            if is_checkout_refunded(remote_data):
+                refunded_count += 1
+                self._reconcile_refunded(tx_obj, remote_data, dry_run=dry_run)
+            elif not quiet:
+                self.stdout.write(
+                    f"✓ {tx_obj.transaction_reference} ({tx_obj.sumup_checkout_id}): still PAID"
+                )
+
+        summary_msg = (
+            f"Sweep complete: {checked} checked, {refunded_count} external refund(s) reconciled, "
+            f"{errors_count} error(s)."
+        )
+        if dry_run:
+            summary_msg = f"[DRY RUN] {summary_msg}"
+
+        if refunded_count > 0:
+            self.stdout.write(self.style.SUCCESS(summary_msg))
+        elif not quiet:
+            self.stdout.write(summary_msg)
+
+    def _reconcile_refunded(self, tx_obj, remote_data, dry_run=False):
+        """Apply external refund adjustments across PaymentTransaction, EventRegistration,
+        CrushCredit, and PremiumMembership under atomic lock order."""
+        ref = tx_obj.transaction_reference
+        cid = tx_obj.sumup_checkout_id
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"[DRY RUN] External refund detected on {ref} (checkout {cid}). Would reconcile to REFUNDED."
+                )
+            )
+            return
+
+        # LOCK ORDER: PaymentTransaction FIRST, then EventRegistration / CrushProfile / CrushCredit
+        with transaction.atomic():
+            locked_tx = (
+                PaymentTransaction.objects.select_for_update()
+                .filter(pk=tx_obj.pk)
+                .first()
+            )
+            if not locked_tx or locked_tx.status != PaymentTransaction.Status.PAID:
+                logger.info(
+                    "Skipping reconciliation for %s — status is already %s",
+                    ref,
+                    locked_tx.status if locked_tx else "None",
+                )
+                return
+
+            locked_tx.status = PaymentTransaction.Status.REFUNDED
+            locked_tx.raw_response = remote_data
+            locked_tx.failure_reason = (
+                "External refund detected and reconciled by background sweep."
+            )
+            locked_tx.save(
+                update_fields=["status", "raw_response", "failure_reason", "updated_at"]
+            )
+
+            # 1. Reconcile EventRegistration
+            if locked_tx.event_registration_id:
+                reg = (
+                    EventRegistration.objects.select_for_update()
+                    .filter(pk=locked_tx.event_registration_id)
+                    .first()
+                )
+                if reg:
+                    reg.payment_confirmed = False
+                    reg.payment_date = None
+                    update_fields = ["payment_confirmed", "payment_date"]
+
+                    # If the registration was confirmed and hasn't attended yet, cancel it.
+                    # Saving status='cancelled' invokes promote_waitlist_on_cancellation automatically.
+                    if reg.status == "confirmed":
+                        reg.status = "cancelled"
+                        update_fields.append("status")
+
+                    reg.save(update_fields=update_fields)
+                    logger.info(
+                        "Reconciled event registration %s to payment_confirmed=False (status=%s) after external refund.",
+                        reg.pk,
+                        reg.status,
+                    )
+
+            # 2. Reconcile PremiumMembership
+            if locked_tx.premium_membership_id:
+                pm = (
+                    PremiumMembership.objects.select_for_update()
+                    .filter(pk=locked_tx.premium_membership_id)
+                    .first()
+                )
+                if pm:
+                    pm.status = "cancelled"
+                    pm.payment_confirmed = False
+                    pm.payment_date = None
+                    pm.save(update_fields=["status", "payment_confirmed", "payment_date"])
+                    logger.info(
+                        "Reconciled premium membership %s to cancelled after external refund.",
+                        pm.pk,
+                    )
+
+            # 3. Reconcile linked CrushCredits (to prevent double-dip of cash refund + active credit)
+            credit_filters = Q(source_payment=locked_tx)
+            if locked_tx.event_registration_id:
+                credit_filters |= Q(source_registration_id=locked_tx.event_registration_id)
+
+            linked_credits = (
+                CrushCredit.objects.select_for_update()
+                .filter(credit_filters)
+            )
+            for credit in linked_credits:
+                if credit.status == CrushCredit.Status.ACTIVE:
+                    if credit.redeemed_cents == 0:
+                        credit.status = CrushCredit.Status.VOID
+                        credit.note = (
+                            f"{credit.note}\nVoided: External SumUp cash refund reconciled."
+                        ).strip()
+                        credit.save(update_fields=["status", "note"])
+                        logger.info(
+                            "Voided unused CrushCredit #%s following external cash refund on payment %s.",
+                            credit.pk,
+                            ref,
+                        )
+                    else:
+                        credit.status = CrushCredit.Status.VOID
+                        credit.note = (
+                            f"{credit.note}\nVoided (WARNING: {credit.redeemed_cents} cents already redeemed): "
+                            f"External SumUp cash refund reconciled."
+                        ).strip()
+                        credit.save(update_fields=["status", "note"])
+                        logger.warning(
+                            "CrushCredit #%s had %s cents already redeemed when external cash refund on payment %s was reconciled!",
+                            credit.pk,
+                            credit.redeemed_cents,
+                            ref,
+                        )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Reconciled external refund for {ref} (checkout {cid}) -> status=REFUNDED"
+            )
+        )

--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -24,6 +24,7 @@ Usage::
 import logging
 import time
 from datetime import timedelta
+from decimal import Decimal, InvalidOperation
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
@@ -34,9 +35,56 @@ from crush_lu.models.credits import CrushCredit
 from crush_lu.models.events import EventRegistration
 from crush_lu.models.payments import PaymentTransaction
 from crush_lu.models.profiles import PremiumMembership
+from crush_lu.services.credits import void_credit
 from crush_lu.services.sumup import SumUpClient, SumUpError
 
 logger = logging.getLogger(__name__)
+
+
+def _to_decimal(value) -> Decimal:
+    """Coerce a SumUp amount to Decimal, never raising.
+
+    SumUp is not consistent about whether amounts come back as numbers or as
+    numeric strings, and a bare ``"0.00" > 0`` raises TypeError on Python 3.
+    ``is_checkout_refunded()`` is called *outside* the per-row try/except in
+    ``handle()``, so an uncaught TypeError there would kill the entire sweep
+    rather than skip one checkout. Everything numeric from SumUp goes through
+    here — the same defensive coercion ``views_payments`` already applies.
+    """
+    if value is None:
+        return Decimal("0")
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def refunded_amount(data: dict) -> Decimal:
+    """Best available total refunded on this checkout.
+
+    Returns ``Decimal("0")`` when SumUp signals a refund by status alone and
+    reports no amount — callers must treat that as "amount unknown", not as
+    "nothing was refunded".
+    """
+    if not isinstance(data, dict):
+        return Decimal("0")
+
+    candidates = [_to_decimal(data.get("amount_refunded"))]
+
+    per_tx_total = Decimal("0")
+    refunds_total = Decimal("0")
+    for tx in data.get("transactions") or []:
+        if not isinstance(tx, dict):
+            continue
+        per_tx_total += _to_decimal(tx.get("amount_refunded"))
+        for refund in tx.get("refunds") or []:
+            if isinstance(refund, dict):
+                refunds_total += _to_decimal(refund.get("amount"))
+
+    candidates.extend([per_tx_total, refunds_total])
+    return max(candidates)
 
 
 def is_checkout_refunded(data: dict) -> bool:
@@ -47,6 +95,9 @@ def is_checkout_refunded(data: dict) -> bool:
     - Any transaction entry status == "REFUNDED"
     - Any transaction entry has non-empty "refunds" list or amount_refunded > 0
     - Top-level amount_refunded > 0
+
+    Detection only. Whether the refund was full or partial is decided by the
+    caller against the captured amount — see ``handle()``.
     """
     if not isinstance(data, dict):
         return False
@@ -55,7 +106,7 @@ def is_checkout_refunded(data: dict) -> bool:
     if status == "REFUNDED":
         return True
 
-    if (data.get("amount_refunded") or 0) > 0:
+    if _to_decimal(data.get("amount_refunded")) > 0:
         return True
 
     transactions = data.get("transactions") or []
@@ -65,7 +116,7 @@ def is_checkout_refunded(data: dict) -> bool:
         tx_status = (tx.get("status") or "").upper()
         if tx_status == "REFUNDED":
             return True
-        if tx.get("refunds") or (tx.get("amount_refunded") or 0) > 0:
+        if tx.get("refunds") or _to_decimal(tx.get("amount_refunded")) > 0:
             return True
 
     return False
@@ -80,6 +131,15 @@ class Command(BaseCommand):
             type=int,
             default=30,
             help="Number of lookback days for PAID transactions (default: 30)",
+        )
+        parser.add_argument(
+            "--include-partial",
+            action="store_true",
+            help=(
+                "Also reconcile refunds smaller than the captured amount. Off by "
+                "default: a partial refund would otherwise cancel a still-mostly-paid "
+                "registration and free its seat."
+            ),
         )
         parser.add_argument(
             "--dry-run",
@@ -109,6 +169,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         days = options["days"]
         dry_run = options["dry_run"]
+        include_partial = options["include_partial"]
         quiet = options["quiet"]
         checkout_id = options.get("checkout_id")
         reference = options.get("reference")
@@ -154,6 +215,7 @@ class Command(BaseCommand):
         checked = 0
         refunded_count = 0
         errors_count = 0
+        partial_count = 0
 
         for tx_obj in qs:
             checked += 1
@@ -176,7 +238,56 @@ class Command(BaseCommand):
                 )
                 continue
 
-            if is_checkout_refunded(remote_data):
+            try:
+                refunded = is_checkout_refunded(remote_data)
+            except Exception as exc:  # defensive: never let one payload kill the sweep
+                errors_count += 1
+                logger.exception(
+                    "Could not interpret SumUp payload for checkout %s: %s",
+                    tx_obj.sumup_checkout_id,
+                    exc,
+                )
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Unreadable payload for checkout {tx_obj.sumup_checkout_id} "
+                        f"({tx_obj.transaction_reference}): {exc}"
+                    )
+                )
+                continue
+
+            if refunded:
+                # A partial refund is not a cancellation. Reconciling one would
+                # unbook a still-mostly-paid seat, release it to the waitlist and
+                # void the member's credit over what may be a small goodwill
+                # adjustment. Amount 0 means SumUp signalled the refund by status
+                # alone and told us no amount — treated as full, as before.
+                refunded_amt = refunded_amount(remote_data)
+                captured_amt = tx_obj.amount or Decimal("0")
+                is_partial = (
+                    refunded_amt > 0
+                    and captured_amt > 0
+                    and refunded_amt < captured_amt
+                )
+
+                if is_partial and not include_partial:
+                    partial_count += 1
+                    logger.warning(
+                        "PARTIAL refund on %s (checkout %s): %s of %s refunded. "
+                        "Left unreconciled for manual review — rerun with "
+                        "--include-partial to force it.",
+                        tx_obj.transaction_reference,
+                        tx_obj.sumup_checkout_id,
+                        refunded_amt,
+                        captured_amt,
+                    )
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"⚠ PARTIAL refund {refunded_amt}/{captured_amt} on "
+                            f"{tx_obj.transaction_reference} — needs manual review, not reconciled."
+                        )
+                    )
+                    continue
+
                 refunded_count += 1
                 self._reconcile_refunded(tx_obj, remote_data, dry_run=dry_run)
             elif not quiet:
@@ -186,6 +297,7 @@ class Command(BaseCommand):
 
         summary_msg = (
             f"Sweep complete: {checked} checked, {refunded_count} external refund(s) reconciled, "
+            f"{partial_count} partial refund(s) flagged for manual review, "
             f"{errors_count} error(s)."
         )
         if dry_run:
@@ -277,41 +389,67 @@ class Command(BaseCommand):
                     )
 
             # 3. Reconcile linked CrushCredits (to prevent double-dip of cash refund + active credit)
+            #
+            # The registration clause is deliberately narrowed to credits with no
+            # payment of their own. EventRegistration rows are REUSED across
+            # re-registration cycles (see EventRegistration.save()), so matching on
+            # registration alone would also catch a still-active credit issued in an
+            # earlier cycle against a different payment — silently destroying credit
+            # the member is genuinely owed. A credit naming its own source_payment
+            # is only ours when that payment is the one being refunded.
             credit_filters = Q(source_payment=locked_tx)
             if locked_tx.event_registration_id:
-                credit_filters |= Q(source_registration_id=locked_tx.event_registration_id)
+                credit_filters |= Q(
+                    source_registration_id=locked_tx.event_registration_id,
+                    source_payment__isnull=True,
+                )
 
-            linked_credits = (
-                CrushCredit.objects.select_for_update()
-                .filter(credit_filters)
+            # Model instances, not values_list: redeemed_cents is a computed
+            # property over the redemption rows, not a column.
+            linked_credits = list(
+                CrushCredit.objects.filter(credit_filters).filter(
+                    status=CrushCredit.Status.ACTIVE
+                )
             )
-            for credit in linked_credits:
-                if credit.status == CrushCredit.Status.ACTIVE:
-                    if credit.redeemed_cents == 0:
-                        credit.status = CrushCredit.Status.VOID
-                        credit.note = (
-                            f"{credit.note}\nVoided: External SumUp cash refund reconciled."
-                        ).strip()
-                        credit.save(update_fields=["status", "note"])
-                        logger.info(
-                            "Voided unused CrushCredit #%s following external cash refund on payment %s.",
-                            credit.pk,
-                            ref,
-                        )
-                    else:
-                        credit.status = CrushCredit.Status.VOID
-                        credit.note = (
-                            f"{credit.note}\nVoided (WARNING: {credit.redeemed_cents} cents already redeemed): "
-                            f"External SumUp cash refund reconciled."
-                        ).strip()
-                        credit.save(update_fields=["status", "note"])
-                        logger.warning(
-                            "CrushCredit #%s had %s cents already redeemed when external cash refund on payment %s was reconciled!",
-                            credit.pk,
-                            credit.redeemed_cents,
-                            ref,
-                        )
+            for linked in linked_credits:
+                credit_pk = linked.pk
+                redeemed_cents = linked.redeemed_cents
+                # Voiding goes through services.credits.void_credit(), the single
+                # guarded door that module's docstring requires, rather than a
+                # second hand-rolled copy of the same lifecycle that can drift.
+                # require_unspent=False: a cash refund supersedes a partly spent
+                # credit, and the note records that it was already drawn on.
+                if redeemed_cents:
+                    note = (
+                        f"Voided (WARNING: {redeemed_cents} cents already redeemed): "
+                        "External SumUp cash refund reconciled."
+                    )
+                else:
+                    note = "Voided: External SumUp cash refund reconciled."
 
+                _credit, outcome = void_credit(
+                    credit_pk, note=note, require_unspent=False
+                )
+                if outcome != "voided":
+                    logger.info(
+                        "CrushCredit #%s not voided (%s) during reconciliation of %s.",
+                        credit_pk,
+                        outcome,
+                        ref,
+                    )
+                elif redeemed_cents:
+                    logger.warning(
+                        "CrushCredit #%s had %s cents already redeemed when external cash refund on payment %s was reconciled!",
+                        credit_pk,
+                        redeemed_cents,
+                        ref,
+                    )
+                else:
+                    logger.info(
+                        "Voided unused CrushCredit #%s following external cash refund on payment %s.",
+                        credit_pk,
+                        ref,
+                    )
         self.stdout.write(
             self.style.SUCCESS(
                 f"Reconciled external refund for {ref} (checkout {cid}) -> status=REFUNDED"

--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -192,10 +192,9 @@ class Command(BaseCommand):
             qs = qs.filter(transaction_reference=reference)
         else:
             cutoff = timezone.now() - timedelta(days=days)
-            qs = qs.filter(
-                created_at__gte=cutoff,
-                sumup_checkout_id__isnull=False,
-            ).exclude(sumup_checkout_id="")
+            # sumup_checkout_id is CharField(blank=True) with no null=True, so
+            # the column is never NULL — excluding "" is the whole filter.
+            qs = qs.filter(created_at__gte=cutoff).exclude(sumup_checkout_id="")
 
         qs = qs.order_by("-created_at")
         total_count = qs.count()
@@ -288,8 +287,32 @@ class Command(BaseCommand):
                     )
                     continue
 
+                # The write path needs the same boundary as the read path.
+                # _reconcile_refunded writes across four models and calls
+                # void_credit(), which opens with an unguarded .get() — a
+                # DoesNotExist, IntegrityError or deadlock would otherwise
+                # propagate out of this loop and kill the run. Worse, the
+                # queryset is ordered with no per-run offset, so one poisoned
+                # row would abort every future sweep at the same place.
+                try:
+                    self._reconcile_refunded(tx_obj, remote_data, dry_run=dry_run)
+                except Exception as exc:
+                    errors_count += 1
+                    logger.exception(
+                        "Failed to reconcile refund for %s (checkout %s): %s",
+                        tx_obj.transaction_reference,
+                        tx_obj.sumup_checkout_id,
+                        exc,
+                    )
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Error reconciling {tx_obj.transaction_reference} "
+                            f"({tx_obj.sumup_checkout_id}): {exc}"
+                        )
+                    )
+                    continue
+
                 refunded_count += 1
-                self._reconcile_refunded(tx_obj, remote_data, dry_run=dry_run)
             elif not quiet:
                 self.stdout.write(
                     f"✓ {tx_obj.transaction_reference} ({tx_obj.sumup_checkout_id}): still PAID"
@@ -412,44 +435,49 @@ class Command(BaseCommand):
                 )
             )
             for linked in linked_credits:
-                credit_pk = linked.pk
-                redeemed_cents = linked.redeemed_cents
                 # Voiding goes through services.credits.void_credit(), the single
                 # guarded door that module's docstring requires, rather than a
                 # second hand-rolled copy of the same lifecycle that can drift.
                 # require_unspent=False: a cash refund supersedes a partly spent
                 # credit, and the note records that it was already drawn on.
-                if redeemed_cents:
-                    note = (
-                        f"Voided (WARNING: {redeemed_cents} cents already redeemed): "
-                        "External SumUp cash refund reconciled."
-                    )
-                else:
-                    note = "Voided: External SumUp cash refund reconciled."
-
-                _credit, outcome = void_credit(
-                    credit_pk, note=note, require_unspent=False
+                credit, outcome = void_credit(
+                    linked.pk,
+                    note="Voided: External SumUp cash refund reconciled.",
+                    require_unspent=False,
                 )
                 if outcome != "voided":
                     logger.info(
                         "CrushCredit #%s not voided (%s) during reconciliation of %s.",
-                        credit_pk,
+                        linked.pk,
                         outcome,
                         ref,
                     )
-                elif redeemed_cents:
+                    continue
+
+                # Read the redemption total off the row void_credit LOCKED, not
+                # off the unlocked snapshot the candidate query returned. A
+                # concurrent redemption between those two points would otherwise
+                # write a wrong number onto an append-only ledger row.
+                redeemed_cents = credit.redeemed_cents
+                if redeemed_cents:
+                    credit.note = (
+                        f"{credit.note}\nWARNING: {redeemed_cents} cents already "
+                        "redeemed before this void."
+                    ).strip()
+                    credit.save(update_fields=["note"])
                     logger.warning(
                         "CrushCredit #%s had %s cents already redeemed when external cash refund on payment %s was reconciled!",
-                        credit_pk,
+                        credit.pk,
                         redeemed_cents,
                         ref,
                     )
                 else:
                     logger.info(
                         "Voided unused CrushCredit #%s following external cash refund on payment %s.",
-                        credit_pk,
+                        credit.pk,
                         ref,
                     )
+
         self.stdout.write(
             self.style.SUCCESS(
                 f"Reconciled external refund for {ref} (checkout {cid}) -> status=REFUNDED"

--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -34,7 +34,7 @@ from django.utils import timezone
 from crush_lu.models.credits import CrushCredit
 from crush_lu.models.events import EventRegistration
 from crush_lu.models.payments import PaymentTransaction
-from crush_lu.models.profiles import PremiumMembership
+from crush_lu.models.profiles import CrushProfile, PremiumMembership
 from crush_lu.services.credits import void_credit
 from crush_lu.services.sumup import SumUpClient, SumUpError
 
@@ -428,6 +428,44 @@ class Command(BaseCommand):
                         "Reconciled premium membership %s to cancelled after external refund.",
                         pm.pk,
                     )
+
+                    # PremiumMembership.confirm() writes CrushProfile.assigned_coach
+                    # and there is no symmetric undo — cancel() only handles pending
+                    # memberships. Leaving it set is not cosmetic: the premium
+                    # reserved-seat gates read `profile.assigned_coach_id` directly
+                    # (views_events.py:701, :924, :1448), so a refunded member would
+                    # keep claiming premium-reserved seats even though
+                    # has_active_premium correctly says otherwise.
+                    #
+                    # Cleared only when this membership is what assigned it. A coach
+                    # the member holds for another reason (the attendance auto-assign
+                    # in signals.py, the 0150 backfill) names a different coach and is
+                    # left alone. Accepted edge: a member who earned coach A by
+                    # attending and then bought premium with the same coach A loses
+                    # the assignment here — EventRegistration.checkin_granted_coach
+                    # records that provenance, but restoring from it is a separate
+                    # product decision.
+                    #
+                    # Lock order mirrors confirm(): PremiumMembership then
+                    # CrushProfile, with PaymentTransaction already held above.
+                    profile = (
+                        CrushProfile.objects.select_for_update()
+                        .filter(user_id=pm.user_id)
+                        .first()
+                    )
+                    if profile and profile.assigned_coach_id == pm.coach_id:
+                        profile.assigned_coach = None
+                        profile.assigned_coach_at = None
+                        profile.save(
+                            update_fields=["assigned_coach", "assigned_coach_at"]
+                        )
+                        logger.warning(
+                            "Cleared assigned_coach %s from profile %s: the premium "
+                            "membership that assigned it was cancelled by external refund on %s.",
+                            pm.coach_id,
+                            profile.pk,
+                            ref,
+                        )
 
             # 3. Reconcile linked CrushCredits (to prevent double-dip of cash refund + active credit)
             #

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -366,6 +366,43 @@ class SumUpReconciliationCommandTests(TestCase):
         )
 
 
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.Command._reconcile_refunded")
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_write_failure_does_not_abort_the_sweep(
+        self, mock_get_checkout, mock_reconcile
+    ):
+        """One poisoned row must cost one row, not the whole run.
+
+        The queryset is ordered with no per-run offset, so an unguarded write
+        failure would abort every future sweep at the same transaction.
+        """
+        other = PaymentTransaction.objects.create(
+            transaction_reference="CRUSH-EVT-42-second",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id="chk_second",
+            amount=Decimal("15.50"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            user=self.user,
+            event=self.event,
+            raw_response={"status": "PAID"},
+        )
+        mock_get_checkout.return_value = {"id": "x", "status": "REFUNDED"}
+        mock_reconcile.side_effect = [RuntimeError("deadlock"), None]
+
+        out = io.StringIO()
+        call_command("reconcile_sumup_payments", stdout=out)
+
+        # Both rows were attempted despite the first one blowing up.
+        self.assertEqual(mock_reconcile.call_count, 2)
+        output = out.getvalue()
+        self.assertIn("Error reconciling", output)
+        self.assertIn("Sweep complete", output)
+        self.assertIn("1 error(s)", output)
+        self.assertTrue(other.pk)
+
+
 class ExternalRefundRegressionTests(TestCase):
     """Regressions for the four review findings on PR #903."""
 

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -1,0 +1,267 @@
+"""
+Tests for Tier-2 SumUp refund reconciliation sweep (reconcile_sumup_payments).
+"""
+
+import io
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from crush_lu.management.commands.reconcile_sumup_payments import is_checkout_refunded
+from crush_lu.models.credits import CrushCredit, CreditRedemption
+from crush_lu.models.events import EventRegistration, MeetupEvent
+from crush_lu.models.payments import PaymentTransaction
+from crush_lu.models.profiles import CrushProfile, CrushCoach, PremiumMembership
+from crush_lu.services.sumup import SumUpError
+
+User = get_user_model()
+
+
+class IsCheckoutRefundedTests(TestCase):
+    def test_top_level_status_refunded(self):
+        self.assertTrue(is_checkout_refunded({"status": "REFUNDED"}))
+        self.assertTrue(is_checkout_refunded({"status": "refunded"}))
+
+    def test_top_level_amount_refunded(self):
+        self.assertTrue(is_checkout_refunded({"status": "PAID", "amount_refunded": 15.50}))
+
+    def test_transaction_item_status_refunded(self):
+        payload = {
+            "status": "PAID",
+            "transactions": [
+                {"id": "txn-1", "status": "REFUNDED", "amount": 15.50}
+            ],
+        }
+        self.assertTrue(is_checkout_refunded(payload))
+
+    def test_transaction_item_refunds_array(self):
+        payload = {
+            "status": "PAID",
+            "transactions": [
+                {"id": "txn-1", "status": "SUCCESSFUL", "refunds": [{"amount": 15.50}]}
+            ],
+        }
+        self.assertTrue(is_checkout_refunded(payload))
+
+    def test_transaction_item_amount_refunded(self):
+        payload = {
+            "status": "PAID",
+            "transactions": [
+                {"id": "txn-1", "status": "SUCCESSFUL", "amount_refunded": 10.00}
+            ],
+        }
+        self.assertTrue(is_checkout_refunded(payload))
+
+    def test_normal_paid_payload_returns_false(self):
+        payload = {
+            "status": "PAID",
+            "transactions": [
+                {"id": "txn-1", "status": "SUCCESSFUL", "amount": 15.50}
+            ],
+        }
+        self.assertFalse(is_checkout_refunded(payload))
+
+    def test_empty_or_invalid_payload(self):
+        self.assertFalse(is_checkout_refunded({}))
+        self.assertFalse(is_checkout_refunded(None))
+
+
+class SumUpReconciliationCommandTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="reconcile_member",
+            email="reconcile_member@test.crush.lu",
+            password="secretpassword123",
+        )
+        self.profile = CrushProfile.objects.create(
+            user=self.user,
+            date_of_birth=date(1995, 1, 1),
+            gender="F",
+            location="Luxembourg",
+            verification_status="verified",
+            completion_status="step4",
+        )
+        self.event = MeetupEvent.objects.create(
+            title="Speed Dating #42",
+            event_type="speed_dating",
+            location="Luxembourg City",
+            address="10 Grand Rue",
+            date_time=timezone.now() + timedelta(days=7),
+            registration_deadline=timezone.now() + timedelta(days=6),
+            registration_fee=Decimal("15.50"),
+            max_participants=20,
+            is_published=True,
+        )
+        self.registration = EventRegistration.objects.create(
+            event=self.event,
+            user=self.user,
+            status="confirmed",
+            payment_confirmed=True,
+            payment_date=timezone.now(),
+        )
+        self.payment = PaymentTransaction.objects.create(
+            transaction_reference="CRUSH-EVT-42-reconcile",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id="chk_refund_123",
+            amount=Decimal("15.50"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            user=self.user,
+            event_registration=self.registration,
+            event=self.event,
+            raw_response={"status": "PAID"},
+        )
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_reconcile_external_refund_event_registration(self, mock_get_checkout):
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "REFUNDED",
+            "amount": 15.50,
+            "transactions": [{"id": "txn-1", "status": "REFUNDED"}],
+        }
+
+        out = io.StringIO()
+        call_command("reconcile_sumup_payments", stdout=out)
+
+        self.payment.refresh_from_db()
+        self.registration.refresh_from_db()
+
+        self.assertEqual(self.payment.status, PaymentTransaction.Status.REFUNDED)
+        self.assertIn("External refund detected", self.payment.failure_reason)
+        self.assertFalse(self.registration.payment_confirmed)
+        self.assertIsNone(self.registration.payment_date)
+        self.assertEqual(self.registration.status, "cancelled")
+        self.assertIn("1 external refund(s) reconciled", out.getvalue())
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_reconcile_dry_run_makes_no_db_changes(self, mock_get_checkout):
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "REFUNDED",
+        }
+
+        out = io.StringIO()
+        call_command("reconcile_sumup_payments", "--dry-run", stdout=out)
+
+        self.payment.refresh_from_db()
+        self.registration.refresh_from_db()
+
+        self.assertEqual(self.payment.status, PaymentTransaction.Status.PAID)
+        self.assertTrue(self.registration.payment_confirmed)
+        self.assertEqual(self.registration.status, "confirmed")
+        self.assertIn("[DRY RUN]", out.getvalue())
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_reconcile_voids_unspent_crush_credit(self, mock_get_checkout):
+        credit = CrushCredit.objects.create(
+            user=self.user,
+            amount_cents=1550,
+            currency="EUR",
+            reason=CrushCredit.Reason.EVENT_CANCELLED,
+            status=CrushCredit.Status.ACTIVE,
+            source_payment=self.payment,
+            source_registration=self.registration,
+            cash_refund_eligible=True,
+        )
+
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "REFUNDED",
+        }
+
+        call_command("reconcile_sumup_payments", quiet=True)
+
+        credit.refresh_from_db()
+        self.assertEqual(credit.status, CrushCredit.Status.VOID)
+        self.assertIn("External SumUp cash refund reconciled", credit.note)
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_reconcile_handles_partially_spent_crush_credit_with_warning(self, mock_get_checkout):
+        credit = CrushCredit.objects.create(
+            user=self.user,
+            amount_cents=2000,
+            currency="EUR",
+            reason=CrushCredit.Reason.EVENT_CANCELLED,
+            status=CrushCredit.Status.ACTIVE,
+            source_payment=self.payment,
+            source_registration=self.registration,
+            cash_refund_eligible=True,
+        )
+        CreditRedemption.objects.create(
+            credit=credit,
+            amount_cents=1000,
+        )
+
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "REFUNDED",
+        }
+
+        call_command("reconcile_sumup_payments", quiet=True)
+
+        credit.refresh_from_db()
+        self.assertEqual(credit.status, CrushCredit.Status.VOID)
+        self.assertIn("already redeemed", credit.note)
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_reconcile_premium_membership_refund(self, mock_get_checkout):
+        coach_user = User.objects.create_user(
+            username="coach_sam",
+            email="coach_sam@crush.lu",
+            password="password123",
+        )
+        coach = CrushCoach.objects.create(
+            user=coach_user,
+            is_active=True,
+            accepting_premium=True,
+            max_premium_members=10,
+        )
+        pm = PremiumMembership.objects.create(
+            user=self.user,
+            coach=coach,
+            status="active",
+        )
+        prem_tx = PaymentTransaction.objects.create(
+            transaction_reference="CRUSH-PREM-42-test",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id="chk_prem_refund",
+            amount=Decimal("10.00"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.PREMIUM_MEMBERSHIP,
+            user=self.user,
+            premium_membership=pm,
+            raw_response={"status": "PAID"},
+        )
+
+        mock_get_checkout.return_value = {
+            "id": "chk_prem_refund",
+            "status": "REFUNDED",
+        }
+
+        call_command("reconcile_sumup_payments", checkout_id="chk_prem_refund")
+
+        prem_tx.refresh_from_db()
+        pm.refresh_from_db()
+        self.assertEqual(prem_tx.status, PaymentTransaction.Status.REFUNDED)
+        self.assertEqual(pm.status, "cancelled")
+        self.assertFalse(pm.payment_confirmed)
+        self.assertIsNone(pm.payment_date)
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_sumup_api_error_does_not_crash_sweep(self, mock_get_checkout):
+        mock_get_checkout.side_effect = SumUpError("500 Internal Server Error")
+
+        out = io.StringIO()
+        call_command("reconcile_sumup_payments", stdout=out)
+
+        self.payment.refresh_from_db()
+        self.assertEqual(self.payment.status, PaymentTransaction.Status.PAID)
+        self.assertIn("1 error(s)", out.getvalue())

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -3,6 +3,7 @@ Tests for Tier-2 SumUp refund reconciliation sweep (reconcile_sumup_payments).
 """
 
 import io
+import json
 from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
@@ -421,6 +422,25 @@ class ExternalRefundRegressionTests(TestCase):
         )
         # Garbage must degrade to "not refunded", never explode.
         self.assertFalse(is_checkout_refunded({"status": "PAID", "amount_refunded": "not-a-number"}))
+
+    def test_nan_and_infinity_do_not_kill_the_sweep(self):
+        """json.loads parses NaN/Infinity by default, and Decimal accepts both.
+
+        Neither raises on construction; NaN raises InvalidOperation from the
+        max() comparison inside refunded_amount(), which is outside the
+        caller's try/except. Same guard as views_payments' donation parse.
+        """
+        for token in ("NaN", "Infinity", "-Infinity"):
+            with self.subTest(token=token):
+                self.assertEqual(
+                    refunded_amount({"amount_refunded": token}), Decimal("0")
+                )
+                self.assertFalse(is_checkout_refunded({"status": "PAID", "amount_refunded": token}))
+
+        # And the real json path, not just the literal strings.
+        payload = json.loads('{"status": "PAID", "amount_refunded": NaN}')
+        self.assertEqual(refunded_amount(payload), Decimal("0"))
+        self.assertFalse(is_checkout_refunded(payload))
 
     def test_refunded_amount_reads_every_payload_shape(self):
         self.assertEqual(refunded_amount({"amount_refunded": "2.50"}), Decimal("2.50"))

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -438,6 +438,75 @@ class SumUpReconciliationCommandTests(TestCase):
         self.assertIn("1 error(s)", output)
 
 
+    def _make_coach(self, username):
+        coach_user = User.objects.create_user(
+            username=username, email=f"{username}@crush.lu", password="password123"
+        )
+        return CrushCoach.objects.create(
+            user=coach_user,
+            is_active=True,
+            accepting_premium=True,
+            max_premium_members=10,
+        )
+
+    def _premium_payment(self, pm, checkout_id):
+        return PaymentTransaction.objects.create(
+            transaction_reference=f"CRUSH-PREM-{checkout_id}",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id=checkout_id,
+            amount=Decimal("10.00"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.PREMIUM_MEMBERSHIP,
+            user=self.user,
+            premium_membership=pm,
+            raw_response={"status": "PAID"},
+        )
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_refund_clears_the_coach_that_membership_assigned(self, mock_get_checkout):
+        """The premium reserved-seat gates read assigned_coach_id directly
+        (views_events.py:701, :924, :1448), so a stale coach keeps a refunded
+        member claiming premium seats."""
+        coach = self._make_coach("coach_clears")
+        pm = PremiumMembership.objects.create(
+            user=self.user, coach=coach, status="active"
+        )
+        self._premium_payment(pm, "chk_clear_coach")
+        self.profile.assigned_coach = coach
+        self.profile.assigned_coach_at = timezone.now()
+        self.profile.save(update_fields=["assigned_coach", "assigned_coach_at"])
+
+        mock_get_checkout.return_value = {"id": "chk_clear_coach", "status": "REFUNDED"}
+        call_command("reconcile_sumup_payments", checkout_id="chk_clear_coach", quiet=True)
+
+        self.profile.refresh_from_db()
+        self.assertIsNone(self.profile.assigned_coach_id)
+        self.assertIsNone(self.profile.assigned_coach_at)
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_refund_leaves_a_coach_this_membership_did_not_assign(self, mock_get_checkout):
+        """A coach held for another reason (attendance auto-assign, the 0150
+        backfill) names a different coach and must survive the refund."""
+        membership_coach = self._make_coach("coach_membership")
+        other_coach = self._make_coach("coach_attendance")
+        pm = PremiumMembership.objects.create(
+            user=self.user, coach=membership_coach, status="active"
+        )
+        self._premium_payment(pm, "chk_keep_coach")
+        self.profile.assigned_coach = other_coach
+        self.profile.assigned_coach_at = timezone.now()
+        self.profile.save(update_fields=["assigned_coach", "assigned_coach_at"])
+
+        mock_get_checkout.return_value = {"id": "chk_keep_coach", "status": "REFUNDED"}
+        call_command("reconcile_sumup_payments", checkout_id="chk_keep_coach", quiet=True)
+
+        self.profile.refresh_from_db()
+        pm.refresh_from_db()
+        self.assertEqual(pm.status, "cancelled")
+        self.assertEqual(self.profile.assigned_coach_id, other_coach.pk)
+
+
 class ExternalRefundRegressionTests(TestCase):
     """Regressions for the four review findings on PR #903."""
 

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -12,7 +12,10 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
-from crush_lu.management.commands.reconcile_sumup_payments import is_checkout_refunded
+from crush_lu.management.commands.reconcile_sumup_payments import (
+    is_checkout_refunded,
+    refunded_amount,
+)
 from crush_lu.models.credits import CrushCredit, CreditRedemption
 from crush_lu.models.events import EventRegistration, MeetupEvent
 from crush_lu.models.payments import PaymentTransaction
@@ -265,3 +268,131 @@ class SumUpReconciliationCommandTests(TestCase):
         self.payment.refresh_from_db()
         self.assertEqual(self.payment.status, PaymentTransaction.Status.PAID)
         self.assertIn("1 error(s)", out.getvalue())
+
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_partial_refund_is_not_reconciled(self, mock_get_checkout):
+        """A EUR2 goodwill refund on a EUR15.50 seat must not unbook the seat."""
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "PAID",
+            "amount_refunded": "2.00",
+        }
+
+        out = io.StringIO()
+        call_command("reconcile_sumup_payments", stdout=out)
+
+        self.payment.refresh_from_db()
+        self.registration.refresh_from_db()
+        self.assertEqual(self.payment.status, PaymentTransaction.Status.PAID)
+        self.assertEqual(self.registration.status, "confirmed")
+        self.assertTrue(self.registration.payment_confirmed)
+        self.assertIn("PARTIAL", out.getvalue())
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_partial_refund_reconciles_when_forced(self, mock_get_checkout):
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "PAID",
+            "amount_refunded": "2.00",
+        }
+
+        call_command("reconcile_sumup_payments", include_partial=True, quiet=True)
+
+        self.payment.refresh_from_db()
+        self.assertEqual(self.payment.status, PaymentTransaction.Status.REFUNDED)
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_full_refund_still_reconciles(self, mock_get_checkout):
+        mock_get_checkout.return_value = {
+            "id": "chk_refund_123",
+            "status": "PAID",
+            "amount_refunded": "15.50",
+        }
+
+        call_command("reconcile_sumup_payments", quiet=True)
+
+        self.payment.refresh_from_db()
+        self.registration.refresh_from_db()
+        self.assertEqual(self.payment.status, PaymentTransaction.Status.REFUNDED)
+        self.assertEqual(self.registration.status, "cancelled")
+
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_credit_from_an_earlier_cycle_is_not_voided(self, mock_get_checkout):
+        """EventRegistration rows are reused across re-registration cycles.
+
+        A credit issued against payment A must survive a refund on payment B,
+        even though both name the same registration row.
+        """
+        payment_a = PaymentTransaction.objects.create(
+            transaction_reference="CRUSH-EVT-42-cycle-one",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id="chk_cycle_one",
+            amount=Decimal("15.50"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            user=self.user,
+            event_registration=self.registration,
+            event=self.event,
+            raw_response={"status": "PAID"},
+        )
+        earlier_credit = CrushCredit.objects.create(
+            user=self.user,
+            amount_cents=1550,
+            currency="EUR",
+            reason=CrushCredit.Reason.EVENT_CANCELLED,
+            status=CrushCredit.Status.ACTIVE,
+            source_payment=payment_a,
+            source_registration=self.registration,
+            cash_refund_eligible=True,
+        )
+
+        # Only the *second* payment is refunded externally.
+        mock_get_checkout.side_effect = lambda cid: (
+            {"id": cid, "status": "REFUNDED"}
+            if cid == "chk_refund_123"
+            else {"id": cid, "status": "PAID"}
+        )
+
+        call_command("reconcile_sumup_payments", quiet=True)
+
+        earlier_credit.refresh_from_db()
+        self.assertEqual(
+            earlier_credit.status,
+            CrushCredit.Status.ACTIVE,
+            "credit from payment A's cycle must not be voided by a refund on payment B",
+        )
+
+
+class ExternalRefundRegressionTests(TestCase):
+    """Regressions for the four review findings on PR #903."""
+
+    def test_numeric_string_amount_does_not_raise(self):
+        """SumUp may return amounts as strings; `"0.00" > 0` is a TypeError.
+
+        is_checkout_refunded() is called outside the per-row try/except in
+        handle(), so an uncaught TypeError here killed the whole sweep.
+        """
+        self.assertFalse(is_checkout_refunded({"status": "PAID", "amount_refunded": "0.00"}))
+        self.assertTrue(is_checkout_refunded({"status": "PAID", "amount_refunded": "2.50"}))
+        self.assertFalse(
+            is_checkout_refunded(
+                {"status": "PAID", "transactions": [{"status": "SUCCESSFUL", "amount_refunded": "0.00"}]}
+            )
+        )
+        # Garbage must degrade to "not refunded", never explode.
+        self.assertFalse(is_checkout_refunded({"status": "PAID", "amount_refunded": "not-a-number"}))
+
+    def test_refunded_amount_reads_every_payload_shape(self):
+        self.assertEqual(refunded_amount({"amount_refunded": "2.50"}), Decimal("2.50"))
+        self.assertEqual(
+            refunded_amount({"transactions": [{"amount_refunded": 4}]}), Decimal("4")
+        )
+        self.assertEqual(
+            refunded_amount({"transactions": [{"refunds": [{"amount": "1.25"}, {"amount": "0.75"}]}]}),
+            Decimal("2.00"),
+        )
+        # Status-only refund reports no amount: 0 means "unknown", not "nothing".
+        self.assertEqual(refunded_amount({"status": "REFUNDED"}), Decimal("0"))

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -404,6 +404,40 @@ class SumUpReconciliationCommandTests(TestCase):
         self.assertTrue(other.pk)
 
 
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_malformed_json_body_does_not_kill_the_sweep(self, mock_get_checkout):
+        """A 2xx with a non-JSON body raises JSONDecodeError, not SumUpError.
+
+        SumUpClient.get_checkout() wraps only requests.RequestException, so a
+        proxy returning an HTML error page with a 200 escapes as a bare
+        ValueError and would abort every remaining row.
+        """
+        PaymentTransaction.objects.create(
+            transaction_reference="CRUSH-EVT-42-after-bad-body",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id="chk_after",
+            amount=Decimal("15.50"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            user=self.user,
+            event=self.event,
+            raw_response={"status": "PAID"},
+        )
+        mock_get_checkout.side_effect = [
+            json.JSONDecodeError("Expecting value", "<html>502</html>", 0),
+            {"id": "chk_after", "status": "PAID"},
+        ]
+
+        out = io.StringIO()
+        call_command("reconcile_sumup_payments", stdout=out)
+
+        self.assertEqual(mock_get_checkout.call_count, 2)
+        output = out.getvalue()
+        self.assertIn("Sweep complete", output)
+        self.assertIn("1 error(s)", output)
+
+
 class ExternalRefundRegressionTests(TestCase):
     """Regressions for the four review findings on PR #903."""
 


### PR DESCRIPTION
## Summary

Tier-2 of the two-tier SumUp refund design. Tier 1 (#893) covers the refund a staff member clicks in Django admin. This is the other half: SumUp sends **no webhook** for a refund initiated directly in its merchant portal or on a POS terminal, so those refunds are invisible to Django and leave registrations, Crush Credit and memberships silently out of sync.

`reconcile_sumup_payments` polls recently-settled `PAID` SumUp transactions, detects external refunds, and brings financial + downstream state back in line.

## How it works

Queries `PaymentTransaction` rows that are `provider=SUMUP, status=PAID`, then re-fetches each checkout from SumUp and tests it with `is_checkout_refunded()`, which treats any of these as a refund:

- checkout-level `status == "REFUNDED"`
- top-level `amount_refunded > 0`
- any transaction entry with `status == "REFUNDED"`
- any transaction entry with a non-empty `refunds` list or `amount_refunded > 0`

The heuristic is deliberately broad because SumUp reports refunds inconsistently across payload shapes.

On a hit, `_reconcile_refunded()` re-syncs under `select_for_update()` locks across `PaymentTransaction`, `EventRegistration`, `PremiumMembership` and `CrushCredit`.

## Usage

```
# default: PAID checkouts from the last 30 days
python manage.py reconcile_sumup_payments

# preview, no writes
python manage.py reconcile_sumup_payments --dry-run

# wider window, quiet
python manage.py reconcile_sumup_payments --days 60 --quiet

# single checkout / single reference
python manage.py reconcile_sumup_payments --checkout-id <id>
python manage.py reconcile_sumup_payments --reference <ref>
```

`--batch-delay` sleeps between API calls to stay clear of SumUp rate limits. A `SumUpError` on one checkout is logged and the sweep continues — one bad row can't abort the run.

## Tests

13 tests in `crush_lu/tests/test_sumup_reconciliation.py`:

- 7 on the detection heuristic, including normal-PAID and empty/invalid payloads returning `False`
- external refund against an event registration
- `--dry-run` makes no DB changes
- unspent Crush Credit is voided
- **partially spent** Crush Credit is handled with a warning rather than a silent negative balance
- premium membership refund
- a SumUp API error does not crash the sweep

## Review notes

- Not yet wired to a scheduler. Worth a `--dry-run` against prod before adding it to the schedule — see the standing lesson in the scheduled-jobs memory that a timer has three independently-silent failure modes.
- The refund heuristic errs toward false positives by design. A false positive un-books a real registration, so the `--dry-run` output is the thing to read carefully first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
