### PR TITLE
fix(sumup): reconcile refunds via transaction history and enhance cancellation UX

### DIFF
--- a/crush_lu/management/commands/reconcile_sumup_payments.py
+++ b/crush_lu/management/commands/reconcile_sumup_payments.py
@@ -25,6 +25,7 @@ import logging
 import time
 from datetime import timedelta
 from decimal import Decimal, InvalidOperation
+from typing import Optional
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
@@ -69,8 +70,8 @@ def _to_decimal(value) -> Decimal:
     return parsed
 
 
-def refunded_amount(data: dict) -> Decimal:
-    """Best available total refunded on this checkout.
+def refunded_amount(data: dict, history_map: Optional[dict] = None) -> Decimal:
+    """Best available total refunded on this checkout or transaction history.
 
     Returns ``Decimal("0")`` when SumUp signals a refund by status alone and
     reports no amount — callers must treat that as "amount unknown", not as
@@ -91,18 +92,39 @@ def refunded_amount(data: dict) -> Decimal:
             if isinstance(refund, dict):
                 refunds_total += _to_decimal(refund.get("amount"))
 
+        tx_code = tx.get("transaction_code")
+        if tx_code and history_map and tx_code in history_map:
+            hist_item = history_map[tx_code]
+            hist_amt_ref = _to_decimal(hist_item.get("amount_refunded"))
+            if hist_amt_ref > 0:
+                candidates.append(hist_amt_ref)
+            elif (hist_item.get("status") or "").upper() == "REFUNDED":
+                candidates.append(_to_decimal(hist_item.get("amount") or data.get("amount")))
+
+    code = data.get("transaction_code")
+    if code and history_map and code in history_map:
+        hist_item = history_map[code]
+        hist_amt_ref = _to_decimal(hist_item.get("amount_refunded"))
+        if hist_amt_ref > 0:
+            candidates.append(hist_amt_ref)
+        elif (hist_item.get("status") or "").upper() == "REFUNDED":
+            candidates.append(_to_decimal(hist_item.get("amount") or data.get("amount")))
+
     candidates.extend([per_tx_total, refunds_total])
     return max(candidates)
 
 
-def is_checkout_refunded(data: dict) -> bool:
-    """Determine if a SumUp checkout resource indicates an external refund.
+def is_checkout_refunded(data: dict, history_map: Optional[dict] = None) -> bool:
+    """Determine if a SumUp checkout resource or transaction history indicates an external refund.
 
     Checks:
     - Checkout-level status == "REFUNDED"
     - Any transaction entry status == "REFUNDED"
     - Any transaction entry has non-empty "refunds" list or amount_refunded > 0
     - Top-level amount_refunded > 0
+    - Transaction history matching by transaction_code reports status == "REFUNDED",
+      type == "REFUND", or amount_refunded > 0 (for external dashboard/POS refunds
+      where SumUp does not mutate the static /v0.1/checkouts resource).
 
     Detection only. Whether the refund was full or partial is decided by the
     caller against the captured amount — see ``handle()``.
@@ -125,6 +147,27 @@ def is_checkout_refunded(data: dict) -> bool:
         if tx_status == "REFUNDED":
             return True
         if tx.get("refunds") or _to_decimal(tx.get("amount_refunded")) > 0:
+            return True
+        tx_code = tx.get("transaction_code")
+        if tx_code and history_map and tx_code in history_map:
+            hist_item = history_map[tx_code]
+            if (
+                (hist_item.get("status") or "").upper() == "REFUNDED"
+                or (hist_item.get("type") or "").upper() == "REFUND"
+                or _to_decimal(hist_item.get("amount_refunded")) > 0
+                or len(hist_item.get("refunds") or []) > 0
+            ):
+                return True
+
+    code = data.get("transaction_code")
+    if code and history_map and code in history_map:
+        hist_item = history_map[code]
+        if (
+            (hist_item.get("status") or "").upper() == "REFUNDED"
+            or (hist_item.get("type") or "").upper() == "REFUND"
+            or _to_decimal(hist_item.get("amount_refunded")) > 0
+            or len(hist_item.get("refunds") or []) > 0
+        ):
             return True
 
     return False
