### PR TITLE
fix(connect): stop inviting members who paused Connect themselves

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -2299,6 +2299,32 @@ def send_connect_beta_invite(user, wave, request=None):
         logger.info(f"Skipping Connect beta invite to {user.email} - unsubscribed")
         return 0
 
+    # Re-read the pause at send time, not only when the caller built its cohort.
+    # A wave is up to 200 sends off one materialised list, so a member who hits
+    # pause while the run is working through the earlier recipients would
+    # otherwise still be mailed by that same run. This is a fresh query (the
+    # cohort only select_related's the profile), which is the point.
+    #
+    # Placed beside the unsubscribe guard rather than in the command so it
+    # covers every caller, and returning 0 reuses the established contract:
+    # the caller leaves the row un-stamped, so reactivating restores the member
+    # to a future wave instead of silently consuming their slot.
+    # NB: query, do NOT traverse ``user.crush_connect_membership``. That is a
+    # reverse OneToOne whose descriptor caches, so on a ``user`` instance that
+    # already touched it the attribute hands back a STALE object — measured:
+    # the cached copy reported is_paused False while the row said True. A guard
+    # reading the cache re-checks nothing, and worse, does so nondeterministically
+    # depending on how the caller built its queryset.
+    from .models.crush_connect import CrushConnectMembership
+
+    if CrushConnectMembership.objects.filter(
+        user=user, paused_at__isnull=False
+    ).exists():
+        logger.info(
+            "Skipping Connect beta invite to %s - paused Crush Connect", user.email
+        )
+        return 0
+
     cta_url = get_user_language_url(user, _CONNECT_BETA_CTA_URL_NAME[wave], request)
     dashboard_url = get_user_language_url(user, "crush_lu:dashboard", request)
 

--- a/crush_lu/management/commands/send_connect_beta_invites.py
+++ b/crush_lu/management/commands/send_connect_beta_invites.py
@@ -118,10 +118,15 @@ def candidates_for_wave(wave):
         # waitlist -> onboarded -> paused is a reachable, live state that
         # otherwise stays a candidate forever.
         #
-        # exclude(...__isnull=False), NOT filter(paused_at__isnull=True): the
-        # membership is a OneToOne that most of the waitlist does not have at
-        # all, and filtering across it would inner-join them all away. exclude()
-        # drops only the rows that actually have a paused membership.
+        # Written as exclude(...__isnull=False) because that states the rule
+        # directly: drop the rows that have a paused membership. The obvious
+        # alternative, filter(paused_at__isnull=True), happens to behave
+        # identically -- checked, both emit a LEFT OUTER JOIN, because Django
+        # promotes the join for __isnull=True -- so members who never onboarded
+        # survive either way. That equivalence is the kind of thing that is easy
+        # to assume and easy to get backwards, so
+        # test_a_member_without_a_membership_row_is_still_a_candidate pins the
+        # behaviour rather than trusting either reading of it.
         .exclude(user__crush_connect_membership__paused_at__isnull=False)
         .select_related("user__crushprofile")
         .order_by("joined_at")

--- a/crush_lu/management/commands/send_connect_beta_invites.py
+++ b/crush_lu/management/commands/send_connect_beta_invites.py
@@ -112,6 +112,36 @@ def candidates_for_wave(wave):
             beta_invited_at__isnull=True,
             notification_preference=True,
         )
+        # A member who paused Crush Connect themselves must not be mailed
+        # "your Connect Week is open" — their own pause is what is holding it
+        # shut. Nothing deletes the waitlist row when a member onboards, so
+        # waitlist -> onboarded -> paused is a reachable, live state that
+        # otherwise stays a candidate forever.
+        #
+        # exclude(...__isnull=False), NOT filter(paused_at__isnull=True): the
+        # membership is a OneToOne that most of the waitlist does not have at
+        # all, and filtering across it would inner-join them all away. exclude()
+        # drops only the rows that actually have a paused membership.
+        .exclude(user__crush_connect_membership__paused_at__isnull=False)
+        .select_related("user__crushprofile")
+        .order_by("joined_at")
+    )
+    return [row for row in rows if wave_for_user(row.user) == wave]
+
+
+def paused_candidates_for_wave(wave):
+    """The members ``candidates_for_wave`` just dropped for pausing.
+
+    Reporting-only, and deliberately wave-scoped the same way the cohort is: a
+    flat count of every paused waitlist row would report wave-2 members while
+    wave 1 is being sent, which is worse than saying nothing.
+    """
+    rows = (
+        CrushConnectWaitlist.objects.filter(
+            beta_invited_at__isnull=True,
+            notification_preference=True,
+            user__crush_connect_membership__paused_at__isnull=False,
+        )
         .select_related("user__crushprofile")
         .order_by("joined_at")
     )
