### PR TITLE
fix(connect): partition invite skip reporting

### DIFF
--- a/crush_lu/management/commands/send_connect_beta_invites.py
+++ b/crush_lu/management/commands/send_connect_beta_invites.py
@@ -98,6 +98,32 @@ def wave_for_user(user) -> int:
     return CONNECT_BETA_WAVE_UNVERIFIED
 
 
+def _active_uninvited_waitlist():
+    """Shared active-account base for invite and reporting cohorts."""
+    return (
+        CrushConnectWaitlist.objects.filter(
+            beta_invited_at__isnull=True,
+            notification_preference=True,
+            user__is_active=True,
+        )
+        # A ban keeps the CrushProfile but sets ``user.is_active`` False, and a
+        # profile deactivation sets ``crushprofile.is_active`` False. Neither is
+        # visible to ``can_send_email``, which only reads EmailPreference.
+        #
+        # The profile flag must stay an ``exclude(...=False)``: a waitlist
+        # member need not have a CrushProfile at all, and filtering
+        # ``crushprofile__is_active=True`` would inner-join those members away.
+        .exclude(user__crushprofile__is_active=False)
+        # ``delete_crushlu_profile_only`` deletes the CrushProfile, keeps the
+        # Django user active, and sets ``data_consent.crushlu_banned=True``.
+        # This too must remain an exclusion because a live member may have no
+        # UserDataConsent row.
+        .exclude(user__data_consent__crushlu_banned=True)
+        .select_related("user__crushprofile")
+        .order_by("joined_at")
+    )
+
+
 def candidates_for_wave(wave):
     """Un-invited, consenting waitlist members currently in ``wave``.
 
@@ -108,110 +134,54 @@ def candidates_for_wave(wave):
     something worth denormalising a column for.
     """
     rows = (
-        CrushConnectWaitlist.objects.filter(
-            beta_invited_at__isnull=True,
-            notification_preference=True,
+        _active_uninvited_waitlist()
+        # A self-pause and coach exclusion are independent, reachable states.
+        .exclude(user__crush_connect_membership__paused_at__isnull=False).exclude(
+            user__crush_connect_membership__excluded_by_coach=True
         )
-        # A member who paused Crush Connect themselves must not be mailed
-        # "your Connect Week is open" — their own pause is what is holding it
-        # shut. Nothing deletes the waitlist row when a member onboards, so
-        # waitlist -> onboarded -> paused is a reachable, live state that
-        # otherwise stays a candidate forever.
-        #
-        # Written as exclude(...__isnull=False) because that states the rule
-        # directly: drop the rows that have a paused membership. The obvious
-        # alternative, filter(paused_at__isnull=True), happens to behave
-        # identically -- checked, both emit a LEFT OUTER JOIN, because Django
-        # promotes the join for __isnull=True -- so members who never onboarded
-        # survive either way. That equivalence is the kind of thing that is easy
-        # to assume and easy to get backwards, so
-        # test_a_member_without_a_membership_row_is_still_a_candidate pins the
-        # behaviour rather than trusting either reading of it.
-        .exclude(user__crush_connect_membership__paused_at__isnull=False)
-        # The coach panic button is a moderation action, not a preference: it
-        # "removes a member from every other user's pool and blocks their
-        # Connect surfaces" (CrushConnectMembership docstring). Mailing an
-        # excluded member "your Connect Week is open" would walk them straight
-        # into surfaces the exclusion exists to shut, which is the one failure
-        # mode a safety control must not have. Excluded and paused are stored
-        # separately on purpose -- so that a voluntary break is never recorded
-        # as a moderation action -- so neither filter implies the other and
-        # both have to be stated here.
-        .exclude(user__crush_connect_membership__excluded_by_coach=True)
-        # A ban keeps the CrushProfile but sets ``user.is_active`` False, and a
-        # profile deactivation sets ``crushprofile.is_active`` False. Neither is
-        # visible to ``can_send_email``, which only reads EmailPreference -- the
-        # same P1 already documented on ``send_profile_completion_reminders``,
-        # which filters on exactly these two flags for exactly this reason.
-        #
-        # ``user__is_active`` is a plain filter because every waitlist row has a
-        # user. The profile flag must be an ``exclude(...=False)`` instead: a
-        # waitlist member need not have a CrushProfile at all (see
-        # test_user_without_profile_is_wave_three), and filtering
-        # ``crushprofile__is_active=True`` would inner-join those members away.
-        .filter(user__is_active=True)
-        .exclude(user__crushprofile__is_active=False)
-        # The third deactivation flag, and the one neither of the above catches.
-        # ``delete_crushlu_profile_only`` is the "delete my Crush.lu presence but
-        # keep my PowerUp account" path: it deletes the CrushProfile, KEEPS the
-        # Django user active, and sets ``data_consent.crushlu_banned=True`` as a
-        # permanent bar on re-creating the profile. The waitlist row is a
-        # OneToOne on *User* with on_delete=CASCADE, and that user is retained,
-        # so the row survives the deletion with notification_preference intact.
-        #
-        # Such a member is therefore active, profile-less -- i.e. wave 3 -- and
-        # was a live candidate: we would mail a Connect launch invite to someone
-        # who deleted their Crush.lu account. Excluded, not filtered on
-        # ``crushlu_banned=False``, because a user may have no data_consent row.
-        .exclude(user__data_consent__crushlu_banned=True)
-        .select_related("user__crushprofile")
-        .order_by("joined_at")
     )
     return [row for row in rows if wave_for_user(row.user) == wave]
 
 
 def paused_candidates_for_wave(wave):
-    """The members ``candidates_for_wave`` just dropped for pausing.
+    """The active members ``candidates_for_wave`` dropped for pausing.
 
-    Reporting-only, and deliberately wave-scoped the same way the cohort is: a
-    flat count of every paused waitlist row would report wave-2 members while
-    wave 1 is being sent, which is worse than saying nothing.
+    Reporting-only and wave-scoped. A coach exclusion outranks a self-pause,
+    so that reachable combination is counted only by the moderation bucket.
     """
     rows = (
-        CrushConnectWaitlist.objects.filter(
-            beta_invited_at__isnull=True,
-            notification_preference=True,
-            user__crush_connect_membership__paused_at__isnull=False,
+        _active_uninvited_waitlist().filter(
+            user__crush_connect_membership__paused_at__isnull=False
         )
-        # A coach exclusion does not clear ``paused_at``, so "paused AND
-        # excluded" is reachable and would otherwise be counted once here and
-        # once in ``coach_excluded_candidates_for_wave`` -- two skipped members
-        # reported for one real one, which breaks the aggregate reconciliation
-        # these counts exist to feed. Attribute the member to the exclusion,
-        # matching the send-time guard's precedence: the moderation action is
-        # the reason that matters, not the member's own snooze.
+        # Attribute paused + coach-excluded members to the higher-precedence
+        # moderation action so the reporting buckets cannot overlap.
         .exclude(user__crush_connect_membership__excluded_by_coach=True)
-        .select_related("user__crushprofile")
-        .order_by("joined_at")
     )
     return [row for row in rows if wave_for_user(row.user) == wave]
 
 
 def coach_excluded_candidates_for_wave(wave):
-    """The members ``candidates_for_wave`` just dropped for coach exclusion.
+    """The active members dropped for coach exclusion, wave-scoped."""
+    rows = _active_uninvited_waitlist().filter(
+        user__crush_connect_membership__excluded_by_coach=True
+    )
+    return [row for row in rows if wave_for_user(row.user) == wave]
 
-    Reporting-only, wave-scoped for the same reason as
-    ``paused_candidates_for_wave``. Counted separately from the paused figure
-    rather than folded into one "skipped" total: one number is a member's own
-    choice and the other is a moderation action, and a coach reading "3
-    skipped" cannot tell whether the panic button actually held.
+
+def inactive_candidates_for_wave(wave):
+    """The members dropped because their account is inactive or deleted.
+
+    This is the complement of the shared active-account base within the full
+    un-invited, consenting waitlist. The activity rules therefore have one
+    definition that cohort selection and every lower-precedence bucket share.
     """
+    active_ids = _active_uninvited_waitlist().order_by().values("pk")
     rows = (
         CrushConnectWaitlist.objects.filter(
             beta_invited_at__isnull=True,
             notification_preference=True,
-            user__crush_connect_membership__excluded_by_coach=True,
         )
+        .exclude(pk__in=active_ids)
         .select_related("user__crushprofile")
         .order_by("joined_at")
     )
@@ -295,16 +265,19 @@ class Command(BaseCommand):
         # Say so out loud: a cohort that silently shrank looks identical to one
         # that was always that size, and "why did N members not get this?" is
         # the first question anyone asks after a wave goes out.
-        paused_skipped = len(paused_candidates_for_wave(wave))
-        if paused_skipped:
+        inactive_skipped = len(inactive_candidates_for_wave(wave))
+        if inactive_skipped:
             self.stdout.write(
-                f"  skipped, paused Connect themselves: {paused_skipped}"
+                f"  skipped, account inactive or deleted: {inactive_skipped}"
             )
         coach_excluded_skipped = len(coach_excluded_candidates_for_wave(wave))
         if coach_excluded_skipped:
             self.stdout.write(
                 f"  skipped, excluded by a coach: {coach_excluded_skipped}"
             )
+        paused_skipped = len(paused_candidates_for_wave(wave))
+        if paused_skipped:
+            self.stdout.write(f"  skipped, paused Connect themselves: {paused_skipped}")
 
         if not candidates:
             self.stdout.write(self.style.SUCCESS("Nothing to send."))

--- a/crush_lu/tests/test_connect_beta_invite_inactive.py
+++ b/crush_lu/tests/test_connect_beta_invite_inactive.py
@@ -35,17 +35,27 @@ as ``exclude(crushprofile__is_active=False)``, and
 ``test_a_member_without_a_profile_is_still_a_candidate`` holds that line.
 """
 
+from io import StringIO
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.cache import cache
 from django.core.management import call_command
+from django.utils import timezone
 
 from crush_lu.management.commands.send_connect_beta_invites import (
     candidates_for_wave,
+    coach_excluded_candidates_for_wave,
+    inactive_candidates_for_wave,
+    paused_candidates_for_wave,
+    wave_for_user,
 )
 from crush_lu.models import CrushProfile, UserDataConsent
-from crush_lu.models.crush_connect import CrushConnectWaitlist
+from crush_lu.models.crush_connect import (
+    CrushConnectMembership,
+    CrushConnectWaitlist,
+)
 from crush_lu.tests.test_crush_connect import _make_user, _mark_attended
 
 
@@ -96,15 +106,87 @@ def test_profile_deactivated_member_is_not_an_invite_candidate():
 
 
 @pytest.mark.django_db
+def test_inactive_reporting_takes_precedence_over_pause_and_coach_exclusion():
+    """Each inactive account belongs only to the highest-precedence bucket."""
+    banned_and_paused = _banned(_waitlisted_member("banned_and_paused"))
+    paused_membership = CrushConnectMembership.objects.get(user=banned_and_paused)
+    paused_membership.pause()
+
+    banned_and_excluded = _banned(_waitlisted_member("banned_and_excluded"))
+    excluded_membership = CrushConnectMembership.objects.get(user=banned_and_excluded)
+    excluded_membership.excluded_by_coach = True
+    excluded_membership.excluded_at = timezone.now()
+    excluded_membership.save(update_fields=["excluded_by_coach", "excluded_at"])
+
+    _profile_deactivated(_waitlisted_member("profile_deactivated"))
+    _crushlu_banned(_waitlisted_member("crushlu_deleted"))
+
+    out = StringIO()
+    call_command("send_connect_beta_invites", "--wave", "1", "--dry-run", stdout=out)
+    report = out.getvalue()
+
+    assert "skipped, account inactive or deleted: 3" in report
+    assert "skipped, paused Connect themselves" not in report
+    assert "skipped, excluded by a coach" not in report
+
+    wave_three_out = StringIO()
+    call_command(
+        "send_connect_beta_invites",
+        "--wave",
+        "3",
+        "--dry-run",
+        stdout=wave_three_out,
+    )
+    assert "skipped, account inactive or deleted: 1" in wave_three_out.getvalue()
+
+
+@pytest.mark.django_db
+def test_reporting_buckets_partition_the_uninvited_consenting_wave():
+    eligible = _waitlisted_member("partition_eligible")
+
+    paused = _waitlisted_member("partition_paused")
+    CrushConnectMembership.objects.get(user=paused).pause()
+
+    excluded = _waitlisted_member("partition_excluded")
+    excluded_membership = CrushConnectMembership.objects.get(user=excluded)
+    excluded_membership.excluded_by_coach = True
+    excluded_membership.excluded_at = timezone.now()
+    excluded_membership.save(update_fields=["excluded_by_coach", "excluded_at"])
+
+    inactive = _banned(_waitlisted_member("partition_inactive"))
+    CrushConnectMembership.objects.get(user=inactive).pause()
+
+    bucket_ids = [
+        {row.user_id for row in candidates_for_wave(1)},
+        {row.user_id for row in paused_candidates_for_wave(1)},
+        {row.user_id for row in coach_excluded_candidates_for_wave(1)},
+        {row.user_id for row in inactive_candidates_for_wave(1)},
+    ]
+    all_bucket_ids = set().union(*bucket_ids)
+    full_wave_ids = {
+        row.user_id
+        for row in CrushConnectWaitlist.objects.filter(
+            beta_invited_at__isnull=True,
+            notification_preference=True,
+        ).select_related("user__crushprofile")
+        if wave_for_user(row.user) == 1
+    }
+
+    assert full_wave_ids == {eligible.id, paused.id, excluded.id, inactive.id}
+    assert all_bucket_ids == full_wave_ids
+    assert sum(len(ids) for ids in bucket_ids) == len(full_wave_ids)
+
+
+@pytest.mark.django_db
 def test_banned_member_is_not_mailed():
     user = _banned(_waitlisted_member("banned_send"))
     mail.outbox.clear()
 
     call_command("send_connect_beta_invites", "--wave", "1")
 
-    assert user.email not in [addr for m in mail.outbox for addr in m.to], (
-        f"banned member {user.email} was mailed a Connect beta invite"
-    )
+    assert user.email not in [
+        addr for m in mail.outbox for addr in m.to
+    ], f"banned member {user.email} was mailed a Connect beta invite"
 
 
 @pytest.mark.django_db
@@ -115,9 +197,9 @@ def test_banned_member_row_is_not_consumed():
     call_command("send_connect_beta_invites", "--wave", "1")
 
     row = CrushConnectWaitlist.objects.get(user=user)
-    assert row.beta_invited_at is None, (
-        "a skipped banned member had their invite slot consumed"
-    )
+    assert (
+        row.beta_invited_at is None
+    ), "a skipped banned member had their invite slot consumed"
 
 
 @pytest.mark.django_db
@@ -156,9 +238,9 @@ def test_an_active_member_is_still_invited():
     """Guard against over-correcting: the normal path must keep working."""
     user = _waitlisted_member("active_and_clear")
 
-    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
-        "the activity filters dropped a member in good standing"
-    )
+    assert user.id in [
+        row.user_id for row in candidates_for_wave(1)
+    ], "the activity filters dropped a member in good standing"
 
 
 def _crushlu_banned(user):
@@ -209,9 +291,9 @@ def test_a_deleted_crushlu_member_is_not_mailed():
 
     call_command("send_connect_beta_invites", "--wave", "3")
 
-    assert user.email not in [addr for m in mail.outbox for addr in m.to], (
-        f"banned member {user.email} was mailed a Connect beta invite"
-    )
+    assert user.email not in [
+        addr for m in mail.outbox for addr in m.to
+    ], f"banned member {user.email} was mailed a Connect beta invite"
 
 
 @pytest.mark.django_db
@@ -242,9 +324,9 @@ def test_a_member_without_a_consent_row_is_still_a_candidate():
     UserDataConsent.objects.filter(user=user).delete()
     assert not UserDataConsent.objects.filter(user=user).exists()
 
-    assert user.id in [row.user_id for row in candidates_for_wave(1)], (
-        "the ban filter dropped a member who has no UserDataConsent row"
-    )
+    assert user.id in [
+        row.user_id for row in candidates_for_wave(1)
+    ], "the ban filter dropped a member who has no UserDataConsent row"
 
 
 @pytest.mark.django_db
@@ -269,3 +351,18 @@ def test_a_member_without_a_profile_is_still_a_candidate():
         "the profile-activity filter dropped a member who has no CrushProfile "
         "row, who belongs in wave 3"
     )
+
+
+@pytest.mark.django_db
+def test_a_member_without_profile_or_consent_rows_is_still_a_candidate():
+    """Both optional activity relations may be absent on one live member."""
+    user = get_user_model().objects.create_user(
+        username="no_profile_or_consent_rows",
+        email="no_profile_or_consent_rows@example.com",
+        password="testpass123",
+    )
+    CrushProfile.objects.filter(user=user).delete()
+    UserDataConsent.objects.filter(user=user).delete()
+    CrushConnectWaitlist.objects.create(user=user, notification_preference=True)
+
+    assert user.id in [row.user_id for row in candidates_for_wave(3)]


### PR DESCRIPTION
## Summary
- centralize the uninvited, consenting, active-account waitlist queryset used by invite selection and reporting
- report banned, deactivated, and deleted accounts in one inactive/deleted bucket
- enforce inactive > coach-excluded > paused precedence so all four cohorts partition each wave exactly
- retain members whose optional CrushProfile or UserDataConsent rows are absent

## Verification
- `58 passed`: four Connect beta invite suites
- `4817 passed, 32 skipped, 92 subtests passed`: full pytest suite
- Black and Ruff clean on both changed files
- `git diff --check` clean
- independent read-only Claude review: PASS, no blocking findings

## Safety
- reporting-only follow-up; `crush_lu/email_helpers.py` is untouched
- no live command run and no invite sent

Kanban: t_016cc69f