### PR TITLE
Fix quiz projector display ignoring the URL language

### DIFF
--- a/crush_lu/consumers.py
+++ b/crush_lu/consumers.py
@@ -84,6 +84,23 @@ def _build_round_data(round_obj):
     return data
 
 
+def _build_round_title_fields(round_obj):
+    """Build the flat ``round_title`` / ``round_title_<lang>`` keys.
+
+    Payloads that carry a round title inline rather than a nested
+    ``current_round`` object (the rotate broadcast, the display polling API)
+    use this so the client can localize them the same way. Without the
+    per-language keys those clients fall back to whichever single language
+    the server happened to render.
+    """
+    fields = {"round_title": round_obj.title}
+    for lang in _QUIZ_LANGUAGES:
+        val = getattr(round_obj, f"title_{lang}", None)
+        if val:
+            fields[f"round_title_{lang}"] = val
+    return fields
+
+
 class BaseCrushWebsocketConsumer(AsyncJsonWebsocketConsumer):
     """Base WebSocket consumer with defensive channel group join/discard."""
 
@@ -1869,12 +1886,15 @@ class QuizConsumer(BaseCrushWebsocketConsumer):
                 round_number,
             )
 
-        return {
-            "round_title": next_round.title,
+        rotation_payload = {
             "round_number": round_number,
             "is_bonus": next_round.is_bonus,
             "assignments": assignments,
         }
+        # Per-language titles, so a /fr/ or /de/ screen shows the new round's
+        # title in its own language instead of keeping the previous round's.
+        rotation_payload.update(_build_round_title_fields(next_round))
+        return rotation_payload
 
     @database_sync_to_async
     def score_answer(self, user_id, question_id, answer):

--- a/crush_lu/static/crush_lu/js/quiz-display.js
+++ b/crush_lu/static/crush_lu/js/quiz-display.js
@@ -5,6 +5,51 @@
  * Connects via WebSocket (display_token auth) for real-time updates.
  */
 document.addEventListener("alpine:init", function () {
+    // Detect the display language from the URL prefix (/en/, /de/, /fr/) or the
+    // server-rendered <html lang>. Quiz payloads arrive over the WebSocket, which
+    // has no LocaleMiddleware, so the default `text`/`choices`/`title` keys are
+    // always rendered in the fallback language. The per-language keys
+    // (`text_fr`, `choices_de`, ...) are what the projector must read.
+    var _quizLang = (function () {
+        var match = window.location.pathname.match(/^\/(en|de|fr)\//);
+        if (match) return match[1];
+        var htmlLang = document.documentElement.lang || "en";
+        if (htmlLang.indexOf("de") === 0) return "de";
+        if (htmlLang.indexOf("fr") === 0) return "fr";
+        return "en";
+    })();
+
+    /**
+     * Pick the best localized value from a payload object.
+     * Tries ``key_<lang>`` first, then falls back to ``key``.
+     */
+    function _localized(obj, key) {
+        if (!obj) return "";
+        var langKey = key + "_" + _quizLang;
+        if (obj[langKey] !== undefined && obj[langKey] !== null && obj[langKey] !== "")
+            return obj[langKey];
+        return obj[key] !== undefined && obj[key] !== null ? obj[key] : "";
+    }
+
+    /**
+     * Pick the best localized choices array from a payload object.
+     * Tries ``choices_<lang>`` first, then falls back to ``choices``.
+     */
+    function _localizedChoices(obj) {
+        if (!obj) return [];
+        var langKey = "choices_" + _quizLang;
+        if (obj[langKey] && obj[langKey].length > 0) return obj[langKey];
+        return obj.choices || [];
+    }
+
+    /** Map a raw choices array to plain display strings. */
+    function _choiceTexts(choices) {
+        return (choices || []).map(function (c) {
+            if (c && typeof c === "object") return c.text || "";
+            return c;
+        });
+    }
+
     Alpine.data("quizDisplay", function () {
         var eventId = parseInt(this.$el.dataset.eventId) || 0;
         var quizId = parseInt(this.$el.dataset.quizId) || 0;
@@ -502,7 +547,7 @@ document.addEventListener("alpine:init", function () {
                 this.quizStatus = data.status || "draft";
 
                 if (data.current_round) {
-                    this.roundName = data.current_round.title || "";
+                    this.roundName = _localized(data.current_round, "title");
                     this.isBonusRound = data.current_round.is_bonus || false;
                 }
 
@@ -548,7 +593,7 @@ document.addEventListener("alpine:init", function () {
             handleQuestion: function (data) {
                 if (this.connected) this.stopPolling();
                 this.questionId = data.id || null;
-                this.questionText = data.text || "";
+                this.questionText = _localized(data, "text");
                 this.questionType = data.question_type || "multiple_choice";
                 this.questionPoints = data.points || 10;
                 this.questionMedia = data.media || { kind: "none", url: null };
@@ -558,17 +603,13 @@ document.addEventListener("alpine:init", function () {
                 this.scoredCount = data.scored_count || 0;
                 this.totalTables = data.total_tables || this.totalTables;
 
-                // Extract choices
-                this.choices = [];
-                if (data.choices && data.choices.length > 0) {
-                    this.choices = data.choices.map(function (c) {
-                        return c.text || c;
-                    });
-                }
+                // Extract choices (localized when the payload carries them)
+                this.choices = _choiceTexts(_localizedChoices(data));
 
                 // Round name from context
-                if (data.round_title) {
-                    this.roundName = data.round_title;
+                var roundTitle = _localized(data, "round_title");
+                if (roundTitle) {
+                    this.roundName = roundTitle;
                 }
 
                 // Start countdown — use nullish check so time_remaining=0 is respected
@@ -585,7 +626,7 @@ document.addEventListener("alpine:init", function () {
                 // Build question from quiz.state format
                 var q = data.question;
                 this.questionId = q.id || null;
-                this.questionText = q.text || "";
+                this.questionText = _localized(q, "text");
                 this.questionType = q.question_type || "multiple_choice";
                 this.questionPoints = q.points || 10;
                 this.questionMedia = q.media || { kind: "none", url: null };
@@ -595,12 +636,7 @@ document.addEventListener("alpine:init", function () {
                 this.scoredCount = data.scored_count || 0;
                 this.totalTables = data.total_tables || this.totalTables;
 
-                this.choices = [];
-                if (q.choices && q.choices.length > 0) {
-                    this.choices = q.choices.map(function (c) {
-                        return c.text || c;
-                    });
-                }
+                this.choices = _choiceTexts(_localizedChoices(q));
 
                 var time =
                     data.time_remaining != null ? data.time_remaining : data.time || 30;
@@ -639,7 +675,7 @@ document.addEventListener("alpine:init", function () {
                 } else if (data.status === "active") {
                     this.quizStatus = "active";
                     if (data.current_round) {
-                        this.roundName = data.current_round.title || "";
+                        this.roundName = _localized(data.current_round, "title");
                         this.isBonusRound = data.current_round.is_bonus || false;
                     }
                 } else if (data.status === "paused") {
@@ -800,7 +836,7 @@ document.addEventListener("alpine:init", function () {
                         // Handle question data from polling (fallback when no WebSocket)
                         if (data.question && !self.connected) {
                             self.questionId = data.question.id || null;
-                            self.questionText = data.question.text || "";
+                            self.questionText = _localized(data.question, "text");
                             self.questionType =
                                 data.question.question_type || "multiple_choice";
                             self.questionPoints = data.question.points || 10;
@@ -812,17 +848,11 @@ document.addEventListener("alpine:init", function () {
                             self.questionIndex = data.question_index || 0;
                             self.questionTotal = data.question_total || 0;
                             self.isBonusRound = data.is_bonus || false;
-                            self.roundName = data.round_title || "";
+                            self.roundName = _localized(data, "round_title");
 
-                            self.choices = [];
-                            if (
-                                data.question.choices &&
-                                data.question.choices.length > 0
-                            ) {
-                                self.choices = data.question.choices.map(function (c) {
-                                    return c.text || c;
-                                });
-                            }
+                            self.choices = _choiceTexts(
+                                _localizedChoices(data.question),
+                            );
 
                             // Show reveal if all scored, otherwise question/scoring
                             if (data.reveal_results) {

--- a/crush_lu/static/crush_lu/js/quiz-display.js
+++ b/crush_lu/static/crush_lu/js/quiz-display.js
@@ -25,10 +25,18 @@ document.addEventListener("alpine:init", function () {
      */
     function _localized(obj, key) {
         if (!obj) return "";
-        var langKey = key + "_" + _quizLang;
-        if (obj[langKey] !== undefined && obj[langKey] !== null && obj[langKey] !== "")
-            return obj[langKey];
-        return obj[key] !== undefined && obj[key] !== null ? obj[key] : "";
+        // `key_<lang>` first, then the explicit `key_en`, and only then the bare
+        // `key`. The bare key is rendered server side in whatever language was
+        // active there — on the language-neutral polling API that is a guess
+        // from the cookie / Accept-Language header, so preferring `key_en`
+        // keeps an untranslated question on the configured English fallback
+        // instead of a third language the projector URL never asked for.
+        var candidates = [key + "_" + _quizLang, key + "_en", key];
+        for (var i = 0; i < candidates.length; i++) {
+            var val = obj[candidates[i]];
+            if (val !== undefined && val !== null && val !== "") return val;
+        }
+        return "";
     }
 
     /**
@@ -37,9 +45,13 @@ document.addEventListener("alpine:init", function () {
      */
     function _localizedChoices(obj) {
         if (!obj) return [];
-        var langKey = "choices_" + _quizLang;
-        if (obj[langKey] && obj[langKey].length > 0) return obj[langKey];
-        return obj.choices || [];
+        // Same fallback order as _localized, for the same reason.
+        var candidates = ["choices_" + _quizLang, "choices_en", "choices"];
+        for (var i = 0; i < candidates.length; i++) {
+            var val = obj[candidates[i]];
+            if (val && val.length > 0) return val;
+        }
+        return [];
     }
 
     /** Map a raw choices array to plain display strings. */
@@ -741,6 +753,18 @@ document.addEventListener("alpine:init", function () {
             },
 
             handleRotate: function (data) {
+                // Rotation moves the quiz into the next round. The question
+                // broadcast that follows carries no round title, and polling is
+                // stopped while the WebSocket is up, so this is the only chance
+                // to refresh the header before the next question appears.
+                var roundTitle = _localized(data, "round_title");
+                if (roundTitle) {
+                    this.roundName = roundTitle;
+                }
+                if (data.is_bonus !== undefined) {
+                    this.isBonusRound = data.is_bonus;
+                }
+
                 // After rotation, show leaderboard briefly then wait for next question
                 if (this.leaderboardTables.length > 0) {
                     this.screen = "leaderboard";

--- a/crush_lu/tests/test_quiz.py
+++ b/crush_lu/tests/test_quiz.py
@@ -2613,6 +2613,62 @@ class TestQuizTableDisplay:
         assert data["attended_count"] == 0
         assert "quiz_status" in data
 
+    def test_display_data_includes_per_language_question_fields(
+        self, client, quiz_event, quiz_round, quiz_questions
+    ):
+        """The polling payload must carry ``text_<lang>`` / ``choices_<lang>``.
+
+        The projector page is language-prefixed but this endpoint is not, so the
+        display picks its language client side from these keys. Without them the
+        big screen renders English on /fr/ and /de/.
+        """
+        question = quiz_questions[0]
+        question.text_fr = "Quelle est la capitale du Luxembourg ?"
+        question.text_de = "Was ist die Hauptstadt von Luxemburg?"
+        question.choices_fr = [
+            {"text": "Luxembourg-Ville", "is_correct": True},
+            {"text": "Esch-sur-Alzette", "is_correct": False},
+            {"text": "Differdange", "is_correct": False},
+        ]
+        question.save()
+        quiz_round.title_fr = "Manche 1 : Brise-glace"
+        quiz_round.save()
+
+        quiz_event.status = "active"
+        quiz_event.current_round = quiz_round
+        quiz_event.current_question_index = 0
+        quiz_event.save()
+
+        response = client.get(f"/api/quiz/{quiz_event.event_id}/display-data/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert (
+            data["question"]["text_fr"]
+            == "Quelle est la capitale du Luxembourg ?"
+        )
+        assert data["question"]["text_de"] == "Was ist die Hauptstadt von Luxemburg?"
+        assert data["question"]["choices_fr"][0]["text"] == "Luxembourg-Ville"
+        assert data["round_title_fr"] == "Manche 1 : Brise-glace"
+
+    def test_display_data_never_leaks_answers(
+        self, client, quiz_event, quiz_round, quiz_questions
+    ):
+        """Reusing the WebSocket builder must keep ``include_answers=False``."""
+        quiz_event.status = "active"
+        quiz_event.current_round = quiz_round
+        quiz_event.current_question_index = 0
+        quiz_event.save()
+
+        response = client.get(f"/api/quiz/{quiz_event.event_id}/display-data/")
+
+        assert response.status_code == 200
+        question = response.json()["question"]
+        assert not any(k.startswith("choices_with_answers") for k in question)
+        assert not any(k.startswith("correct_answer") for k in question)
+        for choice in question["choices"]:
+            assert "is_correct" not in choice
+
     def test_display_pin_gate_shown_when_token_set(self, client, quiz_event):
         """Display shows PIN gate when display_token is configured."""
         quiz_event.display_token = "1234"

--- a/crush_lu/tests/test_quiz.py
+++ b/crush_lu/tests/test_quiz.py
@@ -356,6 +356,44 @@ class TestAdvanceRoundAndRotate:
 
 
 @pytest.mark.django_db
+class TestRotationPayloadLocalization:
+    """The rotate broadcast carries the round title inline rather than a nested
+    ``current_round``, and the question broadcast that follows carries no title
+    at all. Without per-language keys a /fr/ or /de/ screen keeps showing the
+    previous round's title once the new round's first question appears."""
+
+    @pytest.fixture(autouse=True)
+    def _keep_test_connection_open(self, monkeypatch):
+        monkeypatch.setattr("channels.db.close_old_connections", lambda *a, **kw: None)
+
+    def test_rotate_payload_carries_per_language_round_titles(self, quiz_event):
+        from asgiref.sync import async_to_sync
+
+        from crush_lu.consumers import QuizConsumer
+
+        first = QuizRound.objects.create(quiz=quiz_event, title="Round 1", sort_order=0)
+        second = QuizRound.objects.create(
+            quiz=quiz_event, title="Round 2", sort_order=1
+        )
+        second.title_fr = "Manche 2"
+        second.title_de = "Runde 2"
+        second.save()
+
+        quiz_event.current_round = first
+        quiz_event.status = "active"
+        quiz_event.save()
+
+        consumer = QuizConsumer()
+        consumer.quiz_id = quiz_event.id
+        result = async_to_sync(consumer.advance_round_and_rotate)()
+
+        assert "error" not in result, f"unexpected error: {result.get('error')}"
+        assert result["round_title"] == "Round 2"
+        assert result["round_title_fr"] == "Manche 2"
+        assert result["round_title_de"] == "Runde 2"
+
+
+@pytest.mark.django_db
 class TestQuizStartRotationFailure:
     """Bug: clicking Rotate Tables on round 0→1 silently did nothing
     because start_quiz_from_first_round swallowed rotation generation

--- a/crush_lu/views_quiz.py
+++ b/crush_lu/views_quiz.py
@@ -448,7 +448,7 @@ def quiz_table_display_data(request, event_id):
         # LocaleMiddleware guessed — the projector picks its own language client
         # side from those keys. include_answers stays False: the display must
         # never receive the answer key.
-        from crush_lu.consumers import _build_question_data, _build_round_data
+        from crush_lu.consumers import _build_question_data, _build_round_title_fields
 
         data["question"] = _build_question_data(question, include_answers=False)
 
@@ -457,11 +457,7 @@ def quiz_table_display_data(request, event_id):
         data["question_total"] = questions.count()
         data["is_bonus"] = quiz.current_round.is_bonus if quiz.current_round else False
         if quiz.current_round:
-            round_data = _build_round_data(quiz.current_round)
-            data["round_title"] = round_data.get("title") or ""
-            for key, value in round_data.items():
-                if key.startswith("title_"):
-                    data["round_" + key] = value
+            data.update(_build_round_title_fields(quiz.current_round))
         else:
             data["round_title"] = ""
         data["time_per_question"] = (

--- a/crush_lu/views_quiz.py
+++ b/crush_lu/views_quiz.py
@@ -442,26 +442,28 @@ def quiz_table_display_data(request, event_id):
 
     question = quiz.get_current_question()
     if question and quiz.is_active:
-        data["question"] = {
-            "id": question.id,
-            "text": question.text,
-            "question_type": question.question_type,
-            "points": question.points,
-            "media": question.get_media_payload(),
-        }
-        if question.question_type in ("multiple_choice", "true_false"):
-            from crush_lu.models.quiz import parse_choices
+        # Reuse the WebSocket payload builder so the polling fallback carries the
+        # same per-language keys (text_fr, choices_de, ...). This endpoint is not
+        # under i18n_patterns, so the active language here is whatever
+        # LocaleMiddleware guessed — the projector picks its own language client
+        # side from those keys. include_answers stays False: the display must
+        # never receive the answer key.
+        from crush_lu.consumers import _build_question_data, _build_round_data
 
-            choices = parse_choices(question.choices)
-            data["question"]["choices"] = [
-                {"text": c["text"]} for c in choices if isinstance(c, dict)
-            ]
+        data["question"] = _build_question_data(question, include_answers=False)
 
         questions = quiz.current_round.questions.order_by("sort_order")
         data["question_index"] = quiz.current_question_index
         data["question_total"] = questions.count()
         data["is_bonus"] = quiz.current_round.is_bonus if quiz.current_round else False
-        data["round_title"] = quiz.current_round.title if quiz.current_round else ""
+        if quiz.current_round:
+            round_data = _build_round_data(quiz.current_round)
+            data["round_title"] = round_data.get("title") or ""
+            for key, value in round_data.items():
+                if key.startswith("title_"):
+                    data["round_" + key] = value
+        else:
+            data["round_title"] = ""
         data["time_per_question"] = (
             quiz.current_round.time_per_question if quiz.current_round else 30
         )


### PR DESCRIPTION
## Purpose

* The quiz projector display always rendered question text, answer choices and round titles in **English**, even on `/fr/quiz/{event_id}/display/` and `/de/quiz/{event_id}/display/`. Only the static `{% trans %}` chrome switched language.
* **Root cause:** the quiz content reaches the display over the WebSocket, which runs outside the request/response cycle and therefore has no `LocaleMiddleware`. `crush_lu/consumers.py` already broadcasts per-language keys (`text_fr`, `choices_de`, `title_fr`, …) next to the default `text` / `choices` / `title`, and `quiz-live.js` (attendee + host views) picks the right one client side — but `quiz-display.js` was never given that logic, so it read the default keys, which modeltranslation resolves against the fallback language (`en`).
* Secondary cause: the HTTP polling fallback (`/api/quiz/{event_id}/display-data/`) is deliberately **not** under `i18n_patterns`, so it emitted a single language decided by whatever `LocaleMiddleware` guessed from the cookie / `Accept-Language` header — not the language of the projector URL.
* Third cause, found during review: `advance_round_and_rotate()` emitted `round_title` as a **single-language** string. Since the rotate broadcast carries the title inline (not as a nested `current_round`) and the question broadcast that follows carries no title at all, the header kept the previous round's title after a rotation. `quiz-live.js` had this bug too — it has been calling `_localized(data, "round_title")` on the rotate payload all along, against keys the server never sent.

### What changed

* `crush_lu/static/crush_lu/js/quiz-display.js` — added the same `_quizLang` / `_localized` / `_localizedChoices` helpers already used by `quiz-live.js`, and applied them everywhere question text, answer choices and round titles are read: `handleQuestion`, `showQuestion`, `handleQuizState`, `handleStatus`, `handleRotate`, and the polling fallback. The fallback order is `key_{lang}` → `key_en` → `key`: the bare key is whatever language the server had active, which on the language-neutral polling API is a guess from the cookie / `Accept-Language` header, so preferring `key_en` keeps an untranslated question on the configured English fallback instead of a third language.
* `crush_lu/consumers.py` — new `_build_round_title_fields()` emits `round_title` plus `round_title_{lang}`; `advance_round_and_rotate()` now returns those. This also fixes the attendee view, which was already asking for those keys.
* `crush_lu/views_quiz.py` (`quiz_table_display_data`) — reuses the WebSocket payload builders so the polling fallback carries the same per-language keys. `include_answers=False` is kept, so the answer key is still never sent to the display.
* `crush_lu/tests/test_quiz.py` — regression tests for the per-language payload keys, the per-language rotate payload, and the answer-leak guard on the reused builder.

Note: this fixes the *plumbing*. A question still shows English on `/fr/` if no French translation exists for it in the DB — the fallback is intentional. Translations are entered via the `QuizQuestion` / `QuizRound` admin (both are `TranslationAdmin`).

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

The default `text` / `choices` / `title` / `round_title` keys are still emitted, so any other client reading the old shape is unaffected.

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```
git checkout claude/quiz-live-display-language-o6nd1l
```

* Test the code

```
pytest crush_lu/tests/test_quiz.py -k "display_data or rotate_payload"
```

Manual check:
1. In the admin, give a `QuizRound` title and at least one `QuizQuestion` (text + choices) French and German translations.
2. Start the quiz and open `/fr/quiz/{event_id}/display/` and `/de/quiz/{event_id}/display/` on the projector.
3. Advance a question from the host panel, then rotate into the next round.

## What to Check

Verify that the following are valid

* On `/fr/` the projector shows the French question text, French answer choices and French round title; same for `/de/`; `/en/` is unchanged.
* After rotating into a new round, the header shows the **new** round's title in the projector's language, not the previous round's.
* Both transports behave the same — the WebSocket path (ASGI, `USE_ASGI_DEV`) and the HTTP polling fallback (plain WSGI, or WebSocket disconnected).
* A question with no French translation falls back to English rather than rendering blank or picking up the browser's locale.
* `/api/quiz/{event_id}/display-data/` never contains `choices_with_answers*`, `correct_answer*`, or `is_correct` inside `question.choices`.

## Other Information

The Python test suite could not be executed in the authoring environment (no outbound PyPI access there, so Django was not installed). CI has run it on both commits: all 15 checks are green on `88201e6`, including `Run Tests (Python 3.12)`, `Lint and Format Check` and `JavaScript Lint`.