### PR TITLE
fix(payments): give payment receipts language-prefixed footer links

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -738,6 +738,13 @@ def _send_payment_receipt(payment, *, subject_message, template_name, request=No
         "payment": payment,
         "LANGUAGE_CODE": lang,
         "social_links": get_social_links(),
+        # base_email.html's footer defaults are UNPREFIXED (/about/, /events/),
+        # and every member route lives under i18n_patterns. Without these the
+        # body arrives in French while its own footer links resolve by browser
+        # negotiation — an English page for a French-preferring member. Keyed on
+        # the resolved recipient, so an assisted purchase still links in the
+        # member's language, not the staff opener's.
+        **get_email_base_urls(user, request),
     }
 
     with translation.override(lang):

--- a/crush_lu/tests/test_sumup_payments.py
+++ b/crush_lu/tests/test_sumup_payments.py
@@ -833,6 +833,32 @@ class PremiumBetaAllowlistTests(SiteTestMixin, TestCase):
         self.assertEqual(mail.outbox[0].to, [self.user.email])
         self.assertNotIn(staff.email, mail.outbox[0].to)
 
+    def test_a_receipt_footer_links_in_the_recipients_language(self):
+        """The body is translated; the footer must not send them to English.
+
+        base_email.html's footer defaults are unprefixed (`/about/`), and every
+        member route lives under i18n_patterns — so an omitted `about_url`
+        resolves by browser negotiation, not by the language of the email.
+        """
+        from django.core import mail
+        from crush_lu.email_helpers import send_premium_membership_payment_receipt
+
+        profile = self.user.crushprofile
+        profile.preferred_language = "fr"
+        profile.save(update_fields=["preferred_language"])
+        tx = self._open_checkout()
+
+        mail.outbox = []
+        send_premium_membership_payment_receipt(tx)
+
+        # send_domain_email puts the HTML straight in .body and flips the
+        # content type; there is no alternatives list to read.
+        html = mail.outbox[0].body
+        self.assertIn("/fr/about/", html)
+        self.assertIn("/fr/events/", html)
+        for unprefixed in ("https://crush.lu/about/", "https://crush.lu/events/"):
+            self.assertNotIn(unprefixed, html)
+
     def test_a_receipt_greets_a_member_who_has_no_first_name(self):
         """Social signups whose provider supplies no given name keep
         ``first_name=""``. The greeting must not render as "Thank you, !"."""


### PR DESCRIPTION
Follow-up to #924. Codex raised this as P2 on `c0112fd9` **after** that PR had already merged, so it lands as its own change.

## The bug

`base_email.html`'s footer defaults are unprefixed:

```
<a href="{{ about_url|default:'https://crush.lu/about/' }}">
<a href="{{ events_url|default:'https://crush.lu/events/' }}">
```

Every member route lives under `i18n_patterns`. The receipt context omitted `home_url` / `about_url` / `events_url`, so those defaults won and the links resolved by **browser** language negotiation instead of the language of the email.

Rendered proof, from the test failing against the previous commit — a fully French receipt whose own footer is unprefixed:

```html
<h1>Paiement reçu</h1>
<h2>Merci !</h2>
<p>Nous avons bien reçu votre paiement pour l'adhésion Premium…</p>
...
<a href="https://crush.lu/about/">À propos</a> |
<a href="https://crush.lu/events/">Événements</a>
```

A French-preferring member on an English browser reads a French email and lands on English pages.

## The fix

Spread the existing `get_email_base_urls(user, request)` into the context — the helper every other sender already uses. One line plus a comment.

Two details worth noting:

- **Keyed on the resolved recipient, not `payment.user`.** Same rule as the receipt address itself (#924): on a staff-assisted purchase `payment.user` is the *staff* account, so keying the URLs off it would link in the staff member's language.
- **`request=None` is the normal case here.** Receipts are sent from a `transaction.on_commit` callback that carries only the payment. `get_user_language_url` documents and handles this, falling back to the canonical domain via `build_absolute_url`.

`settings_url` and `terms_url` also come along, but `base_email.html` only renders `settings_url` inside `{% if unsubscribe_url %}` — which receipts deliberately do not set — so this does not put an opt-out on a transactional email.

## Verification

- Test **fails against the previous commit** with `'/fr/about/' not found`, and passes with the fix — it asserts both that `/fr/about/` and `/fr/events/` are present *and* that the unprefixed forms are absent
- `pytest crush_lu/tests/test_sumup_payments.py` — **184 passed** on SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
