### PR TITLE
fix(wallet): use PassKit SHA-1 manifest hashes

### DIFF
--- a/crush_lu/tests/test_apple_wallet.py
+++ b/crush_lu/tests/test_apple_wallet.py
@@ -148,7 +148,8 @@ class TestBuildApplePass:
         manifest = json.loads(zf.read("manifest.json"))
 
         for filename, expected_hash in manifest.items():
-            actual_hash = hashlib.sha256(zf.read(filename)).hexdigest()
+            assert len(expected_hash) == 40
+            actual_hash = hashlib.sha1(zf.read(filename)).hexdigest()  # nosec B324
             assert actual_hash == expected_hash, f"Hash mismatch for {filename}"
 
 
@@ -193,6 +194,20 @@ class TestBuildAppleEventTicket:
         assert "pass.json" in names
         assert "manifest.json" in names
         assert "signature" in names
+
+    def test_manifest_matches_file_hashes(self, event_with_registrations):
+        from crush_lu.wallet.apple_event_ticket import build_apple_event_ticket
+
+        _event, registrations = event_with_registrations
+        pkpass_bytes = build_apple_event_ticket(registrations[0])
+
+        zf = zipfile.ZipFile(BytesIO(pkpass_bytes))
+        manifest = json.loads(zf.read("manifest.json"))
+
+        for filename, expected_hash in manifest.items():
+            assert len(expected_hash) == 40
+            actual_hash = hashlib.sha1(zf.read(filename)).hexdigest()  # nosec B324
+            assert actual_hash == expected_hash, f"Hash mismatch for {filename}"
 
     def test_pass_uses_event_ticket_style(self, event_with_registrations):
         from crush_lu.wallet.apple_event_ticket import build_apple_event_ticket

--- a/crush_lu/tests/test_apple_wallet_manifest.py
+++ b/crush_lu/tests/test_apple_wallet_manifest.py
@@ -1,0 +1,40 @@
+"""Certificate-free regression tests for PKPass manifest hashes."""
+
+import hashlib
+import json
+import zipfile
+from io import BytesIO
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("style", "fields"),
+    [
+        pytest.param("generic", {"generic": {}}, id="member-pass"),
+        pytest.param("eventTicket", {"eventTicket": {}}, id="event-ticket"),
+    ],
+)
+def test_pkpass_manifest_uses_passkit_sha1_hashes(monkeypatch, style, fields):
+    from crush_lu.wallet import apple_pass
+
+    monkeypatch.setattr(apple_pass, "_load_brand_assets", dict)
+    monkeypatch.setattr(apple_pass, "_sign_manifest", lambda _manifest: b"signature")
+
+    payload = {
+        "formatVersion": 1,
+        "passTypeIdentifier": "pass.lu.crush",
+        "serialNumber": f"test-{style}",
+        "teamIdentifier": "C5XDPB2G33",
+        "organizationName": "Crush.lu",
+        "description": "Manifest regression test",
+        **fields,
+    }
+    pkpass_bytes = apple_pass._build_pkpass(payload)
+
+    with zipfile.ZipFile(BytesIO(pkpass_bytes)) as pkpass:
+        manifest = json.loads(pkpass.read("manifest.json"))
+        for filename, expected_hash in manifest.items():
+            assert len(expected_hash) == 40
+            actual_hash = hashlib.sha1(pkpass.read(filename)).hexdigest()  # nosec B324
+            assert actual_hash == expected_hash, f"Hash mismatch for {filename}"

--- a/crush_lu/wallet/apple_pass.py
+++ b/crush_lu/wallet/apple_pass.py
@@ -343,11 +343,12 @@ def _build_pkpass(pass_payload, files=None):
         pass_payload, ensure_ascii=False, separators=(",", ":")
     ).encode("utf-8")
 
-    # Build manifest (SHA-256 hashes of all files, supported since iOS 13+)
+    # The PKPass format requires SHA-1 file hashes in manifest.json. SHA-1 is
+    # used only for package compatibility here; the detached signature uses SHA-256.
     manifest = {}
-    manifest["pass.json"] = hashlib.sha256(pass_json_bytes).hexdigest()
+    manifest["pass.json"] = hashlib.sha1(pass_json_bytes).hexdigest()  # nosec B324
     for filename, content in files.items():
-        manifest[filename] = hashlib.sha256(content).hexdigest()
+        manifest[filename] = hashlib.sha1(content).hexdigest()  # nosec B324
 
     manifest_bytes = json.dumps(
         manifest, ensure_ascii=False, separators=(",", ":")


### PR DESCRIPTION
## Summary
- generate PKPass `manifest.json` entries with the SHA-1 digests required by PassKit
- keep the detached PKCS#7 signature on SHA-256
- correct the existing member-pass regression test and add event-ticket coverage
- add certificate-free tests so CI catches 64-character SHA-256 regressions

## Verification
- RED: member and event-ticket tests failed with `64 != 40` before the fix
- GREEN: targeted manifest tests: 2 passed
- Wallet/PassKit regression suite: 213 passed
- Ruff: passed on production file and certificate-free tests
- Bandit: passed on production file (`# nosec B324` documents format-mandated non-security SHA-1)
- `git diff --check`: passed
- independent review: no security concerns or logic errors

## Deployment
Server-only fix. No new iOS build is required. After deployment, retest Apple Wallet using TestFlight 1.0.2 (4).