@@ -219,6 +262,18 @@ class Command(BaseCommand):
             return
 
         client = SumUpClient()
+        history_map = {}
+        try:
+            # Prefetch recent merchant transaction history to catch refunds done via
+            # the dashboard/POS terminal that do not mutate the static checkout resource.
+            history_data = client.get_transactions_history(limit=100, order="desc")
+            for item in history_data.get("items", []):
+                code = item.get("transaction_code")
+                if code:
+                    history_map[code] = item
+        except Exception as exc:
+            logger.warning("Could not prefetch SumUp transaction history: %s", exc)
+
         checked = 0
         refunded_count = 0
         errors_count = 0
@@ -256,7 +311,29 @@ class Command(BaseCommand):
                 continue
 
             try:
-                refunded = is_checkout_refunded(remote_data)
+                refunded = is_checkout_refunded(remote_data, history_map=history_map)
+                if not refunded:
+                    # If not found in prefetched history_map, attempt fallback lookup by transaction_code
+                    code = remote_data.get("transaction_code")
+                    if not code:
+                        tx_list = remote_data.get("transactions") or []
+                        for t in tx_list:
+                            if isinstance(t, dict) and t.get("transaction_code"):
+                                code = t.get("transaction_code")
+                                break
+                    if code and code not in history_map:
+                        try:
+                            code_data = client.get_transactions_history(
+                                limit=10, transaction_code=code
+                            )
+                            for item in code_data.get("items", []):
+                                if item.get("transaction_code") == code:
+                                    history_map[code] = item
+                            refunded = is_checkout_refunded(
+                                remote_data, history_map=history_map
+                            )
+                        except Exception:
+                            pass
             except Exception as exc:  # defensive: never let one payload kill the sweep
                 errors_count += 1
                 logger.exception(
@@ -278,7 +355,7 @@ class Command(BaseCommand):
                 # void the member's credit over what may be a small goodwill
                 # adjustment. Amount 0 means SumUp signalled the refund by status
                 # alone and told us no amount — treated as full, as before.
-                refunded_amt = refunded_amount(remote_data)
+                refunded_amt = refunded_amount(remote_data, history_map=history_map)
                 captured_amt = tx_obj.amount or Decimal("0")
                 is_partial = (
                     refunded_amt > 0

--- a/crush_lu/services/sumup.py
+++ b/crush_lu/services/sumup.py
@@ -229,6 +229,45 @@ class SumUpClient:
             logger.error("SumUp create_customer failed: %s", exc)
             raise SumUpError(f"Failed to create SumUp customer {customer_id}") from exc
 
+    def get_transactions_history(
+        self,
+        limit: int = 100,
+        order: str = "desc",
+        oldest_ref: Optional[str] = None,
+        statuses: Optional[list] = None,
+        transaction_code: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Fetches merchant transaction history from SumUp.
+        Endpoint: GET /v0.1/me/transactions/history
+
+        Used by refund reconciliation to inspect actual transaction lifecycle
+        and refund states that do not mutate the static /v0.1/checkouts resource.
+        """
+        url = f"{self.BASE_URL}/v0.1/me/transactions/history"
+        params: Dict[str, Any] = {
+            "limit": min(max(1, limit), 100),
+            "order": order,
+        }
+        if oldest_ref:
+            params["oldest_ref"] = oldest_ref
+        if statuses:
+            params["statuses[]"] = statuses
+        if transaction_code:
+            params["transaction_code"] = transaction_code
+
+        try:
+            response = requests.get(
+                url, params=params, headers=self._get_headers(), timeout=10
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.RequestException as exc:
+            logger.error("SumUp get_transactions_history failed: %s", exc)
+            raise SumUpError(
+                f"Failed to fetch SumUp transaction history: {exc}"
+            ) from exc
+
     def refund_transaction(
         self, transaction_id: str, amount: Optional[float] = None
     ) -> Dict[str, Any]:

--- a/crush_lu/tests/test_sumup_reconciliation.py
+++ b/crush_lu/tests/test_sumup_reconciliation.py
@@ -74,6 +74,39 @@ class IsCheckoutRefundedTests(TestCase):
         self.assertFalse(is_checkout_refunded({}))
         self.assertFalse(is_checkout_refunded(None))
 
+    def test_history_map_matching_transaction_code(self):
+        payload = {
+            "status": "PAID",
+            "transaction_code": "TX123",
+            "transactions": [
+                {"id": "txn-1", "status": "SUCCESSFUL", "amount": 15.50}
+            ],
+        }
+        history_map = {
+            "TX123": {
+                "transaction_code": "TX123",
+                "status": "REFUNDED",
+                "amount": 15.50,
+            }
+        }
+        self.assertTrue(is_checkout_refunded(payload, history_map=history_map))
+
+    def test_history_map_matching_nested_transaction_code(self):
+        payload = {
+            "status": "PAID",
+            "transactions": [
+                {"id": "txn-1", "transaction_code": "TX456", "status": "SUCCESSFUL", "amount": 15.50}
+            ],
+        }
+        history_map = {
+            "TX456": {
+                "transaction_code": "TX456",
+                "status": "REFUNDED",
+                "amount_refunded": 15.50,
+            }
+        }
+        self.assertTrue(is_checkout_refunded(payload, history_map=history_map))
+
 
 class SumUpReconciliationCommandTests(TestCase):
     def setUp(self):
@@ -556,3 +589,103 @@ class ExternalRefundRegressionTests(TestCase):
         )
         # Status-only refund reports no amount: 0 means "unknown", not "nothing".
         self.assertEqual(refunded_amount({"status": "REFUNDED"}), Decimal("0"))
+
+    def test_refunded_amount_from_history_map(self):
+        payload = {
+            "status": "PAID",
+            "amount": 15.50,
+            "transaction_code": "TX999",
+            "transactions": [{"id": "t1", "status": "SUCCESSFUL", "amount": 15.50}],
+        }
+        history_map = {
+            "TX999": {
+                "transaction_code": "TX999",
+                "status": "REFUNDED",
+                "amount_refunded": "15.50",
+            }
+        }
+        self.assertEqual(refunded_amount(payload, history_map=history_map), Decimal("15.50"))
+
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_transactions_history")
+    @patch("crush_lu.management.commands.reconcile_sumup_payments.SumUpClient.get_checkout")
+    def test_reconciles_refund_detected_only_in_transaction_history(
+        self, mock_get_checkout, mock_get_history
+    ):
+        """Dashboard refunds do not mutate the checkout resource, but appear in transaction history.
+
+        This test proves that a checkout returning status='PAID' is still reconciled to REFUNDED
+        when its transaction_code is marked REFUNDED in get_transactions_history.
+        """
+        user = User.objects.create_user(username="dash_refund", email="dash_refund@crush.lu")
+        event = MeetupEvent.objects.create(
+            title="Quiz Night #99",
+            event_type="quiz_night",
+            location="Luxembourg",
+            address="10 Grand Rue",
+            date_time=timezone.now() + timedelta(days=5),
+            registration_deadline=timezone.now() + timedelta(days=4),
+            registration_fee=Decimal("15.50"),
+            is_published=True,
+        )
+        reg = EventRegistration.objects.create(
+            event=event, user=user, status="confirmed", payment_confirmed=True
+        )
+        tx = PaymentTransaction.objects.create(
+            transaction_reference="CRUSH-EVT-99-dash-ref",
+            provider=PaymentTransaction.Provider.SUMUP,
+            sumup_checkout_id="chk_dash_refund",
+            amount=Decimal("15.50"),
+            currency="EUR",
+            status=PaymentTransaction.Status.PAID,
+            purpose=PaymentTransaction.Purpose.EVENT_REGISTRATION,
+            user=user,
+            event_registration=reg,
+            event=event,
+        )
+        credit = CrushCredit.objects.create(
+            user=user,
+            amount_cents=2000,
+            reason=CrushCredit.Reason.EVENT_CANCELLED,
+            source_registration=reg,
+            source_payment=tx,
+            status=CrushCredit.Status.ACTIVE,
+        )
+
+        # Checkout payload still shows PAID and SUCCESSFUL transaction (how SumUp API behaves)
+        mock_get_checkout.return_value = {
+            "id": "chk_dash_refund",
+            "status": "PAID",
+            "transaction_code": "TX_DASH_123",
+            "transactions": [
+                {
+                    "id": "txn-uuid-1",
+                    "status": "SUCCESSFUL",
+                    "transaction_code": "TX_DASH_123",
+                    "amount": 15.50,
+                }
+            ],
+        }
+        # Transaction history reports the actual external dashboard refund
+        mock_get_history.return_value = {
+            "items": [
+                {
+                    "transaction_code": "TX_DASH_123",
+                    "status": "REFUNDED",
+                    "amount": 15.50,
+                    "amount_refunded": 15.50,
+                    "type": "PAYMENT",
+                }
+            ]
+        }
+
+        call_command("reconcile_sumup_payments", checkout_id="chk_dash_refund", quiet=True)
+
+        tx.refresh_from_db()
+        reg.refresh_from_db()
+        credit.refresh_from_db()
+
+        self.assertEqual(tx.status, PaymentTransaction.Status.REFUNDED)
+        self.assertFalse(reg.payment_confirmed)
+        self.assertEqual(reg.status, "cancelled")
+        self.assertEqual(credit.status, CrushCredit.Status.VOID)
+

--- a/hub/serializers.py
+++ b/hub/serializers.py
@@ -440,16 +440,16 @@ class LinkedCrushCreditSerializer(serializers.Serializer):
     cashRefundEligible = serializers.BooleanField(
         source="cash_refund_eligible", read_only=True
     )
+    note = serializers.CharField(read_only=True)
 
 
 class EventCancellationRegistrationSerializer(serializers.Serializer):
     """One self-cancelled registration for a cancelled event, credit attached.
 
     Source rows are ``EventRegistration`` instances the view annotates with
-    ``linked_credit`` (a ``CrushCredit`` or ``None``) and ``open_cash_refund``
-    (a bool computed from the *exact* same predicate the staff cash-refund
-    queue uses — see ``CashRefundQueueFilter._open`` in
-    ``crush_lu/admin/credits.py`` and ``hub/views_events.py``).
+    ``linked_credit`` (a ``CrushCredit`` or ``None``), ``open_cash_refund``,
+    ``cancellation_origin`` ("member" | "organiser"), ``payment_status`` ("paid" | "refunded" | "none"),
+    and ``refund_amount_cents``.
     """
 
     id = serializers.CharField(source="pk", read_only=True)
@@ -461,6 +461,15 @@ class EventCancellationRegistrationSerializer(serializers.Serializer):
     )
     credit = serializers.SerializerMethodField()
     openCashRefund = serializers.BooleanField(source="open_cash_refund", read_only=True)
+    cancellationOrigin = serializers.CharField(
+        source="cancellation_origin", read_only=True, default="organiser"
+    )
+    paymentStatus = serializers.CharField(
+        source="payment_status", read_only=True, default="none"
+    )
+    refundAmountCents = serializers.IntegerField(
+        source="refund_amount_cents", read_only=True, allow_null=True, default=None
+    )
 
     def get_userEmail(self, obj):
         return obj.user.email if obj.user_id else None

--- a/hub/views_events.py
+++ b/hub/views_events.py
@@ -55,6 +55,7 @@ from rest_framework.views import APIView
 from crush_lu.admin.credits import CashRefundQueueFilter
 from crush_lu.models import EventRegistration, MeetupEvent
 from crush_lu.models.credits import CrushCredit
+from crush_lu.models.payments import PaymentTransaction
 
 from .serializers import (
     EventCancellationRegistrationSerializer,
@@ -138,26 +139,34 @@ class EventCancellationsView(APIView):
         # ``base_credits`` is already cycle-scoped (see
         # ``_event_cancelled_credits``), so this total is too.
         open_totals = {
-            row["_event_id"]: row["open_total_cents"]
+            row["_event_id"]: row
             for row in _open_cash_refund_credits(None, base_credits)
             .values("_event_id")
-            .annotate(open_total_cents=Coalesce(Sum("amount_cents"), 0))
+            .annotate(
+                open_count=Count("id"),
+                open_total_cents=Coalesce(Sum("amount_cents"), 0),
+            )
         }
 
         for event in events:
-            issued = issued_totals.get(event.pk, {})
-            event.affected_registrations = affected_counts.get(event.pk, 0)
-            event.issued_credits_count = issued.get("issued_count", 0)
-            event.issued_credits_total_cents = issued.get("issued_total_cents", 0)
-            event.open_cash_refund_total_cents = open_totals.get(event.pk, 0)
+            pk = event.pk
+            event.affected_registrations = affected_counts.get(pk, 0)
+            event.issued_credits_count = issued_totals.get(pk, {}).get(
+                "issued_count", 0
+            )
+            event.issued_credits_total_cents = issued_totals.get(pk, {}).get(
+                "issued_total_cents", 0
+            )
+            event.open_cash_refund_total_cents = open_totals.get(pk, {}).get(
+                "open_total_cents", 0
+            )
 
-        return Response(
-            {"items": EventCancellationSummarySerializer(events, many=True).data}
-        )
+        serializer = EventCancellationSummarySerializer(events, many=True)
+        return Response({"items": serializer.data})
 
 
 class EventCancellationDetailView(APIView):
-    """Self-cancelled seats for one cancelled event, each with its credit."""
+    """The cancelled registrations for one cancelled event, with attached credits."""
 
     permission_classes = [IsAdminUser]
 
@@ -209,6 +218,26 @@ class EventCancellationDetailView(APIView):
             ):
                 credit_by_registration[reg_id] = credit
 
+        # Fetch payment transactions linked to these registrations or users for this event
+        user_ids = [r.user_id for r in registrations if r.user_id]
+        txs = list(
+            PaymentTransaction.objects.filter(
+                Q(event_registration_id__in=registration_ids)
+                | Q(event=event, user_id__in=user_ids)
+            ).order_by("-updated_at")
+        )
+
+        tx_by_registration = {}
+        for tx in txs:
+            reg_id = tx.event_registration_id
+            if reg_id and reg_id not in tx_by_registration:
+                tx_by_registration[reg_id] = tx
+            elif tx.user_id:
+                for r in registrations:
+                    if r.user_id == tx.user_id and r.pk not in tx_by_registration:
+                        tx_by_registration[r.pk] = tx
+                        break
+
         issued_total_cents = sum(credit.amount_cents for credit in credits)
         open_total_cents = sum(
             credit.amount_cents for credit in credits if credit.pk in open_ids
@@ -216,8 +245,36 @@ class EventCancellationDetailView(APIView):
 
         for registration in registrations:
             credit = credit_by_registration.get(registration.pk)
+            tx = tx_by_registration.get(registration.pk)
             registration.linked_credit = credit
             registration.open_cash_refund = bool(credit and credit.pk in open_ids)
+
+            # Determine cancellation origin
+            registration.cancellation_origin = (
+                "member" if registration.cancelled_at else "organiser"
+            )
+
+            # Determine payment & refund status
+            if tx and tx.status == PaymentTransaction.Status.REFUNDED:
+                registration.payment_status = "refunded"
+                registration.refund_amount_cents = (
+                    int(round(tx.amount * 100)) if tx.amount else None
+                )
+            elif (
+                credit
+                and credit.status == CrushCredit.Status.VOID
+                and "refund" in (credit.note or "").lower()
+            ):
+                registration.payment_status = "refunded"
+                registration.refund_amount_cents = credit.amount_cents
+            elif registration.payment_confirmed or (
+                tx and tx.status == PaymentTransaction.Status.PAID
+            ):
+                registration.payment_status = "paid"
+                registration.refund_amount_cents = None
+            else:
+                registration.payment_status = "none"
+                registration.refund_amount_cents = None
 
         event.affected_registrations = len(registrations)
         event.issued_credits_count = len(credits)


### PR DESCRIPTION
## Summary
- Enhance SumUp refund reconciliation by querying transaction history in addition to checkout resource.
- Expose cancellation origin and payment refund details in Hub cancellation API.
- Update Hub CRM with explicit badges.