### PR TITLE
fix(crush): unblock FCP/LCP, close Lighthouse a11y failures, nonce the gtag scripts

### DIFF
--- a/azureproject/templatetags/analytics.py
+++ b/azureproject/templatetags/analytics.py
@@ -91,7 +91,14 @@ def analytics_head(context):
 
     # Get CSP nonce from request (if available)
     nonce = get_nonce(request) if request else None
-    nonce_attr = f' nonce="{nonce}"' if nonce else ''
+    # `is not None`, not truthiness: request._csp_nonce is a django.utils.csp.LazyNonce
+    # whose __bool__ is False until the value has actually been generated. analytics_head
+    # renders first in <head>, before any {{ csp_nonce }}, so a truthiness test always
+    # saw False and emitted the gtag scripts with no nonce at all. Harmless while the
+    # policy is report-only; the moment SECURE_CSP_REPORT_ONLY becomes SECURE_CSP those
+    # scripts get blocked (CSP3 ignores 'unsafe-inline' once a nonce is present) and
+    # analytics goes dark. Interpolating the nonce below is what forces generation.
+    nonce_attr = f' nonce="{nonce}"' if nonce is not None else ''
 
     # Check existing consent from cookies
     # Returns True if consented, False if declined, True if not yet decided
@@ -164,7 +171,8 @@ def analytics_body(context):
 
     # Get CSP nonce from request (if available)
     nonce = get_nonce(request) if request else None
-    nonce_attr = f' nonce="{nonce}"' if nonce else ''
+    # `is not None`: LazyNonce is falsy until generated — see analytics_head above.
+    nonce_attr = f' nonce="{nonce}"' if nonce is not None else ''
 
     if not has_marketing_consent:
         # Return placeholder that can be activated later
@@ -224,7 +232,8 @@ def ga4_event(context, event_name, **params):
 
     request = context.get('request')
     nonce = get_nonce(request) if request else None
-    nonce_attr = f' nonce="{nonce}"' if nonce else ''
+    # `is not None`: LazyNonce is falsy until generated — see analytics_head above.
+    nonce_attr = f' nonce="{nonce}"' if nonce is not None else ''
 
     # Build params object — use json.dumps for safe JS serialization (prevents XSS)
     if params:
@@ -252,7 +261,8 @@ def fb_event(context, event_name, **params):
 
     request = context.get('request')
     nonce = get_nonce(request) if request else None
-    nonce_attr = f' nonce="{nonce}"' if nonce else ''
+    # `is not None`: LazyNonce is falsy until generated — see analytics_head above.
+    nonce_attr = f' nonce="{nonce}"' if nonce is not None else ''
 
     # Build params object — use json.dumps for safe JS serialization (prevents XSS)
     if params:
@@ -299,7 +309,8 @@ def appinsights_head(context):
 
     request = context.get('request')
     nonce = get_nonce(request) if request else None
-    nonce_attr = f' nonce="{nonce}"' if nonce else ''
+    # `is not None`: LazyNonce is falsy until generated — see analytics_head above.
+    nonce_attr = f' nonce="{nonce}"' if nonce is not None else ''
 
     # Get user ID for authenticated user tracking (anonymous if not logged in)
     user_id = ''
@@ -352,7 +363,8 @@ def appinsights_event(context, event_name, **params):
 
     request = context.get('request')
     nonce = get_nonce(request) if request else None
-    nonce_attr = f' nonce="{nonce}"' if nonce else ''
+    # `is not None`: LazyNonce is falsy until generated — see analytics_head above.
+    nonce_attr = f' nonce="{nonce}"' if nonce is not None else ''
 
     # Build properties object — use json.dumps for safe JS serialization (prevents XSS)
     if params:

--- a/core/templates/includes/cookie_banner.html
+++ b/core/templates/includes/cookie_banner.html
@@ -6,7 +6,7 @@
 <div id="cookie-consent-banner" class="cookie-banner" role="dialog" aria-labelledby="cookie-banner-title" aria-describedby="cookie-banner-description" style="display: none;">
     <div class="cookie-banner-content">
         <div class="cookie-banner-text">
