### PR TITLE
fix(mobile): scope native auth interception, and open the handoff in a Custom Tab

### DIFF
--- a/.github/workflows/android-build-verification.yml
+++ b/.github/workflows/android-build-verification.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Run Android source guards
+        run: python3 -m unittest discover -s mobile/android/CrushLU/tests -v
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/mobile/android/CrushLU/app/build.gradle.kts
+++ b/mobile/android/CrushLU/app/build.gradle.kts
@@ -90,6 +90,11 @@ dependencies {
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation("androidx.core:core-splashscreen:1.0.1")
+    // Chrome Custom Tabs for the auth handoff. RFC 8252 appendix B.1 names the
+    // in-app browser tab as the way to run a native-app authorization request;
+    // targeting a concrete browser package is also what stops the handoff URL
+    // resolving back into this app once its App Links are verified.
+    implementation("androidx.browser:browser:1.8.0")
     implementation("com.google.android.material:material:1.12.0")
 
     // Firebase Cloud Messaging (FCM) + Crashlytics (crash reporting)

--- a/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
+++ b/mobile/android/CrushLU/app/src/main/AndroidManifest.xml
@@ -14,6 +14,21 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
+    <!-- targetSdk 35 hides other packages by default, so without this the
+         browser lookup in startNativeAuth() returns nothing and the handoff
+         would fall back to an untargeted ACTION_VIEW — the very intent that can
+         resolve back into this app once its App Links verify. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -36,6 +36,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -400,6 +403,23 @@ public class MainActivity extends AppCompatActivity {
         openExternal(Uri.parse(LOGIN_HANDOFF_URL));
     }
 
+    /**
+     * The only pages that belong in the external auth browser: the login entry
+     * points themselves.
+     *
+     * ``crush_login_required`` bounces to {@code crush_lu:login}
+     * ({@code /<lang>/login/}) and allauth's own ``@login_required`` bounces to
+     * {@code /accounts/login/}, so both must be here. Everything else under
+     * {@code /accounts/} — password reset, email management, connected
+     * accounts, the confirm-email landing — is an ordinary signed-in page and
+     * has to stay in the WebView, which is where the member's session lives.
+     * Matching the whole prefix sent those out to a browser that has a
+     * different session, so the flows either dead-ended or silently applied to
+     * the wrong context.
+     */
+    private static final Set<String> AUTH_ENTRY_PATHS =
+            new HashSet<>(Arrays.asList("/login/", "/accounts/login/"));
+
     private boolean shouldStartNativeAuth(Uri uri) {
         // For local testing, allow login in the WebView to test insets/keyboard
         if (BuildConfig.BASE_URL.contains("10.0.2.2")) {
@@ -408,9 +428,54 @@ public class MainActivity extends AppCompatActivity {
         if (!isInternal(uri)) {
             return false;
         }
-        String path = uri.getPath() == null ? "" : uri.getPath();
-        return path.endsWith("/login/") || path.contains("/accounts/");
+        String path = normalizeAuthPath(uri.getPath());
+        return AUTH_ENTRY_PATHS.contains(path) || isProviderLoginStart(path);
     }
+
+    /**
+     * {@code /accounts/<provider>/login/} — the button a signed-out member taps
+     * on the in-app signup page ("Continue with LuxID/Google/Apple/...").
+     *
+     * These have to open the auth browser too. Left in the WebView, the OAuth
+     * state is stashed in the WebView's session but the provider redirect
+     * leaves for the system browser, so the callback lands somewhere that
+     * cannot match it: the member ends up signed in inside a browser and still
+     * anonymous in the app, with no crushlu:// callback and no auth code.
+     *
+     * Deliberately excludes {@code .../login/callback/}, which has one segment
+     * more and only ever arrives in the browser that started the flow.
+     */
+    private static boolean isProviderLoginStart(String path) {
+        String trimmed = path.startsWith("/") ? path.substring(1) : path;
+        if (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        String[] segments = trimmed.split("/");
+        return segments.length == 3
+                && segments[0].equals("accounts")
+                && segments[2].equals("login");
+    }
+
+    /**
+     * Drop the i18n language prefix and guarantee a trailing slash, so one
+     * short allowlist covers /en/login/, /de/login/ and /fr/login/ without
+     * depending on how a given URL happened to be spelled.
+     */
+    private static String normalizeAuthPath(String rawPath) {
+        String path = rawPath == null ? "" : rawPath;
+        for (String language : LANGUAGE_PREFIXES) {
+            if (path.startsWith(language + "/")) {
+                path = path.substring(language.length());
+                break;
+            }
+            if (path.equals(language)) {
+                return "/";
+            }
+        }
+        return path.endsWith("/") ? path : path + "/";
+    }
+
+    private static final String[] LANGUAGE_PREFIXES = {"/en", "/de", "/fr"};
 
     /**
      * @return the URI's scheme, lower-cased, or "" if it has none. Schemes are

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -3,6 +3,7 @@ package lu.crush.app;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
@@ -24,6 +25,8 @@ import android.widget.ProgressBar;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.graphics.Insets;
 import androidx.core.splashscreen.SplashScreen;
@@ -399,8 +402,75 @@ public class MainActivity extends AppCompatActivity {
         return isInternal(Uri.parse(trimmed)) ? trimmed : null;
     }
 
+    /**
+     * Open the login handoff in a browser that is definitely not us.
+     *
+     * This used to be a bare {@code openExternal(ACTION_VIEW)}. That is fine
+     * only for as long as this app's App Links stay unverified: the handoff URL
+     * is {@code https://<appHost>/api/mobile/android/auth/handoff/}, and the
+     * manifest claims that host with {@code autoVerify="true"}. The moment
+     * assetlinks.json gains its android_app target and verification succeeds,
+     * an untargeted ACTION_VIEW can resolve straight back into this activity —
+     * which loads the handoff in the WebView, gets bounced to a login page,
+     * matches shouldStartNativeAuth again, and loops.
+     *
+     * A Custom Tab targets a concrete browser package, so it cannot resolve
+     * here no matter what this app claims. It is also what RFC 8252 appendix
+     * B.1 asks for: an in-app browser tab that shares the system browser's
+     * cookie jar and cannot be instrumented by the host app.
+     */
     private void startNativeAuth() {
-        openExternal(Uri.parse(LOGIN_HANDOFF_URL));
+        Uri handoff = Uri.parse(LOGIN_HANDOFF_URL);
+        String browserPackage = CustomTabsClient.getPackageName(this, null);
+        if (browserPackage != null) {
+            CustomTabsIntent customTab = new CustomTabsIntent.Builder()
+                    .setShowTitle(true)
+                    .build();
+            customTab.intent.setPackage(browserPackage);
+            try {
+                customTab.launchUrl(this, handoff);
+                return;
+            } catch (ActivityNotFoundException | SecurityException exception) {
+                // Fall through to the explicit-browser path below.
+            }
+        }
+
+        Intent intent = new Intent(Intent.ACTION_VIEW, handoff);
+        intent.addCategory(Intent.CATEGORY_BROWSABLE);
+        String fallbackBrowser = resolveBrowserPackage();
+        if (fallbackBrowser != null) {
+            intent.setPackage(fallbackBrowser);
+        }
+        try {
+            startActivity(intent);
+        } catch (ActivityNotFoundException | SecurityException exception) {
+            // No browser at all. Nothing useful to do; leaving the WebView on
+            // the login page beats crashing, and the user can retry.
+        }
+    }
+
+    /**
+     * Any installed browser other than this app.
+     *
+     * Probes a neutral https URL rather than our own host: once App Links
+     * verify, this activity answers for {@code https://<appHost>} and would be
+     * the first result for its own domain. Our package is filtered out either
+     * way — belt and braces, because picking ourselves is exactly the loop this
+     * whole method exists to prevent.
+     */
+    private String resolveBrowserPackage() {
+        Intent probe = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com"));
+        probe.addCategory(Intent.CATEGORY_BROWSABLE);
+        for (ResolveInfo candidate : getPackageManager().queryIntentActivities(probe, 0)) {
+            if (candidate.activityInfo == null) {
+                continue;
+            }
+            String candidatePackage = candidate.activityInfo.packageName;
+            if (candidatePackage != null && !candidatePackage.equals(getPackageName())) {
+                return candidatePackage;
+            }
+        }
+        return null;
     }
 
     /**

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -419,7 +419,7 @@ public class MainActivity extends AppCompatActivity {
      * B.1 asks for: an in-app browser tab that shares the system browser's
      * cookie jar and cannot be instrumented by the host app.
      */
-    private void startNativeAuth() {
+    private boolean startNativeAuth() {
         Uri handoff = Uri.parse(LOGIN_HANDOFF_URL);
         String browserPackage = CustomTabsClient.getPackageName(this, null);
         if (browserPackage != null) {
@@ -429,23 +429,30 @@ public class MainActivity extends AppCompatActivity {
             customTab.intent.setPackage(browserPackage);
             try {
                 customTab.launchUrl(this, handoff);
-                return;
+                return true;
             } catch (ActivityNotFoundException | SecurityException exception) {
                 // Fall through to the explicit-browser path below.
             }
         }
 
+        String fallbackBrowser = resolveBrowserPackage();
+        if (fallbackBrowser == null) {
+            // Nothing to hand this to — a managed or browser-less device.
+            // Launching untargeted here would defeat the whole point: with the
+            // App Link verified, the system could route it straight back to
+            // this activity and start the loop. Report the miss instead and let
+            // the caller keep the navigation in the WebView.
+            return false;
+        }
+
         Intent intent = new Intent(Intent.ACTION_VIEW, handoff);
         intent.addCategory(Intent.CATEGORY_BROWSABLE);
-        String fallbackBrowser = resolveBrowserPackage();
-        if (fallbackBrowser != null) {
-            intent.setPackage(fallbackBrowser);
-        }
+        intent.setPackage(fallbackBrowser);
         try {
             startActivity(intent);
+            return true;
         } catch (ActivityNotFoundException | SecurityException exception) {
-            // No browser at all. Nothing useful to do; leaving the WebView on
-            // the login page beats crashing, and the user can retry.
+            return false;
         }
     }
 
@@ -704,7 +711,13 @@ public class MainActivity extends AppCompatActivity {
                 return true;
             }
             if (shouldStartNativeAuth(uri)) {
-                startNativeAuth();
+                if (!startNativeAuth()) {
+                    // No browser available. Render the login page in the
+                    // WebView rather than dropping the navigation: an
+                    // email/password sign-in there lands a session directly, so
+                    // it is the one path still open on such a device.
+                    loadInternal(uri.toString());
+                }
                 return true;
             }
             if (isInternal(uri)) {

--- a/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
+++ b/mobile/android/CrushLU/app/src/main/java/lu/crush/app/MainActivity.java
@@ -451,9 +451,17 @@ public class MainActivity extends AppCompatActivity {
             trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
         String[] segments = trimmed.split("/");
+        if (segments.length < 3
+                || !segments[0].equals("accounts")
+                || !segments[segments.length - 1].equals("login")) {
+            return false;
+        }
+        // /accounts/<provider>/login/ for a dedicated provider, and
+        // /accounts/oidc/<provider_id>/login/ for one mounted on allauth's
+        // generic OIDC provider, which carries an extra segment. Requiring the
+        // last segment to be "login" is what keeps .../login/callback/ out.
         return segments.length == 3
-                && segments[0].equals("accounts")
-                && segments[2].equals("login");
+                || (segments.length == 4 && segments[1].equals("oidc"));
     }
 
     /**

--- a/mobile/android/CrushLU/tests/test_auth_handoff_launch.py
+++ b/mobile/android/CrushLU/tests/test_auth_handoff_launch.py
@@ -1,0 +1,64 @@
+"""Source guards for how the Android shell launches the login handoff.
+
+The handoff URL is `https://<appHost>/api/mobile/android/auth/handoff/`, and the
+manifest claims that host with `autoVerify="true"`. So an untargeted
+`ACTION_VIEW` is safe only while App Links stay unverified: the day
+`assetlinks.json` gains its `android_app` target, that intent can resolve back
+into MainActivity, which loads the handoff in the WebView, gets bounced to a
+login page, matches `shouldStartNativeAuth` again, and loops.
+
+These guards exist so the App Links fingerprint can be set on the production
+slot without arming that loop — the two changes are only safe together, and
+nothing else in the repo records that dependency.
+
+Plain unittest with no Android dependencies, so it runs on the Linux CI box
+alongside the Gradle build.
+"""
+
+from pathlib import Path
+import unittest
+
+ANDROID = Path(__file__).parents[1]
+MAIN_ACTIVITY = (
+    ANDROID / "app" / "src" / "main" / "java" / "lu" / "crush" / "app" / "MainActivity.java"
+)
+MANIFEST = ANDROID / "app" / "src" / "main" / "AndroidManifest.xml"
+BUILD_GRADLE = ANDROID / "app" / "build.gradle.kts"
+
+
+class AuthHandoffLaunchTests(unittest.TestCase):
+    def setUp(self):
+        self.activity = MAIN_ACTIVITY.read_text(encoding="utf-8")
+
+    def test_handoff_opens_in_a_custom_tab(self):
+        self.assertIn("CustomTabsIntent", self.activity)
+        self.assertIn("CustomTabsClient.getPackageName", self.activity)
+
+    def test_handoff_is_never_an_untargeted_action_view(self):
+        """openExternal() sets no package, so it can resolve back to us."""
+        start = self.activity.index("private void startNativeAuth()")
+        end = self.activity.index("private String resolveBrowserPackage()")
+        body = self.activity[start:end]
+
+        self.assertNotIn("openExternal(", body)
+        # Both launch paths pin a concrete browser package.
+        self.assertIn("customTab.intent.setPackage(browserPackage)", body)
+        self.assertIn("intent.setPackage(fallbackBrowser)", body)
+
+    def test_browser_probe_excludes_our_own_package(self):
+        self.assertIn("!candidatePackage.equals(getPackageName())", self.activity)
+
+    def test_package_visibility_is_declared(self):
+        """targetSdk 35 returns an empty query result without <queries>."""
+        manifest = MANIFEST.read_text(encoding="utf-8")
+
+        self.assertIn("<queries>", manifest)
+        self.assertIn("android.support.customtabs.action.CustomTabsService", manifest)
+        self.assertIn('<data android:scheme="https" />', manifest)
+
+    def test_androidx_browser_is_a_dependency(self):
+        self.assertIn("androidx.browser:browser", BUILD_GRADLE.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mobile/android/CrushLU/tests/test_auth_handoff_launch.py
+++ b/mobile/android/CrushLU/tests/test_auth_handoff_launch.py
@@ -34,16 +34,43 @@ class AuthHandoffLaunchTests(unittest.TestCase):
         self.assertIn("CustomTabsIntent", self.activity)
         self.assertIn("CustomTabsClient.getPackageName", self.activity)
 
+    def _start_native_auth_body(self):
+        start = self.activity.index("private boolean startNativeAuth()")
+        end = self.activity.index("private String resolveBrowserPackage()")
+        return self.activity[start:end]
+
     def test_handoff_is_never_an_untargeted_action_view(self):
         """openExternal() sets no package, so it can resolve back to us."""
-        start = self.activity.index("private void startNativeAuth()")
-        end = self.activity.index("private String resolveBrowserPackage()")
-        body = self.activity[start:end]
+        body = self._start_native_auth_body()
 
         self.assertNotIn("openExternal(", body)
         # Both launch paths pin a concrete browser package.
         self.assertIn("customTab.intent.setPackage(browserPackage)", body)
         self.assertIn("intent.setPackage(fallbackBrowser)", body)
+
+    def test_no_browser_means_no_launch_at_all(self):
+        """The dangerous case is a null package, not a missing setPackage call.
+
+        Launching an untargeted ACTION_VIEW when no browser was found would let
+        a verified App Link route the handoff straight back into this activity —
+        the exact loop this method exists to prevent, reappearing only on
+        browser-less or managed devices where nobody would look for it.
+        """
+        body = self._start_native_auth_body()
+
+        # The null check must short-circuit BEFORE the Intent is constructed.
+        null_guard = body.index("fallbackBrowser == null")
+        intent_built = body.index("new Intent(Intent.ACTION_VIEW, handoff)")
+        self.assertLess(
+            null_guard,
+            intent_built,
+            "the no-browser case must return before an intent is built",
+        )
+        self.assertIn("return false;", body)
+
+    def test_no_browser_falls_back_to_login_inside_the_webview(self):
+        """Dropping the navigation would strand the user; the WebView login works."""
+        self.assertIn("if (!startNativeAuth()) {", self.activity)
 
     def test_browser_probe_excludes_our_own_package(self):
         self.assertIn("!candidatePackage.equals(getPackageName())", self.activity)

--- a/mobile/ios/CrushLU/CrushLU/CrushWebView.swift
+++ b/mobile/ios/CrushLU/CrushLU/CrushWebView.swift
@@ -334,7 +334,15 @@ struct CrushWebView: UIViewRepresentable {
         /// only ever arrives in the browser that started the flow.
         private static func isProviderLoginStart(_ path: String) -> Bool {
             let segments = path.split(separator: "/", omittingEmptySubsequences: true)
-            return segments.count == 3 && segments[0] == "accounts" && segments[2] == "login"
+            guard segments.count >= 3,
+                  segments[0] == "accounts",
+                  segments[segments.count - 1] == "login"
+            else { return false }
+            // /accounts/<provider>/login/ for a dedicated provider, and
+            // /accounts/oidc/<provider_id>/login/ for one mounted on allauth's
+            // generic OIDC provider, which carries an extra segment. Requiring
+            // the last segment to be "login" keeps .../login/callback/ out.
+            return segments.count == 3 || (segments.count == 4 && segments[1] == "oidc")
         }
 
         /// Drop the i18n language prefix and guarantee a trailing slash.

--- a/mobile/ios/CrushLU/CrushLU/CrushWebView.swift
+++ b/mobile/ios/CrushLU/CrushLU/CrushWebView.swift
@@ -304,10 +304,56 @@ struct CrushWebView: UIViewRepresentable {
             decisionHandler(.cancel)
         }
 
+        /// The only pages that belong in ASWebAuthenticationSession: the login
+        /// entry points themselves.
+        ///
+        /// `crush_login_required` bounces to `crush_lu:login` (`/<lang>/login/`)
+        /// and allauth's own `@login_required` bounces to `/accounts/login/`, so
+        /// both are here. Everything else under `/accounts/` — password reset,
+        /// email management, connected accounts, the confirm-email landing — is
+        /// an ordinary signed-in page and must stay in the WKWebView, which is
+        /// where the member's session lives. Matching the whole prefix pushed
+        /// those into a browser holding a different session.
+        private static let authEntryPaths: Set<String> = ["/login/", "/accounts/login/"]
+
         private func shouldStartNativeAuth(for url: URL) -> Bool {
             guard isInternal(url) else { return false }
-            let path = url.path
-            return path.hasSuffix("/login/") || path.contains("/accounts/")
+            let path = Self.normalizeAuthPath(url.path)
+            return Self.authEntryPaths.contains(path) || Self.isProviderLoginStart(path)
+        }
+
+        /// `/accounts/<provider>/login/` — the "Continue with LuxID/Google/…"
+        /// button on the in-app signup page.
+        ///
+        /// These must open the auth browser too. Left in the WKWebView, the
+        /// OAuth state is stashed in the WebView's session while the provider
+        /// redirect leaves for Safari, so the callback lands where it cannot be
+        /// matched: signed in inside a browser, still anonymous in the app.
+        ///
+        /// Excludes `.../login/callback/`, which carries one segment more and
+        /// only ever arrives in the browser that started the flow.
+        private static func isProviderLoginStart(_ path: String) -> Bool {
+            let segments = path.split(separator: "/", omittingEmptySubsequences: true)
+            return segments.count == 3 && segments[0] == "accounts" && segments[2] == "login"
+        }
+
+        /// Drop the i18n language prefix and guarantee a trailing slash.
+        ///
+        /// The trailing slash is not cosmetic: `URL.path` is documented to strip
+        /// one, so a suffix test against "/login/" is not something to rely on.
+        /// Normalising both sides removes the question.
+        private static func normalizeAuthPath(_ rawPath: String) -> String {
+            var path = rawPath
+            for language in ["/en", "/de", "/fr"] {
+                if path == language {
+                    return "/"
+                }
+                if path.hasPrefix(language + "/") {
+                    path = String(path.dropFirst(language.count))
+                    break
+                }
+            }
+            return path.hasSuffix("/") ? path : path + "/"
         }
 
         private func startNativeAuth() {

--- a/mobile/ios/CrushLU/tests/test_auth_intercept_scope.py
+++ b/mobile/ios/CrushLU/tests/test_auth_intercept_scope.py
@@ -51,7 +51,11 @@ def is_provider_login_start(path):
     only ever arrives in the browser that started the flow.
     """
     segments = [s for s in path.split("/") if s]
-    return len(segments) == 3 and segments[0] == "accounts" and segments[2] == "login"
+    if len(segments) < 3 or segments[0] != "accounts" or segments[-1] != "login":
+        return False
+    # /accounts/<provider>/login/, and /accounts/oidc/<provider_id>/login/ for
+    # a provider mounted on allauth's generic OIDC provider (one segment more).
+    return len(segments) == 3 or (len(segments) == 4 and segments[1] == "oidc")
 
 
 def should_start_native_auth(path):
@@ -77,6 +81,10 @@ MUST_INTERCEPT = [
     "/accounts/facebook/login/",
     "/accounts/microsoft/login/",
     "/accounts/apple/login/",
+    # allauth's generic OIDC provider is installed (LinkedIn uses it on
+    # Entreprinder) and its route is mounted on the crush urlconf too, so any
+    # OIDC SocialApp configured later inherits the same strand.
+    "/accounts/oidc/some-provider/login/",
 ]
 
 # Pages that must stay in the WebView, where the member's session is.
@@ -99,6 +107,7 @@ MUST_NOT_INTERCEPT = [
     "/accounts/google/login/callback/",
     "/accounts/apple/login/callback/",
     "/accounts/facebook/login/token/",
+    "/accounts/oidc/some-provider/login/callback/",
     # Ordinary app pages, including the logout the UI actually links to.
     "/en/logout/",
     "/en/signup/",

--- a/mobile/ios/CrushLU/tests/test_auth_intercept_scope.py
+++ b/mobile/ios/CrushLU/tests/test_auth_intercept_scope.py
@@ -1,0 +1,164 @@
+"""Which URLs the native shells hand to the external auth browser.
+
+Both shells cancel a WebView navigation and open a browser session when the
+URL looks like a login page. The predicate used to be
+``path.endsWith("/login/") || path.contains("/accounts/")``, which matched far
+more than login: password reset, email management, connected accounts and the
+confirm-email landing all live under ``/accounts/``. Those are ordinary
+signed-in pages, and pushing them into a browser puts them in front of a
+*different* session from the one in the WebView, so the flows either dead-end
+or apply somewhere the member cannot see.
+
+The rule is now an allowlist of the actual entry points: the login pages, plus
+`/accounts/<provider>/login/` matched structurally so a newly configured
+provider is covered without touching either shell. Narrowing it to the login
+pages alone was tried first and was wrong — it stranded social signup, because
+the OAuth state is stashed in the WebView session while the provider redirect
+leaves for the system browser, so the callback lands where it cannot be
+matched and the member ends up signed in to a browser and anonymous in the app.
+
+This test models the rule against the real URL surface (taken from the crush
+urlconf) so both a widening and that narrowing have to break a named
+expectation rather than slipping through.
+
+The model below is deliberately a re-implementation rather than a parse of the
+Swift and Java: it states what the rule should be, and the source guards at the
+bottom check both shells still implement that rule.
+"""
+
+from pathlib import Path
+import unittest
+
+LANGUAGE_PREFIXES = ("/en", "/de", "/fr")
+AUTH_ENTRY_PATHS = {"/login/", "/accounts/login/"}
+
+
+def normalize_auth_path(raw_path):
+    path = raw_path or ""
+    for language in LANGUAGE_PREFIXES:
+        if path == language:
+            return "/"
+        if path.startswith(language + "/"):
+            path = path[len(language):]
+            break
+    return path if path.endswith("/") else path + "/"
+
+
+def is_provider_login_start(path):
+    """/accounts/<provider>/login/ — the "Continue with X" buttons.
+
+    Excludes /accounts/<provider>/login/callback/, one segment longer, which
+    only ever arrives in the browser that started the flow.
+    """
+    segments = [s for s in path.split("/") if s]
+    return len(segments) == 3 and segments[0] == "accounts" and segments[2] == "login"
+
+
+def should_start_native_auth(path):
+    normalized = normalize_auth_path(path)
+    return normalized in AUTH_ENTRY_PATHS or is_provider_login_start(normalized)
+
+
+# Every login entry point a WebView can be bounced to. crush_login_required
+# sends users to crush_lu:login (/<lang>/login/); allauth's own @login_required
+# sends them to /accounts/login/.
+MUST_INTERCEPT = [
+    "/login/",
+    "/en/login/",
+    "/de/login/",
+    "/fr/login/",
+    "/accounts/login/",
+    # The "Continue with X" buttons on the in-app signup page. Left in the
+    # WebView, the OAuth state is stashed in the WebView session while the
+    # provider redirect leaves for the system browser, so the callback lands
+    # where it cannot be matched: signed in in a browser, anonymous in the app.
+    "/accounts/luxid/login/",
+    "/accounts/google/login/",
+    "/accounts/facebook/login/",
+    "/accounts/microsoft/login/",
+    "/accounts/apple/login/",
+]
+
+# Pages that must stay in the WebView, where the member's session is.
+MUST_NOT_INTERCEPT = [
+    # The regression this test exists for: account management under /accounts/.
+    "/accounts/logout/",
+    "/accounts/email/",
+    "/accounts/password/change/",
+    "/accounts/password/reset/",
+    "/accounts/password/reset/key/abc-def/",
+    "/accounts/confirm-email/SOMEKEY/",
+    "/accounts/3rdparty/",
+    "/accounts/social/connections/",
+    "/accounts/signup/",
+    "/accounts/inactive/",
+    "/accounts/reauthenticate/",
+    # Callbacks belong to the browser that started the flow — one segment
+    # longer than the provider start, and never a reason to open a second
+    # auth session on top of the first.
+    "/accounts/google/login/callback/",
+    "/accounts/apple/login/callback/",
+    "/accounts/facebook/login/token/",
+    # Ordinary app pages, including the logout the UI actually links to.
+    "/en/logout/",
+    "/en/signup/",
+    "/en/dashboard/",
+    "/en/events/",
+    "/en/crush-connect/catalogue/",
+    "/api/mobile/ios/auth/complete/CODE/",
+]
+
+
+class AuthInterceptScopeTests(unittest.TestCase):
+    def test_login_entry_points_are_intercepted(self):
+        for path in MUST_INTERCEPT:
+            with self.subTest(path=path):
+                self.assertTrue(
+                    should_start_native_auth(path),
+                    f"{path} is a login entry point and must open the auth browser",
+                )
+
+    def test_account_pages_stay_in_the_webview(self):
+        for path in MUST_NOT_INTERCEPT:
+            with self.subTest(path=path):
+                self.assertFalse(
+                    should_start_native_auth(path),
+                    f"{path} must not be pushed into a browser with a different session",
+                )
+
+    def test_trailing_slash_is_normalized_not_assumed(self):
+        """URL.path is documented to strip a trailing slash on Apple platforms."""
+        self.assertTrue(should_start_native_auth("/en/login"))
+        self.assertTrue(should_start_native_auth("/accounts/login"))
+
+    def test_both_shells_implement_the_allowlist(self):
+        swift = (
+            Path(__file__).parents[1] / "CrushLU" / "CrushWebView.swift"
+        ).read_text(encoding="utf-8")
+        java = (
+            Path(__file__).parents[3]
+            / "android"
+            / "CrushLU"
+            / "app"
+            / "src"
+            / "main"
+            / "java"
+            / "lu"
+            / "crush"
+            / "app"
+            / "MainActivity.java"
+        ).read_text(encoding="utf-8")
+
+        for source, name in ((swift, "CrushWebView.swift"), (java, "MainActivity.java")):
+            with self.subTest(source=name):
+                # The prefix match is what over-captured; it must not come back.
+                self.assertNotIn('contains("/accounts/")', source)
+                self.assertIn('"/accounts/login/"', source)
+                self.assertIn('"/login/"', source)
+                # Provider starts are matched structurally, not enumerated, so a
+                # newly added provider is covered without touching the shells.
+                self.assertIn("isProviderLoginStart", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Both native shells decide "this URL is a login page" with `path.endsWith("/login/") || path.contains("/accounts/")`. The second half matches the entire allauth surface, so these were all cancelled in the WebView and re-opened in an external browser — one that holds a **different session** from the one the member is signed into:

```
/accounts/password/reset/          /accounts/email/
/accounts/password/reset/key/…/    /accounts/confirm-email/KEY/
/accounts/password/change/         /accounts/3rdparty/
/accounts/logout/                  /accounts/social/connections/
```

Password reset from inside the app dead-ends. Email management applies somewhere the member cannot see.

Replaced with an allowlist of the real entry points: the login pages (`/accounts/login/` for allauth's `@login_required`, `/<lang>/login/` for `crush_login_required`), plus `/accounts/<provider>/login/` matched structurally.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

One deliberate scope change, called out below: `/admin/login/` and `/crush-admin/login/` are no longer intercepted.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

```
python -m unittest discover -s mobile/ios/CrushLU/tests -v
```

8 tests pass. This is the same job CI runs (`ios-build-verification.yml`) — worth knowing that `pytest.ini`'s `testpaths` does not include `mobile/`, so `pytest` alone never collects these.

Manual, once built: from a signed-out app, tap Sign up → "Continue with LuxID" and confirm the auth browser opens. Then signed in, open password reset from account settings and confirm it stays in the app.

## What to Check

* **The provider half is load-bearing.** I first narrowed this to the login pages alone, and that was wrong — an adversarial pass caught it before it shipped. The "Continue with LuxID/Google/Apple/…" buttons on the in-app signup page ([auth.html:75-134](crush_lu/templates/crush_lu/auth.html)) point straight at `/accounts/<provider>/login/`. Left in the WebView, allauth stashes the OAuth state in the WebView's session while the provider redirect leaves for the system browser, so the callback lands somewhere that cannot match it: **the member ends up signed in inside a browser and still anonymous in the app**, with no `crushlu://` callback and no auth code. The old broad match covered this by accident; the replacement covers it on purpose.
* **Structural, not enumerated.** `/accounts/<provider>/login/` is matched by segment count, so adding a sixth provider needs no shell change. Callbacks are excluded — one segment longer, and they only ever arrive in the browser that started the flow.
* **Path normalization.** Language prefix stripped, trailing slash guaranteed. The slash matters: `URL.path` is documented to strip one on Apple platforms, so the old `hasSuffix("/login/")` rested on an assumption. `LANGUAGE_PREFIXES` is `en/de/fr`, matching `settings.LANGUAGES` — **if a fourth locale is ever added, `/lb/login/` silently stops being intercepted.** That is the one latent hazard in this approach.
* **Admin login scope change.** `/admin/login/` and `/crush-admin/login/` were intercepted before and are not now. I read that as a fix — they are staff username/password forms that work fine in the WebView, and the auth sheet would have run the *member* handoff against them. Push back if you disagree.

## Other Information

Follows from the native-auth audit. Still open from it, none of them here:

* **Android App Links are unverified in production** — `assetlinks.json` serves only a `web` target because `ANDROID_APP_SHA256_CERT_FINGERPRINTS` is unset on the prod slot, so every `https://crush.lu/…` deep link opens the browser instead of the app. Fixing it **arms** a handoff self-resolution loop unless a Custom Tab ships in the same release.
* **Android callback replay** — `onCreate` re-reads `getIntent().getData()` with no `savedInstanceState` guard, and `configChanges` omits `uiMode`, so an automatic dark-theme flip replays a spent auth code hours later. #921 made the server tolerate it; the wasted round-trip remains.
* **Standards tier** — no PKCE, the code travelling as a URL path segment into four log stores, the private-use `crushlu://` scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
