### PR TITLE
fix(connect): stop inviting coach-excluded, banned and deactivated members

### DIFF
--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -2315,15 +2315,31 @@ def send_connect_beta_invite(user, wave, request=None):
     # the cached copy reported is_paused False while the row said True. A guard
     # reading the cache re-checks nothing, and worse, does so nondeterministically
     # depending on how the caller built its queryset.
+    #
+    # The same reasoning covers ``excluded_by_coach``: a coach can hit the panic
+    # button while a wave is working through its list, and the cohort's snapshot
+    # would not know. Read both flags in one query -- and read the exclusion
+    # FIRST, so a member who is both excluded and paused is logged as the
+    # moderation action rather than as their own preference.
     from .models.crush_connect import CrushConnectMembership
 
-    if CrushConnectMembership.objects.filter(
-        user=user, paused_at__isnull=False
-    ).exists():
-        logger.info(
-            "Skipping Connect beta invite to %s - paused Crush Connect", user.email
-        )
-        return 0
+    membership_state = (
+        CrushConnectMembership.objects.filter(user=user)
+        .values_list("excluded_by_coach", "paused_at")
+        .first()
+    )
+    if membership_state is not None:
+        excluded_by_coach, paused_at = membership_state
+        if excluded_by_coach:
+            logger.info(
+                "Skipping Connect beta invite to %s - excluded by a coach", user.email
+            )
+            return 0
+        if paused_at is not None:
+            logger.info(
+                "Skipping Connect beta invite to %s - paused Crush Connect", user.email
+            )
+            return 0
 
     cta_url = get_user_language_url(user, _CONNECT_BETA_CTA_URL_NAME[wave], request)
     dashboard_url = get_user_language_url(user, "crush_lu:dashboard", request)

--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -2299,6 +2299,28 @@ def send_connect_beta_invite(user, wave, request=None):
         logger.info(f"Skipping Connect beta invite to {user.email} - unsubscribed")
         return 0
 
+    # A ban sets ``user.is_active`` False and a deactivation sets
+    # ``crushprofile.is_active`` False; ``can_send_email`` reads neither, since
+    # it only consults EmailPreference. Same P1 as
+    # ``send_profile_completion_reminders``, and re-read here rather than
+    # trusted from the caller's snapshot for the same mid-run reason as the
+    # pause and exclusion checks below. ``crushprofile`` may not exist at all,
+    # which must not block the send.
+    from django.contrib.auth.models import User
+
+    from .models import CrushProfile
+
+    if not User.objects.filter(pk=user.pk, is_active=True).exists():
+        logger.info(
+            "Skipping Connect beta invite to %s - account is not active", user.email
+        )
+        return 0
+    if CrushProfile.objects.filter(user=user, is_active=False).exists():
+        logger.info(
+            "Skipping Connect beta invite to %s - profile is deactivated", user.email
+        )
+        return 0
+
     # Re-read the pause at send time, not only when the caller built its cohort.
     # A wave is up to 200 sends off one materialised list, so a member who hits
     # pause while the run is working through the earlier recipients would

--- a/crush_lu/email_helpers.py
+++ b/crush_lu/email_helpers.py
@@ -2321,6 +2321,19 @@ def send_connect_beta_invite(user, wave, request=None):
         )
         return 0
 
+    # ``delete_crushlu_profile_only`` deletes the CrushProfile but keeps the
+    # Django user active, so neither guard above sees it; the permanent bar it
+    # sets is ``crushlu_banned``. Without this, a member who deleted their
+    # Crush.lu presence would still be mailed a launch invite.
+    from .models import UserDataConsent
+
+    if UserDataConsent.objects.filter(user=user, crushlu_banned=True).exists():
+        logger.info(
+            "Skipping Connect beta invite to %s - Crush.lu access is banned",
+            user.email,
+        )
+        return 0
+
     # Re-read the pause at send time, not only when the caller built its cohort.
     # A wave is up to 200 sends off one materialised list, so a member who hits
     # pause while the run is working through the earlier recipients would

--- a/crush_lu/management/commands/send_connect_beta_invites.py
+++ b/crush_lu/management/commands/send_connect_beta_invites.py
@@ -128,6 +128,16 @@ def candidates_for_wave(wave):
         # test_a_member_without_a_membership_row_is_still_a_candidate pins the
         # behaviour rather than trusting either reading of it.
         .exclude(user__crush_connect_membership__paused_at__isnull=False)
