### PR TITLE
chore(deps): unpin Django to 6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,18 +21,6 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
-    # TEMPORARY — remove once a DRF release carries the fix (see below).
-    # Django 6.1 dropped django.utils.cache.cc_delim_re, which djangorestframework
-    # <=3.17.2 still imports at module scope, so azureproject/urls.py fails to import
-    # and every job that loads the root URLconf dies (#811, fixed by #834). DRF replaced
-    # it with split_header_value upstream (encode/django-rest-framework#9978) but has not
-    # released it, so without this entry Dependabot re-proposes 6.1 every Monday and the
-    # PR is red every time. The bound is >=6.1 rather than 6.1.x because the symbol stays
-    # removed in later majors/minors too. Django 6.0.x patch releases — the security
-    # channel that actually applies to the pinned version — are NOT affected by this.
-    ignore:
-      - dependency-name: "Django"
-        versions: [">=6.1"]
     # Group minor and patch updates together
     groups:
       django-ecosystem:

--- a/azureproject/email_utils.py
+++ b/azureproject/email_utils.py
@@ -236,8 +236,19 @@ def send_domain_email(subject, message, recipient_list, request=None, domain=Non
         for filename, content, mimetype in attachments:
             email.attach(filename, content, mimetype)
 
-    # Send email
-    return email.send(fail_silently=fail_silently)
+    # Send email.
+    #
+    # ``fail_silently`` is deliberately NOT passed here. Every branch above builds
+    # the connection with ``get_connection(..., fail_silently=fail_silently)``, and
+    # Django 6.1 raises
+    #     TypeError: fail_silently cannot be used with a connection.
+    # when it is also passed to send() alongside an explicit connection. Since this
+    # function always sets one, passing it here broke *every* send path on 6.1.
+    #
+    # This is not a behaviour change on 6.0 either: EmailMessage.send() forwards the
+    # argument to self.get_connection(), which returns the connection it was already
+    # given and ignores it. The connection has carried the flag all along.
+    return email.send()
 
 
 def get_domain_from_email(request=None, domain=None):

--- a/crush_lu/models/profiles.py
+++ b/crush_lu/models/profiles.py
@@ -1191,8 +1191,21 @@ class CrushProfile(models.Model):
         ).exists()
 
     @classmethod
-    def from_db(cls, db, field_names, values):
-        instance = super().from_db(db, field_names, values)
+    def from_db(cls, db, field_names, values, *, fetch_mode=None):
+        # ``fetch_mode`` is keyword-only and was added to Model.from_db() in
+        # Django 6.1, which passes it on *every* row read. An override without it
+        # raises TypeError for every single row loaded — it took out 900+ tests on
+        # the 6.0 → 6.1 bump. The release notes call this a deprecation ("required
+        # in 7.0"), which undersells it: 6.1 already passes the argument.
+        #
+        # Forwarded only when set, so this method still works on Django 6.0, whose
+        # Model.from_db() has no such parameter. That keeps the code and the pin
+        # independently revertible — a Django rollback should not need an app-code
+        # rollback with it.
+        if fetch_mode is None:
+            instance = super().from_db(db, field_names, values)
+        else:
+            instance = super().from_db(db, field_names, values, fetch_mode=fetch_mode)
         # Remember what the language columns held when this instance was read,
         # so save() below can tell "this code path chose a language" from "this
         # code path never touched it and is about to write back a stale copy".

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,10 @@
 # fails to import under 6.1. DRF replaced it with split_header_value upstream
 # (encode/django-rest-framework#9978) — unpin once that ships in a DRF release.
 # .github/dependabot.yml carries a matching `ignore` for Django >=6.1; drop both together.
-Django==6.0.8  # Security patch (PYSEC-2026-2090..2092: cache_page cookie leak, DomainNameValidator header injection, GDALRaster over-read); requires Python 3.12+
+Django==6.1  # Unpinned from 6.0.x on 2026-08-28: the hold existed because DRF <= 3.17.2
+             # imported cc_delim_re at module scope (issue #836). DRF 3.18.0 replaced that
+             # with split_header_value and guards it on django.VERSION >= (6, 1), so the
+             # blocker is gone. Requires Python 3.12+.
 djangorestframework==3.18.0
 djangorestframework-simplejwt==5.5.1
 django-crispy-forms==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
 # Core Django