@@ -192,6 +222,14 @@ class Command(BaseCommand):
             f"  eligible, not yet invited: {len(candidates)}  "
             f"(limit {limit}{', DRY RUN' if dry_run else ''})"
         )
+        # Say so out loud: a cohort that silently shrank looks identical to one
+        # that was always that size, and "why did N members not get this?" is
+        # the first question anyone asks after a wave goes out.
+        paused_skipped = len(paused_candidates_for_wave(wave))
+        if paused_skipped:
+            self.stdout.write(
+                f"  skipped, paused Connect themselves: {paused_skipped}"
+            )
 
         if not candidates:
             self.stdout.write(self.style.SUCCESS("Nothing to send."))

--- a/crush_lu/tests/test_connect_beta_invite_pause.py
+++ b/crush_lu/tests/test_connect_beta_invite_pause.py
@@ -1,0 +1,147 @@
+"""Regression: the Connect beta invite must respect a member's own pause.
+
+``send_connect_beta_invites`` (Task 13.4, #911) and the member-controlled
+Connect pause (#919) shipped alongside each other and were never cross-checked.
+They overlap on a real, reachable member state:
+
+  * ``CrushConnectMembership.pause()`` is a self-service snooze that removes a
+    member from "new Connect discovery and interaction flows" (model docstring).
+    It writes ``paused_at`` only — it never touches the waitlist row.
+  * ``candidates_for_wave`` filters solely on ``beta_invited_at__isnull=True``
+    and ``notification_preference=True``. It never looks at the membership.
+
+Nothing deletes the ``CrushConnectWaitlist`` row when a member onboards, so an
+early adopter who joined the waitlist, onboarded into Connect, then hit pause
+is still a live invite candidate. The campaign then mails them "your Connect
+Week is open" while their own pause is what is holding it shut.
+
+The precedent for the fix is already in this codebase: ``pre_screening_
+notifications`` gates both of its sends on ``submission.is_paused``.
+"""
+
+from io import StringIO
+
+import pytest
+from django.core import mail
+from django.core.cache import cache
+from django.core.management import call_command
+
+from crush_lu.management.commands.send_connect_beta_invites import (
+    candidates_for_wave,
+    paused_candidates_for_wave,
+)
+from crush_lu.models.crush_connect import (
+    CrushConnectMembership,
+    CrushConnectWaitlist,
+)
+from crush_lu.tests.test_crush_connect import _make_user, _mark_attended
+
+
+@pytest.fixture(autouse=True)
+def _clear_invite_lock():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _waitlisted_paused_member(username="paused_member"):
+    """A wave-1 (event-verified) waitlist member who has paused Connect."""
+    user = _make_user(username=username, premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    membership, _ = CrushConnectMembership.objects.get_or_create(user=user)
+    membership.pause()
+    assert membership.is_paused, "fixture must actually pause the member"
+    return user
+
+
+@pytest.mark.django_db
+def test_paused_member_is_not_an_invite_candidate():
+    """A self-paused member must drop out of the cohort entirely."""
+    user = _waitlisted_paused_member()
+
+    candidates = candidates_for_wave(1)
+
+    assert user.id not in [row.user_id for row in candidates], (
+        "a member who paused Crush Connect themselves is still selected for "
+        "the beta invite campaign"
+    )
+
+
+@pytest.mark.django_db
+def test_paused_member_is_not_mailed():
+    """End-to-end: the command must not send to a paused member."""
+    user = _waitlisted_paused_member()
+    mail.outbox.clear()
+
+    call_command("send_connect_beta_invites", "--wave", "1")
+
+    recipients = [addr for m in mail.outbox for addr in m.to]
+    assert user.email not in recipients, (
+        f"paused member {user.email} was mailed a Connect beta invite"
+    )
+
+
+@pytest.mark.django_db
+def test_paused_member_row_is_not_consumed():
+    """Skipping must not stamp ``beta_invited_at``.
+
+    The row is left un-stamped on purpose so that resuming the membership
+    restores the member to a future wave, exactly like the unsubscribe path
+    which the command already leaves un-stamped ("an unsubscribe is not an
+    invite, and stamping it would consume the member's slot").
+    """
+    user = _waitlisted_paused_member()
+
+    call_command("send_connect_beta_invites", "--wave", "1")
+
+    row = CrushConnectWaitlist.objects.get(user=user)
+    assert row.beta_invited_at is None, (
+        "a skipped paused member had their invite slot consumed"
+    )
+
+
+@pytest.mark.django_db
+def test_unpaused_member_is_still_invited():
+    """Guard against over-correcting: the normal path must keep working."""
+    user = _make_user(username="active_member", premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    candidates = candidates_for_wave(1)
+
+    assert user.id in [row.user_id for row in candidates]
+
+
+@pytest.mark.django_db
+def test_resumed_member_becomes_a_candidate_again():
+    """Pause is reversible, so exclusion from the cohort must be too."""
+    user = _waitlisted_paused_member(username="resumer")
+    membership = CrushConnectMembership.objects.get(user=user)
+    # reactivate(), not resume(): it also rebuilds the MatchScore cache that
+    # pause() dropped, which is why the un-pause is not just a flag flip.
+    membership.reactivate()
+    assert not membership.is_paused
+
+    candidates = candidates_for_wave(1)
+
+    assert user.id in [row.user_id for row in candidates]
+
+
+@pytest.mark.django_db
+def test_the_skipped_count_is_reported_and_wave_scoped():
+    """An operator must be able to see the cohort shrank, and why.
+
+    Wave-scoped on purpose: a flat count of every paused row would report
+    wave-2 members while wave 1 is being sent.
+    """
+    paused = _waitlisted_paused_member(username="paused_w1")
+
+    assert [row.user_id for row in paused_candidates_for_wave(1)] == [paused.id]
+    # ...and they are not double-counted into a wave they do not belong to.
+    assert paused.id not in [row.user_id for row in paused_candidates_for_wave(2)]
+
+    out = StringIO()
+    call_command("send_connect_beta_invites", "--wave", "1", "--dry-run", stdout=out)
+    assert "skipped, paused Connect themselves: 1" in out.getvalue()

--- a/crush_lu/tests/test_connect_beta_invite_pause.py
+++ b/crush_lu/tests/test_connect_beta_invite_pause.py
@@ -145,3 +145,77 @@ def test_the_skipped_count_is_reported_and_wave_scoped():
     out = StringIO()
     call_command("send_connect_beta_invites", "--wave", "1", "--dry-run", stdout=out)
     assert "skipped, paused Connect themselves: 1" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_a_member_who_pauses_mid_run_is_not_mailed():
+    """The cohort filter alone leaves a time-of-check/time-of-use hole.
+
+    ``candidates_for_wave`` materialises a list, then the command works through
+    up to 200 sends. A member who hits pause while the run is still on earlier
+    recipients is already in that list, so the send itself has to re-check.
+    """
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _make_user(username="mid_run", premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    # In the cohort at check time...
+    assert user.id in [row.user_id for row in candidates_for_wave(1)]
+
+    # ...then they pause while the run is under way.
+    membership, _ = CrushConnectMembership.objects.get_or_create(user=user)
+    membership.pause()
+
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 1)
+
+    assert delivered == 0, "a member who paused mid-run was still mailed"
+    assert user.email not in [addr for m in mail.outbox for addr in m.to]
+
+
+def _waitlisted_without_membership(username="no_membership"):
+    """A waitlist member who never onboarded — the majority of the waitlist.
+
+    ``_make_user`` always creates a CrushConnectMembership, so the row has to
+    be removed explicitly to model someone who only ever joined the waitlist.
+    """
+    user = _make_user(username=username, premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectMembership.objects.filter(user=user).delete()
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+    assert not CrushConnectMembership.objects.filter(user=user).exists()
+    return user
+
+
+@pytest.mark.django_db
+def test_a_member_without_a_membership_row_is_still_a_candidate():
+    """Most of the waitlist never onboarded; they must stay in the wave.
+
+    The cohort now reaches across an optional OneToOne, and the risk in doing
+    that is excluding everyone who simply has no row on the far side —
+    silently emptying the campaign, which is far worse than the bug being
+    fixed. As it happens both spellings survive it (``exclude(...isnull=False)``
+    and ``filter(...isnull=True)`` both emit a LEFT OUTER JOIN, since Django
+    promotes the join for ``__isnull=True``), so this is not guarding one
+    spelling against the other — it pins the behaviour itself, for whoever
+    edits this filter next.
+    """
+    user = _waitlisted_without_membership()
+
+    assert user.id in [row.user_id for row in candidates_for_wave(1)]
+
+
+@pytest.mark.django_db
+def test_a_member_without_a_membership_row_is_still_mailed():
+    """The same trap at the send-time guard: "no row" must mean "not paused"."""
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _waitlisted_without_membership(username="no_membership_send")
+
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 1)
+
+    assert delivered == 1
+    assert user.email in [addr for m in mail.outbox for addr in m.to]


### PR DESCRIPTION
## The bug

`send_connect_beta_invites` (Task 13.4, #911) and the member-controlled Connect pause (#919) shipped alongside each other and were **never cross-checked**. `candidates_for_wave` filtered only on `beta_invited_at__isnull=True` and `notification_preference=True` — the command referenced `CrushConnectMembership` **zero** times.

Nothing deletes the `CrushConnectWaitlist` row when a member onboards, so **waitlist → onboarded → paused** is reachable and stays a live invite candidate forever. The campaign then mails them *"your Connect Week is open"* while their own pause is what is holding it shut.

## Scope — #919 is not broken

`matching.py` already filters `paused_at__isnull=True`, so **discovery honours the pause** exactly as the model docstring promises. The invite campaign was the only unguarded surface. The precedent for the fix is `pre_screening_notifications`, which gates both of its sends on `submission.is_paused` (verified: lines 126 and 190).

## Two layers, because one was not enough

**1. The cohort** (`candidates_for_wave`) excludes members with a paused membership.

**2. The send itself re-checks** (Codex P2 on this PR). The cohort is a materialised list and a wave is up to 200 sends, so a member who pauses while the run works through earlier recipients was still mailed by that same run. The guard sits beside the unsubscribe check in `send_connect_beta_invite` so it covers every caller, and returns `0` — reusing the contract where the command leaves the row un-stamped, so reactivating restores the member to a future wave instead of consuming their slot.

> ⚠️ **The first attempt at layer 2 did not work, and the test caught it.** Reading `user.crush_connect_membership` traverses a reverse OneToOne whose descriptor **caches** — measured, the cached copy reported `is_paused False` while the row said `True`. That guard re-checked nothing, and would have failed nondeterministically depending on how the caller built its queryset. It is now an explicit `.filter(...).exists()` query.

## Correction to an earlier version of this description

An earlier revision claimed that writing the cohort filter as `filter(paused_at__isnull=True)` instead of `exclude(...__isnull=False)` would inner-join every member without a membership row out of the wave, and that `test_unpaused_member_is_still_invited` guarded against it. **Both halves were wrong**, and are corrected in `e649353b`:

- Django **promotes the join to a LEFT OUTER JOIN** for `__isnull=True`, so the two spellings are equivalent here — verified by inspecting the generated SQL and by running the whole suite against both forms.
- `_make_user` **always** creates a `CrushConnectMembership`, so that test never exercised a membership-less member at all.

The real gap that hid behind the wrong claim is now closed: `_waitlisted_without_membership` deletes the row explicitly, and two tests pin that such a member stays both a candidate and a recipient. `exclude()` is kept because it states the rule directly, not because the alternative is broken.

## Reporting

The skipped count is surfaced, and **wave-scoped** — a flat count would report wave-2 members while wave 1 was being sent, so `paused_candidates_for_wave` shares the cohort's own wave walk:

```
Wave 1 — Connect Week
  eligible, not yet invited: 42  (limit 200, DRY RUN)
  skipped, paused Connect themselves: 3
```

## Provenance

The regression tests were rescued from an uncommitted detached worktree where they were the sole artifact, one `git worktree prune` from being lost. They were written against `dc844b2b` and called `membership.resume()`, **a method that does not exist** — the real one is `reactivate()`, which also rebuilds the `MatchScore` cache that `pause()` drops.

## Verification

- The rescued tests **bite**: against the unfixed command, `test_paused_member_is_not_an_invite_candidate` fails with `assert 1 not in [1]`
- **9 pause tests**: not-a-candidate, not-mailed end-to-end, row-not-consumed, unpaused-still-invited, reactivate-restores, wave-scoped reporting, pauses-mid-run, and two for the membership-less member
- **23 existing invite tests + 63 wider Connect tests green**
- `makemigrations --check --dry-run` — no changes; `manage.py check` — no issues

## Blast radius today

Bounded: invites grant nothing and Connect is still beta (`CRUSH_CONNECT_LAUNCHED` unset). A trust bug, not an entitlement leak — but it mails exactly the people who asked to be left alone, so it should land before any further wave is sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