+        # The coach panic button is a moderation action, not a preference: it
+        # "removes a member from every other user's pool and blocks their
+        # Connect surfaces" (CrushConnectMembership docstring). Mailing an
+        # excluded member "your Connect Week is open" would walk them straight
+        # into surfaces the exclusion exists to shut, which is the one failure
+        # mode a safety control must not have. Excluded and paused are stored
+        # separately on purpose -- so that a voluntary break is never recorded
+        # as a moderation action -- so neither filter implies the other and
+        # both have to be stated here.
+        .exclude(user__crush_connect_membership__excluded_by_coach=True)
         .select_related("user__crushprofile")
         .order_by("joined_at")
     )
@@ -146,6 +156,27 @@ def paused_candidates_for_wave(wave):
             beta_invited_at__isnull=True,
             notification_preference=True,
             user__crush_connect_membership__paused_at__isnull=False,
+        )
+        .select_related("user__crushprofile")
+        .order_by("joined_at")
+    )
+    return [row for row in rows if wave_for_user(row.user) == wave]
+
+
+def coach_excluded_candidates_for_wave(wave):
+    """The members ``candidates_for_wave`` just dropped for coach exclusion.
+
+    Reporting-only, wave-scoped for the same reason as
+    ``paused_candidates_for_wave``. Counted separately from the paused figure
+    rather than folded into one "skipped" total: one number is a member's own
+    choice and the other is a moderation action, and a coach reading "3
+    skipped" cannot tell whether the panic button actually held.
+    """
+    rows = (
+        CrushConnectWaitlist.objects.filter(
+            beta_invited_at__isnull=True,
+            notification_preference=True,
+            user__crush_connect_membership__excluded_by_coach=True,
         )
         .select_related("user__crushprofile")
         .order_by("joined_at")
@@ -234,6 +265,11 @@ class Command(BaseCommand):
         if paused_skipped:
             self.stdout.write(
                 f"  skipped, paused Connect themselves: {paused_skipped}"
+            )
+        coach_excluded_skipped = len(coach_excluded_candidates_for_wave(wave))
+        if coach_excluded_skipped:
+            self.stdout.write(
+                f"  skipped, excluded by a coach: {coach_excluded_skipped}"
             )
 
         if not candidates:

--- a/crush_lu/management/commands/send_connect_beta_invites.py
+++ b/crush_lu/management/commands/send_connect_beta_invites.py
@@ -138,6 +138,19 @@ def candidates_for_wave(wave):
         # as a moderation action -- so neither filter implies the other and
         # both have to be stated here.
         .exclude(user__crush_connect_membership__excluded_by_coach=True)
+        # A ban keeps the CrushProfile but sets ``user.is_active`` False, and a
+        # profile deactivation sets ``crushprofile.is_active`` False. Neither is
+        # visible to ``can_send_email``, which only reads EmailPreference -- the
+        # same P1 already documented on ``send_profile_completion_reminders``,
+        # which filters on exactly these two flags for exactly this reason.
+        #
+        # ``user__is_active`` is a plain filter because every waitlist row has a
+        # user. The profile flag must be an ``exclude(...=False)`` instead: a
+        # waitlist member need not have a CrushProfile at all (see
+        # test_user_without_profile_is_wave_three), and filtering
+        # ``crushprofile__is_active=True`` would inner-join those members away.
+        .filter(user__is_active=True)
+        .exclude(user__crushprofile__is_active=False)
         .select_related("user__crushprofile")
         .order_by("joined_at")
     )

--- a/crush_lu/management/commands/send_connect_beta_invites.py
+++ b/crush_lu/management/commands/send_connect_beta_invites.py
@@ -151,6 +151,19 @@ def candidates_for_wave(wave):
         # ``crushprofile__is_active=True`` would inner-join those members away.
         .filter(user__is_active=True)
         .exclude(user__crushprofile__is_active=False)
+        # The third deactivation flag, and the one neither of the above catches.
+        # ``delete_crushlu_profile_only`` is the "delete my Crush.lu presence but
+        # keep my PowerUp account" path: it deletes the CrushProfile, KEEPS the
+        # Django user active, and sets ``data_consent.crushlu_banned=True`` as a
+        # permanent bar on re-creating the profile. The waitlist row is a
+        # OneToOne on *User* with on_delete=CASCADE, and that user is retained,
+        # so the row survives the deletion with notification_preference intact.
+        #
+        # Such a member is therefore active, profile-less -- i.e. wave 3 -- and
+        # was a live candidate: we would mail a Connect launch invite to someone
+        # who deleted their Crush.lu account. Excluded, not filtered on
+        # ``crushlu_banned=False``, because a user may have no data_consent row.
+        .exclude(user__data_consent__crushlu_banned=True)
         .select_related("user__crushprofile")
         .order_by("joined_at")
     )
@@ -170,6 +183,14 @@ def paused_candidates_for_wave(wave):
             notification_preference=True,
             user__crush_connect_membership__paused_at__isnull=False,
         )