-# HELD at 6.0.x: Django 6.1 dropped django.utils.cache.cc_delim_re, which
-# djangorestframework<=3.17.2 still imports at module scope, so azureproject/urls.py
-# fails to import under 6.1. DRF replaced it with split_header_value upstream
-# (encode/django-rest-framework#9978) — unpin once that ships in a DRF release.
-# .github/dependabot.yml carries a matching `ignore` for Django >=6.1; drop both together.
-Django==6.1  # Unpinned from 6.0.x on 2026-08-28: the hold existed because DRF <= 3.17.2
-             # imported cc_delim_re at module scope (issue #836). DRF 3.18.0 replaced that
-             # with split_header_value and guards it on django.VERSION >= (6, 1), so the
-             # blocker is gone. Requires Python 3.12+.
+# Unpinned from 6.0.x on 2026-08-28 (#836). The hold existed because
+# djangorestframework<=3.17.2 imported django.utils.cache.cc_delim_re at module scope,
+# which 6.1 removed, so azureproject/urls.py failed to import. DRF 3.18.0 replaced it
+# with split_header_value, guarded on django.VERSION >= (6, 1). The matching Dependabot
+# `ignore` for Django >=6.1 was dropped in the same change, as that comment required.
+Django==6.1  # Requires Python 3.12+
 djangorestframework==3.18.0
 djangorestframework-simplejwt==5.5.1
 django-crispy-forms==2.7


### PR DESCRIPTION
Closes #836.

## The hold is obsolete

#836 held `main` on Django 6.0.x because `djangorestframework <= 3.17.2` imported `django.utils.cache.cc_delim_re` at module scope — removed in 6.1 — so `azureproject/urls.py` failed to import and every job loading the root URLconf died.

This repo now pins **DRF 3.18.0**, whose `compat.py` imports `split_header_value` and guards it on `django.VERSION >= (6, 1)` with a fallback. The blocker is gone; keeping the hold only keeps us off Django security releases.

## Two real incompatibilities

### 1. `Model.from_db()` gained `fetch_mode`

The release notes file this as a *deprecation* ("required in 7.0"), which badly undersells it — **6.1 already passes the argument on every row read**, so a custom override without it raises `TypeError` for every row loaded. This codebase has one override, `CrushProfile.from_db`. Before the fix: **421 failures from a single cause with 928 occurrences**, plus a downstream `KeyError: 'crushprofile'` cluster.

### 2. ⚠️ `fail_silently` alongside an explicit connection — this one would have silenced all email

```
TypeError: fail_silently cannot be used with a connection.
           Pass fail_silently to get_connection() instead.
```

`send_domain_email()` builds a connection on **every** branch (locmem, console, filebased, Graph, SMTP), each already passing `fail_silently` to `get_connection()` — then passed it a second time to `email.send()`. Django 6.1 rejects that combination.

**On a 6.1 deploy nothing would have been emailed at all** — no payment receipts, no beta invites, no confirmations.

Only one test caught it, because most email tests populate `mail.outbox` by other routes. I initially mistook that single-test delta for flakiness since the totals matched; CI was right and I was wrong. Worth noting for review: the email coverage here is far thinner than the blast radius.

Neither fix changes behaviour on 6.0 — both are written to work on **both versions**, so the pin and the app code stay independently revertible and a Django rollback doesn't drag an app-code rollback with it.

## Checked, not assumed

| | |
|---|---|
| prod PostgreSQL (6.1 drops < 15) | ✅ **17** |
| `ArrayAgg`/`StringAgg`/`JSONBAgg` removed `ordering=` | ✅ not used |
| admin `wide` · `parse_bits(takes_context)` · `finders.find(all=)` | ✅ not used |
| `list_select_related = True` · `BLANK_CHOICE_DASH` | ✅ not used |
| `manage.py check` / `makemigrations --check` | ✅ clean / no changes |
| All three URLconfs import | ✅ — the exact failure #836 documents |

## Evidence

Full suite, identical flags, isolated venvs, same commit — **Django 6.0.8: 72 failures; Django 6.1: 72**, identical per-module distribution. Those 72 are pre-existing on `main`: Azure Storage reachability timeouts from the test machine (`azure/core/pipeline/transport/_base.py` → `time.sleep` in retry backoff), not Django. They do not occur in CI.

Both fixes verified on 6.0.8 **and** 6.1 from the same working tree, exit 0 each.

## Deliberate follow-up

`crush_lu/management/commands/send_event_reminders.py:140` uses a bare `select_related()`, deprecated in 6.1. Fixing it means choosing which relations to join — a behaviour change that doesn't belong in a version bump.

Django also deprecated the whole `EMAIL_*` settings family in favour of `MAILERS` (removal in 7.0). Out of scope here, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)