-            <h4 id="cookie-banner-title">{% trans "Cookie Settings" %}</h4>
+            <p id="cookie-banner-title" class="cookie-banner-title">{% trans "Cookie Settings" %}</p>
             <p id="cookie-banner-description">
                 {% trans "We use cookies to enhance your experience. Analytics cookies help us understand how you use our site. You can accept all cookies or customize your preferences." %}
             </p>
@@ -121,14 +121,21 @@ html.dark .cookie-banner {
     min-width: 300px;
 }
 
-html.dark .cookie-banner-text h4,
+html.dark .cookie-banner-text .cookie-banner-title,
 html.dark .cookie-modal-header h4 {
     color: #f1f5f9;
 }
 
-.cookie-banner-text h4 {
+/* Dialog title. A paragraph, not a heading: role="dialog" is named via
+   aria-labelledby, so no heading is needed here — and as a level-4 heading appended
+   after the footer it broke the page's heading outline (Lighthouse heading-order).
+   Specificity is deliberate: .cookie-banner-text p would otherwise win on `color`
+   and shrink the title to body text. */
+.cookie-banner-text .cookie-banner-title {
     margin: 0 0 0.5rem 0;
     font-size: 1.1rem;
+    font-weight: 700;
+    color: inherit;
 }
 
 .cookie-banner-text p {

--- a/crush_lu/static/crush_lu/js/htmx-csrf.js
+++ b/crush_lu/static/crush_lu/js/htmx-csrf.js
@@ -4,8 +4,8 @@
  * Sets HTMX headers from hidden input for CSRF protection.
  * Works correctly when CSRF_COOKIE_HTTPONLY=True.
  *
- * This must run synchronously before HTMX initializes, so it's
- * loaded without defer attribute.
+ * Loaded with defer, which still runs this before the deferred HTMX bundle
+ * (defer preserves document order) while keeping it off the critical path.
  */
 (function () {
     "use strict";

--- a/crush_lu/templates/crush_lu/base.html
+++ b/crush_lu/templates/crush_lu/base.html
@@ -22,9 +22,27 @@
     <link rel="dns-prefetch" href="https://js.monitor.azure.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <!-- Editorial display serif for hero / section headlines (body stays on Inter). -->
+    <!-- Editorial display serif for hero / section headlines (body stays on Inter).
+         Loaded OFF the critical path: a render-blocking stylesheet here cost ~771ms of
+         FCP/LCP (Lighthouse 2026-08-21, mobile). The preload keeps it at high priority,
+         media="print" keeps it from blocking first paint, and the nonce'd script below
+         promotes it to media="all" once it lands. Safe because the face is requested
+         with display=swap and .hero-title falls back to Georgia, so the LCP heading
+         paints immediately and swaps in Fraunces when it arrives. -->
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500..700&display=swap">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500..700&display=swap">
+    <link id="crush-display-font" rel="stylesheet" media="print" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500..700&display=swap">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500..700&display=swap"></noscript>
+    <script nonce="{{ csp_nonce }}">
+        // Promote the display face to a live stylesheet. Kept in a nonce'd external
+        // block rather than an onload="" attribute: an inline event handler is exactly
+        // what the nonce CSP is meant to reject.
+        (function () {
+            var link = document.getElementById('crush-display-font');
+            if (!link) { return; }
+            var promote = function () { link.media = 'all'; };
+            if (link.sheet) { promote(); } else { link.addEventListener('load', promote); }
+        })();
+    </script>
 
     <!-- SEO: Canonical URL (self-referencing - each language version is its own canonical) -->
     <link rel="canonical" href="{% block canonical_url %}{% canonical_url %}{% endblock %}">
@@ -156,7 +174,7 @@
         .hero-section{background:linear-gradient(135deg,#9B59B6 0%,#FF6B9D 100%);color:#fff;padding:5rem 1rem;width:100vw;margin-left:calc(-50vw + 50%);margin-top:-2rem!important;position:relative;overflow:hidden;border-radius:0 0 50px 50px}
         html.dark .hero-section{background:linear-gradient(135deg,#581C87 0%,#9F1239 100%)}
         .hero-content{position:relative;z-index:1;max-width:1200px;margin:0 auto}
-        .hero-title{font-size:clamp(2.5rem,6vw,4.5rem);font-weight:800;margin-bottom:1.5rem;line-height:1.2}
+        .hero-title{font-family:"Fraunces",Georgia,"Times New Roman",serif;font-size:clamp(2.75rem,6.5vw,5rem);font-weight:600;font-variation-settings:"opsz" 144;letter-spacing:-.02em;line-height:1.05;margin-bottom:1.5rem}
         .hero-subtitle{font-size:clamp(1.1rem,2.5vw,1.5rem);opacity:.95;margin-bottom:2.5rem;max-width:700px}
         .hero-emoji{font-size:clamp(8rem,20vw,15rem);display:inline-block}
         .hero-ghost-svg{width:clamp(8rem,20vw,15rem);height:auto;display:inline-block;filter:drop-shadow(0 10px 30px rgba(0,0,0,.15))}
@@ -185,8 +203,12 @@
     {# HTMX CSRF Token - Read from hidden input for reliable cross-language support #}
     {# This works correctly when CSRF_COOKIE_HTTPONLY=True #}
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}" id="csrf-token-input">
-    {# External script for CSP compliance - runs synchronously before HTMX #}
-    <script nonce="{{ csp_nonce }}" src="{% static 'crush_lu/js/htmx-csrf.js' %}"></script>
+    {% comment %}
+       External script for CSP compliance. Deferred, not parser-blocking: defer keeps
+       document order among src'd scripts, so this still runs before the deferred HTMX
+       bundle at the bottom of the page, which is the ordering that actually matters.
+    {% endcomment %}
+    <script nonce="{{ csp_nonce }}" defer src="{% static 'crush_lu/js/htmx-csrf.js' %}"></script>
     {% include "includes/staging_banner.html" %}
     {% analytics_body %}
     <!-- Skip to main content link for keyboard/screen reader users -->
@@ -1340,8 +1362,11 @@
     <!-- JavaScript i18n catalog (must load before components that use gettext()).
          Pass the page's language explicitly: the catalog route sits outside
          i18n_patterns, so it would otherwise be negotiated from the cookie /
-         Accept-Language and could disagree with this page. -->
-    <script nonce="{{ csp_nonce }}" src="{% url 'javascript-catalog-lang' LANGUAGE_CODE %}"></script>
+         Accept-Language and could disagree with this page.
+         Deferred: no template calls gettext() inline at parse time, and defer preserves
+         document order, so the catalog still lands before every deferred consumer
+         below (toast, confirm-sheet, alpine-components). -->
+    <script nonce="{{ csp_nonce }}" defer src="{% url 'javascript-catalog-lang' LANGUAGE_CODE %}"></script>
 
     <!-- HTMX (HTML-driven interactivity) - deferred for non-blocking load -->
     <script nonce="{{ csp_nonce }}" defer src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js"

--- a/crush_lu/templates/crush_lu/includes/event_card.html
+++ b/crush_lu/templates/crush_lu/includes/event_card.html
@@ -12,7 +12,7 @@
         {% if is_past %}
         <span class="absolute top-3 left-3 inline-flex items-center px-2.5 py-1 text-xs font-semibold bg-gray-700/80 text-white rounded-full backdrop-blur-sm">{% trans "Past Event" %}</span>
         {% elif event.is_live %}
-        <span class="absolute top-3 left-3 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold bg-red-500 text-white rounded-full backdrop-blur-sm">
+        <span class="absolute top-3 left-3 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold bg-red-600 text-white rounded-full backdrop-blur-sm">
             <span class="animate-pulse w-2 h-2 rounded-full bg-white"></span>{% trans "Live now" %}
         </span>
         {% endif %}
@@ -34,7 +34,7 @@
                     {{ event.get_event_type_display }}
                 </span>
                 {% if event.is_live and not is_past %}
-                <span class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-semibold bg-red-500 text-white rounded-full backdrop-blur-sm">
+                <span class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-semibold bg-red-600 text-white rounded-full backdrop-blur-sm">
                     <span class="animate-pulse w-2 h-2 rounded-full bg-white"></span>{% trans "Live now" %}
                 </span>
                 {% endif %}
@@ -62,7 +62,7 @@
         {% if is_past %}
         {# Simplified past event card body #}
         <div class="flex justify-between items-start mb-3">
-            <h5 class="font-semibold text-lg mb-0 dark:text-white">{{ event.title }}</h5>
+            <h3 class="font-semibold text-lg mb-0 dark:text-white">{{ event.title }}</h3>
             <span class="badge-crush-soft">{{ event.get_event_type_display }}</span>
         </div>
 
@@ -88,7 +88,7 @@
         </div>
         {% endif %}
         <div class="flex justify-between items-start mb-3">
-            <h5 class="font-semibold text-lg mb-0 dark:text-white">{{ event.title }}</h5>
+            <h3 class="font-semibold text-lg mb-0 dark:text-white">{{ event.title }}</h3>
             <span class="badge-crush-soft">{{ event.get_event_type_display }}</span>
         </div>
 
@@ -115,7 +115,7 @@
             <div class="flex justify-between items-center mb-3">
                 <small class="text-gray-500 dark:text-gray-400">
                     {% if event.is_full %}
-                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold bg-red-500 text-white rounded-full">{% trans "Full" %}</span>
+                        <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold bg-red-600 text-white rounded-full">{% trans "Full" %}</span>
                     {% else %}
                         {% blocktrans count counter=event.spots_remaining %}{{ counter }} spot left{% plural %}{{ counter }} spots left{% endblocktrans %}
                     {% endif %}

--- a/crush_lu/tests/test_security.py
+++ b/crush_lu/tests/test_security.py
@@ -8,8 +8,10 @@ Tests for:
 - Permissions-Policy headers
 - PII masking in logs
 """
+import os
 import re
 from datetime import date
+from unittest import mock
 
 from django.test import Client, TestCase, override_settings
 from django.contrib.auth import get_user_model
@@ -183,6 +185,33 @@ class TestCSPInlineScriptNonces(SiteTestCase):
         client = Client(HTTP_HOST='entreprinder.lu')
         response = client.get('/login_complete/')
         self._assert_all_inline_scripts_nonced(response, '/login_complete/')
+
+    @mock.patch.dict(os.environ, {'GA4_CRUSH_LU': 'G-TESTNONCE1'})
+    def test_analytics_head_inline_scripts_carry_nonce(self):
+        """{% analytics_head %} renders the first inline scripts in <head>.
+
+        Regression test for the gtag blocks shipping with no nonce at all
+        (found on production 2026-08-21 via the browser console; Lighthouse
+        surfaced it as two /csp-report/ POSTs and an inspector-issues fail).
+
+        The cause is subtle enough to be worth pinning: request._csp_nonce is a
+        django.utils.csp.LazyNonce whose __bool__ stays False until the value is
+        generated, so the tag's `if nonce` truthiness check was False for the
+        first tag to render — and analytics_head is line 9 of base.html, before
+        any {{ csp_nonce }}. The sibling tests above never caught it
+        because analytics_context reads GA4_CRUSH_LU off os.environ and matches
+        request.get_host() exactly — both unset/mismatched in tests — so analytics_head returns '' and emits no scripts at
+        all. Hence the explicit 'dataLayer' guard below: without it this test
+        passes vacuously, which is exactly how the bug reached production.
+        """
+        client = Client(HTTP_HOST='crush.lu')
+        response = client.get('/en/')
+        self.assertIn(
+            'dataLayer', response.content.decode(),
+            'analytics_head did not render — analytics_context matches the host '
+            'exactly, so this test would otherwise pass vacuously'
+        )
+        self._assert_all_inline_scripts_nonced(response, '/en/ (with GA4 configured)')
 
     def test_power_up_finops_dashboard_inline_scripts_carry_nonce(self):
         """Power Up FinOps dashboard renders config as JSON data blocks —

--- a/tailwind-src/crush_lu/tailwind-input.css
+++ b/tailwind-src/crush_lu/tailwind-input.css
@@ -10270,42 +10270,56 @@ html.dark .ghost-story-nav-btn:hover {
 
 .ghost-story-dots {
     display: flex;
-    gap: 0.5rem;
+    /* No gap: each dot already carries a 1.5rem hit area, which puts neighbouring
+       centres 24px apart. Adding gap on top would stretch the row without helping. */
+    gap: 0;
     align-items: center;
     justify-content: center;
 }
 
+/* The button is a transparent 24x24 hit area (WCAG 2.5.8 / Lighthouse target-size);
+   ::before draws the 8px dot people actually see. Before this the button *was* the
+   8px dot, giving an 8px-wide target with ~4px of safe space between neighbours. */
 .ghost-story-dot {
+    width: 1.5rem;
+    height: 1.5rem;
+    display: grid;
+    place-items: center;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.ghost-story-dot::before {
+    content: "";
     width: 0.5rem;
     height: 0.5rem;
     border-radius: 50%;
     background: rgba(155, 89, 182, 0.3);
-    border: none;
-    cursor: pointer;
     transition: all 0.3s ease;
-    padding: 0;
 }
 
-.ghost-story-dot:hover {
+.ghost-story-dot:hover::before {
     background: rgba(155, 89, 182, 0.5);
     transform: scale(1.3);
 }
 
-.ghost-story-dot-active {
+.ghost-story-dot-active::before {
     background: #9b59b6;
     transform: scale(1.4);
     box-shadow: 0 0 8px rgba(155, 89, 182, 0.5);
 }
 
-html.dark .ghost-story-dot {
+html.dark .ghost-story-dot::before {
     background: rgba(139, 92, 246, 0.3);
 }
 
-html.dark .ghost-story-dot:hover {
+html.dark .ghost-story-dot:hover::before {
     background: rgba(139, 92, 246, 0.5);
 }
 
-html.dark .ghost-story-dot-active {
+html.dark .ghost-story-dot-active::before {
     background: #a78bfa;
     box-shadow: 0 0 8px rgba(167, 139, 250, 0.5);
 }
@@ -10508,7 +10522,8 @@ html.dark .ghost-story-heart-svg {
     }
 
     .ghost-story-dots {
-        gap: 0.375rem;
+        /* Hit areas already set the spacing; see .ghost-story-dot. */
+        gap: 0;
     }
 
     .ghost-story-cta-btn {


### PR DESCRIPTION
## Purpose

Acts on a mobile Lighthouse run of `https://crush.lu/en/` in incognito (perf **85**, a11y **91**, best-practices **96**, SEO **100**).

The performance score decomposes to **FCP 0.58 + LCP 0.64**, with TBT 0.96 / CLS 1.0 / SI 0.96. So the entire 15-point gap is the render-blocking chain — *not* the tempting byte-diet items (`alpine-components.js` is 655KB / 94% unused; GTM + Facebook are 296KB of the 726KB page). Those cost bandwidth, not points, and are deliberately left alone.

**Performance**
* Google Fonts stylesheet blocked render for **~771ms**. Now off the critical path: preload keeps priority, `media="print"` keeps it out of first paint, and a nonce'd script promotes it to `media="all"`. Not an `onload=""` attribute — that inline handler is exactly what the nonce CSP is meant to reject.
* Safe because Fraunces is requested with `display=swap` and `.hero-title` falls back to Georgia, so the LCP heading no longer waits on the network.
* Deferred the jsi18n catalog and `htmx-csrf.js`. No template calls `gettext()` inline at parse time, and `defer` preserves document order, so both still land before every deferred consumer.
* Synced the inlined critical-CSS `.hero-title` to the real bundle rule, so the LCP paint is final-form rather than a restyle.

**Accessibility** — all three failing audits
* `bg-red-500` on white measures 3.81:1, below the 4.5:1 AA floor at 12px. `red-600` measures 4.77:1.
* `event_card` emitted `<h3>` in the no-image branch but `<h5>` in the two image branches, under the same `<h2>` section heading.
* Cookie banner title was an `<h4>` appended after the footer — now a paragraph, since `role="dialog"` takes its name from `aria-labelledby`.
* Ghost-story dots keep their 8px look but sit in 24×24 hit areas (WCAG 2.5.8); the visual dot moved to `::before`.

**CSP — the `inspector-issues` failure, and the find worth reviewing**

Loading production in a browser showed **both inline `gtag` scripts shipping with no nonce at all**. `request._csp_nonce` is a `django.utils.csp.LazyNonce` whose `__bool__` stays `False` until the value is generated, and `{% analytics_head %}` renders at line 9 of `base.html` — before any `{{ csp_nonce }}` — so `if nonce` was always `False` for it.

Harmless today because the policy is report-only. **The moment `SECURE_CSP_REPORT_ONLY` becomes `SECURE_CSP`, those scripts get blocked** (CSP3 ignores `'unsafe-inline'` once a nonce is present) and GA4 goes dark silently. Fixed at all six call sites.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

Behaviour-preserving. The one visible change is cosmetic: the ghost-story dot row is wider (centres 24px apart instead of 16px) now that each dot carries a real hit area.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```
git clone https://github.com/EuphoriaLux/Multi-Domain-Django-Platform.git
cd Multi-Domain-Django-Platform
git checkout claude/crush-lu-lighthouse-c4c23e
```

* Test the code

```
# SQLite, in-process (matches CI)
DBHOST='' python -m pytest crush_lu/tests hub/tests power_up/finops/tests power_up/atmos/tests -n 0

# The CSP regression specifically
DBHOST='' python -m pytest crush_lu/tests/test_security.py::TestCSPInlineScriptNonces -n 0
```

Result on this branch: **4690 passed, 31 skipped.**

`test_preview_can_load_roster_photos` fails on a clean `main` too — confirmed by stashing — and is unrelated to this PR, so it is deselected in the run above.

## What to Check

* **The regression test genuinely bites.** `TestCSPInlineScriptNonces` already asserted this exact invariant for three other pages and never caught the bug, because GA4 is unconfigured in tests so `analytics_head` returns `''` and emits nothing. The new case configures it via the `GA4_CRUSH_LU` env var and the `crush.lu` host, and carries a guard assertion so it cannot pass vacuously. I verified it fails when the fix is reverted.
* **`tailwind.css` build artifact is untouched.** Only `tailwind-input.css` is edited, per the repo rule that deploy rebuilds the bundle. Verified it compiles to a scratch file.
* **Font swap on the hero.** The display face now arrives after first paint; confirm the Georgia → Fraunces swap reads acceptably on a cold load.
* **Ghost-story dots** in both light and dark mode — the hover/active/dark rules all moved to `::before`.
* **Cookie banner title** styling across domains — `core/templates/` is shared, and the CSS was retargeted from a tag selector to a class, with specificity chosen so `.cookie-banner-text p` can't win on `color`.

## Other Information

**Expected outcome:** roughly **92–95** performance, not 100. `tailwind.css` remains render-blocking and is the rest of the estimate (~900ms of the 1,720ms total).

**Left out deliberately, needs a decision:**

1. **Async `tailwind.css`.** The biggest remaining perf item. Worth noting the inlined critical CSS currently does nothing for FCP, since nothing paints until the blocking bundle lands — it only starts paying once the bundle is async. Real upside, real FOUC risk below the fold; wants a browser test before shipping.
2. **The Facebook pixel fires a `PageView` with the consent banner still up** — visible in the report's network table (`coo=false`). On an EU dating site that's worth a look, and gating it would incidentally help performance.
3. **An esbuild minify + sourcemap step for `alpine-components.js`** (~23KB plus parse time) would mirror the existing Tailwind step, but it touches the deploy pipeline so it isn't in this PR. `valid-source-maps` is weight-0, so the sourcemap is only worth adding if the minify lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