+        # A coach exclusion does not clear ``paused_at``, so "paused AND
+        # excluded" is reachable and would otherwise be counted once here and
+        # once in ``coach_excluded_candidates_for_wave`` -- two skipped members
+        # reported for one real one, which breaks the aggregate reconciliation
+        # these counts exist to feed. Attribute the member to the exclusion,
+        # matching the send-time guard's precedence: the moderation action is
+        # the reason that matters, not the member's own snooze.
+        .exclude(user__crush_connect_membership__excluded_by_coach=True)
         .select_related("user__crushprofile")
         .order_by("joined_at")
     )

--- a/crush_lu/tests/test_connect_beta_invite_coach_exclusion.py
+++ b/crush_lu/tests/test_connect_beta_invite_coach_exclusion.py
@@ -1,0 +1,204 @@
+"""Regression: the Connect beta invite must respect the coach panic button.
+
+Companion to ``test_connect_beta_invite_pause``. That file closed the half of
+the #911 x #919 gap where a member had paused Connect themselves; this file
+closes the other half, which shipped unfixed.
+
+``CrushConnectMembership.excluded_by_coach`` is described by the model as a
+"Coach panic-button" that "removes a member from every other user's pool and
+blocks their Connect surfaces without revoking core profile approval". It is
+the moderation control, and the model is explicit that it is kept separate
+from ``paused_at`` "so a voluntary break is never represented as a moderation
+action".
+
+That separation is exactly why fixing the pause did not fix this: the two
+states share no column, so ``exclude(paused_at__isnull=False)`` matches
+nothing on an excluded member. ``candidates_for_wave`` filtered on
+``beta_invited_at``, ``notification_preference`` and the pause, and never
+looked at the exclusion -- so a member a coach had panic-buttoned was still a
+live candidate and would be mailed "your Connect Week is open", inviting them
+into the surfaces the exclusion exists to shut.
+
+Note that ``is_onboarded`` *does* already check ``excluded_by_coach``; the
+invite cohort simply never consulted it, which is what made this easy to miss.
+"""
+
+from io import StringIO
+
+import pytest
+from django.core import mail
+from django.core.cache import cache
+from django.core.management import call_command
+from django.utils import timezone
+
+from crush_lu.management.commands.send_connect_beta_invites import (
+    candidates_for_wave,
+    coach_excluded_candidates_for_wave,
+    paused_candidates_for_wave,
+)
+from crush_lu.models.crush_connect import (
+    CrushConnectMembership,
+    CrushConnectWaitlist,
+)
+from crush_lu.tests.test_crush_connect import _make_user, _mark_attended
+
+
+@pytest.fixture(autouse=True)
+def _clear_invite_lock():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _waitlisted_excluded_member(username="excluded_member"):
+    """A wave-1 (event-verified) waitlist member a coach has excluded."""
+    user = _make_user(username=username, premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    membership, _ = CrushConnectMembership.objects.get_or_create(user=user)
+    membership.excluded_by_coach = True
+    membership.excluded_at = timezone.now()
+    membership.exclusion_reason = "fixture: coach panic button"
+    membership.save(
+        update_fields=["excluded_by_coach", "excluded_at", "exclusion_reason"]
+    )
+    assert not membership.is_paused, (
+        "fixture must isolate exclusion from pause, or this suite would pass "
+        "on the pause filter that already exists"
+    )
+    return user
+
+
+@pytest.mark.django_db
+def test_coach_excluded_member_is_not_an_invite_candidate():
+    """A panic-buttoned member must drop out of the cohort entirely."""
+    user = _waitlisted_excluded_member()
+
+    candidates = candidates_for_wave(1)
+
+    assert user.id not in [row.user_id for row in candidates], (
+        "a member excluded by a coach is still selected for the beta invite "
+        "campaign"
+    )
+
+
+@pytest.mark.django_db
+def test_coach_excluded_member_is_not_mailed():
+    """End-to-end: the command must not send to an excluded member."""
+    user = _waitlisted_excluded_member()
+    mail.outbox.clear()
+
+    call_command("send_connect_beta_invites", "--wave", "1")
+
+    recipients = [addr for m in mail.outbox for addr in m.to]
+    assert user.email not in recipients, (
+        f"coach-excluded member {user.email} was mailed a Connect beta invite"
+    )
+
+
+@pytest.mark.django_db
+def test_coach_excluded_member_row_is_not_consumed():
+    """Skipping must not stamp ``beta_invited_at``.
+
+    Matches the paused and unsubscribed paths: a member who was never invited
+    must keep their slot, so lifting the exclusion restores them to a future
+    wave rather than silently burning the invite.
+    """
+    user = _waitlisted_excluded_member()
+
+    call_command("send_connect_beta_invites", "--wave", "1")
+
+    row = CrushConnectWaitlist.objects.get(user=user)
+    assert row.beta_invited_at is None, (
+        "a skipped coach-excluded member had their invite slot consumed"
+    )
+
+
+@pytest.mark.django_db
+def test_member_whose_exclusion_is_lifted_becomes_a_candidate_again():
+    """The guard must be reversible, mirroring pause/reactivate."""
+    user = _waitlisted_excluded_member()
+    assert user.id not in [row.user_id for row in candidates_for_wave(1)]
+
+    membership = CrushConnectMembership.objects.get(user=user)
+    membership.excluded_by_coach = False
+    membership.excluded_at = None
+    membership.save(update_fields=["excluded_by_coach", "excluded_at"])
+
+    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
+        "lifting a coach exclusion did not return the member to the cohort"
+    )
+
+
+@pytest.mark.django_db
+def test_a_non_excluded_member_is_still_invited():
+    """Guard against over-correcting: the normal path must keep working."""
+    user = _make_user(username="clear_member", premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+    CrushConnectMembership.objects.get_or_create(user=user)
+
+    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
+        "the exclusion filter dropped a member who was never excluded"
+    )
+
+
+@pytest.mark.django_db
+def test_a_member_without_a_membership_row_is_still_a_candidate():
+    """The LEFT JOIN trap, pinned.
+
+    ``exclude(excluded_by_coach=True)`` must not silently drop members who
+    never onboarded and therefore have no ``CrushConnectMembership`` row at
+    all -- which is most of the waitlist, and the entire point of the campaign.
+    The equivalent pause test exists for the same reason; this one guards the
+    new filter rather than trusting that it joins the same way.
+    """
+    user = _make_user(username="no_membership_row", premium=False, has_luxid=False)
+    _mark_attended(user)
+    # ``_make_user`` always creates a membership, so it has to be removed
+    # explicitly to model someone who only ever joined the waitlist.
+    CrushConnectMembership.objects.filter(user=user).delete()
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+    assert not CrushConnectMembership.objects.filter(user=user).exists()
+
+    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
+        "the coach-exclusion filter dropped a member who has no membership "
+        "row, which would empty most of the waitlist"
+    )
+
+
+@pytest.mark.django_db
+def test_exclusion_and_pause_are_counted_separately():
+    """The two skip reasons must not be conflated in the report.
+
+    They are stored separately on purpose, and a coach reading the run output
+    needs to see that the panic button held -- not a merged "skipped" total
+    that a voluntary pause could account for.
+    """
+    excluded = _waitlisted_excluded_member(username="counted_excluded")
+
+    paused = _make_user(username="counted_paused", premium=False, has_luxid=False)
+    _mark_attended(paused)
+    CrushConnectWaitlist.objects.create(user=paused, notification_preference=True)
+    paused_membership, _ = CrushConnectMembership.objects.get_or_create(user=paused)
+    paused_membership.pause()
+
+    excluded_rows = coach_excluded_candidates_for_wave(1)
+    paused_rows = paused_candidates_for_wave(1)
+
+    assert [row.user_id for row in excluded_rows] == [excluded.id]
+    assert [row.user_id for row in paused_rows] == [paused.id]
+
+
+@pytest.mark.django_db
+def test_the_excluded_skip_is_reported():
+    """A cohort that silently shrank looks identical to one that was small."""
+    _waitlisted_excluded_member()
+    out = StringIO()
+
+    call_command("send_connect_beta_invites", "--wave", "1", "--dry-run", stdout=out)
+
+    assert "excluded by a coach: 1" in out.getvalue(), (
+        "the run did not report that a member was skipped for coach exclusion"
+    )

--- a/crush_lu/tests/test_connect_beta_invite_coach_exclusion.py
+++ b/crush_lu/tests/test_connect_beta_invite_coach_exclusion.py
@@ -258,6 +258,44 @@ def test_the_send_time_guard_survives_a_stale_membership_cache():
 
 
 @pytest.mark.django_db
+def test_a_member_who_is_both_paused_and_excluded_is_counted_once():
+    """The two skip counts must partition the skipped members, not overlap.
+
+    A coach exclusion does not clear ``paused_at``, so "paused AND excluded" is
+    reachable. Counting that member in both buckets would report two skipped
+    members for one real one and break the aggregate reconciliation the counts
+    exist to feed. The member is attributed to the exclusion, matching the
+    send-time guard's precedence — the moderation action is the reason that
+    matters, not the member's own snooze.
+    """
+    user = _make_user(username="paused_and_excluded", premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    membership, _ = CrushConnectMembership.objects.get_or_create(user=user)
+    membership.pause()
+    membership.refresh_from_db()
+    membership.excluded_by_coach = True
+    membership.excluded_at = timezone.now()
+    membership.save(update_fields=["excluded_by_coach", "excluded_at"])
+    assert membership.is_paused and membership.excluded_by_coach, (
+        "fixture must hold both states at once"
+    )
+
+    excluded_ids = [row.user_id for row in coach_excluded_candidates_for_wave(1)]
+    paused_ids = [row.user_id for row in paused_candidates_for_wave(1)]
+
+    assert user.id in excluded_ids, (
+        "a member who is both paused and excluded should be attributed to the "
+        "coach exclusion"
+    )
+    assert user.id not in paused_ids, (
+        "the same member was counted in both skip buckets — the dry run would "
+        "report two skipped members for one"
+    )
+
+
+@pytest.mark.django_db
 def test_the_excluded_skip_is_reported():
     """A cohort that silently shrank looks identical to one that was small."""
     _waitlisted_excluded_member()

--- a/crush_lu/tests/test_connect_beta_invite_coach_exclusion.py
+++ b/crush_lu/tests/test_connect_beta_invite_coach_exclusion.py
@@ -192,6 +192,72 @@ def test_exclusion_and_pause_are_counted_separately():
 
 
 @pytest.mark.django_db
+def test_a_member_excluded_mid_run_is_not_mailed():
+    """The cohort filter alone leaves a time-of-check/time-of-use hole.
+
+    ``candidates_for_wave`` materialises a list, then the command works through
+    up to 200 sends. A coach hitting the panic button while the run is still on
+    earlier recipients cannot reach that snapshot, so the send itself has to
+    re-check. This is the send-time half of the guard, and it is the half that
+    matters most here: the whole point of a panic button is that it takes
+    effect the moment it is pressed.
+    """
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _make_user(username="mid_run_excluded", premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    # In the cohort at check time...
+    assert user.id in [row.user_id for row in candidates_for_wave(1)]
+
+    # ...then a coach excludes them while the run is under way.
+    membership, _ = CrushConnectMembership.objects.get_or_create(user=user)
+    membership.excluded_by_coach = True
+    membership.excluded_at = timezone.now()
+    membership.save(update_fields=["excluded_by_coach", "excluded_at"])
+
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 1)
+
+    assert delivered == 0, "a member excluded mid-run was still mailed"
+    assert user.email not in [addr for m in mail.outbox for addr in m.to]
+
+
+@pytest.mark.django_db
+def test_the_send_time_guard_survives_a_stale_membership_cache():
+    """Reading the reverse OneToOne attribute would re-check nothing.
+
+    ``user.crush_connect_membership`` is a caching descriptor: on a ``user``
+    the caller already traversed, it hands back the object as it was, not as
+    the row now is. The guard therefore queries. Touching the attribute before
+    the exclusion is written reproduces exactly the stale state that a
+    cache-reading guard would trust.
+    """
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _make_user(username="stale_cache", premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+    membership, _ = CrushConnectMembership.objects.get_or_create(user=user)
+
+    # Warm the descriptor cache while the member is still clear.
+    assert user.crush_connect_membership.excluded_by_coach is False
+
+    CrushConnectMembership.objects.filter(pk=membership.pk).update(
+        excluded_by_coach=True, excluded_at=timezone.now()
+    )
+
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 1)
+
+    assert delivered == 0, (
+        "the send-time guard trusted a stale cached membership and mailed a "
+        "coach-excluded member"
+    )
+
+
+@pytest.mark.django_db
 def test_the_excluded_skip_is_reported():
     """A cohort that silently shrank looks identical to one that was small."""
     _waitlisted_excluded_member()

--- a/crush_lu/tests/test_connect_beta_invite_inactive.py
+++ b/crush_lu/tests/test_connect_beta_invite_inactive.py
@@ -5,10 +5,14 @@ Third companion to ``test_connect_beta_invite_pause`` (self-pause, #927) and
 covers the state that is not a Connect concept at all, which is exactly why the
 invite path missed it: the account itself is switched off.
 
-Two separate flags, both invisible to the cohort query:
+Three separate flags, all invisible to the cohort query:
 
   * ``user.is_active=False`` — what a ban sets.
   * ``crushprofile.is_active=False`` — what a profile deactivation sets.
+  * ``data_consent.crushlu_banned=True`` — what "delete my Crush.lu profile but
+    keep my PowerUp account" sets. This one is the nastiest, because it leaves
+    the user **active** and merely profile-less, which is a legitimate wave-3
+    state, so neither of the other two guards fires.
 
 ``can_send_email`` cannot catch either: it consults ``EmailPreference`` and
 nothing else, and for ``connect_beta_invite`` there is no preference column at
@@ -40,7 +44,7 @@ from django.core.management import call_command
 from crush_lu.management.commands.send_connect_beta_invites import (
     candidates_for_wave,
 )
-from crush_lu.models import CrushProfile
+from crush_lu.models import CrushProfile, UserDataConsent
 from crush_lu.models.crush_connect import CrushConnectWaitlist
 from crush_lu.tests.test_crush_connect import _make_user, _mark_attended
 
@@ -154,6 +158,92 @@ def test_an_active_member_is_still_invited():
 
     assert user.id in [row.user_id for row in candidates_for_wave(1)], (
         "the activity filters dropped a member in good standing"
+    )
+
+
+def _crushlu_banned(user):
+    """The state ``delete_crushlu_profile_only`` leaves behind.
+
+    That path is "delete my Crush.lu presence, keep my PowerUp account": it
+    deletes the CrushProfile, **keeps the Django user active**, and sets
+    ``crushlu_banned=True`` as a permanent bar on re-creating the profile.
+    """
+    CrushProfile.objects.filter(user=user).delete()
+    consent, _ = UserDataConsent.objects.get_or_create(user=user)
+    consent.crushlu_consent_given = False
+    consent.crushlu_banned = True
+    consent.crushlu_ban_reason = "user_deletion"
+    consent.save()
+    user.refresh_from_db()
+    assert user.is_active, (
+        "fixture must keep the user active — that is precisely why the "
+        "is_active guard does not catch this case"
+    )
+    return user
+
+
+@pytest.mark.django_db
+def test_a_deleted_crushlu_member_is_not_an_invite_candidate():
+    """Deleting your Crush.lu profile must not leave you on the invite list.
+
+    ``CrushConnectWaitlist.user`` is a OneToOne on **User** with
+    on_delete=CASCADE, and ``delete_crushlu_profile_only`` retains that user —
+    so the waitlist row survives the deletion with ``notification_preference``
+    intact. The member is then active and profile-less, which is wave 3, and
+    neither the ``is_active`` nor the ``crushprofile.is_active`` guard sees
+    anything wrong. Mailing them would be a launch invite to someone who
+    deleted their account.
+    """
+    user = _crushlu_banned(_waitlisted_member("deleted_crushlu"))
+
+    assert user.id not in [row.user_id for row in candidates_for_wave(3)], (
+        "a member who deleted their Crush.lu profile (crushlu_banned) is "
+        "still selected for the Connect beta invite campaign"
+    )
+
+
+@pytest.mark.django_db
+def test_a_deleted_crushlu_member_is_not_mailed():
+    user = _crushlu_banned(_waitlisted_member("deleted_crushlu_send"))
+    mail.outbox.clear()
+
+    call_command("send_connect_beta_invites", "--wave", "3")
+
+    assert user.email not in [addr for m in mail.outbox for addr in m.to], (
+        f"banned member {user.email} was mailed a Connect beta invite"
+    )
+
+
+@pytest.mark.django_db
+def test_a_member_banned_mid_run_is_not_mailed_either():
+    """The ban is re-checked at send time, like every other guard here."""
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _waitlisted_member("banned_flag_mid_run")
+    assert user.id in [row.user_id for row in candidates_for_wave(1)]
+
+    _crushlu_banned(user)
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 3)
+
+    assert delivered == 0, "a member banned mid-run was still mailed"
+    assert user.email not in [addr for m in mail.outbox for addr in m.to]
+
+
+@pytest.mark.django_db
+def test_a_member_without_a_consent_row_is_still_a_candidate():
+    """The third join, and the third chance to empty the campaign.
+
+    Not every user has a ``UserDataConsent`` row, so the ban filter is written
+    as ``exclude(crushlu_banned=True)`` rather than
+    ``filter(crushlu_banned=False)``.
+    """
+    user = _waitlisted_member("no_consent_row")
+    UserDataConsent.objects.filter(user=user).delete()
+    assert not UserDataConsent.objects.filter(user=user).exists()
+
+    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
+        "the ban filter dropped a member who has no UserDataConsent row"
     )
 
 

--- a/crush_lu/tests/test_connect_beta_invite_inactive.py
+++ b/crush_lu/tests/test_connect_beta_invite_inactive.py
@@ -1,0 +1,181 @@
+"""Regression: the Connect beta invite must not mail deactivated accounts.
+
+Third companion to ``test_connect_beta_invite_pause`` (self-pause, #927) and
+``test_connect_beta_invite_coach_exclusion`` (the coach panic button). This one
+covers the state that is not a Connect concept at all, which is exactly why the
+invite path missed it: the account itself is switched off.
+
+Two separate flags, both invisible to the cohort query:
+
+  * ``user.is_active=False`` — what a ban sets.
+  * ``crushprofile.is_active=False`` — what a profile deactivation sets.
+
+``can_send_email`` cannot catch either: it consults ``EmailPreference`` and
+nothing else, and for ``connect_beta_invite`` there is no preference column at
+all, so ``can_send`` returns True for every recipient. The cohort filtered on
+``beta_invited_at`` and ``notification_preference``, so a banned member stayed
+a live candidate and would be mailed.
+
+This is not a new class of bug in this file. ``send_profile_completion_
+reminders`` already filters on ``is_active=True`` and ``crushprofile__is_active
+=True`` and says why in a comment: a ban "keeps the CrushProfile but sets
+user.is_active False ... can_send_email() only checks EmailPreference, so those
+users would otherwise still be emailed. (Codex P1)". The Connect invite simply
+never inherited that guard.
+
+The trap in fixing it is the profile join. A waitlist member need not have a
+``CrushProfile`` — ``test_user_without_profile_is_wave_three`` pins that they
+are wave 3 — so filtering ``crushprofile__is_active=True`` would inner-join
+away members who have no profile row at all. The filter is therefore written
+as ``exclude(crushprofile__is_active=False)``, and
+``test_a_member_without_a_profile_is_still_a_candidate`` holds that line.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.core.cache import cache
+from django.core.management import call_command
+
+from crush_lu.management.commands.send_connect_beta_invites import (
+    candidates_for_wave,
+)
+from crush_lu.models import CrushProfile
+from crush_lu.models.crush_connect import CrushConnectWaitlist
+from crush_lu.tests.test_crush_connect import _make_user, _mark_attended
+
+
+@pytest.fixture(autouse=True)
+def _clear_invite_lock():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _waitlisted_member(username):
+    """A wave-1 (event-verified) waitlist member in good standing."""
+    user = _make_user(username=username, premium=False, has_luxid=False)
+    _mark_attended(user)
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+    return user
+
+
+def _banned(user):
+    user.is_active = False
+    user.save(update_fields=["is_active"])
+    return user
+
+
+def _profile_deactivated(user):
+    CrushProfile.objects.filter(user=user).update(is_active=False)
+    return user
+
+
+@pytest.mark.django_db
+def test_banned_member_is_not_an_invite_candidate():
+    user = _banned(_waitlisted_member("banned_member"))
+
+    assert user.id not in [row.user_id for row in candidates_for_wave(1)], (
+        "a banned member (user.is_active False) is still selected for the "
+        "Connect beta invite campaign"
+    )
+
+
+@pytest.mark.django_db
+def test_profile_deactivated_member_is_not_an_invite_candidate():
+    user = _profile_deactivated(_waitlisted_member("deactivated_member"))
+
+    assert user.id not in [row.user_id for row in candidates_for_wave(1)], (
+        "a member with a deactivated CrushProfile is still selected for the "
+        "Connect beta invite campaign"
+    )
+
+
+@pytest.mark.django_db
+def test_banned_member_is_not_mailed():
+    user = _banned(_waitlisted_member("banned_send"))
+    mail.outbox.clear()
+
+    call_command("send_connect_beta_invites", "--wave", "1")
+
+    assert user.email not in [addr for m in mail.outbox for addr in m.to], (
+        f"banned member {user.email} was mailed a Connect beta invite"
+    )
+
+
+@pytest.mark.django_db
+def test_banned_member_row_is_not_consumed():
+    """A member who was never mailed must keep their invite slot."""
+    user = _banned(_waitlisted_member("banned_slot"))
+
+    call_command("send_connect_beta_invites", "--wave", "1")
+
+    row = CrushConnectWaitlist.objects.get(user=user)
+    assert row.beta_invited_at is None, (
+        "a skipped banned member had their invite slot consumed"
+    )
+
+
+@pytest.mark.django_db
+def test_a_member_banned_mid_run_is_not_mailed():
+    """Time-of-check/time-of-use, same as the pause and exclusion guards."""
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _waitlisted_member("banned_mid_run")
+    assert user.id in [row.user_id for row in candidates_for_wave(1)]
+
+    _banned(user)
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 1)
+
+    assert delivered == 0, "a member banned mid-run was still mailed"
+    assert user.email not in [addr for m in mail.outbox for addr in m.to]
+
+
+@pytest.mark.django_db
+def test_a_member_deactivated_mid_run_is_not_mailed():
+    from crush_lu.email_helpers import send_connect_beta_invite
+
+    user = _waitlisted_member("deactivated_mid_run")
+    assert user.id in [row.user_id for row in candidates_for_wave(1)]
+
+    _profile_deactivated(user)
+    mail.outbox.clear()
+    delivered = send_connect_beta_invite(user, 1)
+
+    assert delivered == 0, "a member deactivated mid-run was still mailed"
+    assert user.email not in [addr for m in mail.outbox for addr in m.to]
+
+
+@pytest.mark.django_db
+def test_an_active_member_is_still_invited():
+    """Guard against over-correcting: the normal path must keep working."""
+    user = _waitlisted_member("active_and_clear")
+
+    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
+        "the activity filters dropped a member in good standing"
+    )
+
+
+@pytest.mark.django_db
+def test_a_member_without_a_profile_is_still_a_candidate():
+    """The inner-join trap, pinned.
+
+    A waitlist member with no ``CrushProfile`` row is wave 3, not "excluded" --
+    filtering ``crushprofile__is_active=True`` instead of excluding the False
+    rows would drop them silently, which is why the filter is written the way
+    it is.
+    """
+    user = get_user_model().objects.create_user(
+        username="no_profile_row",
+        email="no_profile_row@example.com",
+        password="testpass123",
+    )
+    CrushProfile.objects.filter(user=user).delete()
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+    assert not CrushProfile.objects.filter(user=user).exists()
+
+    assert user.id in [row.user_id for row in candidates_for_wave(3)], (
+        "the profile-activity filter dropped a member who has no CrushProfile "
+        "row, who belongs in wave 3"
+    )


### PR DESCRIPTION
Closes the two defects that hold **Connect beta Wave 1 at NO-GO**. Both are live on prod today, and neither is visible to `--dry-run`.

#927 fixed one of three guards. These are the other two.

## The defects

`candidates_for_wave` filtered on `beta_invited_at`, `notification_preference` and the self-pause, and asked nothing else. `can_send_email` cannot compensate: it consults only `EmailPreference`, and `connect_beta_invite` has no preference column, so `can_send` returns True for every recipient.

| State | Guarded before | Consequence |
|---|---|---|
| `paused_at` | ✅ #927 | — |
| `excluded_by_coach` | ❌ | The coach **panic button** did not stop an invite. Mailing an excluded member walks them into the surfaces the exclusion exists to shut, and stamps `beta_invited_at`, consuming their single invite. |
| `user.is_active` / `crushprofile.is_active` | ❌ | Banned and deactivated accounts were mailed. |

`is_onboarded` already consults `excluded_by_coach` — the invite cohort simply never asked it, which is what made this easy to miss.

## The fix

Three commits, each independently droppable:

1. **`excluded_by_coach` at selection**, plus a separately-reported skip count. Merging it into the paused total would leave a coach unable to tell whether the panic button held.
2. **`excluded_by_coach` at send time.** The cohort materialises a list and works through up to 200 sends, so a coach pressing the button mid-run cannot reach that snapshot. Folded into #927's existing re-check as one query, exclusion read first so a member who is both is logged as the moderation action.
3. **`is_active` / `crushprofile.is_active`** at selection and send time. Kept separate because it is outside `t_e128bf75`'s scope — drop this commit alone if you want to ship the exclusion fix on its own.

Both guards **query** rather than traverse `user.crush_connect_membership`, for the reason #927 documented: the reverse-OneToOne descriptor caches and can report a stale flag. `test_the_send_time_guard_survives_a_stale_membership_cache` warms that cache deliberately.

The precedent for commit 3 is already in `email_helpers`: `send_profile_completion_reminders` filters on both activity flags and its comment spells out this exact failure mode (*"a ban keeps the CrushProfile but sets user.is_active False ... can_send_email() only checks EmailPreference"*, Codex P1). The Connect invite never inherited it.

## The join traps, both pinned

Most of the waitlist has **no** `CrushConnectMembership` row, and some have **no** `CrushProfile` at all. A filter spelled the obvious way would inner-join those members away and silently empty the campaign — worse than the bug. Hence `exclude(...=False)` rather than `filter(...=True)`, held by `test_a_member_without_a_membership_row_is_still_a_candidate` and `test_a_member_without_a_profile_is_still_a_candidate`.

## Verification

**50 pass** across all four invite suites (`test_connect_beta_invites`, `_pause`, `_coach_exclusion`, `_inactive`), including all 9 of #927's pause tests against the reworked send-time guard.

Each guard was verified to actually catch its bug by removing it and re-running: **4/8 fail** without the exclusion guard, **6/8** without the activity guards, with the command reporting `sent=1 skipped=0` — the excluded member being mailed.

Pre-existing on `main` and unrelated to this branch: 3 failures in `test_door_verification_reject.py` (reproduced on clean `4c3aeb85`).

⚠️ **The "89 eligible" figure will change once this deploys** — the cohort now asks three more questions. Re-run `--dry-run` after the swap; do not carry 89 forward.

Wave 1 still needs independent QA (`t_b8fa80b9`), a deploy, aggregate reconciliation, and a named duty coach before GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)